### PR TITLE
feat: move executor CLI args onto WorkflowExecutor

### DIFF
--- a/src/griptape_nodes/bootstrap/workflow_executors/local_session_workflow_executor.py
+++ b/src/griptape_nodes/bootstrap/workflow_executors/local_session_workflow_executor.py
@@ -31,6 +31,7 @@ from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 if TYPE_CHECKING:
     from argparse import ArgumentParser, Namespace
     from collections.abc import Callable
+    from pathlib import Path
     from types import TracebackType
 
 logger = logging.getLogger(__name__)
@@ -43,8 +44,14 @@ class LocalSessionWorkflowExecutor(LocalWorkflowExecutor, SubprocessWebSocketSen
         storage_backend: StorageBackend = StorageBackend.LOCAL,
         on_start_flow_result: Callable[[ResultPayload], None] | None = None,
         save_on_failure_path: str | None = None,
+        *,
+        project_file_path: Path | None = None,
     ):
-        super().__init__(storage_backend=storage_backend, save_on_failure_path=save_on_failure_path)
+        super().__init__(
+            storage_backend=storage_backend,
+            project_file_path=project_file_path,
+            save_on_failure_path=save_on_failure_path,
+        )
         self._init_websocket_sender(session_id)
         self._on_start_flow_result = on_start_flow_result
 
@@ -82,6 +89,8 @@ class LocalSessionWorkflowExecutor(LocalWorkflowExecutor, SubprocessWebSocketSen
         self,
         flow_input: Any,
         storage_backend: StorageBackend | None = None,
+        *,
+        pickle_control_flow_result: bool | None = None,
         **kwargs: Any,
     ) -> None:
         """Executes a local workflow.
@@ -92,6 +101,8 @@ class LocalSessionWorkflowExecutor(LocalWorkflowExecutor, SubprocessWebSocketSen
         Parameters:
             flow_input: Input data for the flow, typically a dictionary.
             storage_backend: The storage backend to use for the workflow execution.
+            pickle_control_flow_result: Per-call override for the executor's
+                save-time default. None means "use the instance default".
 
         Returns:
             None
@@ -100,6 +111,7 @@ class LocalSessionWorkflowExecutor(LocalWorkflowExecutor, SubprocessWebSocketSen
             await self._arun(
                 flow_input=flow_input,
                 storage_backend=storage_backend,
+                pickle_control_flow_result=pickle_control_flow_result,
                 **kwargs,
             )
         except Exception as e:
@@ -121,6 +133,8 @@ class LocalSessionWorkflowExecutor(LocalWorkflowExecutor, SubprocessWebSocketSen
         self,
         flow_input: Any,
         storage_backend: StorageBackend | None = None,
+        *,
+        pickle_control_flow_result: bool | None = None,
         **kwargs: Any,
     ) -> None:
         """Internal async run method with detailed event handling and websocket integration."""
@@ -131,10 +145,10 @@ class LocalSessionWorkflowExecutor(LocalWorkflowExecutor, SubprocessWebSocketSen
         )
 
         # Send the run command to actually execute it (fire and forget)
-        pickle_control_flow_result = kwargs.get("pickle_control_flow_result", False)
-        start_flow_request = StartFlowRequest(
-            flow_name=flow_name, pickle_control_flow_result=pickle_control_flow_result
+        effective_pickle = (
+            pickle_control_flow_result if pickle_control_flow_result is not None else self._pickle_control_flow_result
         )
+        start_flow_request = StartFlowRequest(flow_name=flow_name, pickle_control_flow_result=effective_pickle)
         start_flow_task = asyncio.create_task(GriptapeNodes.ahandle_request(start_flow_request))
 
         is_flow_finished = False
@@ -234,11 +248,13 @@ class LocalSessionWorkflowExecutor(LocalWorkflowExecutor, SubprocessWebSocketSen
             raise error
 
     @classmethod
-    def add_cli_arguments(cls, parser: ArgumentParser) -> None:
-        # Compose the smaller helpers directly: this executor's constructor does
-        # not accept project_file_path, so we skip --project-file-path.
-        cls._add_storage_backend_argument(parser)
-        cls._add_save_on_failure_argument(parser)
+    def add_cli_arguments(
+        cls,
+        parser: ArgumentParser,
+        *,
+        pickle_control_flow_result_default: bool = False,
+    ) -> None:
+        super().add_cli_arguments(parser, pickle_control_flow_result_default=pickle_control_flow_result_default)
         parser.add_argument(
             "--session-id",
             default=None,
@@ -248,7 +264,5 @@ class LocalSessionWorkflowExecutor(LocalWorkflowExecutor, SubprocessWebSocketSen
     @classmethod
     def _cli_constructor_kwargs(cls, args: Namespace) -> dict[str, Any]:
         kwargs = super()._cli_constructor_kwargs(args)
-        # LocalSessionWorkflowExecutor.__init__ does not accept project_file_path; drop it.
-        kwargs.pop("project_file_path", None)
         kwargs["session_id"] = args.session_id
         return kwargs

--- a/src/griptape_nodes/bootstrap/workflow_executors/local_session_workflow_executor.py
+++ b/src/griptape_nodes/bootstrap/workflow_executors/local_session_workflow_executor.py
@@ -29,6 +29,7 @@ from griptape_nodes.retained_mode.events.execution_events import (
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace
     from collections.abc import Callable
     from types import TracebackType
 
@@ -231,3 +232,23 @@ class LocalSessionWorkflowExecutor(LocalWorkflowExecutor, SubprocessWebSocketSen
 
         if error is not None:
             raise error
+
+    @classmethod
+    def add_cli_arguments(cls, parser: ArgumentParser) -> None:
+        # Compose the smaller helpers directly: this executor's constructor does
+        # not accept project_file_path, so we skip --project-file-path.
+        cls._add_storage_backend_argument(parser)
+        cls._add_save_on_failure_argument(parser)
+        parser.add_argument(
+            "--session-id",
+            default=None,
+            help="ID of the session to use",
+        )
+
+    @classmethod
+    def _cli_constructor_kwargs(cls, args: Namespace) -> dict[str, Any]:
+        kwargs = super()._cli_constructor_kwargs(args)
+        # LocalSessionWorkflowExecutor.__init__ does not accept project_file_path; drop it.
+        kwargs.pop("project_file_path", None)
+        kwargs["session_id"] = args.session_id
+        return kwargs

--- a/src/griptape_nodes/bootstrap/workflow_executors/local_workflow_executor.py
+++ b/src/griptape_nodes/bootstrap/workflow_executors/local_workflow_executor.py
@@ -43,6 +43,7 @@ from griptape_nodes.retained_mode.events.workflow_events import (
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 if TYPE_CHECKING:
+    from argparse import ArgumentParser, Namespace
     from types import TracebackType
 
 logger = logging.getLogger(__name__)
@@ -427,3 +428,28 @@ class LocalWorkflowExecutor(WorkflowExecutor):
 
         if error is not None:
             raise error
+
+    @classmethod
+    def add_cli_arguments(cls, parser: ArgumentParser) -> None:
+        super().add_cli_arguments(parser)
+        cls._add_save_on_failure_argument(parser)
+
+    @classmethod
+    def _add_save_on_failure_argument(cls, parser: ArgumentParser) -> None:
+        parser.add_argument(
+            "--save-on-failure",
+            nargs="?",
+            const="",
+            default=None,
+            help=(
+                "On failure, save the current workflow state as a .py file. "
+                "With no value: uses the project 'save_failed_workflow' situation. "
+                "With a value: absolute or project-relative path."
+            ),
+        )
+
+    @classmethod
+    def _cli_constructor_kwargs(cls, args: Namespace) -> dict[str, Any]:
+        kwargs = super()._cli_constructor_kwargs(args)
+        kwargs["save_on_failure_path"] = args.save_on_failure
+        return kwargs

--- a/src/griptape_nodes/bootstrap/workflow_executors/local_workflow_executor.py
+++ b/src/griptape_nodes/bootstrap/workflow_executors/local_workflow_executor.py
@@ -54,7 +54,7 @@ class LocalExecutorError(Exception):
 
 
 class LocalWorkflowExecutor(WorkflowExecutor):
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         storage_backend: StorageBackend = StorageBackend.LOCAL,
         *,
@@ -62,8 +62,9 @@ class LocalWorkflowExecutor(WorkflowExecutor):
         skip_library_loading: bool = False,
         workflows_to_register: list[str] | None = None,
         save_on_failure_path: str | None = None,
+        pickle_control_flow_result: bool = False,
     ):
-        super().__init__()
+        super().__init__(pickle_control_flow_result=pickle_control_flow_result)
         self._set_storage_backend(storage_backend=storage_backend)
         self._project_file_path = project_file_path
         self._skip_library_loading = skip_library_loading
@@ -372,6 +373,8 @@ class LocalWorkflowExecutor(WorkflowExecutor):
         self,
         flow_input: Any,
         storage_backend: StorageBackend | None = None,
+        *,
+        pickle_control_flow_result: bool | None = None,
         **kwargs: Any,
     ) -> None:
         """Executes a local workflow.
@@ -383,6 +386,8 @@ class LocalWorkflowExecutor(WorkflowExecutor):
             workflow_name: The name of the workflow to execute.
             flow_input: Input data for the flow, typically a dictionary.
             storage_backend: The storage backend to use for the workflow execution.
+            pickle_control_flow_result: Per-call override for the executor's
+                save-time default. None means "use the instance default".
 
         Returns:
             None
@@ -394,10 +399,10 @@ class LocalWorkflowExecutor(WorkflowExecutor):
         )
 
         # Now send the run command to actually execute it
