### PR TITLE
test: add NodeExecutor contract tests

### DIFF
--- a/tests/unit/common/test_node_executor_execute.py
+++ b/tests/unit/common/test_node_executor_execute.py
@@ -1,0 +1,272 @@
+"""Contract tests for NodeExecutor.execute().
+
+These tests describe the observable contract of `NodeExecutor.execute(node)`
+without relying on internals. They cover three behavioral clusters:
+
+1. Dispatch contract: a plain BaseNode results in an ExecuteNodeRequest whose
+   payload reflects the node's name, parameter values, and metadata at the
+   moment of dispatch (defensive copies, not live references).
+2. Failure contract: when the dispatched request returns a failure result,
+   execute() raises RuntimeError that carries the node name and the failure
+   details, and outputs are not copied back onto the node.
+3. Special-node routing: BaseWhileNodeGroup, BaseIterativeNodeGroup,
+   BaseIterativeEndNode, and SubflowNodeGroup (with LOCAL_EXECUTION) take
+   their dedicated paths and do NOT dispatch an ExecuteNodeRequest.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from griptape_nodes.common.node_executor import NodeExecutor
+from griptape_nodes.exe_types.base_iterative_nodes import BaseIterativeEndNode
+from griptape_nodes.exe_types.node_groups import (
+    BaseIterativeNodeGroup,
+    BaseWhileNodeGroup,
+    SubflowNodeGroup,
+)
+from griptape_nodes.exe_types.node_types import LOCAL_EXECUTION
+from griptape_nodes.retained_mode.events.execution_events import (
+    ExecuteNodeRequest,
+    ExecuteNodeResultFailure,
+    ExecuteNodeResultSuccess,
+)
+
+_GRIPTAPE_NODES_PATH = "griptape_nodes.common.node_executor.GriptapeNodes"
+
+
+def _make_executor() -> NodeExecutor:
+    return NodeExecutor.__new__(NodeExecutor)
+
+
+def _make_node(
+    name: str = "TestNode",
+    parameter_values: dict[str, Any] | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> MagicMock:
+    node = MagicMock()
+    node.name = name
+    node.parameter_values = parameter_values if parameter_values is not None else {}
+    node.parameter_output_values = {}
+    node.metadata = metadata if metadata is not None else {}
+    return node
+
+
+def _success_result(outputs: dict[str, Any] | None = None) -> ExecuteNodeResultSuccess:
+    return ExecuteNodeResultSuccess(
+        result_details="ok",
+        parameter_output_values=outputs or {},
+    )
+
+
+class TestExecuteDispatchContract:
+    """A plain BaseNode dispatches a single ExecuteNodeRequest carrying its state."""
+
+    @pytest.mark.asyncio
+    async def test_dispatches_execute_node_request_for_plain_node(self) -> None:
+        node = _make_node(name="Greeter")
+
+        with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
+            mock_gn.ahandle_request = AsyncMock(return_value=_success_result())
+            await _make_executor().execute(node)
+
+        mock_gn.ahandle_request.assert_awaited_once()
+        request = mock_gn.ahandle_request.call_args.args[0]
+        assert isinstance(request, ExecuteNodeRequest)
+        assert request.node_name == "Greeter"
+
+    @pytest.mark.asyncio
+    async def test_dispatches_current_parameter_values(self) -> None:
+        node = _make_node(parameter_values={"in": "hi", "n": 3})
+
+        with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
+            mock_gn.ahandle_request = AsyncMock(return_value=_success_result())
+            await _make_executor().execute(node)
+
+        request = mock_gn.ahandle_request.call_args.args[0]
+        assert request.parameter_values == {"in": "hi", "n": 3}
+
+    @pytest.mark.asyncio
+    async def test_dispatched_parameter_values_are_independent_copy(self) -> None:
+        """Mutating node.parameter_values after dispatch must not leak into the request."""
+        node = _make_node(parameter_values={"in": "hi"})
+        captured: dict[str, Any] = {}
+
+        async def capture(req: Any) -> ExecuteNodeResultSuccess:
+            # Mutate the node's live dict; the request's snapshot must not change.
+            node.parameter_values["in"] = "MUTATED"
+            captured["params"] = req.parameter_values
+            return _success_result()
+
+        with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
+            mock_gn.ahandle_request = AsyncMock(side_effect=capture)
+            await _make_executor().execute(node)
+
+        assert captured["params"] == {"in": "hi"}
+
+    @pytest.mark.asyncio
+    async def test_dispatches_node_metadata(self) -> None:
+        node = _make_node(metadata={"node_type": "Foo", "library": "Bar"})
+
+        with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
+            mock_gn.ahandle_request = AsyncMock(return_value=_success_result())
+            await _make_executor().execute(node)
+
+        request = mock_gn.ahandle_request.call_args.args[0]
+        assert request.node_metadata == {"node_type": "Foo", "library": "Bar"}
+
+    @pytest.mark.asyncio
+    async def test_dispatched_metadata_is_independent_copy(self) -> None:
+        node = _make_node(metadata={"node_type": "Foo", "library": "Bar"})
+        captured: dict[str, Any] = {}
+
+        async def capture(req: Any) -> ExecuteNodeResultSuccess:
+            node.metadata["library"] = "MUTATED"
+            captured["meta"] = req.node_metadata
+            return _success_result()
+
+        with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
+            mock_gn.ahandle_request = AsyncMock(side_effect=capture)
+            await _make_executor().execute(node)
+
+        assert captured["meta"] == {"node_type": "Foo", "library": "Bar"}
+
+    @pytest.mark.asyncio
+    async def test_outputs_from_result_are_copied_back_to_node(self) -> None:
+        node = _make_node()
+
+        with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
+            mock_gn.ahandle_request = AsyncMock(
+                return_value=_success_result({"a": 1, "b": "two"}),
+            )
+            await _make_executor().execute(node)
+
+        assert node.parameter_output_values == {"a": 1, "b": "two"}
+
+
+class TestExecuteFailureContract:
+    """A non-success result is converted into a RuntimeError that explains the failure."""
+
+    @pytest.mark.asyncio
+    async def test_raises_runtime_error_when_result_is_failure(self) -> None:
+        node = _make_node(name="Broken")
+        failure = ExecuteNodeResultFailure(result_details="boom")
+
+        with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
+            mock_gn.ahandle_request = AsyncMock(return_value=failure)
+
+            with pytest.raises(RuntimeError):
+                await _make_executor().execute(node)
+
+    @pytest.mark.asyncio
+    async def test_runtime_error_mentions_node_name(self) -> None:
+        node = _make_node(name="Broken")
+        failure = ExecuteNodeResultFailure(result_details="boom")
+
+        with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
+            mock_gn.ahandle_request = AsyncMock(return_value=failure)
+
+            with pytest.raises(RuntimeError, match="Broken"):
+                await _make_executor().execute(node)
+
+    @pytest.mark.asyncio
+    async def test_runtime_error_mentions_failure_details(self) -> None:
+        node = _make_node(name="Broken")
+        failure = ExecuteNodeResultFailure(result_details="kaboom-detail")
+
+        with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
+            mock_gn.ahandle_request = AsyncMock(return_value=failure)
+
+            with pytest.raises(RuntimeError, match="kaboom-detail"):
+                await _make_executor().execute(node)
+
+    @pytest.mark.asyncio
+    async def test_outputs_are_not_copied_back_on_failure(self) -> None:
+        node = _make_node()
+        failure = ExecuteNodeResultFailure(result_details="boom")
+
+        with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
+            mock_gn.ahandle_request = AsyncMock(return_value=failure)
+
+            with pytest.raises(RuntimeError):
+                await _make_executor().execute(node)
+
+        assert node.parameter_output_values == {}
+
+
+class TestExecuteSpecialNodeRouting:
+    """Special node types take dedicated paths and never dispatch ExecuteNodeRequest."""
+
+    @pytest.mark.asyncio
+    async def test_basewhilenodegroup_routes_to_handle_while_group_execution(self) -> None:
+        node = MagicMock(spec=BaseWhileNodeGroup)
+        node.name = "WhileGroup"
+
+        executor = _make_executor()
+        with (
+            patch(_GRIPTAPE_NODES_PATH) as mock_gn,
+            patch.object(NodeExecutor, "handle_while_group_execution", new_callable=AsyncMock) as mock_while,
+            patch.object(NodeExecutor, "handle_iterative_group_execution", new_callable=AsyncMock) as mock_iter,
+            patch.object(NodeExecutor, "handle_loop_execution", new_callable=AsyncMock) as mock_loop,
+        ):
+            mock_gn.ahandle_request = AsyncMock()
+            await executor.execute(node)
+
+        mock_while.assert_awaited_once_with(node)
+        mock_iter.assert_not_awaited()
+        mock_loop.assert_not_awaited()
+        mock_gn.ahandle_request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_baseiterativenodegroup_routes_to_handle_iterative_group_execution(self) -> None:
+        node = MagicMock(spec=BaseIterativeNodeGroup)
+        node.name = "IterGroup"
+
+        executor = _make_executor()
+        with (
+            patch(_GRIPTAPE_NODES_PATH) as mock_gn,
+            patch.object(NodeExecutor, "handle_while_group_execution", new_callable=AsyncMock) as mock_while,
+            patch.object(NodeExecutor, "handle_iterative_group_execution", new_callable=AsyncMock) as mock_iter,
+            patch.object(NodeExecutor, "handle_loop_execution", new_callable=AsyncMock) as mock_loop,
+        ):
+            mock_gn.ahandle_request = AsyncMock()
+            await executor.execute(node)
+
+        mock_iter.assert_awaited_once_with(node)
+        mock_while.assert_not_awaited()
+        mock_loop.assert_not_awaited()
+        mock_gn.ahandle_request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_baseiterativeendnode_routes_to_handle_loop_execution(self) -> None:
+        node = MagicMock(spec=BaseIterativeEndNode)
+        node.name = "EndLoop"
+
+        executor = _make_executor()
+        with (
+            patch(_GRIPTAPE_NODES_PATH) as mock_gn,
+            patch.object(NodeExecutor, "handle_loop_execution", new_callable=AsyncMock) as mock_loop,
+        ):
+            mock_gn.ahandle_request = AsyncMock()
+            await executor.execute(node)
+
+        mock_loop.assert_awaited_once_with(node)
+        mock_gn.ahandle_request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_subflownodegroup_local_execution_calls_aprocess(self) -> None:
+        """When execution_environment is LOCAL_EXECUTION, run aprocess in-process and skip dispatch."""
+        node = MagicMock(spec=SubflowNodeGroup)
+        node.name = "Subflow"
+        node.execution_environment = MagicMock()
+        node.execution_environment.name = "execution_environment"
+        node.get_parameter_value = MagicMock(return_value=LOCAL_EXECUTION)
+        node.aprocess = AsyncMock()
+
+        with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
+            mock_gn.ahandle_request = AsyncMock()
+            await _make_executor().execute(node)
+
+        node.aprocess.assert_awaited_once()
+        mock_gn.ahandle_request.assert_not_awaited()

--- a/tests/unit/common/test_node_executor_helpers.py
+++ b/tests/unit/common/test_node_executor_helpers.py
@@ -1,0 +1,297 @@
+"""Contract tests for NodeExecutor helpers and SubflowNodeGroup execute() branches.
+
+These tests describe the observable contract of:
+
+* ``NodeExecutor.get_workflow_handler`` - returns the registered handler for a
+  library, or raises ``ValueError`` with the library name in the message.
+* ``NodeExecutor._deserialize_parameter_value`` - resolves UUID-referenced
+  pickled bytes back into Python objects, with explicit fallbacks when the
+  stored value is not a UUID reference, not a string, or not unpicklable.
+* ``NodeExecutor._extract_parameter_output_values`` - merges per-node output
+  dicts from a subprocess result, using the deserializer for UUID references
+  and falling back to a pre-mapping flat shape for backward compatibility.
+* ``NodeExecutor.execute`` - the remaining ``SubflowNodeGroup`` branches
+  (private execution, library-name execution) and the unexpected-result-type
+  edge case.
+"""
+
+import pickle
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from griptape_nodes.common.node_executor import NodeExecutor
+from griptape_nodes.exe_types.node_groups import SubflowNodeGroup
+from griptape_nodes.exe_types.node_types import LOCAL_EXECUTION, PRIVATE_EXECUTION
+from griptape_nodes.retained_mode.events.execution_events import ExecuteNodeResultSuccess
+from griptape_nodes.retained_mode.events.workflow_events import PublishWorkflowRequest
+
+_GRIPTAPE_NODES_PATH = "griptape_nodes.common.node_executor.GriptapeNodes"
+
+
+def _make_executor() -> NodeExecutor:
+    return NodeExecutor.__new__(NodeExecutor)
+
+
+def _make_subflow_node(execution_type: str) -> MagicMock:
+    node = MagicMock(spec=SubflowNodeGroup)
+    node.name = "Subflow"
+    node.execution_environment = MagicMock()
+    node.execution_environment.name = "execution_environment"
+    node.get_parameter_value = MagicMock(return_value=execution_type)
+    node.aprocess = AsyncMock()
+    node.subflow_execution_component = MagicMock()
+    node.subflow_execution_component.clear_execution_state = MagicMock()
+    return node
+
+
+class TestGetWorkflowHandler:
+    """get_workflow_handler returns the PublishWorkflowRequest handler for a library."""
+
+    def test_returns_registered_handler_for_known_library(self) -> None:
+        sentinel_handler = object()
+        with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
+            mock_lm = MagicMock()
+            mock_lm.get_registered_event_handlers.return_value = {"my_lib": sentinel_handler}
+            mock_gn.LibraryManager.return_value = mock_lm
+
+            handler = _make_executor().get_workflow_handler("my_lib")
+
+        assert handler is sentinel_handler
+        mock_lm.get_registered_event_handlers.assert_called_once_with(PublishWorkflowRequest)
+
+    def test_raises_value_error_when_library_unregistered(self) -> None:
+        with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
+            mock_lm = MagicMock()
+            mock_lm.get_registered_event_handlers.return_value = {}
+            mock_gn.LibraryManager.return_value = mock_lm
+
+            with pytest.raises(ValueError, match="missing_lib"):
+                _make_executor().get_workflow_handler("missing_lib")
+
+
+class TestDeserializeParameterValue:
+    """_deserialize_parameter_value resolves UUID-referenced pickled values."""
+
+    def test_returns_param_value_unchanged_when_not_a_uuid_reference(self) -> None:
+        executor = _make_executor()
+        sentinel = object()
+
+        result = executor._deserialize_parameter_value(
+            param_name="x",
+            param_value=sentinel,
+            unique_uuid_to_values={"some-uuid": "irrelevant"},
+        )
+
+        assert result is sentinel
+
+    def test_returns_stored_value_directly_when_not_a_string(self) -> None:
+        executor = _make_executor()
+        stored = {"already": "deserialized"}
+
+        result = executor._deserialize_parameter_value(
+            param_name="x",
+            param_value="uuid-1",
+            unique_uuid_to_values={"uuid-1": stored},
+        )
+
+        assert result is stored
+
+    def test_unpickles_string_representation_of_bytes(self) -> None:
+        executor = _make_executor()
+        original = {"answer": 42, "items": [1, 2, 3]}
+        pickled_repr = repr(pickle.dumps(original))  # e.g. "b'\\x80\\x04...'"
+
+        result = executor._deserialize_parameter_value(
+            param_name="payload",
+            param_value="uuid-1",
+            unique_uuid_to_values={"uuid-1": pickled_repr},
+        )
+
+        assert result == original
+
+    def test_returns_original_string_when_eval_fails(self) -> None:
+        executor = _make_executor()
+
+        result = executor._deserialize_parameter_value(
+            param_name="payload",
+            param_value="uuid-1",
+            unique_uuid_to_values={"uuid-1": "not a bytes literal"},
+        )
+
+        assert result == "not a bytes literal"
+
+    def test_returns_original_string_when_eval_yields_non_bytes(self) -> None:
+        """If literal_eval returns something that isn't bytes, fall through to the string."""
+        executor = _make_executor()
+
+        result = executor._deserialize_parameter_value(
+            param_name="payload",
+            param_value="uuid-1",
+            # "[1, 2, 3]" evals to a list, not bytes
+            unique_uuid_to_values={"uuid-1": "[1, 2, 3]"},
+        )
+
+        assert result == "[1, 2, 3]"
+
+    def test_returns_original_string_when_unpickle_fails(self) -> None:
+        executor = _make_executor()
+        # Valid bytes literal but not a valid pickle stream.
+        bogus = repr(b"\x99garbage\x00")
+
+        result = executor._deserialize_parameter_value(
+            param_name="payload",
+            param_value="uuid-1",
+            unique_uuid_to_values={"uuid-1": bogus},
+        )
+
+        assert result == bogus
+
+
+class TestExtractParameterOutputValues:
+    """_extract_parameter_output_values merges per-node outputs from a subprocess result."""
+
+    def test_returns_empty_dict_for_empty_input(self) -> None:
+        assert _make_executor()._extract_parameter_output_values({}) == {}
+
+    def test_passes_through_values_when_no_uuid_mapping(self) -> None:
+        executor = _make_executor()
+        subprocess_result: dict[str, Any] = {
+            "node_a": {"parameter_output_values": {"out1": 1, "out2": "two"}},
+        }
+
+        assert executor._extract_parameter_output_values(subprocess_result) == {"out1": 1, "out2": "two"}
+
+    def test_deserializes_uuid_referenced_values(self) -> None:
+        executor = _make_executor()
+        original = [10, 20, 30]
+        pickled_repr = repr(pickle.dumps(original))
+        subprocess_result: dict[str, Any] = {
+            "node_a": {
+                "parameter_output_values": {"items": "uuid-1"},
+                "unique_parameter_uuid_to_values": {"uuid-1": pickled_repr},
+            },
+        }
+
+        assert executor._extract_parameter_output_values(subprocess_result) == {"items": original}
+
+    def test_merges_outputs_from_multiple_result_dicts(self) -> None:
+        executor = _make_executor()
+        subprocess_result: dict[str, Any] = {
+            "node_a": {"parameter_output_values": {"a": 1}},
+            "node_b": {"parameter_output_values": {"b": 2}},
+        }
+
+        assert executor._extract_parameter_output_values(subprocess_result) == {"a": 1, "b": 2}
+
+    def test_backward_compatible_with_flat_result_shape(self) -> None:
+        """Old flat structure: result dict directly contains output keys."""
+        executor = _make_executor()
+        subprocess_result: dict[str, Any] = {
+            "node_a": {"out1": "hello", "out2": "world"},
+        }
+
+        assert executor._extract_parameter_output_values(subprocess_result) == {"out1": "hello", "out2": "world"}
+
+
+class TestExecuteSubflowNodeGroupBranches:
+    """SubflowNodeGroup non-local branches delegate to dedicated workflow paths."""
+
+    @pytest.mark.asyncio
+    async def test_private_execution_calls_private_workflow_path(self) -> None:
+        node = _make_subflow_node(PRIVATE_EXECUTION)
+
+        with (
+            patch(_GRIPTAPE_NODES_PATH) as mock_gn,
+            patch.object(NodeExecutor, "_execute_private_workflow", new_callable=AsyncMock) as mock_private,
+            patch.object(NodeExecutor, "_execute_library_workflow", new_callable=AsyncMock) as mock_library,
+        ):
+            mock_gn.ahandle_request = AsyncMock()
+            await _make_executor().execute(node)
+
+        mock_private.assert_awaited_once_with(node)
+        mock_library.assert_not_awaited()
+        node.aprocess.assert_not_awaited()
+        mock_gn.ahandle_request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_library_execution_routes_through_library_workflow(self) -> None:
+        """A non-Local, non-Private execution_environment is treated as a library name."""
+        node = _make_subflow_node("some_library_name")
+
+        with (
+            patch(_GRIPTAPE_NODES_PATH) as mock_gn,
+            patch.object(NodeExecutor, "_execute_private_workflow", new_callable=AsyncMock) as mock_private,
+            patch.object(NodeExecutor, "_execute_library_workflow", new_callable=AsyncMock) as mock_library,
+        ):
+            mock_gn.ahandle_request = AsyncMock()
+            await _make_executor().execute(node)
+
+        mock_library.assert_awaited_once_with(node, "some_library_name")
+        mock_private.assert_not_awaited()
+        node.aprocess.assert_not_awaited()
+        mock_gn.ahandle_request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_subprocess_paths_clear_execution_state_first(self) -> None:
+        """Both PRIVATE and library paths must clear execution state before running."""
+        node = _make_subflow_node(PRIVATE_EXECUTION)
+
+        with (
+            patch(_GRIPTAPE_NODES_PATH),
+            patch.object(NodeExecutor, "_execute_private_workflow", new_callable=AsyncMock),
+        ):
+            await _make_executor().execute(node)
+
+        node.subflow_execution_component.clear_execution_state.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_local_execution_does_not_clear_execution_state(self) -> None:
+        """LOCAL_EXECUTION runs aprocess directly; clearing subprocess state is unnecessary."""
+        node = _make_subflow_node(LOCAL_EXECUTION)
+
+        with patch(_GRIPTAPE_NODES_PATH):
+            await _make_executor().execute(node)
+
+        node.subflow_execution_component.clear_execution_state.assert_not_called()
+
+
+class TestExecuteUnexpectedResultType:
+    """Anything that isn't an ExecuteNodeResultSuccess is surfaced as a RuntimeError."""
+
+    @pytest.mark.asyncio
+    async def test_raises_when_result_is_not_a_success_payload(self) -> None:
+        node = MagicMock()
+        node.name = "Weird"
+        node.parameter_values = {}
+        node.parameter_output_values = {}
+        node.metadata = {}
+
+        not_a_payload: Any = "not a payload at all"
+
+        with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
+            mock_gn.ahandle_request = AsyncMock(return_value=not_a_payload)
+
+            with pytest.raises(RuntimeError, match="Weird"):
+                await _make_executor().execute(node)
+
+
+class TestExecuteSuccessReturnsNone:
+    """The contract of execute() is to return None; all output flows via parameter_output_values."""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_success(self) -> None:
+        node = MagicMock()
+        node.name = "Plain"
+        node.parameter_values = {}
+        node.parameter_output_values = {}
+        node.metadata = {}
+
+        with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
+            mock_gn.ahandle_request = AsyncMock(
+                return_value=ExecuteNodeResultSuccess(result_details="ok", parameter_output_values={"x": 1}),
+            )
+            result = await _make_executor().execute(node)
+
+        assert result is None

