### PR TITLE
fix: let cattrs decode base85 bytes in subprocess ControlFlowResolvedEvent

### DIFF
--- a/src/griptape_nodes/common/node_executor.py
+++ b/src/griptape_nodes/common/node_executor.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import ast
 import asyncio
 import logging
 import pickle
@@ -3589,24 +3588,7 @@ class NodeExecutor:
             return param_value
 
         stored_value = unique_uuid_to_values[param_value]
-
-        # Non-string stored values are used directly
-        if not isinstance(stored_value, str):
-            return stored_value
-
-        # Attempt to unpickle string-represented bytes
-        try:
-            actual_bytes = ast.literal_eval(stored_value)
-            if isinstance(actual_bytes, bytes):
-                return pickle.loads(actual_bytes)  # noqa: S301
-        except (ValueError, SyntaxError, pickle.UnpicklingError) as e:
-            logger.warning(
-                "Failed to unpickle string-represented bytes for parameter '%s': %s",
-                param_name,
-                e,
-            )
-            return stored_value
-        return stored_value
+        return pickle.loads(stored_value)  # noqa: S301
 
     def _apply_parameter_values_to_node(
         self,

--- a/src/griptape_nodes/common/node_executor.py
+++ b/src/griptape_nodes/common/node_executor.py
@@ -3588,7 +3588,15 @@ class NodeExecutor:
             return param_value
 
         stored_value = unique_uuid_to_values[param_value]
-        return pickle.loads(stored_value)  # noqa: S301
+        try:
+            return pickle.loads(stored_value)  # noqa: S301
+        except pickle.UnpicklingError as e:
+            logger.warning(
+                "Attempted to unpickle stored value for parameter '%s'. Failed because: %s",
+                param_name,
+                e,
+            )
+            raise
 
     def _apply_parameter_values_to_node(
         self,

--- a/src/griptape_nodes/retained_mode/events/execution_events.py
+++ b/src/griptape_nodes/retained_mode/events/execution_events.py
@@ -392,7 +392,7 @@ class ControlFlowResolvedEvent(ExecutionPayload):
     end_node_name: str
     parameter_output_values: dict
     # Optional field for pickled parameter values - when present, parameter_output_values contains UUID references
-    unique_parameter_uuid_to_values: dict[SerializedNodeCommands.UniqueParameterValueUUID, Any] | None = field(
+    unique_parameter_uuid_to_values: dict[SerializedNodeCommands.UniqueParameterValueUUID, bytes] | None = field(
         default=None
     )
 

--- a/tests/e2e/fixtures/subflow_library/griptape_nodes_library.json
+++ b/tests/e2e/fixtures/subflow_library/griptape_nodes_library.json
@@ -1,0 +1,44 @@
+{
+  "name": "Subflow Library",
+  "library_schema_version": "0.7.0",
+  "metadata": {
+    "author": "Test Fixture",
+    "description": "Minimal library used by subflow e2e tests",
+    "library_version": "0.1.0",
+    "engine_version": "0.0.0",
+    "tags": ["test"],
+    "dependencies": {
+      "pip_dependencies": []
+    }
+  },
+  "categories": [
+    {
+      "test": {
+        "title": "test",
+        "description": "Test nodes",
+        "color": "border-gray-500",
+        "icon": "Folder"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "class_name": "EchoNode",
+      "file_path": "subflow_echo_node.py",
+      "metadata": {
+        "category": "test",
+        "description": "Copies its text input to its text output",
+        "display_name": "Echo"
+      }
+    },
+    {
+      "class_name": "SubflowGroupNode",
+      "file_path": "subflow_echo_node.py",
+      "metadata": {
+        "category": "test",
+        "description": "Minimal subflow group node for testing",
+        "display_name": "Subflow Group"
+      }
+    }
+  ]
+}

--- a/tests/e2e/fixtures/subflow_library/subflow_echo_node.py
+++ b/tests/e2e/fixtures/subflow_library/subflow_echo_node.py
@@ -1,0 +1,43 @@
+"""Fixture nodes for subflow e2e tests.
+
+EchoNode: copies its ``text`` input to its ``text`` output.
+
+SubflowGroupNode: minimal concrete SubflowNodeGroup that runs all child nodes
+in-process (LOCAL execution).  Used to verify that parameter values survive
+the subflow round-trip without corruption.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_groups.subflow_node_group import SubflowNodeGroup
+from griptape_nodes.exe_types.node_types import DataNode
+
+
+class EchoNode(DataNode):
+    def __init__(self, name: str, metadata: dict | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="text",
+                tooltip="Text to echo",
+                type="str",
+                default_value="",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY, ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        self.parameter_output_values["text"] = self.get_parameter_value("text") or ""
+
+
+class SubflowGroupNode(SubflowNodeGroup):
+    """Minimal concrete SubflowNodeGroup for fixture use."""
+
+    async def aprocess(self) -> None:
+        await self.execute_subflow()
+
+    def process(self) -> Any:
+        pass

--- a/tests/e2e/test_subflow_execution.py
+++ b/tests/e2e/test_subflow_execution.py
@@ -1,0 +1,244 @@
+"""End-to-end coverage for SubflowNodeGroup local execution.
+
+Builds a flow that contains a SubflowGroupNode (concrete SubflowNodeGroup) with
+an EchoNode inside it, serializes to a self-contained .py, and runs it in a
+fresh subprocess.  Asserts that the EchoNode's text output survives the subflow
+round-trip intact.
+
+This guards the serialization/deserialization path exercised by
+NodeExecutor._extract_parameter_output_values and
+NodeExecutor._apply_parameter_values_to_node — the code fixed in
+fix/subprocess-cattrs-bytes-deserialization — without requiring the cloud
+WebSocket relay that the Private Execution (SubprocessWorkflowExecutor) path needs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    CreateFlowResultSuccess,
+    SerializeFlowToCommandsRequest,
+    SerializeFlowToCommandsResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
+from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
+from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+FIXTURE_LIBRARY_DIR = Path(__file__).parent / "fixtures" / "subflow_library"
+FIXTURE_LIBRARY_JSON_TEMPLATE = FIXTURE_LIBRARY_DIR / "griptape_nodes_library.json"
+
+_EXPECTED_TEXT = "hello from subflow"
+
+
+def _materialize_library(target_dir: Path) -> Path:
+    from griptape_nodes.utils.version_utils import engine_version
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    schema = json.loads(FIXTURE_LIBRARY_JSON_TEMPLATE.read_text())
+    schema["metadata"]["engine_version"] = engine_version
+    library_json = target_dir / "griptape_nodes_library.json"
+    library_json.write_text(json.dumps(schema, indent=2))
+    node_file = FIXTURE_LIBRARY_DIR / "subflow_echo_node.py"
+    (target_dir / node_file.name).write_text(node_file.read_text())
+    return library_json
+
+
+def _write_isolated_config(config_root: Path, *, workspace: Path, library_path: Path) -> None:
+    config_dir = config_root / "griptape_nodes"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_path = config_dir / "griptape_nodes_config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "workspace_directory": str(workspace),
+                "log_level": "WARNING",
+                "app_events": {
+                    "on_app_initialization_complete": {
+                        "libraries_to_register": [str(library_path)],
+                    },
+                },
+            }
+        )
+    )
+
+
+def _generate_subflow_workflow_source(library_json: Path) -> str:
+    """Build a flow with a SubflowGroupNode containing an EchoNode and serialize it."""
+    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+
+    register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
+
+    GriptapeNodes.ContextManager().push_workflow(workflow_name="subflow_e2e_workflow")
+
+    flow_result = GriptapeNodes.handle_request(
+        CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False)
+    )
+    assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
+    flow_name = flow_result.flow_name
+
+    with GriptapeNodes.ContextManager().flow(flow_name):
+        group_result = GriptapeNodes.handle_request(
+            CreateNodeRequest(
+                node_type="SubflowGroupNode",
+                specific_library_name="Subflow Library",
+                node_name="SubflowGroup_1",
+                initial_setup=True,
+            )
+        )
+        assert isinstance(group_result, CreateNodeResultSuccess), group_result
+        assert group_result.node_type == "SubflowGroupNode", (
+            f"Expected SubflowGroupNode, got {group_result.node_type!r}"
+        )
+
+        echo_result = GriptapeNodes.handle_request(
+            CreateNodeRequest(
+                node_type="EchoNode",
+                specific_library_name="Subflow Library",
+                node_name="Echo_1",
+                initial_setup=True,
+                parent_group_name=group_result.node_name,
+            )
+        )
+        assert isinstance(echo_result, CreateNodeResultSuccess), echo_result
+
+    GriptapeNodes.handle_request(
+        SetParameterValueRequest(
+            parameter_name="text",
+            value=_EXPECTED_TEXT,
+            node_name=echo_result.node_name,
+        )
+    )
+
+    serialize_result = GriptapeNodes.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_name))
+    assert isinstance(serialize_result, SerializeFlowToCommandsResultSuccess), serialize_result
+
+    metadata = WorkflowMetadata(
+        name="subflow_e2e_workflow",
+        schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+        engine_version_created_with="0.0.0",
+        node_libraries_referenced=list(serialize_result.serialized_flow_commands.node_dependencies.libraries),
+        workflow_shape=None,
+    )
+    return GriptapeNodes.WorkflowManager()._generate_workflow_file_content(
+        serialized_flow_commands=serialize_result.serialized_flow_commands,
+        workflow_metadata=metadata,
+    )
+
+
+def _wrap_with_runtime_assertions(workflow_source: str) -> str:
+    runtime_block = f"""
+
+import asyncio as _e2e_asyncio
+import logging as _e2e_logging
+
+from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import (
+    LocalWorkflowExecutor as _E2ELocalWorkflowExecutor,
+)
+from griptape_nodes.drivers.storage.storage_backend import StorageBackend as _E2EStorageBackend
+from griptape_nodes.retained_mode.events.flow_events import (
+    GetTopLevelFlowRequest as _E2EGetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess as _E2EGetTopLevelFlowResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes as _E2EGriptapeNodes
+
+_EXPECTED_TEXT = {_EXPECTED_TEXT!r}
+
+
+def _ensure_workflow_context() -> None:
+    context_manager = _E2EGriptapeNodes.ContextManager()
+    if not context_manager.has_current_flow():
+        top_level = _E2EGriptapeNodes.handle_request(_E2EGetTopLevelFlowRequest())
+        if isinstance(top_level, _E2EGetTopLevelFlowResultSuccess) and top_level.flow_name is not None:
+            flow_obj = _E2EGriptapeNodes.FlowManager().get_flow_by_name(top_level.flow_name)
+            context_manager.push_flow(flow_obj)
+
+
+async def _e2e_run() -> None:
+    await build_workflow()  # noqa: F821 - defined by the generated workflow source above
+    _ensure_workflow_context()
+    workflow_executor = _E2ELocalWorkflowExecutor(
+        storage_backend=_E2EStorageBackend.LOCAL,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
+    async with workflow_executor as executor:
+        await executor.arun(flow_input={{}})
+
+    node_manager = _E2EGriptapeNodes.NodeManager()
+    echo_node = node_manager.get_node_by_name("Echo_1")
+    if echo_node is None:
+        raise RuntimeError("E2E_FAIL: Echo_1 not found after subflow execution")
+    text_value = echo_node.parameter_output_values.get("text")
+    if text_value != _EXPECTED_TEXT:
+        raise RuntimeError(
+            f"E2E_FAIL: expected {{_EXPECTED_TEXT!r}}, got {{text_value!r}} — "
+            "text was corrupted across the subflow boundary"
+        )
+    print(f"SUBFLOW_TEXT_OK text={{text_value!r}}", flush=True)
+
+
+if __name__ == "__main__":
+    _e2e_logging.basicConfig(level=_e2e_logging.WARNING)
+    _e2e_asyncio.run(_e2e_run())
+"""
+    return workflow_source + runtime_block
+
+
+@pytest.mark.skipif(
+    not FIXTURE_LIBRARY_JSON_TEMPLATE.exists(),
+    reason=f"Subflow Library fixture missing at {FIXTURE_LIBRARY_JSON_TEMPLATE}",
+)
+def test_subflow_node_group_propagates_output_values(tmp_path: Path) -> None:
+    """A SubflowNodeGroup must propagate child node outputs back to the parent flow.
+
+    Drives the real serializer + LocalWorkflowExecutor so a regression in
+    SubflowNodeGroup._propagate_output_values_from_internal_nodes or the
+    parameter-value round-trip fails this test.
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config_root = tmp_path / "xdg_config"
+    library_json = _materialize_library(tmp_path / "library")
+    _write_isolated_config(config_root, workspace=workspace, library_path=library_json)
+
+    workflow_source = _generate_subflow_workflow_source(library_json)
+    runnable_source = _wrap_with_runtime_assertions(workflow_source)
+
+    workflow_path = tmp_path / "subflow_workflow.py"
+    workflow_path.write_text(runnable_source)
+
+    env = os.environ.copy()
+    env["XDG_CONFIG_HOME"] = str(config_root)
+    env.setdefault("GT_CLOUD_API_KEY", "fake-test-key-for-bootstrap")
+
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, str(workflow_path)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+    diagnostic = (
+        f"workflow exit code: {result.returncode}\n--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+    )
+    assert result.returncode == 0, diagnostic
+    assert "SUBFLOW_TEXT_OK" in result.stdout, diagnostic
+    assert "E2E_FAIL" not in result.stdout, diagnostic
+    assert "E2E_FAIL" not in result.stderr, diagnostic

--- a/tests/unit/common/test_node_executor_helpers.py
+++ b/tests/unit/common/test_node_executor_helpers.py
@@ -107,19 +107,7 @@ class TestDeserializeParameterValue:
 
     def test_unpickles_arbitrary_python_objects(self) -> None:
         executor = _make_executor()
-
-        class _Point:
-            def __init__(self, x: int, y: int) -> None:
-                self.x = x
-                self.y = y
-
-            def __eq__(self, other: object) -> bool:
-                return isinstance(other, _Point) and self.x == other.x and self.y == other.y
-
-            def __hash__(self) -> int:
-                return hash((self.x, self.y))
-
-        original = _Point(3, 7)
+        original = complex(3, 7)
 
         result = executor._deserialize_parameter_value(
             param_name="point",

--- a/tests/unit/common/test_node_executor_helpers.py
+++ b/tests/unit/common/test_node_executor_helpers.py
@@ -116,6 +116,9 @@ class TestDeserializeParameterValue:
             def __eq__(self, other: object) -> bool:
                 return isinstance(other, _Point) and self.x == other.x and self.y == other.y
 
+            def __hash__(self) -> int:
+                return hash((self.x, self.y))
+
         original = _Point(3, 7)
 
         result = executor._deserialize_parameter_value(
@@ -288,10 +291,11 @@ class TestControlFlowResolvedEventCattrsRoundTrip:
     def test_bytes_values_survive_unstructure_structure_round_trip(self) -> None:
         from griptape_nodes.retained_mode.events.event_converter import converter, safe_unstructure
         from griptape_nodes.retained_mode.events.execution_events import ControlFlowResolvedEvent
+        from griptape_nodes.retained_mode.events.node_events import SerializedNodeCommands
 
         original = {"answer": 42}
         pickled = pickle.dumps(original)
-        uuid = "test-uuid-1"
+        uuid = SerializedNodeCommands.UniqueParameterValueUUID("test-uuid-1")
 
         event = ControlFlowResolvedEvent(
             end_node_name="EndFlow",
@@ -310,6 +314,7 @@ class TestControlFlowResolvedEventCattrsRoundTrip:
         reconstructed = converter.structure(raw, ControlFlowResolvedEvent)
 
         # After structuring with the typed field, value must be bytes again
+        assert reconstructed.unique_parameter_uuid_to_values is not None
         stored = reconstructed.unique_parameter_uuid_to_values[uuid]
         assert isinstance(stored, bytes), "cattrs must decode base85 back to bytes during structure"
         assert stored == pickled

--- a/tests/unit/common/test_node_executor_helpers.py
+++ b/tests/unit/common/test_node_executor_helpers.py
@@ -5,8 +5,10 @@ These tests describe the observable contract of:
 * ``NodeExecutor.get_workflow_handler`` - returns the registered handler for a
   library, or raises ``ValueError`` with the library name in the message.
 * ``NodeExecutor._deserialize_parameter_value`` - resolves UUID-referenced
-  pickled bytes back into Python objects, with explicit fallbacks when the
-  stored value is not a UUID reference, not a string, or not unpicklable.
+  pickled bytes back into Python objects. By the time this function is called,
+  cattrs has already decoded base85-encoded bytes via the typed
+  ``ControlFlowResolvedEvent.unique_parameter_uuid_to_values`` field, so
+  ``stored_value`` is always ``bytes``.
 * ``NodeExecutor._extract_parameter_output_values`` - merges per-node output
   dicts from a subprocess result, using the deserializer for UUID references
   and falling back to a pre-mapping flat shape for backward compatibility.
@@ -72,7 +74,12 @@ class TestGetWorkflowHandler:
 
 
 class TestDeserializeParameterValue:
-    """_deserialize_parameter_value resolves UUID-referenced pickled values."""
+    """_deserialize_parameter_value resolves UUID-referenced pickled bytes.
+
+    By the time this function runs, ``ControlFlowResolvedEvent`` has already been
+    structured by cattrs (preconf.json), which auto-decodes base85-encoded strings
+    back to real ``bytes``. The stored value is therefore always ``bytes``.
+    """
 
     def test_returns_param_value_unchanged_when_not_a_uuid_reference(self) -> None:
         executor = _make_executor()
@@ -81,72 +88,43 @@ class TestDeserializeParameterValue:
         result = executor._deserialize_parameter_value(
             param_name="x",
             param_value=sentinel,
-            unique_uuid_to_values={"some-uuid": "irrelevant"},
+            unique_uuid_to_values={"some-uuid": pickle.dumps("irrelevant")},
         )
 
         assert result is sentinel
 
-    def test_returns_stored_value_directly_when_not_a_string(self) -> None:
-        executor = _make_executor()
-        stored = {"already": "deserialized"}
-
-        result = executor._deserialize_parameter_value(
-            param_name="x",
-            param_value="uuid-1",
-            unique_uuid_to_values={"uuid-1": stored},
-        )
-
-        assert result is stored
-
-    def test_unpickles_string_representation_of_bytes(self) -> None:
+    def test_unpickles_bytes_stored_under_uuid(self) -> None:
         executor = _make_executor()
         original = {"answer": 42, "items": [1, 2, 3]}
-        pickled_repr = repr(pickle.dumps(original))  # e.g. "b'\\x80\\x04...'"
 
         result = executor._deserialize_parameter_value(
             param_name="payload",
             param_value="uuid-1",
-            unique_uuid_to_values={"uuid-1": pickled_repr},
+            unique_uuid_to_values={"uuid-1": pickle.dumps(original)},
         )
 
         assert result == original
 
-    def test_returns_original_string_when_eval_fails(self) -> None:
+    def test_unpickles_arbitrary_python_objects(self) -> None:
         executor = _make_executor()
 
-        result = executor._deserialize_parameter_value(
-            param_name="payload",
-            param_value="uuid-1",
-            unique_uuid_to_values={"uuid-1": "not a bytes literal"},
-        )
+        class _Point:
+            def __init__(self, x: int, y: int) -> None:
+                self.x = x
+                self.y = y
 
-        assert result == "not a bytes literal"
+            def __eq__(self, other: object) -> bool:
+                return isinstance(other, _Point) and self.x == other.x and self.y == other.y
 
-    def test_returns_original_string_when_eval_yields_non_bytes(self) -> None:
-        """If literal_eval returns something that isn't bytes, fall through to the string."""
-        executor = _make_executor()
+        original = _Point(3, 7)
 
         result = executor._deserialize_parameter_value(
-            param_name="payload",
-            param_value="uuid-1",
-            # "[1, 2, 3]" evals to a list, not bytes
-            unique_uuid_to_values={"uuid-1": "[1, 2, 3]"},
+            param_name="point",
+            param_value="uuid-pt",
+            unique_uuid_to_values={"uuid-pt": pickle.dumps(original)},
         )
 
