### PR TITLE
Add node_types filter to ListNodesInFlowRequest

### DIFF
--- a/.agents/skills/griptape-nodes-workflows/SKILL.md
+++ b/.agents/skills/griptape-nodes-workflows/SKILL.md
@@ -400,6 +400,7 @@ flow keeps running in the engine until it finishes or errors. A subsequent
 | Lock or unlock a node                                           | `SetLockNodeStateRequest`                                                                                                                                 |
 | Reset a node's parameters to defaults                           | `ResetNodeToDefaultsRequest`                                                                                                                              |
 | Inspect state                                                   | `ListNodesInFlowRequest`, `ListConnectionsForNodeRequest`, `GetNodeResolutionStateRequest`, `GetNodeMetadataRequest`, `GetConnectionsForParameterRequest` |
+| Find nodes by Python class (e.g. StartFlow, Agent)              | `ListNodesInFlowRequest(node_types=["StartFlow", "Agent"])` — returns only nodes whose class name matches; omit to get all nodes |
 | Register a sandbox node type from Python source already on disk | `RegisterSandboxNodeFromSourceRequest` (see Custom nodes below)                                                                                           |
 | Reset everything                                                | `ClearAllObjectStateRequest(i_know_what_im_doing=True)`                                                                                                   |
 

--- a/docs/retained_mode.md
+++ b/docs/retained_mode.md
@@ -88,16 +88,17 @@ ______________________________________________________________________
 ### get_nodes_in_flow
 
 ```python
-cmd.get_nodes_in_flow(flow_name)
+cmd.get_nodes_in_flow(flow_name, node_types=None)
 ```
 
-Lists all nodes within a flow.
+Lists all nodes within a flow, with an optional filter by Python class name.
 
 #### Arguments
 
-| Name      | Argument Type | Required |
-| --------- | :-----------: | :------: |
-| flow_name |    string     |    🟢    |
+| Name       |    Argument Type     | Required |
+| ---------- | :------------------: | :------: |
+| flow_name  |        string        |    🟢    |
+| node_types | list[string] \| None |    🔴    |
 
 #### Return Value
 
@@ -105,7 +106,9 @@ ResultPayload object containing a list of node names
 
 #### Description
 
-Returns all nodes within the specified flow.
+Returns all nodes within the specified flow. When `node_types` is provided, only nodes whose
+Python class name matches one of the entries are returned (e.g. `["StartFlow", "Agent"]`).
+Omit `node_types` or pass `None` to return all nodes.
 
 ______________________________________________________________________
 

--- a/docs/skills/griptape-nodes-workflows/SKILL.md
+++ b/docs/skills/griptape-nodes-workflows/SKILL.md
@@ -400,6 +400,7 @@ flow keeps running in the engine until it finishes or errors. A subsequent
 | Lock or unlock a node                                           | `SetLockNodeStateRequest`                                                                                                                                 |
 | Reset a node's parameters to defaults                           | `ResetNodeToDefaultsRequest`                                                                                                                              |
 | Inspect state                                                   | `ListNodesInFlowRequest`, `ListConnectionsForNodeRequest`, `GetNodeResolutionStateRequest`, `GetNodeMetadataRequest`, `GetConnectionsForParameterRequest` |
+| Find nodes by Python class (e.g. StartFlow, Agent)              | `ListNodesInFlowRequest(node_types=["StartFlow", "Agent"])` — returns only nodes whose class name matches; omit to get all nodes                          |
 | Register a sandbox node type from Python source already on disk | `RegisterSandboxNodeFromSourceRequest` (see Custom nodes below)                                                                                           |
 | Reset everything                                                | `ClearAllObjectStateRequest(i_know_what_im_doing=True)`                                                                                                   |
 

--- a/src/griptape_nodes/retained_mode/events/flow_events.py
+++ b/src/griptape_nodes/retained_mode/events/flow_events.py
@@ -116,12 +116,15 @@ class ListNodesInFlowRequest(RequestPayload):
 
     Args:
         flow_name: Name of the flow to list nodes from (None for current context flow)