-        pickle_control_flow_result = kwargs.get("pickle_control_flow_result", False)
-        start_flow_request = StartFlowRequest(
-            flow_name=flow_name, pickle_control_flow_result=pickle_control_flow_result
+        effective_pickle = (
+            pickle_control_flow_result if pickle_control_flow_result is not None else self._pickle_control_flow_result
         )
+        start_flow_request = StartFlowRequest(flow_name=flow_name, pickle_control_flow_result=effective_pickle)
         start_flow_result = await GriptapeNodes.ahandle_request(start_flow_request)
 
         if start_flow_result.failed():
@@ -430,8 +435,13 @@ class LocalWorkflowExecutor(WorkflowExecutor):
             raise error
 
     @classmethod
-    def add_cli_arguments(cls, parser: ArgumentParser) -> None:
-        super().add_cli_arguments(parser)
+    def add_cli_arguments(
+        cls,
+        parser: ArgumentParser,
+        *,
+        pickle_control_flow_result_default: bool = False,
+    ) -> None:
+        super().add_cli_arguments(parser, pickle_control_flow_result_default=pickle_control_flow_result_default)
         cls._add_save_on_failure_argument(parser)
 
     @classmethod

--- a/src/griptape_nodes/bootstrap/workflow_executors/utils/subprocess_script.py
+++ b/src/griptape_nodes/bootstrap/workflow_executors/utils/subprocess_script.py
@@ -9,7 +9,6 @@ from argparse import ArgumentParser
 from workflow import execute_workflow  # type: ignore[attr-defined]
 
 from griptape_nodes.bootstrap.workflow_executors.local_session_workflow_executor import LocalSessionWorkflowExecutor
-from griptape_nodes.drivers.storage import StorageBackend
 from griptape_nodes.utils import install_file_url_support
 
 # Install file:// URL support for httpx/requests in subprocess
@@ -18,20 +17,11 @@ install_file_url_support()
 
 def _main() -> None:
     parser = ArgumentParser()
+    LocalSessionWorkflowExecutor.add_cli_arguments(parser)
     parser.add_argument(
         "--json-input",
         default=json.dumps({}),
         help="JSON string representing the flow input",
-    )
-    parser.add_argument(
-        "--session-id",
-        default=None,
-        help="ID of the session to use",
-    )
-    parser.add_argument(
-        "--storage-backend",
-        default="local",
-        help="Storage backend to use",
     )
     parser.add_argument(
         "--workflow-path",
@@ -44,32 +34,15 @@ def _main() -> None:
         default=False,
         help="Whether to pickle control flow results",
     )
-    parser.add_argument(
-        "--save-on-failure",
-        nargs="?",
-        const="",
-        default=None,
-        help=(
-            "On failure, save the current workflow state as a .py file. "
-            "With no value: uses the project 'save_failed_workflow' situation. "
-            "With a value: absolute or project-relative path."
-        ),
-    )
     args = parser.parse_args()
     flow_input = json.loads(args.json_input)
 
-    local_session_workflow_executor = LocalSessionWorkflowExecutor(
-        session_id=args.session_id,
-        storage_backend=StorageBackend(args.storage_backend),
-        save_on_failure_path=args.save_on_failure,
-    )
+    local_session_workflow_executor = LocalSessionWorkflowExecutor.from_cli_args(args)
 
-    extra_kwargs: dict = {"save_on_failure_path": args.save_on_failure} if args.save_on_failure is not None else {}
     execute_workflow(
         input=flow_input,
         workflow_executor=local_session_workflow_executor,
         pickle_control_flow_result=args.pickle_control_flow_result,
-        **extra_kwargs,
     )
 
 

--- a/src/griptape_nodes/bootstrap/workflow_executors/workflow_executor.py
+++ b/src/griptape_nodes/bootstrap/workflow_executors/workflow_executor.py
@@ -12,8 +12,9 @@ logger = logging.getLogger(__name__)
 
 
 class WorkflowExecutor:
-    def __init__(self) -> None:
+    def __init__(self, *, pickle_control_flow_result: bool = False) -> None:
         self.output: dict | None = None
+        self._pickle_control_flow_result = pickle_control_flow_result
 
     async def __aenter__(self) -> Self:
         """Async context manager entry."""
@@ -45,16 +46,26 @@ class WorkflowExecutor:
     ) -> None: ...
 
     @classmethod
-    def add_cli_arguments(cls, parser: ArgumentParser) -> None:
+    def add_cli_arguments(
+        cls,
+        parser: ArgumentParser,
+        *,
+        pickle_control_flow_result_default: bool = False,
+    ) -> None:
         """Register executor-level CLI arguments on `parser`.
 
-        Subclasses override and call `super().add_cli_arguments(parser)` to
+        Subclasses override and call `super().add_cli_arguments(parser, ...)` to
         inherit the shared base-class flags before adding their own. Subclasses
         whose constructor cannot accept a particular flag should compose the
         smaller `_add_*_argument` helpers directly instead of calling super.
+
+        `pickle_control_flow_result_default` is forwarded to
+        `_add_pickle_control_flow_result_argument`; it lets generated workflow
+        files seed argparse's default with the save-time choice.
         """
         cls._add_storage_backend_argument(parser)
         cls._add_project_file_path_argument(parser)
+        cls._add_pickle_control_flow_result_argument(parser, default=pickle_control_flow_result_default)
 
     @classmethod
     def _add_storage_backend_argument(cls, parser: ArgumentParser) -> None:
@@ -71,6 +82,19 @@ class WorkflowExecutor:
             "--project-file-path",
             default=None,
             help="Path to a project file to load for the workflow execution",
+        )
+
+    @classmethod
+    def _add_pickle_control_flow_result_argument(cls, parser: ArgumentParser, *, default: bool = False) -> None:
+        # `default` lets callers (e.g. the generated workflow file's __main__)
+        # override the built-in False default with the save-time pickle setting,
+        # so users running the workflow from the CLI get the same default the
+        # workflow was published with.
+        parser.add_argument(
+            "--pickle-control-flow-result",
+            action="store_true",
+            default=default,
+            help="Pickle the control flow result (used by subflow/private-execution callers)",
         )
 
     @classmethod
@@ -92,13 +116,10 @@ class WorkflowExecutor:
 
         Subclasses override to extend the mapping; they should call
         `super()._cli_constructor_kwargs(args)` first and then update the dict