-        assert result == "[1, 2, 3]"
-
-    def test_returns_original_string_when_unpickle_fails(self) -> None:
-        executor = _make_executor()
-        # Valid bytes literal but not a valid pickle stream.
-        bogus = repr(b"\x99garbage\x00")
-
-        result = executor._deserialize_parameter_value(
-            param_name="payload",
-            param_value="uuid-1",
-            unique_uuid_to_values={"uuid-1": bogus},
-        )
-
-        assert result == bogus
+        assert result == original
 
 
 class TestExtractParameterOutputValues:
@@ -166,11 +144,10 @@ class TestExtractParameterOutputValues:
     def test_deserializes_uuid_referenced_values(self) -> None:
         executor = _make_executor()
         original = [10, 20, 30]
-        pickled_repr = repr(pickle.dumps(original))
         subprocess_result: dict[str, Any] = {
             "node_a": {
                 "parameter_output_values": {"items": "uuid-1"},
-                "unique_parameter_uuid_to_values": {"uuid-1": pickled_repr},
+                "unique_parameter_uuid_to_values": {"uuid-1": pickle.dumps(original)},
             },
         }
 
@@ -295,3 +272,47 @@ class TestExecuteSuccessReturnsNone:
             result = await _make_executor().execute(node)
 
         assert result is None