+        node_types: Optional list of Python class names to filter by (e.g. ["StartFlow", "Agent"]).
+            None returns all nodes.
 
     Results: ListNodesInFlowResultSuccess (with node names) | ListNodesInFlowResultFailure (flow not found)
     """
 
     # If None is passed, assumes we're using the flow in the Current Context.
     flow_name: str | None = None
+    node_types: list[str] | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -758,7 +758,11 @@ class FlowManager:
             result = ListNodesInFlowResultFailure(result_details=details)
             return result
 
-        ret_list = list(flow.nodes.keys())
+        if request.node_types is not None:
+            node_type_set = set(request.node_types)
+            ret_list = [name for name, node in flow.nodes.items() if type(node).__name__ in node_type_set]
+        else:
+            ret_list = list(flow.nodes.keys())
         details = f"Successfully got the list of Nodes within Flow '{flow_name}'."
 
         result = ListNodesInFlowResultSuccess(node_names=ret_list, result_details=details)

--- a/src/griptape_nodes/retained_mode/retained_mode.py
+++ b/src/griptape_nodes/retained_mode/retained_mode.py
@@ -229,11 +229,13 @@ class RetainedMode:
         return result
 
     @classmethod
-    def get_nodes_in_flow(cls, flow_name: str) -> ResultPayload:
+    def get_nodes_in_flow(cls, flow_name: str, node_types: list[str] | None = None) -> ResultPayload:
         """Lists all nodes contained within a specific flow.
 
         Args:
             flow_name (str): Name of the flow to inspect.
+            node_types (list[str] | None): Optional list of Python class names to filter by
+                (e.g. ["StartFlow", "Agent"]). None returns all nodes.
 
         Returns:
             ResultPayload: Contains a list of node names in the flow.
@@ -241,8 +243,11 @@ class RetainedMode:
         Example:
             # Get all nodes in a flow
             result = cmd.get_nodes_in_flow("my_flow")
