### PR TITLE
fix: surface library directory path on retryable library failures

### DIFF
--- a/src/griptape_nodes/retained_mode/events/library_events.py
+++ b/src/griptape_nodes/retained_mode/events/library_events.py
@@ -996,9 +996,14 @@ class UpdateLibraryResultFailure(ResultPayloadFailure):
 
     Args:
         retryable: If True, the operation can be retried with overwrite_existing=True
+        existing_path: When the failure is caused by uncommitted changes in the library directory,
+            the absolute path of that directory. Provided as a structured field so clients do not
+            have to parse it out of the human-readable error message (which is unreliable for paths
+            containing ``:``, e.g. Windows drive letters).
     """
 
     retryable: bool = False
+    existing_path: str | None = None
 
 
 @dataclass
@@ -1097,9 +1102,13 @@ class DownloadLibraryResultFailure(ResultPayloadFailure):
 
     Args:
         retryable: If True, the operation can be retried with overwrite_existing=True
+        existing_path: When the failure is caused by an existing target directory, the absolute
+            path of that directory. Provided as a structured field so clients do not have to
+            parse it out of the human-readable error message.
     """
 
     retryable: bool = False
+    existing_path: str | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -4512,7 +4512,11 @@ class LibraryManager:
             retryable = "uncommitted changes" in error_msg or "unstaged changes" in error_msg
 
             details = f"Failed to update Library '{library_name}': {e}"
-            return UpdateLibraryResultFailure(result_details=details, retryable=retryable)
+            return UpdateLibraryResultFailure(
+                result_details=details,
+                retryable=retryable,
+                existing_path=str(library_dir) if retryable else None,
+            )
 
         # Reload library
         reload_result = await self._reload_library_after_git_operation(
@@ -4646,7 +4650,11 @@ class LibraryManager:
                 if request.fail_on_exists:
                     # Fail with retryable error for interactive CLI
                     details = f"Cannot download library: target directory already exists at {target_path}"
-                    return DownloadLibraryResultFailure(result_details=details, retryable=True)
+                    return DownloadLibraryResultFailure(
+                        result_details=details,
+                        retryable=True,
+                        existing_path=str(target_path),
+                    )
 
                 # Skip cloning since directory already exists, but continue with registration
                 skip_clone = True

--- a/tests/unit/retained_mode/managers/test_library_manager_directory_paths.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_directory_paths.py
@@ -2,13 +2,18 @@
 
 import asyncio
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from griptape_nodes.retained_mode.events.library_events import DownloadLibraryResultFailure
+from griptape_nodes.retained_mode.events.library_events import (
+    DownloadLibraryResultFailure,
+    UpdateLibraryRequest,
+    UpdateLibraryResultFailure,
+)
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-from griptape_nodes.utils.git_utils import GitCloneError
+from griptape_nodes.retained_mode.managers.library_manager import LibraryGitOperationContext
+from griptape_nodes.utils.git_utils import GitCloneError, GitPullError
 
 
 class TestGetSandboxDirectory:
@@ -266,3 +271,92 @@ class TestDownloadLibraryRequestPath:
             result = await library_manager.download_library_request(request)
 
         assert isinstance(result, DownloadLibraryResultFailure)
+
+    @pytest.mark.asyncio
+    async def test_existing_target_dir_sets_existing_path(self, griptape_nodes: GriptapeNodes) -> None:
+        """Existing target directory failure carries the path in ``existing_path``.
+
+        When the target directory already exists and fail_on_exists is True, the failure
+        carries the absolute target path in the structured ``existing_path`` field so clients
+        can render it without having to parse the human-readable error message (which is
+        unreliable for paths containing ``:``, e.g. Windows drive letters).
+        """
+        library_manager = griptape_nodes.LibraryManager()
+        config_mgr = MagicMock()
+        config_mgr.get_config_value.return_value = "/opt/libraries"
+        config_mgr.workspace_path = Path("/workspace")
+
+        request = MagicMock()
+        request.git_url = "https://github.com/user/repo.git"
+        request.branch_tag_commit = None
+        request.target_directory_name = "repo"
+        request.download_directory = None
+        request.overwrite_existing = False
+        request.fail_on_exists = True
+
+        with (
+            patch.object(GriptapeNodes, "ConfigManager", return_value=config_mgr),
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.resolve_workspace_path",
+                return_value=Path("/opt/libraries"),
+            ),
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.normalize_github_url",
+                return_value="https://github.com/user/repo.git",
+            ),
+            patch("anyio.Path.mkdir"),
+            patch("anyio.Path.exists", return_value=True),
+        ):
+            result = await library_manager.download_library_request(request)
+
+        assert isinstance(result, DownloadLibraryResultFailure)
+        assert result.retryable is True
+        assert result.existing_path == str(Path("/opt/libraries/repo"))
+
+
+class TestUpdateLibraryRequestExistingPath:
+    """Test update_library_request reports the dirty library directory in ``existing_path``."""
+
+    @pytest.mark.asyncio
+    async def test_uncommitted_changes_sets_existing_path(self, griptape_nodes: GriptapeNodes) -> None:
+        """Uncommitted-changes update failure carries the library directory in ``existing_path``.
+
+        Without this, clients on Windows cannot recover the path from the error message because
+        the drive-letter colon collides with the ``<path>: <reason>`` separator in the
+        human-readable message.
+        """
+        library_manager = griptape_nodes.LibraryManager()
+        library_dir = Path("/var/lib/test_lib")
+
+        validation_context = LibraryGitOperationContext(
+            library=MagicMock(),
+            old_version="1.0.0",
+            library_file_path=str(library_dir / "griptape_nodes_library.json"),
+            library_dir=library_dir,
+        )
+
+        with (
+            patch.object(
+                library_manager,
+                "_validate_and_prepare_library_for_git_operation",
+                new=AsyncMock(return_value=validation_context),
+            ),
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.is_monorepo",
+                return_value=False,
+            ),
+            patch(
+                "griptape_nodes.retained_mode.managers.library_manager.update_library_git",
+                side_effect=GitPullError(
+                    f"Cannot update library at {library_dir}: You have uncommitted changes. "
+                    "Use overwrite_existing=True to discard them."
+                ),
+            ),
+        ):
+            result = await library_manager.update_library_request(
+                UpdateLibraryRequest(library_name="test_lib", overwrite_existing=False)
+            )
+
+        assert isinstance(result, UpdateLibraryResultFailure)
+        assert result.retryable is True
+        assert result.existing_path == str(library_dir)


### PR DESCRIPTION
Reported via griptape-ai/griptape-vsl-gui#2301: the Uncommitted Changes dialog renders only `E` for a Windows path like `E:\Users\bee\nuke` because the frontend was extracting the directory from the prose error message with a regex that stops at the first `:`. The drive-letter colon collides with the `<path>: <reason>` separator.

Rather than make the regex Windows-aware in every client, this exposes the path as a structured field on the two retryable failures (`UpdateLibraryResultFailure` for uncommitted changes, `DownloadLibraryResultFailure` for target-already-exists) so clients can read it directly. The companion frontend change in griptape-ai/griptape-vsl-gui#2304 drops path parsing entirely in favor of `existing_path`; older engines without the field still produce a usable confirmation dialog because `retryable` already gates the overwrite affordance.