-        with their own entries. Uses `getattr` with defaults so subclasses whose
-        `add_cli_arguments` deliberately omits a flag (e.g.
-        `LocalSessionWorkflowExecutor` skips `--project-file-path`) can still
-        call super without crashing on missing attributes.
+        with their own entries.
         """
-        project_file_path = getattr(args, "project_file_path", None)
         return {
             "storage_backend": StorageBackend(args.storage_backend),
-            "project_file_path": Path(project_file_path) if project_file_path is not None else None,
+            "project_file_path": Path(args.project_file_path) if args.project_file_path is not None else None,
+            "pickle_control_flow_result": args.pickle_control_flow_result,
         }

--- a/src/griptape_nodes/bootstrap/workflow_executors/workflow_executor.py
+++ b/src/griptape_nodes/bootstrap/workflow_executors/workflow_executor.py
@@ -1,6 +1,8 @@
 import asyncio
 import logging
 from abc import abstractmethod
+from argparse import ArgumentParser, Namespace
+from pathlib import Path
 from types import TracebackType
 from typing import Any, Self
 
@@ -41,3 +43,62 @@ class WorkflowExecutor:
         storage_backend: StorageBackend = StorageBackend.LOCAL,
         **kwargs: Any,
     ) -> None: ...
+
+    @classmethod
+    def add_cli_arguments(cls, parser: ArgumentParser) -> None:
+        """Register executor-level CLI arguments on `parser`.
+
+        Subclasses override and call `super().add_cli_arguments(parser)` to
+        inherit the shared base-class flags before adding their own. Subclasses
+        whose constructor cannot accept a particular flag should compose the
+        smaller `_add_*_argument` helpers directly instead of calling super.
+        """
+        cls._add_storage_backend_argument(parser)
+        cls._add_project_file_path_argument(parser)
+
+    @classmethod
+    def _add_storage_backend_argument(cls, parser: ArgumentParser) -> None:
+        parser.add_argument(
+            "--storage-backend",
+            choices=[StorageBackend.LOCAL.value, StorageBackend.GTC.value],
+            default=StorageBackend.LOCAL.value,
+            help="Storage backend to use: 'local' for local filesystem or 'gtc' for Griptape Cloud",
+        )
+
+    @classmethod
+    def _add_project_file_path_argument(cls, parser: ArgumentParser) -> None:
+        parser.add_argument(
+            "--project-file-path",
+            default=None,
+            help="Path to a project file to load for the workflow execution",
+        )
+
+    @classmethod
+    def from_cli_args(cls, args: Namespace, **overrides: Any) -> Self:
+        """Construct an executor from a parsed argparse `Namespace`.
+
+        Subclasses override to map their own CLI arguments to constructor kwargs.
+        `**overrides` lets callers (e.g. the generated workflow file's __main__)
+        inject non-CLI constructor kwargs like `skip_library_loading` or
+        `workflows_to_register` that aren't exposed as flags.
+        """
+        kwargs = cls._cli_constructor_kwargs(args)
+        kwargs.update(overrides)
+        return cls(**kwargs)
+
+    @classmethod
+    def _cli_constructor_kwargs(cls, args: Namespace) -> dict[str, Any]:
+        """Return constructor kwargs derived from CLI args.
+
+        Subclasses override to extend the mapping; they should call
+        `super()._cli_constructor_kwargs(args)` first and then update the dict
+        with their own entries. Uses `getattr` with defaults so subclasses whose
+        `add_cli_arguments` deliberately omits a flag (e.g.
+        `LocalSessionWorkflowExecutor` skips `--project-file-path`) can still
+        call super without crashing on missing attributes.
+        """
+        project_file_path = getattr(args, "project_file_path", None)
+        return {
+            "storage_backend": StorageBackend(args.storage_backend),
+            "project_file_path": Path(project_file_path) if project_file_path is not None else None,
+        }

--- a/src/griptape_nodes/node_library/workflow_registry.py
+++ b/src/griptape_nodes/node_library/workflow_registry.py
@@ -46,7 +46,7 @@ class WorkflowShape(BaseModel):
 
 
 class WorkflowMetadata(BaseModel):
-    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.18.0"
+    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.19.0"
 
     name: str
     schema_version: str

--- a/src/griptape_nodes/retained_mode/managers/fitness_problems/workflows/workflow_schema_version_problem.py
+++ b/src/griptape_nodes/retained_mode/managers/fitness_problems/workflows/workflow_schema_version_problem.py
@@ -12,7 +12,9 @@ logger = logging.getLogger(__name__)
 class WorkflowSchemaVersionProblem(WorkflowProblem):
     """Problem indicating a workflow has schema version compatibility issues.
 
-    This is context-specific and likely one-time only per workflow.
+    A workflow may collect more than one of these when it is older than several
+    migrations at once — each `WorkflowVersionCompatibilityCheck` that applies
+    contributes its own instance.
     """
 
     description: str
@@ -21,8 +23,8 @@ class WorkflowSchemaVersionProblem(WorkflowProblem):
     def collate_problems_for_display(cls, instances: list[WorkflowSchemaVersionProblem]) -> str:
         """Display workflow schema version problems."""
         if len(instances) > 1:
-            logger.error(
-                "WorkflowSchemaVersionProblem received %d instances but should typically only receive 1. This may indicate multiple schema issues.",
+            logger.debug(
+                "WorkflowSchemaVersionProblem received %d instances; multiple schema migrations apply to this workflow.",
                 len(instances),
             )
 

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -23,7 +23,6 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
-from griptape_nodes.drivers.storage import StorageBackend
 from griptape_nodes.exe_types.core_types import ParameterTypeBuiltin
 from griptape_nodes.exe_types.flow import ControlFlow
 from griptape_nodes.exe_types.node_types import BaseNode, EndNode, StartNode
@@ -2847,35 +2846,20 @@ class WorkflowManager:
         import_recorder.add_import("asyncio")
         import_recorder.add_import("json")
         import_recorder.add_import("logging")
-        import_recorder.add_from_import("pathlib", "Path")
+        import_recorder.add_from_import("typing", "Any")
         import_recorder.add_from_import(
             "griptape_nodes.bootstrap.workflow_executors.local_workflow_executor", "LocalWorkflowExecutor"
         )
         import_recorder.add_from_import(
             "griptape_nodes.bootstrap.workflow_executors.workflow_executor", "WorkflowExecutor"
         )
-        import_recorder.add_from_import("griptape_nodes.drivers.storage.storage_backend", "StorageBackend")
 
-        # === 1) build the `def execute_workflow(input: dict, storage_backend: str = StorageBackend.LOCAL, workflow_executor: WorkflowExecutor | None = None, pickle_control_flow_result: bool = False) -> dict | None:` ===
-        #   args
+        # === 1) build the `def execute_workflow(input: dict, *, workflow_executor: WorkflowExecutor | None = None, **kwargs: Any) -> dict | None:` ===
+        # `**kwargs` carries through to `LocalWorkflowExecutor(**kwargs)` on the fallback
+        # construction path (when no `workflow_executor` is supplied) and to `executor.arun(**kwargs)`
+        # in all paths. This keeps the helper signature stable as new executor-level options
+        # are added without requiring a workflow file schema bump (issue #4599).
         arg_input = ast.arg(arg="input", annotation=ast.Name(id="dict", ctx=ast.Load()))
-        arg_storage_backend = ast.arg(arg="storage_backend", annotation=ast.Name(id="str", ctx=ast.Load()))
-        arg_project_file_path = ast.arg(
-            arg="project_file_path",
-            annotation=ast.BinOp(
-                left=ast.Name(id="str", ctx=ast.Load()),
-                op=ast.BitOr(),
-                right=ast.Constant(value=None),
-            ),
-        )
-        arg_save_on_failure_path = ast.arg(
-            arg="save_on_failure_path",
-            annotation=ast.BinOp(
-                left=ast.Name(id="str", ctx=ast.Load()),
-                op=ast.BitOr(),
-                right=ast.Constant(value=None),
-            ),
-        )
         arg_workflow_executor = ast.arg(
             arg="workflow_executor",
             annotation=ast.BinOp(
@@ -2884,30 +2868,15 @@ class WorkflowManager:
                 right=ast.Constant(value=None),
             ),
         )
-        arg_pickle_control_flow_result = ast.arg(
-            arg="pickle_control_flow_result", annotation=ast.Name(id="bool", ctx=ast.Load())
-        )
+        kwargs_arg = ast.arg(arg="kwargs", annotation=ast.Name(id="Any", ctx=ast.Load()))
         args = ast.arguments(
             posonlyargs=[],
-            args=[
-                arg_input,
-                arg_storage_backend,
-                arg_project_file_path,
-                arg_save_on_failure_path,
-                arg_workflow_executor,
-                arg_pickle_control_flow_result,
-            ],
+            args=[arg_input],
             vararg=None,
-            kwonlyargs=[],
-            kw_defaults=[],
-            kwarg=None,
-            defaults=[
-                ast.Constant(StorageBackend.LOCAL.value),
-                ast.Constant(value=None),
-                ast.Constant(value=None),
-                ast.Constant(value=None),
-                ast.Constant(value=pickle_control_flow_result),
-            ],
+            kwonlyargs=[arg_workflow_executor],
+            kw_defaults=[ast.Constant(value=None)],
+            kwarg=kwargs_arg,
+            defaults=[],
         )
         #   return annotation: dict | None
         return_annotation = ast.BinOp(
@@ -2919,68 +2888,59 @@ class WorkflowManager:
         # Generate the ensure flow context function call
         ensure_context_call = self._generate_ensure_flow_context_call()
 
-        # Convert string storage_backend to StorageBackend enum
-        storage_backend_convert = ast.Assign(
-            targets=[ast.Name(id="storage_backend_enum", ctx=ast.Store())],
+        # Pop `pickle_control_flow_result` out of `**kwargs` so it doesn't get splatted
+        # into the executor constructor (which doesn't accept it). It's an `arun`-only
+        # kwarg. Default value falls back to the save-time `_PICKLE_CONTROL_FLOW_RESULT`
+        # module-level constant.
+        pickle_pop_stmt = ast.Assign(
+            targets=[ast.Name(id="pickle_control_flow_result", ctx=ast.Store())],
             value=ast.Call(
-                func=ast.Name(id="StorageBackend", ctx=ast.Load()),
-                args=[ast.Name(id="storage_backend", ctx=ast.Load())],
+                func=ast.Attribute(
+                    value=ast.Name(id="kwargs", ctx=ast.Load()),
+                    attr="pop",
+                    ctx=ast.Load(),
+                ),
+                args=[
+                    ast.Constant(value="pickle_control_flow_result"),
+                    ast.Name(id="_PICKLE_CONTROL_FLOW_RESULT", ctx=ast.Load()),
+                ],
                 keywords=[],
             ),
         )
 
-        # Resolve project_file_path string to Path: project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
-        project_file_path_resolve = ast.Assign(
-            targets=[ast.Name(id="project_file_path_resolved", ctx=ast.Store())],
-            value=ast.IfExp(
-                test=ast.Compare(
-                    left=ast.Name(id="project_file_path", ctx=ast.Load()),
-                    ops=[ast.IsNot()],
-                    comparators=[ast.Constant(value=None)],
-                ),
-                body=ast.Call(
-                    func=ast.Name(id="Path", ctx=ast.Load()),
-                    args=[ast.Name(id="project_file_path", ctx=ast.Load())],
-                    keywords=[],
-                ),
-                orelse=ast.Constant(value=None),
-            ),
-        )
-
-        # Create conditional logic: workflow_executor = workflow_executor or LocalWorkflowExecutor(...)
+        # Construct a default LocalWorkflowExecutor only when the caller did not supply one.
+        # `**kwargs` is passed straight through to the constructor; if the caller passed a
+        # typo'd executor kwarg, LocalWorkflowExecutor.__init__ will raise TypeError, which
+        # is the loud failure we want for direct importers.
         # TODO: https://github.com/griptape-ai/griptape-nodes/issues/3771 Update for workflows that call other workflows - need to include referenced workflows in the list
-        executor_assign = ast.Assign(
-            targets=[ast.Name(id="workflow_executor", ctx=ast.Store())],
-            value=ast.BoolOp(
-                op=ast.Or(),
-                values=[
-                    ast.Name(id="workflow_executor", ctx=ast.Load()),
-                    ast.Call(
+        executor_assign = ast.If(
+            test=ast.Compare(
+                left=ast.Name(id="workflow_executor", ctx=ast.Load()),
+                ops=[ast.Is()],
+                comparators=[ast.Constant(value=None)],
+            ),
+            body=[
+                ast.Assign(
+                    targets=[ast.Name(id="workflow_executor", ctx=ast.Store())],
+                    value=ast.Call(
                         func=ast.Name(id="LocalWorkflowExecutor", ctx=ast.Load()),
                         args=[],
                         keywords=[
-                            ast.keyword(
-                                arg="storage_backend", value=ast.Name(id="storage_backend_enum", ctx=ast.Load())
-                            ),
-                            ast.keyword(
-                                arg="project_file_path",
-                                value=ast.Name(id="project_file_path_resolved", ctx=ast.Load()),
-                            ),
-                            ast.keyword(
-                                arg="save_on_failure_path",
-                                value=ast.Name(id="save_on_failure_path", ctx=ast.Load()),
-                            ),
                             ast.keyword(arg="skip_library_loading", value=ast.Constant(value=True)),
                             ast.keyword(
                                 arg="workflows_to_register",
                                 value=ast.List(elts=[ast.Name(id="__file__", ctx=ast.Load())], ctx=ast.Load()),
                             ),
+                            ast.keyword(arg=None, value=ast.Name(id="kwargs", ctx=ast.Load())),
                         ],
                     ),
-                ],
-            ),
+                )
+            ],
+            orelse=[],
         )
-        # Use async context manager for workflow execution
+        # Use async context manager for workflow execution. `pickle_control_flow_result` was
+        # popped out of `**kwargs` above; pass it explicitly. Any remaining `**kwargs` flow
+        # through to `arun` so additional executor-specific options aren't dropped.
         with_stmt = ast.AsyncWith(
             items=[
                 ast.withitem(
@@ -3004,6 +2964,7 @@ class WorkflowManager:
                                     arg="pickle_control_flow_result",
                                     value=ast.Name(id="pickle_control_flow_result", ctx=ast.Load()),
                                 ),
+                                ast.keyword(arg=None, value=ast.Name(id="kwargs", ctx=ast.Load())),
                             ],
                         )
                     )
@@ -3038,8 +2999,7 @@ class WorkflowManager:
             body=[
                 await_main_call,
                 ensure_context_call,
-                storage_backend_convert,
-                project_file_path_resolve,
+                pickle_pop_stmt,
                 executor_assign,
                 with_stmt,
                 return_stmt,
@@ -3069,23 +3029,9 @@ class WorkflowManager:
                                 keywords=[
                                     ast.keyword(arg="input", value=ast.Name(id="input", ctx=ast.Load())),
                                     ast.keyword(
-                                        arg="storage_backend", value=ast.Name(id="storage_backend", ctx=ast.Load())
-                                    ),
-                                    ast.keyword(
-                                        arg="project_file_path",
-                                        value=ast.Name(id="project_file_path", ctx=ast.Load()),
-                                    ),
-                                    ast.keyword(
-                                        arg="save_on_failure_path",
-                                        value=ast.Name(id="save_on_failure_path", ctx=ast.Load()),
-                                    ),
-                                    ast.keyword(
                                         arg="workflow_executor", value=ast.Name(id="workflow_executor", ctx=ast.Load())
                                     ),
-                                    ast.keyword(
-                                        arg="pickle_control_flow_result",
-                                        value=ast.Name(id="pickle_control_flow_result", ctx=ast.Load()),
-                                    ),
+                                    ast.keyword(arg=None, value=ast.Name(id="kwargs", ctx=ast.Load())),
                                 ],
                             )
                         ],
@@ -3105,7 +3051,16 @@ class WorkflowManager:
         # Generate the ensure flow context function
         ensure_context_func = self._generate_ensure_flow_context_function(import_recorder)
 
-        return [ensure_context_func, sync_func_def, async_func_def, if_node]
+        # Module-level constant for the save-time `pickle_control_flow_result` value.
+        # Emitted as `_PICKLE_CONTROL_FLOW_RESULT = <bool>` near the top of the execution
+        # block so both `aexecute_workflow` and `__main__` can reference it.
+        pickle_constant = ast.Assign(
+            targets=[ast.Name(id="_PICKLE_CONTROL_FLOW_RESULT", ctx=ast.Store())],
+            value=ast.Constant(value=pickle_control_flow_result),
+        )
+        ast.fix_missing_locations(pickle_constant)
+
+        return [pickle_constant, ensure_context_func, sync_func_def, async_func_def, if_node]
 
     def _generate_main_block(self, workflow_shape: dict) -> ast.If:
         """Generates the `if __name__ == '__main__':` block for the serialized workflow file."""
@@ -3131,58 +3086,25 @@ class WorkflowManager:
         # Generate parser.add_argument(...) calls for each parameter in workflow_shape
         add_arg_calls = []
 
-        # Add storage backend argument
+        # Delegate executor-level CLI flags to LocalWorkflowExecutor.add_cli_arguments(parser).
+        # This replaces hand-rolled --storage-backend / --project-file-path / --save-on-failure
+        # add_argument calls so that future executor-level flags can be added without bumping
+        # the workflow file schema. See https://github.com/griptape-ai/griptape-nodes/issues/4599.
         add_arg_calls.append(
             ast.Expr(
                 value=ast.Call(
                     func=ast.Attribute(
-                        value=ast.Name(id="parser", ctx=ast.Load()),
-                        attr="add_argument",
+                        value=ast.Name(id="LocalWorkflowExecutor", ctx=ast.Load()),
+                        attr="add_cli_arguments",
                         ctx=ast.Load(),
                     ),
-                    args=[ast.Constant("--storage-backend")],
-                    keywords=[
-                        ast.keyword(
-                            arg="choices",
-                            value=ast.List(
-                                elts=[ast.Constant(StorageBackend.LOCAL.value), ast.Constant(StorageBackend.GTC.value)],
-                                ctx=ast.Load(),
-                            ),
-                        ),
-                        ast.keyword(arg="default", value=ast.Constant(StorageBackend.LOCAL.value)),
-                        ast.keyword(
-                            arg="help",
-                            value=ast.Constant(
-                                "Storage backend to use: 'local' for local filesystem or 'gtc' for Griptape Cloud"
-                            ),
-                        ),
-                    ],
+                    args=[ast.Name(id="parser", ctx=ast.Load())],
+                    keywords=[],
                 )
             )
         )
 
-        # Add project file path argument
-        add_arg_calls.append(
-            ast.Expr(
-                value=ast.Call(
-                    func=ast.Attribute(
-                        value=ast.Name(id="parser", ctx=ast.Load()),
-                        attr="add_argument",
-                        ctx=ast.Load(),
-                    ),
-                    args=[ast.Constant("--project-file-path")],
-                    keywords=[
-                        ast.keyword(arg="default", value=ast.Constant(None)),
-                        ast.keyword(
-                            arg="help",
-                            value=ast.Constant("Path to a project file to load for the workflow execution"),
-                        ),
-                    ],
-                )
-            )
-        )
-
-        # Add json input argument
+        # Add json input argument (workflow-file concern, not executor concern)
         add_arg_calls.append(
             ast.Expr(
                 value=ast.Call(
@@ -3198,33 +3120,6 @@ class WorkflowManager:
                             arg="help",
                             value=ast.Constant(
                                 "JSON string containing parameter values. Takes precedence over individual parameter arguments if provided."
-                            ),
-                        ),
-                    ],
-                )
-            )
-        )
-
-        # Add save-on-failure argument
-        add_arg_calls.append(
-            ast.Expr(
-                value=ast.Call(
-                    func=ast.Attribute(
-                        value=ast.Name(id="parser", ctx=ast.Load()),
-                        attr="add_argument",
-                        ctx=ast.Load(),
-                    ),
-                    args=[ast.Constant("--save-on-failure")],
-                    keywords=[
-                        ast.keyword(arg="nargs", value=ast.Constant("?")),
-                        ast.keyword(arg="const", value=ast.Constant("")),
-                        ast.keyword(arg="default", value=ast.Constant(None)),
-                        ast.keyword(
-                            arg="help",
-                            value=ast.Constant(
-                                "On failure, save the current workflow state as a .py file. "
-                                "With no value: uses the project 'save_failed_workflow' situation. "
-                                "With a value: absolute or project-relative path."
                             ),
                         ),
                     ],
@@ -3410,6 +3305,27 @@ class WorkflowManager:
             orelse=[],
         )
 
+        # Construct the default executor in __main__ via LocalWorkflowExecutor.from_cli_args,
+        # passing skip_library_loading and workflows_to_register as constructor overrides
+        # since they are not exposed on the CLI surface.
+        executor_assign_main = ast.Assign(
+            targets=[ast.Name(id="executor", ctx=ast.Store())],
+            value=ast.Call(
+                func=ast.Attribute(
+                    value=ast.Name(id="LocalWorkflowExecutor", ctx=ast.Load()),
+                    attr="from_cli_args",
+                    ctx=ast.Load(),
+                ),
+                args=[ast.Name(id="args", ctx=ast.Load())],
+                keywords=[
+                    ast.keyword(arg="skip_library_loading", value=ast.Constant(value=True)),
+                    ast.keyword(
+                        arg="workflows_to_register",
+                        value=ast.List(elts=[ast.Name(id="__file__", ctx=ast.Load())], ctx=ast.Load()),
+                    ),
+                ],
+            ),
+        )
         workflow_output = ast.Assign(
             targets=[ast.Name(id="workflow_output", ctx=ast.Store())],
             value=ast.Call(
@@ -3417,29 +3333,10 @@ class WorkflowManager:
                 args=[],
                 keywords=[
                     ast.keyword(arg="input", value=ast.Name(id="flow_input", ctx=ast.Load())),
+                    ast.keyword(arg="workflow_executor", value=ast.Name(id="executor", ctx=ast.Load())),
                     ast.keyword(
-                        arg="storage_backend",
-                        value=ast.Attribute(
-                            value=ast.Name(id="args", ctx=ast.Load()),
-                            attr="storage_backend",
-                            ctx=ast.Load(),
-                        ),
-                    ),
-                    ast.keyword(
-                        arg="project_file_path",
-                        value=ast.Attribute(
-                            value=ast.Name(id="args", ctx=ast.Load()),
-                            attr="project_file_path",
-                            ctx=ast.Load(),
-                        ),
-                    ),
-                    ast.keyword(
-                        arg="save_on_failure_path",
-                        value=ast.Attribute(
-                            value=ast.Name(id="args", ctx=ast.Load()),
-                            attr="save_on_failure",
-                            ctx=ast.Load(),
-                        ),
+                        arg="pickle_control_flow_result",
+                        value=ast.Name(id="_PICKLE_CONTROL_FLOW_RESULT", ctx=ast.Load()),
                     ),
                 ],
             ),
@@ -3486,6 +3383,7 @@ class WorkflowManager:
                 flow_input_init,
                 json_input_if,
                 individual_args_else,
+                executor_assign_main,
                 workflow_output,
                 print_output,
             ],

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -2888,31 +2888,26 @@ class WorkflowManager:
         # Generate the ensure flow context function call
         ensure_context_call = self._generate_ensure_flow_context_call()
 
-        # Pop `pickle_control_flow_result` out of `**kwargs` so it doesn't get splatted
-        # into the executor constructor (which doesn't accept it). It's an `arun`-only
-        # kwarg. Default value falls back to the save-time `_PICKLE_CONTROL_FLOW_RESULT`
-        # module-level constant.
-        pickle_pop_stmt = ast.Assign(
-            targets=[ast.Name(id="pickle_control_flow_result", ctx=ast.Store())],
+        # Construct a default LocalWorkflowExecutor only when the caller did not supply one.
+        # Inside the `if`, seed `kwargs["pickle_control_flow_result"]` with the save-time
+        # default via `setdefault` so direct importers who don't pass it explicitly inherit
+        # the publisher's choice. `**kwargs` is then splatted into the constructor; a typo'd
+        # kwarg surfaces as a TypeError from LocalWorkflowExecutor.__init__.
+        # TODO: https://github.com/griptape-ai/griptape-nodes/issues/3771 Update for workflows that call other workflows - need to include referenced workflows in the list
+        pickle_setdefault_stmt = ast.Expr(
             value=ast.Call(
                 func=ast.Attribute(
                     value=ast.Name(id="kwargs", ctx=ast.Load()),
-                    attr="pop",
+                    attr="setdefault",
                     ctx=ast.Load(),
                 ),
                 args=[
                     ast.Constant(value="pickle_control_flow_result"),
-                    ast.Name(id="_PICKLE_CONTROL_FLOW_RESULT", ctx=ast.Load()),
+                    ast.Constant(value=pickle_control_flow_result),
                 ],
                 keywords=[],
-            ),
+            )
         )
-
-        # Construct a default LocalWorkflowExecutor only when the caller did not supply one.
-        # `**kwargs` is passed straight through to the constructor; if the caller passed a
-        # typo'd executor kwarg, LocalWorkflowExecutor.__init__ will raise TypeError, which
-        # is the loud failure we want for direct importers.
-        # TODO: https://github.com/griptape-ai/griptape-nodes/issues/3771 Update for workflows that call other workflows - need to include referenced workflows in the list
         executor_assign = ast.If(
             test=ast.Compare(
                 left=ast.Name(id="workflow_executor", ctx=ast.Load()),
@@ -2920,6 +2915,7 @@ class WorkflowManager:
                 comparators=[ast.Constant(value=None)],
             ),
             body=[
+                pickle_setdefault_stmt,
                 ast.Assign(
                     targets=[ast.Name(id="workflow_executor", ctx=ast.Store())],
                     value=ast.Call(
@@ -2934,13 +2930,13 @@ class WorkflowManager:
                             ast.keyword(arg=None, value=ast.Name(id="kwargs", ctx=ast.Load())),
                         ],
                     ),
-                )
+                ),
             ],
             orelse=[],
         )
-        # Use async context manager for workflow execution. `pickle_control_flow_result` was
-        # popped out of `**kwargs` above; pass it explicitly. Any remaining `**kwargs` flow
-        # through to `arun` so additional executor-specific options aren't dropped.
+        # Use async context manager for workflow execution. Any leftover `**kwargs` flow
+        # through to `arun` (e.g. `pickle_control_flow_result` if the caller wants to
+        # override the executor's instance default for this run only).
         with_stmt = ast.AsyncWith(
             items=[
                 ast.withitem(
@@ -2960,10 +2956,6 @@ class WorkflowManager:
                             args=[],
                             keywords=[
                                 ast.keyword(arg="flow_input", value=ast.Name(id="input", ctx=ast.Load())),
-                                ast.keyword(
-                                    arg="pickle_control_flow_result",
-                                    value=ast.Name(id="pickle_control_flow_result", ctx=ast.Load()),
-                                ),
                                 ast.keyword(arg=None, value=ast.Name(id="kwargs", ctx=ast.Load())),
                             ],
                         )
@@ -2999,7 +2991,6 @@ class WorkflowManager:
             body=[
                 await_main_call,
                 ensure_context_call,
-                pickle_pop_stmt,
                 executor_assign,
                 with_stmt,
                 return_stmt,
@@ -3046,23 +3037,14 @@ class WorkflowManager:
         ast.fix_missing_locations(sync_func_def)
 
         # === 2) build the `if __name__ == "__main__":` block ===
-        if_node = self._generate_main_block(workflow_shape)
+        if_node = self._generate_main_block(workflow_shape, pickle_control_flow_result=pickle_control_flow_result)
 
         # Generate the ensure flow context function
         ensure_context_func = self._generate_ensure_flow_context_function(import_recorder)
 
-        # Module-level constant for the save-time `pickle_control_flow_result` value.
-        # Emitted as `_PICKLE_CONTROL_FLOW_RESULT = <bool>` near the top of the execution
-        # block so both `aexecute_workflow` and `__main__` can reference it.
-        pickle_constant = ast.Assign(
-            targets=[ast.Name(id="_PICKLE_CONTROL_FLOW_RESULT", ctx=ast.Store())],
-            value=ast.Constant(value=pickle_control_flow_result),
-        )
-        ast.fix_missing_locations(pickle_constant)
+        return [ensure_context_func, sync_func_def, async_func_def, if_node]
 
-        return [pickle_constant, ensure_context_func, sync_func_def, async_func_def, if_node]
-
-    def _generate_main_block(self, workflow_shape: dict) -> ast.If:
+    def _generate_main_block(self, workflow_shape: dict, *, pickle_control_flow_result: bool = False) -> ast.If:
         """Generates the `if __name__ == '__main__':` block for the serialized workflow file."""
         main_test = ast.Compare(
             left=ast.Name(id="__name__", ctx=ast.Load()),
@@ -3099,7 +3081,12 @@ class WorkflowManager:
                         ctx=ast.Load(),
                     ),
                     args=[ast.Name(id="parser", ctx=ast.Load())],
-                    keywords=[],
+                    keywords=[
+                        ast.keyword(
+                            arg="pickle_control_flow_result_default",
+                            value=ast.Constant(value=pickle_control_flow_result),
+                        ),
+                    ],
                 )
             )
         )
@@ -3334,10 +3321,6 @@ class WorkflowManager:
                 keywords=[
                     ast.keyword(arg="input", value=ast.Name(id="flow_input", ctx=ast.Load())),
                     ast.keyword(arg="workflow_executor", value=ast.Name(id="executor", ctx=ast.Load())),
-                    ast.keyword(
-                        arg="pickle_control_flow_result",
-                        value=ast.Name(id="_PICKLE_CONTROL_FLOW_RESULT", ctx=ast.Load()),
-                    ),
                 ],
             ),
         )

--- a/src/griptape_nodes/version_compatibility/versions/v0_19_0/__init__.py
+++ b/src/griptape_nodes/version_compatibility/versions/v0_19_0/__init__.py
@@ -1,0 +1,1 @@
+"""Version 0.19.0 workflow compatibility checks."""

--- a/src/griptape_nodes/version_compatibility/versions/v0_19_0/executor_cli_extraction.py
+++ b/src/griptape_nodes/version_compatibility/versions/v0_19_0/executor_cli_extraction.py
@@ -1,0 +1,60 @@
+"""Schema compatibility check for workflows that pre-date executor CLI extraction."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import semver
+
+from griptape_nodes.retained_mode.events.workflow_events import WorkflowStatus
+from griptape_nodes.retained_mode.managers.fitness_problems.workflows.workflow_schema_version_problem import (
+    WorkflowSchemaVersionProblem,
+)
+from griptape_nodes.retained_mode.managers.version_compatibility_manager import (
+    WorkflowVersionCompatibilityCheck,
+    WorkflowVersionCompatibilityIssue,
+)
+
+if TYPE_CHECKING:
+    from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
+
+
+class ExecutorCliExtraction(WorkflowVersionCompatibilityCheck):
+    """Check for workflow schema version compatibility due to executor CLI extraction.
+
+    Schema 0.19.0 moves executor-level CLI argument declarations off the generated
+    workflow file's __main__ block and onto the WorkflowExecutor classes themselves.
+    Workflows saved on earlier schemas still embed the old argparse boilerplate and
+    won't pick up new executor-level flags until they are re-saved.
+    """
+
+    def applies_to_workflow(self, workflow_metadata: WorkflowMetadata) -> bool:
+        try:
+            workflow_version = semver.VersionInfo.parse(workflow_metadata.schema_version)
+            return workflow_version < semver.VersionInfo(0, 19, 0)
+        except Exception:
+            return False
+
+    def check_workflow(self, workflow_metadata: WorkflowMetadata) -> list[WorkflowVersionCompatibilityIssue]:
+        issues = []
+
+        try:
+            workflow_schema_version = semver.VersionInfo.parse(workflow_metadata.schema_version)
+        except Exception:
+            return issues
+
+        if workflow_schema_version < semver.VersionInfo(0, 19, 0):
+            issues.append(
+                WorkflowVersionCompatibilityIssue(
+                    problem=WorkflowSchemaVersionProblem(
+                        description=(
+                            f"Schema version {workflow_metadata.schema_version} older than 0.19.0. "
+                            "Executor-level CLI arguments are now owned by WorkflowExecutor classes; "
+                            "re-save to delegate to the new entry point."
+                        )
+                    ),
+                    severity=WorkflowStatus.FLAWED,
+                )
+            )
+
+        return issues

--- a/tests/unit/bootstrap/workflow_executors/test_local_session_workflow_executor.py
+++ b/tests/unit/bootstrap/workflow_executors/test_local_session_workflow_executor.py
@@ -1,8 +1,7 @@
 """Unit tests for LocalSessionWorkflowExecutor's CLI surface (issue #4599)."""
 
 from argparse import ArgumentParser
-
-import pytest  # type: ignore[reportMissingImports]
+from pathlib import Path
 
 from griptape_nodes.bootstrap.workflow_executors.local_session_workflow_executor import (
     LocalSessionWorkflowExecutor,
@@ -45,16 +44,13 @@ class TestLocalSessionWorkflowExecutorCli:
 
         assert args.session_id is None
 
-    def test_add_cli_arguments_omits_project_file_path(self) -> None:
-        # LocalSessionWorkflowExecutor.__init__ does not accept project_file_path,
-        # so the CLI surface must not expose it (otherwise from_cli_args would have
-        # to special-case dropping it). The override deliberately composes the
-        # smaller `_add_*_argument` helpers instead of calling super().
+    def test_add_cli_arguments_includes_project_file_path(self) -> None:
         parser = ArgumentParser()
         LocalSessionWorkflowExecutor.add_cli_arguments(parser)
 
-        with pytest.raises(SystemExit):
-            parser.parse_args(["--project-file-path", "/some/project.yaml"])
+        args = parser.parse_args(["--project-file-path", "/some/project.yaml"])
+
+        assert args.project_file_path == "/some/project.yaml"
 
     def test_cli_constructor_kwargs_includes_session_id(self) -> None:
         parser = ArgumentParser()
@@ -65,16 +61,14 @@ class TestLocalSessionWorkflowExecutorCli:
 
         assert kwargs["session_id"] == "abc-123"
 
-    def test_cli_constructor_kwargs_drops_project_file_path(self) -> None:
-        # Even though super()._cli_constructor_kwargs sets project_file_path,
-        # the override pops it because __init__ would TypeError on it.
+    def test_cli_constructor_kwargs_project_file_path_converted_to_path(self) -> None:
         parser = ArgumentParser()
         LocalSessionWorkflowExecutor.add_cli_arguments(parser)
-        args = parser.parse_args([])
+        args = parser.parse_args(["--project-file-path", "/some/project.yaml"])
 
         kwargs = LocalSessionWorkflowExecutor._cli_constructor_kwargs(args)
 
-        assert "project_file_path" not in kwargs
+        assert kwargs["project_file_path"] == Path("/some/project.yaml")
 
     def test_cli_constructor_kwargs_storage_backend_converted_to_enum(self) -> None:
         parser = ArgumentParser()

--- a/tests/unit/bootstrap/workflow_executors/test_local_session_workflow_executor.py
+++ b/tests/unit/bootstrap/workflow_executors/test_local_session_workflow_executor.py
@@ -1,0 +1,86 @@
+"""Unit tests for LocalSessionWorkflowExecutor's CLI surface (issue #4599)."""
+
+from argparse import ArgumentParser
+
+import pytest  # type: ignore[reportMissingImports]
+
+from griptape_nodes.bootstrap.workflow_executors.local_session_workflow_executor import (
+    LocalSessionWorkflowExecutor,
+)
+from griptape_nodes.drivers.storage import StorageBackend
+
+
+class TestLocalSessionWorkflowExecutorCli:
+    """Tests for LocalSessionWorkflowExecutor's CLI surface."""
+
+    def test_add_cli_arguments_includes_storage_backend(self) -> None:
+        parser = ArgumentParser()
+        LocalSessionWorkflowExecutor.add_cli_arguments(parser)
+
+        args = parser.parse_args([])
+
+        assert args.storage_backend == StorageBackend.LOCAL.value
+
+    def test_add_cli_arguments_includes_save_on_failure(self) -> None:
+        parser = ArgumentParser()
+        LocalSessionWorkflowExecutor.add_cli_arguments(parser)
+
+        args = parser.parse_args(["--save-on-failure", "/var/dump.py"])
+
+        assert args.save_on_failure == "/var/dump.py"
+
+    def test_add_cli_arguments_includes_session_id(self) -> None:
+        parser = ArgumentParser()
+        LocalSessionWorkflowExecutor.add_cli_arguments(parser)
+
+        args = parser.parse_args(["--session-id", "abc-123"])
+
+        assert args.session_id == "abc-123"
+
+    def test_add_cli_arguments_session_id_defaults_to_none(self) -> None:
+        parser = ArgumentParser()
+        LocalSessionWorkflowExecutor.add_cli_arguments(parser)
+
+        args = parser.parse_args([])
+
+        assert args.session_id is None
+
+    def test_add_cli_arguments_omits_project_file_path(self) -> None:
+        # LocalSessionWorkflowExecutor.__init__ does not accept project_file_path,
+        # so the CLI surface must not expose it (otherwise from_cli_args would have
+        # to special-case dropping it). The override deliberately composes the
+        # smaller `_add_*_argument` helpers instead of calling super().
+        parser = ArgumentParser()
+        LocalSessionWorkflowExecutor.add_cli_arguments(parser)
+
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--project-file-path", "/some/project.yaml"])
+
+    def test_cli_constructor_kwargs_includes_session_id(self) -> None:
+        parser = ArgumentParser()
+        LocalSessionWorkflowExecutor.add_cli_arguments(parser)
+        args = parser.parse_args(["--session-id", "abc-123"])
+
+        kwargs = LocalSessionWorkflowExecutor._cli_constructor_kwargs(args)
+
+        assert kwargs["session_id"] == "abc-123"
+
+    def test_cli_constructor_kwargs_drops_project_file_path(self) -> None:
+        # Even though super()._cli_constructor_kwargs sets project_file_path,
+        # the override pops it because __init__ would TypeError on it.
+        parser = ArgumentParser()
+        LocalSessionWorkflowExecutor.add_cli_arguments(parser)
+        args = parser.parse_args([])
+
+        kwargs = LocalSessionWorkflowExecutor._cli_constructor_kwargs(args)
+
+        assert "project_file_path" not in kwargs
+
+    def test_cli_constructor_kwargs_storage_backend_converted_to_enum(self) -> None:
+        parser = ArgumentParser()
+        LocalSessionWorkflowExecutor.add_cli_arguments(parser)
+        args = parser.parse_args(["--storage-backend", StorageBackend.GTC.value])
+
+        kwargs = LocalSessionWorkflowExecutor._cli_constructor_kwargs(args)
+
+        assert kwargs["storage_backend"] == StorageBackend.GTC

--- a/tests/unit/bootstrap/workflow_executors/test_local_workflow_executor.py
+++ b/tests/unit/bootstrap/workflow_executors/test_local_workflow_executor.py
@@ -189,3 +189,23 @@ class TestLocalWorkflowExecutorCli:
         kwargs = LocalWorkflowExecutor._cli_constructor_kwargs(args)
 
         assert kwargs["project_file_path"] == Path("/some/project.yaml")
+
+    def test_cli_constructor_kwargs_pickle_inherits_argparse_default(self) -> None:
+        # When `add_cli_arguments` was seeded with the save-time default, that
+        # value flows through `_cli_constructor_kwargs` into the constructor.
+        parser = ArgumentParser()
+        LocalWorkflowExecutor.add_cli_arguments(parser, pickle_control_flow_result_default=True)
+        args = parser.parse_args([])
+
+        kwargs = LocalWorkflowExecutor._cli_constructor_kwargs(args)
+
+        assert kwargs["pickle_control_flow_result"] is True
+
+    def test_cli_constructor_kwargs_pickle_flag_overrides_seeded_default(self) -> None:
+        parser = ArgumentParser()
+        LocalWorkflowExecutor.add_cli_arguments(parser, pickle_control_flow_result_default=False)
+        args = parser.parse_args(["--pickle-control-flow-result"])
+
+        kwargs = LocalWorkflowExecutor._cli_constructor_kwargs(args)
+
+        assert kwargs["pickle_control_flow_result"] is True

--- a/tests/unit/bootstrap/workflow_executors/test_local_workflow_executor.py
+++ b/tests/unit/bootstrap/workflow_executors/test_local_workflow_executor.py
@@ -1,5 +1,6 @@
 """Unit tests for LocalWorkflowExecutor._load_project."""
 
+from argparse import ArgumentParser
 from pathlib import Path, PureWindowsPath
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -9,6 +10,7 @@ from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import 
     LocalExecutorError,
     LocalWorkflowExecutor,
 )
+from griptape_nodes.drivers.storage import StorageBackend
 from griptape_nodes.retained_mode.events.project_events import (
     LoadProjectTemplateResultSuccess,
     SetCurrentProjectResultSuccess,
@@ -100,3 +102,90 @@ class TestLoadProject:
 
         # Verify both requests were made
         assert mock_gn.ahandle_request.call_count == EXPECTED_REQUEST_COUNT
+
+
+class TestLocalWorkflowExecutorCli:
+    """Tests for LocalWorkflowExecutor's CLI surface (issue #4599)."""
+
+    def test_add_cli_arguments_includes_base_flags(self) -> None:
+        parser = ArgumentParser()
+        LocalWorkflowExecutor.add_cli_arguments(parser)
+
+        args = parser.parse_args([])
+
+        # Base-class flags carry through.
+        assert args.storage_backend == StorageBackend.LOCAL.value
+        assert args.project_file_path is None
+
+    def test_save_on_failure_absent_is_none(self) -> None:
+        parser = ArgumentParser()
+        LocalWorkflowExecutor.add_cli_arguments(parser)
+
+        args = parser.parse_args([])
+
+        assert args.save_on_failure is None
+
+    def test_save_on_failure_bare_flag_is_empty_string(self) -> None:
+        # `--save-on-failure` with no value should hit the `const=""` default,
+        # which downstream treats as "use the project's save_failed_workflow situation".
+        parser = ArgumentParser()
+        LocalWorkflowExecutor.add_cli_arguments(parser)
+
+        args = parser.parse_args(["--save-on-failure"])
+
+        assert args.save_on_failure == ""
+
+    def test_save_on_failure_with_value(self) -> None:
+        parser = ArgumentParser()
+        LocalWorkflowExecutor.add_cli_arguments(parser)
+
+        args = parser.parse_args(["--save-on-failure", "/var/dump.py"])
+
+        assert args.save_on_failure == "/var/dump.py"
+
+    def test_cli_constructor_kwargs_maps_save_on_failure_to_save_on_failure_path(self) -> None:
+        # Inspect the constructor kwargs derived from CLI args directly, since the
+        # constructor itself reaches into ConfigManager which is awkward to set up here.
+        parser = ArgumentParser()
+        LocalWorkflowExecutor.add_cli_arguments(parser)
+        args = parser.parse_args(["--save-on-failure", "/var/dump.py"])
+
+        kwargs = LocalWorkflowExecutor._cli_constructor_kwargs(args)
+
+        assert kwargs["save_on_failure_path"] == "/var/dump.py"
+
+    def test_cli_constructor_kwargs_storage_backend_default_is_local_enum(self) -> None:
+        parser = ArgumentParser()
+        LocalWorkflowExecutor.add_cli_arguments(parser)
+        args = parser.parse_args([])
+
+        kwargs = LocalWorkflowExecutor._cli_constructor_kwargs(args)
+
+        assert kwargs["storage_backend"] == StorageBackend.LOCAL
+
+    def test_cli_constructor_kwargs_with_gtc_storage_backend(self) -> None:
+        parser = ArgumentParser()
+        LocalWorkflowExecutor.add_cli_arguments(parser)
+        args = parser.parse_args(["--storage-backend", StorageBackend.GTC.value])
+
+        kwargs = LocalWorkflowExecutor._cli_constructor_kwargs(args)
+
+        assert kwargs["storage_backend"] == StorageBackend.GTC
+
+    def test_cli_constructor_kwargs_project_file_path_is_none_when_omitted(self) -> None:
+        parser = ArgumentParser()
+        LocalWorkflowExecutor.add_cli_arguments(parser)
+        args = parser.parse_args([])
+
+        kwargs = LocalWorkflowExecutor._cli_constructor_kwargs(args)
+
+        assert kwargs["project_file_path"] is None
+
+    def test_cli_constructor_kwargs_project_file_path_converted_to_path(self) -> None:
+        parser = ArgumentParser()
+        LocalWorkflowExecutor.add_cli_arguments(parser)
+        args = parser.parse_args(["--project-file-path", "/some/project.yaml"])
+
+        kwargs = LocalWorkflowExecutor._cli_constructor_kwargs(args)
+
+        assert kwargs["project_file_path"] == Path("/some/project.yaml")

--- a/tests/unit/bootstrap/workflow_executors/test_workflow_executor.py
+++ b/tests/unit/bootstrap/workflow_executors/test_workflow_executor.py
@@ -189,9 +189,10 @@ class _CliOnlyExecutor(WorkflowExecutor):
         storage_backend: StorageBackend = StorageBackend.LOCAL,
         *,
         project_file_path: Path | None = None,
+        pickle_control_flow_result: bool = False,
         marker: str | None = None,
     ) -> None:
-        super().__init__()
+        super().__init__(pickle_control_flow_result=pickle_control_flow_result)
         self.storage_backend = storage_backend
         self.project_file_path = project_file_path
         self.marker = marker
@@ -304,3 +305,39 @@ class TestWorkflowExecutorCli:
 
         with pytest.raises(TypeError):
             _CliOnlyExecutor.from_cli_args(args, not_a_real_kwarg=True)
+
+    def test_add_cli_arguments_pickle_default_is_false_when_unspecified(self) -> None:
+        parser = ArgumentParser()
+        WorkflowExecutor.add_cli_arguments(parser)
+
+        args = parser.parse_args([])
+
+        assert args.pickle_control_flow_result is False
+
+    def test_add_cli_arguments_pickle_default_can_be_overridden(self) -> None:
+        # Generated workflow files pass the save-time choice via this kwarg so
+        # `python my_workflow.py` (with no flag) inherits the publisher's setting.
+        parser = ArgumentParser()
+        WorkflowExecutor.add_cli_arguments(parser, pickle_control_flow_result_default=True)
+
+        args = parser.parse_args([])
+
+        assert args.pickle_control_flow_result is True
+
+    def test_add_cli_arguments_pickle_flag_flips_to_true(self) -> None:
+        # `--pickle-control-flow-result` always wins over the seeded default.
+        parser = ArgumentParser()
+        WorkflowExecutor.add_cli_arguments(parser, pickle_control_flow_result_default=False)
+
+        args = parser.parse_args(["--pickle-control-flow-result"])
+
+        assert args.pickle_control_flow_result is True
+
+    def test_from_cli_args_passes_pickle_to_constructor(self) -> None:
+        parser = ArgumentParser()
+        _CliOnlyExecutor.add_cli_arguments(parser, pickle_control_flow_result_default=True)
+        args = parser.parse_args([])
+
+        executor = _CliOnlyExecutor.from_cli_args(args)
+
+        assert executor._pickle_control_flow_result is True

--- a/tests/unit/bootstrap/workflow_executors/test_workflow_executor.py
+++ b/tests/unit/bootstrap/workflow_executors/test_workflow_executor.py
@@ -1,5 +1,7 @@
 """Unit tests for WorkflowExecutor class."""
 
+from argparse import ArgumentParser
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -173,3 +175,132 @@ class TestWorkflowExecutorIntegration:
         # Verify execution completed
         assert result is None  # run method returns None
         assert executor.output == {"sync_result": "success"}
+
+
+class _CliOnlyExecutor(WorkflowExecutor):
+    """Concrete executor whose constructor mirrors the base CLI surface.
+
+    Lets us exercise `add_cli_arguments` / `from_cli_args` without pulling in
+    the full LocalWorkflowExecutor machinery.
+    """
+
+    def __init__(
+        self,
+        storage_backend: StorageBackend = StorageBackend.LOCAL,
+        *,
+        project_file_path: Path | None = None,
+        marker: str | None = None,
+    ) -> None:
+        super().__init__()
+        self.storage_backend = storage_backend
+        self.project_file_path = project_file_path
+        self.marker = marker
+
+    async def arun(
+        self,
+        flow_input: Any,  # noqa: ARG002
+        storage_backend: StorageBackend = StorageBackend.LOCAL,  # noqa: ARG002
+        **kwargs: Any,  # noqa: ARG002
+    ) -> None:
+        return None
+
+
+class TestWorkflowExecutorCli:
+    """Tests for the executor-level CLI surface introduced for issue #4599."""
+
+    def test_add_cli_arguments_registers_storage_backend_with_default_local(self) -> None:
+        parser = ArgumentParser()
+        WorkflowExecutor.add_cli_arguments(parser)
+
+        args = parser.parse_args([])
+
+        assert args.storage_backend == StorageBackend.LOCAL.value
+
+    def test_add_cli_arguments_storage_backend_accepts_gtc(self) -> None:
+        parser = ArgumentParser()
+        WorkflowExecutor.add_cli_arguments(parser)
+
+        args = parser.parse_args(["--storage-backend", StorageBackend.GTC.value])
+
+        assert args.storage_backend == StorageBackend.GTC.value
+
+    def test_add_cli_arguments_storage_backend_rejects_unknown_choice(self) -> None:
+        parser = ArgumentParser()
+        WorkflowExecutor.add_cli_arguments(parser)
+
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--storage-backend", "not-a-backend"])
+
+    def test_add_cli_arguments_project_file_path_defaults_to_none(self) -> None:
+        parser = ArgumentParser()
+        WorkflowExecutor.add_cli_arguments(parser)
+
+        args = parser.parse_args([])
+
+        assert args.project_file_path is None
+
+    def test_add_cli_arguments_project_file_path_accepts_value(self) -> None:
+        parser = ArgumentParser()
+        WorkflowExecutor.add_cli_arguments(parser)
+
+        args = parser.parse_args(["--project-file-path", "/some/project.yaml"])
+
+        assert args.project_file_path == "/some/project.yaml"
+
+    def test_from_cli_args_converts_storage_backend_string_to_enum(self) -> None:
+        parser = ArgumentParser()
+        _CliOnlyExecutor.add_cli_arguments(parser)
+        args = parser.parse_args(["--storage-backend", StorageBackend.GTC.value])
+
+        executor = _CliOnlyExecutor.from_cli_args(args)
+
+        assert executor.storage_backend == StorageBackend.GTC
+
+    def test_from_cli_args_converts_project_file_path_string_to_path(self) -> None:
+        parser = ArgumentParser()
+        _CliOnlyExecutor.add_cli_arguments(parser)
+        args = parser.parse_args(["--project-file-path", "/some/project.yaml"])
+
+        executor = _CliOnlyExecutor.from_cli_args(args)
+
+        assert executor.project_file_path == Path("/some/project.yaml")
+
+    def test_from_cli_args_leaves_project_file_path_as_none_when_omitted(self) -> None:
+        parser = ArgumentParser()
+        _CliOnlyExecutor.add_cli_arguments(parser)
+        args = parser.parse_args([])
+
+        executor = _CliOnlyExecutor.from_cli_args(args)
+
+        assert executor.project_file_path is None
+
+    def test_from_cli_args_applies_overrides_for_non_cli_kwargs(self) -> None:
+        parser = ArgumentParser()
+        _CliOnlyExecutor.add_cli_arguments(parser)
+        args = parser.parse_args([])
+
+        executor = _CliOnlyExecutor.from_cli_args(args, marker="custom")
+
+        assert executor.marker == "custom"
+
+    def test_from_cli_args_overrides_take_precedence_over_cli_values(self) -> None:
+        parser = ArgumentParser()
+        _CliOnlyExecutor.add_cli_arguments(parser)
+        args = parser.parse_args(["--storage-backend", StorageBackend.GTC.value])
+
+        executor = _CliOnlyExecutor.from_cli_args(args, storage_backend=StorageBackend.LOCAL)
+
+        assert executor.storage_backend == StorageBackend.LOCAL
+
+    def test_from_cli_args_raises_type_error_on_unknown_override(self) -> None:
+        """Loud failure for typo'd kwargs is the documented behavior.
+
+        Direct importers get a TypeError rather than a silent no-op when they
+        pass a bogus kwarg.
+        """
+        parser = ArgumentParser()
+        _CliOnlyExecutor.add_cli_arguments(parser)
+        args = parser.parse_args([])
+
+        with pytest.raises(TypeError):
+            _CliOnlyExecutor.from_cli_args(args, not_a_real_kwarg=True)

--- a/tests/unit/version_compatibility/test_executor_cli_extraction.py
+++ b/tests/unit/version_compatibility/test_executor_cli_extraction.py
@@ -1,0 +1,84 @@
+"""Tests for the v0.19.0 ExecutorCliExtraction workflow compatibility check."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from griptape_nodes.retained_mode.events.workflow_events import WorkflowStatus
+from griptape_nodes.retained_mode.managers.fitness_problems.workflows.workflow_schema_version_problem import (
+    WorkflowSchemaVersionProblem,
+)
+from griptape_nodes.version_compatibility.versions.v0_19_0.executor_cli_extraction import (
+    ExecutorCliExtraction,
+)
+
+
+def _make_metadata(schema_version: str) -> MagicMock:
+    metadata = MagicMock()
+    metadata.schema_version = schema_version
+    return metadata
+
+
+class TestExecutorCliExtractionAppliesToWorkflow:
+    """Tests for ExecutorCliExtraction.applies_to_workflow."""
+
+    @pytest.fixture
+    def check(self) -> ExecutorCliExtraction:
+        return ExecutorCliExtraction()
+
+    def test_applies_to_pre_0_19_workflow(self, check: ExecutorCliExtraction) -> None:
+        assert check.applies_to_workflow(_make_metadata("0.18.0")) is True
+
+    def test_applies_to_much_older_workflow(self, check: ExecutorCliExtraction) -> None:
+        assert check.applies_to_workflow(_make_metadata("0.14.0")) is True
+
+    def test_does_not_apply_to_0_19_0_workflow(self, check: ExecutorCliExtraction) -> None:
+        # Boundary condition: exactly the migration version, no migration needed.
+        assert check.applies_to_workflow(_make_metadata("0.19.0")) is False
+
+    def test_does_not_apply_to_post_0_19_workflow(self, check: ExecutorCliExtraction) -> None:
+        assert check.applies_to_workflow(_make_metadata("0.20.0")) is False
+
+    def test_does_not_apply_to_unparsable_version(self, check: ExecutorCliExtraction) -> None:
+        # Defensive default: treat unparsable as out-of-scope rather than crashing.
+        assert check.applies_to_workflow(_make_metadata("not-a-semver")) is False
+
+
+class TestExecutorCliExtractionCheckWorkflow:
+    """Tests for ExecutorCliExtraction.check_workflow."""
+
+    @pytest.fixture
+    def check(self) -> ExecutorCliExtraction:
+        return ExecutorCliExtraction()
+
+    def test_emits_flawed_issue_for_pre_0_19_workflow(self, check: ExecutorCliExtraction) -> None:
+        issues = check.check_workflow(_make_metadata("0.18.0"))
+
+        assert len(issues) == 1
+        assert issues[0].severity == WorkflowStatus.FLAWED
+        assert isinstance(issues[0].problem, WorkflowSchemaVersionProblem)
+
+    def test_problem_description_references_schema_version(self, check: ExecutorCliExtraction) -> None:
+        issues = check.check_workflow(_make_metadata("0.17.0"))
+
+        assert len(issues) == 1
+        problem = issues[0].problem
+        assert isinstance(problem, WorkflowSchemaVersionProblem)
+        assert "0.17.0" in problem.description
+        assert "0.19.0" in problem.description
+
+    def test_no_issues_for_current_schema_version(self, check: ExecutorCliExtraction) -> None:
+        issues = check.check_workflow(_make_metadata("0.19.0"))
+
+        assert issues == []
+
+    def test_no_issues_for_post_0_19_workflow(self, check: ExecutorCliExtraction) -> None:
+        issues = check.check_workflow(_make_metadata("0.20.0"))
+
+        assert issues == []
+
+    def test_no_issues_for_unparsable_version(self, check: ExecutorCliExtraction) -> None:
+        # Mirrors applies_to_workflow's defensive default — no issues, no crash.
+        issues = check.check_workflow(_make_metadata("not-a-semver"))
+
+        assert issues == []


### PR DESCRIPTION
Closes #4599.

## Summary

- Generated workflow files no longer hardcode executor-level argparse boilerplate. `WorkflowExecutor` now owns the CLI surface via `add_cli_arguments(parser)` and `from_cli_args(args, **overrides)` classmethods, and subclasses (`LocalWorkflowExecutor`, `LocalSessionWorkflowExecutor`) override to add their own flags (`--save-on-failure`, `--session-id`).
- `pickle_control_flow_result` is hoisted onto `WorkflowExecutor.__init__` and exposed as a `--pickle-control-flow-result` CLI flag. The save-time default is seeded into argparse via `LocalWorkflowExecutor.add_cli_arguments(parser, pickle_control_flow_result_default=...)`, so `python my_workflow.py` (with no flag) inherits the publisher's setting and the flag always wins when passed.
- The generated `__main__` block collapses to `LocalWorkflowExecutor.add_cli_arguments(parser, pickle_control_flow_result_default=...)` + `from_cli_args(args, ...)`. `aexecute_workflow` / `execute_workflow` keep their public surface — when `workflow_executor=None`, they construct a default `LocalWorkflowExecutor` from `**kwargs` (with the save-time pickle default applied via `kwargs.setdefault`).
- `LocalSessionWorkflowExecutor` now also accepts `--project-file-path` (it was previously omitted via a workaround in `_cli_constructor_kwargs`); its `add_cli_arguments` cleanly defers to `super()` instead of composing helpers.
- `subprocess_script.py` reuses the same contract via `LocalSessionWorkflowExecutor.add_cli_arguments` / `from_cli_args`, removing duplicated argparse setup.
- Schema bumps 0.18 → 0.19 with a `v0_19_0/ExecutorCliExtraction` compatibility check that flags pre-0.19 workflows for one-final re-save. After this lands, future executor-flag additions don't need a schema bump.

## Workflow Diff

Old Workflow Format:

```python
def execute_workflow(input: dict, storage_backend: str='local', project_file_path: str | None=None, save_on_failure_path: str | None=None, workflow_executor: WorkflowExecutor | None=None, pickle_control_flow_result: bool=False) -> dict | None:
    return asyncio.run(aexecute_workflow(input=input, storage_backend=storage_backend, project_file_path=project_file_path, save_on_failure_path=save_on_failure_path, workflow_executor=workflow_executor, pickle_control_flow_result=pickle_control_flow_result))

async def aexecute_workflow(input: dict, storage_backend: str='local', project_file_path: str | None=None, save_on_failure_path: str | None=None, workflow_executor: WorkflowExecutor | None=None, pickle_control_flow_result: bool=False) -> dict | None:
    await build_workflow()
    await _ensure_workflow_context()
    storage_backend_enum = StorageBackend(storage_backend)
    project_file_path_resolved = Path(project_file_path) if project_file_path is not None else None
    workflow_executor = workflow_executor or LocalWorkflowExecutor(storage_backend=storage_backend_enum, project_file_path=project_file_path_resolved, save_on_failure_path=save_on_failure_path, skip_library_loading=True, workflows_to_register=[__file__])
    async with workflow_executor as executor:
        await executor.arun(flow_input=input, pickle_control_flow_result=pickle_control_flow_result)
    return executor.output

if __name__ == '__main__':
    logging.basicConfig(level=logging.INFO)
    parser = argparse.ArgumentParser()
    parser.add_argument('--storage-backend', choices=['local', 'gtc'], default='local', help="Storage backend to use: 'local' for local filesystem or 'gtc' for Griptape Cloud")
    parser.add_argument('--project-file-path', default=None, help='Path to a project file to load for the workflow execution')
    parser.add_argument('--json-input', default=None, help='JSON string containing parameter values. Takes precedence over individual parameter arguments if provided.')
    parser.add_argument('--save-on-failure', nargs='?', const='', default=None, help="On failure, save the current workflow state as a .py file. With no value: uses the project 'save_failed_workflow' situation. With a value: absolute or project-relative path.")
    parser.add_argument('--exec_out', default=None, help='Connection to the next node in the execution chain')
    parser.add_argument('--prompt', default=None, help='New parameter')
    args = parser.parse_args()
    flow_input = {}
    if args.json_input is not None:
        flow_input = json.loads(args.json_input)
    if args.json_input is None:
        if 'Start Flow' not in flow_input:
            flow_input['Start Flow'] = {}
        if args.exec_out is not None:
            flow_input['Start Flow']['exec_out'] = args.exec_out
        if args.prompt is not None:
            flow_input['Start Flow']['prompt'] = args.prompt
    workflow_output = execute_workflow(input=flow_input, storage_backend=args.storage_backend, project_file_path=args.project_file_path, save_on_failure_path=args.save_on_failure)
    print(workflow_output)
```

New Workflow Format:

```python
def execute_workflow(input: dict, *, workflow_executor: WorkflowExecutor | None=None, **kwargs: Any) -> dict | None:
    return asyncio.run(aexecute_workflow(input=input, workflow_executor=workflow_executor, **kwargs))

async def aexecute_workflow(input: dict, *, workflow_executor: WorkflowExecutor | None=None, **kwargs: Any) -> dict | None:
    await build_workflow()
    await _ensure_workflow_context()
    if workflow_executor is None:
        kwargs.setdefault('pickle_control_flow_result', False)
        workflow_executor = LocalWorkflowExecutor(skip_library_loading=True, workflows_to_register=[__file__], **kwargs)
    async with workflow_executor as executor:
        await executor.arun(flow_input=input, **kwargs)
    return executor.output

if __name__ == '__main__':
    logging.basicConfig(level=logging.INFO)
    parser = argparse.ArgumentParser()
    LocalWorkflowExecutor.add_cli_arguments(parser, pickle_control_flow_result_default=False)
    parser.add_argument('--json-input', default=None, help='JSON string containing parameter values. Takes precedence over individual parameter arguments if provided.')
    parser.add_argument('--exec_out', default=None, help='Connection to the next node in the execution chain')
    parser.add_argument('--prompt', default=None, help='New parameter')
    args = parser.parse_args()
    flow_input = {}
    if args.json_input is not None:
        flow_input = json.loads(args.json_input)
    if args.json_input is None:
        if 'Start Flow' not in flow_input:
            flow_input['Start Flow'] = {}
        if args.exec_out is not None:
            flow_input['Start Flow']['exec_out'] = args.exec_out
        if args.prompt is not None:
            flow_input['Start Flow']['prompt'] = args.prompt
    executor = LocalWorkflowExecutor.from_cli_args(args, skip_library_loading=True, workflows_to_register=[__file__])
    workflow_output = execute_workflow(input=flow_input, workflow_executor=executor)
    print(workflow_output)
```

Help output:

```bash
$ python GriptapeNodes/headless_new.py --help
usage: headless_new.py [-h] [--storage-backend {local,gtc}]
                       [--project-file-path PROJECT_FILE_PATH]
                       [--pickle-control-flow-result]
                       [--save-on-failure [SAVE_ON_FAILURE]]
                       [--json-input JSON_INPUT] [--exec_out EXEC_OUT]
                       [--prompt PROMPT]

options:
  -h, --help            show this help message and exit
  --storage-backend {local,gtc}
                        Storage backend to use: 'local' for local filesystem
                        or 'gtc' for Griptape Cloud
  --project-file-path PROJECT_FILE_PATH
                        Path to a project file to load for the workflow
                        execution
  --pickle-control-flow-result
                        Pickle the control flow result (used by
                        subflow/private-execution callers)
  --save-on-failure [SAVE_ON_FAILURE]
                        On failure, save the current workflow state as a .py
                        file. With no value: uses the project
                        'save_failed_workflow' situation. With a value:
                        absolute or project-relative path.
  --json-input JSON_INPUT
                        JSON string containing parameter values. Takes
                        precedence over individual parameter arguments if
                        provided.
  --exec_out EXEC_OUT   Connection to the next node in the execution chain
  --prompt PROMPT       New parameter
```

## Test plan

- [x] \`uv run pytest tests/unit/bootstrap/workflow_executors/ tests/unit/version_compatibility/test_executor_cli_extraction.py\` — 62 passed (covers base CLI surface, Local + Session subclass overrides, pickle CLI flag + seeded default, v0.19 check)
- [x] \`make check\` — clean
- [x] Save a workflow in the editor and diff the generated \`__main__\` against an old file to confirm the shape matches the design
- [x] \`python <saved>.py --help\` lists \`--storage-backend\`, \`--project-file-path\`, \`--pickle-control-flow-result\`, \`--save-on-failure\`, \`--json-input\`, plus per-StartNode flags
- [x] Run \`python <saved>.py --storage-backend local --prompt "hello"\` end-to-end
- [x] Direct-import smoke: \`from <saved> import aexecute_workflow\` with (a) just \`input=...\`, (b) \`input=..., save_on_failure_path="..."\` (kwarg fallback), (c) \`input=..., workflow_executor=MyExecutor(...)\` (escape hatch)
- [x] Trigger via \`SubprocessWorkflowExecutor\` and confirm \`--save-on-failure\` / \`--storage-backend\` reach the subprocess
- [x] Load a pre-0.19 workflow and confirm the new check flags it; re-save and confirm the new file passes