+
+            # Get only Agent nodes
+            result = cmd.get_nodes_in_flow("my_flow", node_types=["Agent"])
         """
-        request = ListNodesInFlowRequest(flow_name=flow_name)
+        request = ListNodesInFlowRequest(flow_name=flow_name, node_types=node_types)
         result = GriptapeNodes().handle_request(request)
         return result
 

--- a/tests/unit/retained_mode/managers/test_flow_manager.py
+++ b/tests/unit/retained_mode/managers/test_flow_manager.py
@@ -390,6 +390,108 @@ class TestStartFlowCancelsOnWaitTimeout:
         cancel_mock.assert_not_called()
 
 
+class TestListNodesInFlowRequest:
+    """Tests for FlowManager.on_list_nodes_in_flow_request node_types filter."""
+
+    def _make_flow(self, nodes: dict) -> object:
+        from unittest.mock import MagicMock
+
+        fake_flow = MagicMock()
+        fake_flow.name = "test_flow"
+        fake_flow.nodes = nodes
+        return fake_flow
+
+    def _run_request(self, griptape_nodes: GriptapeNodes, flow: object, request: object) -> object:
+        from unittest.mock import patch
+
+        from griptape_nodes.retained_mode.managers.flow_manager import ControlFlow
+
+        flow_manager = griptape_nodes.FlowManager()
+        with patch.object(
+            griptape_nodes.ObjectManager(),
+            "attempt_get_object_by_name_as_type",
+            side_effect=lambda _name, typ: flow if typ is ControlFlow else None,
+        ):
+            return flow_manager.on_list_nodes_in_flow_request(request)  # type: ignore[arg-type]
+
+    def test_no_filter_returns_all_nodes(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.retained_mode.events.flow_events import ListNodesInFlowRequest, ListNodesInFlowResultSuccess
+
+        class NoteNode:
+            pass
+
+        flow = self._make_flow({"Note_1": NoteNode(), "Note_2": NoteNode()})
+        result = self._run_request(griptape_nodes, flow, ListNodesInFlowRequest(flow_name="test_flow"))
+
+        assert isinstance(result, ListNodesInFlowResultSuccess)
+        assert set(result.node_names) == {"Note_1", "Note_2"}
+
+    def test_filter_by_matching_class_name_returns_subset(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.retained_mode.events.flow_events import ListNodesInFlowRequest, ListNodesInFlowResultSuccess
+
+        class NoteNode:
+            pass
+
+        class AgentNode:
+            pass
+
+        flow = self._make_flow({"note_1": NoteNode(), "agent_1": AgentNode(), "note_2": NoteNode()})
+        result = self._run_request(
+            griptape_nodes, flow, ListNodesInFlowRequest(flow_name="test_flow", node_types=["NoteNode"])
+        )
+
+        assert isinstance(result, ListNodesInFlowResultSuccess)
+        assert set(result.node_names) == {"note_1", "note_2"}
+
+    def test_filter_by_nonexistent_class_name_returns_empty(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.retained_mode.events.flow_events import ListNodesInFlowRequest, ListNodesInFlowResultSuccess
+
+        class NoteNode:
+            pass
+
+        flow = self._make_flow({"note_1": NoteNode()})
+        result = self._run_request(
+            griptape_nodes, flow, ListNodesInFlowRequest(flow_name="test_flow", node_types=["NonExistentClass"])
+        )
+
+        assert isinstance(result, ListNodesInFlowResultSuccess)
+        assert result.node_names == []
+
+    def test_filter_with_empty_list_returns_empty(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.retained_mode.events.flow_events import ListNodesInFlowRequest, ListNodesInFlowResultSuccess
+
+        class NoteNode:
+            pass
+
+        flow = self._make_flow({"note_1": NoteNode()})
+        result = self._run_request(griptape_nodes, flow, ListNodesInFlowRequest(flow_name="test_flow", node_types=[]))
+
+        assert isinstance(result, ListNodesInFlowResultSuccess)
+        assert result.node_names == []
+
+    def test_filter_with_multiple_types_returns_union(self, griptape_nodes: GriptapeNodes) -> None:
+        from griptape_nodes.retained_mode.events.flow_events import ListNodesInFlowRequest, ListNodesInFlowResultSuccess
+
+        class NoteNode:
+            pass
+
+        class AgentNode:
+            pass
+
+        class OtherNode:
+            pass
+
+        flow = self._make_flow({"note_1": NoteNode(), "agent_1": AgentNode(), "other_1": OtherNode()})
+        result = self._run_request(
+            griptape_nodes,
+            flow,
+            ListNodesInFlowRequest(flow_name="test_flow", node_types=["NoteNode", "AgentNode"]),
+        )
+
+        assert isinstance(result, ListNodesInFlowResultSuccess)
+        assert set(result.node_names) == {"note_1", "agent_1"}
+
+
 class TestAutoLayoutFlowRequest:
     """Tests for FlowManager.on_auto_layout_flow_request."""
 


### PR DESCRIPTION
## Summary

- Adds optional `node_types: list[str] | None` field to `ListNodesInFlowRequest` — when provided, filters results to nodes whose Python class name matches (e.g. `["StartFlow", "Agent"]`); `None` returns all nodes (fully backward compatible)
- Updates `cmd.get_nodes_in_flow()` in `RetainedMode` to expose the same parameter
- Updates both copies of `SKILL.md` and `docs/retained_mode.md` to document the new filter
- Adds 5 unit tests covering: no filter, single-type filter, multi-type filter, unknown type, and empty list

Fixes #4661

## Test plan

- [ ] `make test/unit` passes (5 new tests in `TestListNodesInFlowRequest`)
- [ ] `make check` passes
- [ ] Manually verified in engine: `ListNodesInFlowRequest(flow_name="...", node_types=["StartFlow"])` returns only matching nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--4681.org.readthedocs.build/en/4681/

<!-- readthedocs-preview griptape-nodes end -->