--- a/tests/unit/common/test_node_executor_loop_helpers.py
+++ b/tests/unit/common/test_node_executor_loop_helpers.py
@@ -1,0 +1,255 @@
+"""Contract tests for NodeExecutor loop-control helpers.
+
+These tests cover small, near-pure helpers that decide loop control flow:
+
+* ``get_node_parameter_mappings`` - select the start or end mapping out of a
+  PackageNodesAsSerializedFlowResultSuccess.
+* ``_should_break_loop`` - decide whether a packaged loop body's End node is
+  signaling a break.
+* ``_check_control_source_fired`` - decide whether a (source_node, source_param)
+  pair has fired its control output.
+* ``_find_source_for_control_param`` - return the first source for a given
+  control parameter name, or None.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from griptape_nodes.common.node_executor import NodeExecutor
+from griptape_nodes.exe_types.base_iterative_nodes import BaseIterativeEndNode
+
+_GRIPTAPE_NODES_PATH = "griptape_nodes.common.node_executor.GriptapeNodes"
+
+
+def _make_executor() -> NodeExecutor:
+    return NodeExecutor.__new__(NodeExecutor)
+
+
+def _make_package_result(
+    *,
+    start_node_name: str = "StartPkg",
+    end_node_name: str = "EndPkg",
+    start_param_mappings: dict[str, Any] | None = None,
+    end_param_mappings: dict[str, Any] | None = None,
+) -> MagicMock:
+    """Mock PackageNodesAsSerializedFlowResultSuccess with start/end mappings at indices 0/1."""
+    package_result = MagicMock()
+    start_mapping = MagicMock()
+    start_mapping.node_name = start_node_name
+    start_mapping.parameter_mappings = start_param_mappings or {}
+    end_mapping = MagicMock()
+    end_mapping.node_name = end_node_name
+    end_mapping.parameter_mappings = end_param_mappings or {}
+    package_result.parameter_name_mappings = [start_mapping, end_mapping]
+    return package_result
+
+
+class TestGetNodeParameterMappings:
+    """Returns index 0 for 'start', index 1 for 'end'; raises for anything else."""
+
+    def test_returns_start_mapping_for_start(self) -> None:
+        package = _make_package_result(start_node_name="MyStart")
+        mapping = _make_executor().get_node_parameter_mappings(package, "start")
+        assert mapping.node_name == "MyStart"
+
+    def test_returns_end_mapping_for_end(self) -> None:
+        package = _make_package_result(end_node_name="MyEnd")
+        mapping = _make_executor().get_node_parameter_mappings(package, "end")
+        assert mapping.node_name == "MyEnd"
+
+    def test_is_case_insensitive(self) -> None:
+        package = _make_package_result(start_node_name="MyStart", end_node_name="MyEnd")
+        executor = _make_executor()
+        assert executor.get_node_parameter_mappings(package, "START").node_name == "MyStart"
+        assert executor.get_node_parameter_mappings(package, "End").node_name == "MyEnd"
+
+    def test_raises_value_error_for_other_strings(self) -> None:
+        package = _make_package_result()
+        with pytest.raises(ValueError, match="middle"):
+            _make_executor().get_node_parameter_mappings(package, "middle")
+
+
+class TestShouldBreakLoop:
+    """_should_break_loop returns True iff the deserialized End node signals a break."""
+
+    @staticmethod
+    def _make_end_node(
+        *,
+        is_iterative_end: bool = True,
+        next_control_output: Any = None,
+        break_signal: Any = None,
+    ) -> Any:
+        if not is_iterative_end:
+            node = MagicMock()
+            return node
+        node = MagicMock(spec=BaseIterativeEndNode)
+        node.get_next_control_output.return_value = next_control_output
+        node.break_loop_signal_output = break_signal
+        return node
+
+    def test_returns_false_when_end_name_missing_from_mappings(self) -> None:
+        package = _make_package_result(end_node_name="EndPkg")
+        with patch(_GRIPTAPE_NODES_PATH):
+            result = _make_executor()._should_break_loop({}, package)
+        assert result is False
+
+    def test_returns_false_when_deserialized_end_node_not_found(self) -> None:
+        package = _make_package_result(end_node_name="EndPkg")
+        mappings = {"EndPkg": "EndPkg_inst1"}
+
+        with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
+            mock_gn.NodeManager.return_value.get_node_by_name.return_value = None
+            result = _make_executor()._should_break_loop(mappings, package)
+
+        assert result is False
+
+    def test_returns_false_when_deserialized_node_is_not_iterative_end(self) -> None:
+        package = _make_package_result(end_node_name="EndPkg")
+        mappings = {"EndPkg": "EndPkg_inst1"}
+        non_iterative_node = MagicMock()  # Not a BaseIterativeEndNode
+
+        with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
+            mock_gn.NodeManager.return_value.get_node_by_name.return_value = non_iterative_node
+            result = _make_executor()._should_break_loop(mappings, package)
+
+        assert result is False
+
+    def test_returns_false_when_no_next_control_output(self) -> None:
+        package = _make_package_result(end_node_name="EndPkg")
+        mappings = {"EndPkg": "EndPkg_inst1"}
+        end_node = self._make_end_node(next_control_output=None)
+
+        with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
+            mock_gn.NodeManager.return_value.get_node_by_name.return_value = end_node
+            result = _make_executor()._should_break_loop(mappings, package)
+
+        assert result is False
+
+    def test_returns_false_when_next_control_output_is_not_break_signal(self) -> None:
+        package = _make_package_result(end_node_name="EndPkg")
+        mappings = {"EndPkg": "EndPkg_inst1"}
+        not_break = object()
+        break_signal = object()
+        end_node = self._make_end_node(next_control_output=not_break, break_signal=break_signal)
+
+        with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
+            mock_gn.NodeManager.return_value.get_node_by_name.return_value = end_node
+            result = _make_executor()._should_break_loop(mappings, package)
+
+        assert result is False
+
+    def test_returns_true_when_next_control_output_matches_break_signal(self) -> None:
+        package = _make_package_result(end_node_name="EndPkg")
+        mappings = {"EndPkg": "EndPkg_inst1"}
+        break_signal = object()
+        end_node = self._make_end_node(next_control_output=break_signal, break_signal=break_signal)
+
+        with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
+            mock_gn.NodeManager.return_value.get_node_by_name.return_value = end_node
+            result = _make_executor()._should_break_loop(mappings, package)
+
+        assert result is True
+
+
+class TestCheckControlSourceFired:
+    """_check_control_source_fired matches a node's next control output to a parameter."""
+
+    @staticmethod
+    def _make_source_node(*, next_control_output: Any, params: dict[str, Any] | None = None) -> Any:
+        node = MagicMock()
+        node.get_next_control_output.return_value = next_control_output
+        params = params or {}
+        node.get_parameter_by_name.side_effect = params.get
+        return node
+
+    def test_returns_false_when_source_is_none(self) -> None:
+        with patch(_GRIPTAPE_NODES_PATH):
+            assert _make_executor()._check_control_source_fired(None, {}) is False
+
+    def test_returns_false_when_source_node_not_in_mappings(self) -> None:
+        with patch(_GRIPTAPE_NODES_PATH):
+            result = _make_executor()._check_control_source_fired(("SrcOrig", "out"), {})
+        assert result is False
+
+    def test_returns_false_when_node_manager_raises_value_error(self) -> None:
+        with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
+            mock_gn.NodeManager.return_value.get_node_by_name.side_effect = ValueError("not found")
+            result = _make_executor()._check_control_source_fired(
+                ("SrcOrig", "out"),
+                {"SrcOrig": "Src_inst1"},
+            )
+        assert result is False
+
+    def test_returns_false_when_node_manager_returns_none(self) -> None:
+        with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
+            mock_gn.NodeManager.return_value.get_node_by_name.return_value = None
+            result = _make_executor()._check_control_source_fired(
+                ("SrcOrig", "out"),
+                {"SrcOrig": "Src_inst1"},
+            )
+        assert result is False
+
+    def test_returns_false_when_no_next_control_output(self) -> None:
+        node = self._make_source_node(next_control_output=None)
+        with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
+            mock_gn.NodeManager.return_value.get_node_by_name.return_value = node
+            result = _make_executor()._check_control_source_fired(
+                ("SrcOrig", "out"),
+                {"SrcOrig": "Src_inst1"},
+            )
+        assert result is False
+
+    def test_returns_true_when_next_control_output_matches_parameter(self) -> None:
+        target_param = MagicMock()
+        target_param.name = "out"
+        node = self._make_source_node(
+            next_control_output=target_param,
+            params={"out": target_param},
+        )
+        with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
+            mock_gn.NodeManager.return_value.get_node_by_name.return_value = node
+            result = _make_executor()._check_control_source_fired(
+                ("SrcOrig", "out"),
+                {"SrcOrig": "Src_inst1"},
+            )
+        assert result is True
+
+    def test_returns_false_when_next_control_output_is_a_different_parameter(self) -> None:
+        wrong_param = MagicMock(name="wrong")
+        target_param = MagicMock(name="target")
+        node = self._make_source_node(
+            next_control_output=wrong_param,
+            params={"out": target_param},
+        )
+        with patch(_GRIPTAPE_NODES_PATH) as mock_gn:
+            mock_gn.NodeManager.return_value.get_node_by_name.return_value = node
+            result = _make_executor()._check_control_source_fired(
+                ("SrcOrig", "out"),
+                {"SrcOrig": "Src_inst1"},
+            )
+        assert result is False
+
+
+class TestFindSourceForControlParam:
+    """_find_source_for_control_param returns the first source from the multi-source helper."""
+
+    def test_returns_first_source_when_multiple_present(self) -> None:
+        executor = _make_executor()
+        with patch.object(
+            NodeExecutor,
+            "_find_sources_for_control_param",
+            return_value=[("A", "out"), ("B", "out")],
+        ) as mock_multi:
+            result = executor._find_source_for_control_param([], "break_loop")
+
+        assert result == ("A", "out")
+        mock_multi.assert_called_once_with([], "break_loop")
+
+    def test_returns_none_when_no_sources(self) -> None:
+        executor = _make_executor()
+        with patch.object(NodeExecutor, "_find_sources_for_control_param", return_value=[]):
+            result = executor._find_source_for_control_param([], "break_loop")
+
+        assert result is None


### PR DESCRIPTION
Part of #4608.

Adds three contract test modules for `NodeExecutor` covering its public surface, small helpers, and loop-control predicates. Tests were written red/green: each contract was described from the docstring/signature alone, then run, before reading the implementation. All 52 new tests passed on first run, which is itself a useful signal that the documented behavior of `execute()` and the helpers matches the code.

Lifts `node_executor.py` line coverage from 8.7% to ~18%. Remaining gap is the loop and subflow orchestration methods (`handle_loop_execution`, `handle_while_group_execution`, `handle_iterative_group_execution`, `_execute_loop_iterations_*`, workflow publish/execute helpers), which are better suited to integration-style tests against a small ForEach/While/Subflow group than more mock-heavy unit tests. That work stays open under #4608.
