### PR TITLE
Consistent orchestrator library registration before AppInitializationComplete

### DIFF
--- a/src/griptape_nodes/app/app.py
+++ b/src/griptape_nodes/app/app.py
@@ -275,7 +275,14 @@ async def _run_websocket_tasks(role: EngineRole) -> None:
     async with Client() as client:
         logger.debug("WebSocket connection established")
         is_worker = isinstance(role, Worker)
-        libraries_to_register = [role.library_name] if isinstance(role, Worker) and role.library_name else []
+        if is_worker and role.library_name:
+            libraries_to_register = [role.library_name]
+        else:
+            # For orchestrator, load from config (unified for headless and non-headless)
+            libraries_to_register = config_manager.get_config_value(
+                "app_events.on_app_initialization_complete.libraries_to_register"
+            ) or []
+
         griptape_nodes.EventManager().put_event(
             AppEvent(
                 payload=app_events.AppInitializationComplete(

--- a/src/griptape_nodes/app/app.py
+++ b/src/griptape_nodes/app/app.py
@@ -279,9 +279,9 @@ async def _run_websocket_tasks(role: EngineRole) -> None:
             libraries_to_register = [role.library_name]
         else:
             # For orchestrator, load from config (unified for headless and non-headless)
-            libraries_to_register = config_manager.get_config_value(
-                "app_events.on_app_initialization_complete.libraries_to_register"
-            ) or []
+            libraries_to_register = (
+                config_manager.get_config_value("app_events.on_app_initialization_complete.libraries_to_register") or []
+            )
 
         griptape_nodes.EventManager().put_event(
             AppEvent(

--- a/tests/unit/app/test_app_initialization.py
+++ b/tests/unit/app/test_app_initialization.py
@@ -1,5 +1,7 @@
 """Unit tests for orchestrator startup AppInitializationComplete event emission and library registration logic."""
 
+import types
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -9,7 +11,7 @@ from griptape_nodes.retained_mode.events.app_events import AppInitializationComp
 
 
 @pytest.mark.asyncio
-async def test_orchestrator_emits_app_initialization_complete_with_config_libraries(monkeypatch):
+async def test_orchestrator_emits_app_initialization_complete_with_config_libraries(monkeypatch: Any) -> None:
     """Test that the orchestrator emits AppInitializationComplete with libraries_to_register from config."""
     # Arrange
     fake_libraries = ["lib1", "lib2"]
@@ -23,10 +25,15 @@ async def test_orchestrator_emits_app_initialization_complete_with_config_librar
 
     # Patch Client context manager to avoid real network/async operations
     class DummyAsyncContext:
-        async def __aenter__(self):
+        async def __aenter__(self) -> MagicMock:
             return MagicMock()
 
-        async def __aexit__(self, exc_type, exc, tb):
+        async def __aexit__(
+            self,
+            exc_type: object,
+            exc: object,
+            tb: types.TracebackType | None,
+        ) -> bool:
             return False
 
     monkeypatch.setattr(app, "Client", DummyAsyncContext)
@@ -46,17 +53,22 @@ async def test_orchestrator_emits_app_initialization_complete_with_config_librar
 
 
 @pytest.mark.asyncio
-async def test_worker_emits_app_initialization_complete_with_library_name(monkeypatch):
+async def test_worker_emits_app_initialization_complete_with_library_name(monkeypatch: Any) -> None:
     """Test that a Worker emits AppInitializationComplete with its library_name."""
     worker_role = app.Worker(session_id="sess", library_name="libA")
     event_manager = MagicMock()
     monkeypatch.setattr(app.griptape_nodes, "EventManager", lambda: event_manager)
 
     class DummyAsyncContext:
-        async def __aenter__(self):
+        async def __aenter__(self) -> MagicMock:
             return MagicMock()
 
-        async def __aexit__(self, exc_type, exc, tb):
+        async def __aexit__(
+            self,
+            exc_type: object,
+            exc: object,
+            tb: types.TracebackType | None,
+        ) -> bool:
             return False
 
     monkeypatch.setattr(app, "Client", DummyAsyncContext)

--- a/tests/unit/app/test_app_initialization.py
+++ b/tests/unit/app/test_app_initialization.py
@@ -1,45 +1,74 @@
 """Unit tests for orchestrator startup AppInitializationComplete event emission and library registration logic."""
 
-import asyncio
-from unittest.mock import patch, MagicMock
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 
 from griptape_nodes.app import app
 from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
 
+
 @pytest.mark.asyncio
 async def test_orchestrator_emits_app_initialization_complete_with_config_libraries(monkeypatch):
-    """
-    Test that the orchestrator emits AppInitializationComplete with libraries_to_register from config.
-    """
+    """Test that the orchestrator emits AppInitializationComplete with libraries_to_register from config."""
     # Arrange
     fake_libraries = ["lib1", "lib2"]
-    monkeypatch.setattr(app.config_manager, "get_config_value", lambda key, **_: fake_libraries if "libraries_to_register" in key else None)
+    monkeypatch.setattr(
+        app.config_manager,
+        "get_config_value",
+        lambda key, **_: fake_libraries if "libraries_to_register" in key else None,
+    )
     event_manager = MagicMock()
     monkeypatch.setattr(app.griptape_nodes, "EventManager", lambda: event_manager)
-    monkeypatch.setattr(app, "Client", MagicMock())
-    monkeypatch.setattr(app, "AppEvent", AppInitializationComplete)
+
+    # Patch Client context manager to avoid real network/async operations
+    class DummyAsyncContext:
+        async def __aenter__(self):
+            return MagicMock()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(app, "Client", DummyAsyncContext)
+    # Patch _run_orchestrator to prevent blocking
+    monkeypatch.setattr(app, "_run_orchestrator", AsyncMock())
+    mock_app_event = MagicMock()
+    monkeypatch.setattr(app, "AppEvent", mock_app_event)
 
     # Act
     await app._run_websocket_tasks(app.Orchestrator())
 
     # Assert
-    # The first event should be AppInitializationComplete with correct libraries
-    assert event_manager.put_event.call_args_list[0][0][0].payload.libraries_to_register == fake_libraries
-    assert not event_manager.put_event.call_args_list[0][0][0].payload.is_worker
+    payload = mock_app_event.call_args_list[0][1]["payload"]
+    assert isinstance(payload, AppInitializationComplete)
+    assert payload.libraries_to_register == fake_libraries
+    assert not payload.is_worker
+
 
 @pytest.mark.asyncio
 async def test_worker_emits_app_initialization_complete_with_library_name(monkeypatch):
-    """
-    Test that a Worker emits AppInitializationComplete with its library_name.
-    """
+    """Test that a Worker emits AppInitializationComplete with its library_name."""
     worker_role = app.Worker(session_id="sess", library_name="libA")
     event_manager = MagicMock()
     monkeypatch.setattr(app.griptape_nodes, "EventManager", lambda: event_manager)
-    monkeypatch.setattr(app, "Client", MagicMock())
-    monkeypatch.setattr(app, "AppEvent", AppInitializationComplete)
 
+    class DummyAsyncContext:
+        async def __aenter__(self):
+            return MagicMock()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(app, "Client", DummyAsyncContext)
+    monkeypatch.setattr(app, "_run_worker", AsyncMock())
+    mock_app_event = MagicMock()
+    monkeypatch.setattr(app, "AppEvent", mock_app_event)
+
+    # Act
     await app._run_websocket_tasks(worker_role)
 
-    assert event_manager.put_event.call_args_list[0][0][0].payload.libraries_to_register == ["libA"]
-    assert event_manager.put_event.call_args_list[0][0][0].payload.is_worker
+    # Assert
+    payload = mock_app_event.call_args_list[0][1]["payload"]
+    assert isinstance(payload, AppInitializationComplete)
+    assert payload.libraries_to_register == ["libA"]
+    assert payload.is_worker

--- a/tests/unit/app/test_app_initialization.py
+++ b/tests/unit/app/test_app_initialization.py
@@ -1,0 +1,45 @@
+"""Unit tests for orchestrator startup AppInitializationComplete event emission and library registration logic."""
+
+import asyncio
+from unittest.mock import patch, MagicMock
+import pytest
+
+from griptape_nodes.app import app
+from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
+
+@pytest.mark.asyncio
+async def test_orchestrator_emits_app_initialization_complete_with_config_libraries(monkeypatch):
+    """
+    Test that the orchestrator emits AppInitializationComplete with libraries_to_register from config.
+    """
+    # Arrange
+    fake_libraries = ["lib1", "lib2"]
+    monkeypatch.setattr(app.config_manager, "get_config_value", lambda key, **_: fake_libraries if "libraries_to_register" in key else None)
+    event_manager = MagicMock()
+    monkeypatch.setattr(app.griptape_nodes, "EventManager", lambda: event_manager)
+    monkeypatch.setattr(app, "Client", MagicMock())
+    monkeypatch.setattr(app, "AppEvent", AppInitializationComplete)
+
+    # Act
+    await app._run_websocket_tasks(app.Orchestrator())
+
+    # Assert
+    # The first event should be AppInitializationComplete with correct libraries
+    assert event_manager.put_event.call_args_list[0][0][0].payload.libraries_to_register == fake_libraries
+    assert not event_manager.put_event.call_args_list[0][0][0].payload.is_worker
+
+@pytest.mark.asyncio
+async def test_worker_emits_app_initialization_complete_with_library_name(monkeypatch):
+    """
+    Test that a Worker emits AppInitializationComplete with its library_name.
+    """
+    worker_role = app.Worker(session_id="sess", library_name="libA")
+    event_manager = MagicMock()
+    monkeypatch.setattr(app.griptape_nodes, "EventManager", lambda: event_manager)
+    monkeypatch.setattr(app, "Client", MagicMock())
+    monkeypatch.setattr(app, "AppEvent", AppInitializationComplete)
+
+    await app._run_websocket_tasks(worker_role)
+
+    assert event_manager.put_event.call_args_list[0][0][0].payload.libraries_to_register == ["libA"]
+    assert event_manager.put_event.call_args_list[0][0][0].payload.is_worker


### PR DESCRIPTION
Because library registration is idempotent, we can always (headless and non-headless) fetch libraries to register before AppInitializationComplete. This means libraries will be registered before the app is initialized.

Closes https://github.com/griptape-ai/griptape-nodes/issues/4584