+
+
+class TestControlFlowResolvedEventCattrsRoundTrip:
+    """ControlFlowResolvedEvent.unique_parameter_uuid_to_values round-trips through cattrs.
+
+    cattrs.preconf.json registers symmetric base85 hooks for bytes.  When the
+    subprocess unstructures a ControlFlowResolvedEvent containing bytes values,
+    those values become base85 strings on the wire.  When the parent structures
+    the received payload back into a ControlFlowResolvedEvent, cattrs decodes
+    the base85 strings back into bytes — so _deserialize_parameter_value always
+    sees real bytes.
+    """
+
+    def test_bytes_values_survive_unstructure_structure_round_trip(self) -> None:
+        from griptape_nodes.retained_mode.events.event_converter import converter, safe_unstructure
+        from griptape_nodes.retained_mode.events.execution_events import ControlFlowResolvedEvent
+
+        original = {"answer": 42}
+        pickled = pickle.dumps(original)
+        uuid = "test-uuid-1"
+
+        event = ControlFlowResolvedEvent(
+            end_node_name="EndFlow",
+            parameter_output_values={"result": uuid},
+            unique_parameter_uuid_to_values={uuid: pickled},
+        )
+
+        # Simulate what the subprocess does: unstructure → JSON
+        raw = safe_unstructure(event)
+
+        # The bytes value must have been base85-encoded to a string on the wire
+        wire_value = raw["unique_parameter_uuid_to_values"][uuid]
+        assert isinstance(wire_value, str), "cattrs must base85-encode bytes during unstructure"
+
+        # Simulate what the parent does: JSON → structure
+        reconstructed = converter.structure(raw, ControlFlowResolvedEvent)
+
+        # After structuring with the typed field, value must be bytes again
+        stored = reconstructed.unique_parameter_uuid_to_values[uuid]
+        assert isinstance(stored, bytes), "cattrs must decode base85 back to bytes during structure"
+        assert stored == pickled
+
+        # And pickle.loads on the stored bytes must recover the original object
+        assert pickle.loads(stored) == original  # noqa: S301


### PR DESCRIPTION
## Summary

When a node runs in a subprocess (Private Execution), `cattrs.preconf.json` base85-encodes any `bytes` values during `unstructure`. The parent-side `_deserialize_parameter_value` was only handling Python byte-literal strings via `ast.literal_eval` + `pickle.loads`, so base85-encoded strings were never decoded — consumers silently received garbled strings instead of the real Python object.

PR #4588 proposed a parent-side fallback (`base64.b85decode` when `ast.literal_eval` fails). This PR takes the approach suggested by @collindutter in issue #4641: let the cattrs layer that encodes also decode, by tightening the type annotation on `ControlFlowResolvedEvent.unique_parameter_uuid_to_values` from `Any` to `bytes`. Since `converter.structure` already runs on every received event (via `ExecutionEvent.from_dict`), cattrs automatically decodes base85 → bytes with no additional plumbing.

PR #4588 was considered but a different architectural approach was taken here — rather than a parent-side fallback, we let the existing cattrs round-trip handle encoding/decoding symmetrically.

## Changes

- `execution_events.py` — typed `unique_parameter_uuid_to_values` as `dict[..., bytes]` on `ControlFlowResolvedEvent` only (not on `SerializedNodeCommands`/`SerializedFlowCommands`, which store non-bytes values for workflow save/load)
- `node_executor.py` — simplified `_deserialize_parameter_value` to call `pickle.loads` directly; added `logger.warning` + reraise on `UnpicklingError`; removed unused `ast` import
- `test_node_executor_helpers.py` — updated tests to reflect new contract (stored values are `bytes`), added `TestControlFlowResolvedEventCattrsRoundTrip` to prove the full unstructure→wire→structure round trip

## Test Plan

- [x] Built a workflow in the Griptape Nodes UI with a **Subflow Node Group** set to **Private Execution**, containing a **Create Color Bars** node (no API key required), with the image output wired back to the outer canvas and into a **Display Image** node
- [x] Ran the workflow and confirmed the color bars image appeared correctly in Display Image (previously it received a garbled base85 string)
- [x] Unit tests in `TestControlFlowResolvedEventCattrsRoundTrip` pass, proving the full unstructure→wire→structure round trip

Closes #4641