### PR TITLE
Preview uniquness on same-path overwrites

### DIFF
--- a/src/griptape_nodes/files/file.py
+++ b/src/griptape_nodes/files/file.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import NamedTuple, Protocol, cast, runtime_checkable
 
 from griptape_nodes.common.macro_parser import MacroSyntaxError, ParsedMacro
+from griptape_nodes.files import write_tracker
 from griptape_nodes.retained_mode.events.os_events import (
     ExistingFilePolicy,
     FileIOFailureReason,
@@ -583,7 +584,9 @@ class File:
                 missing_variables=result.missing_variables,
             )
 
-        return Path(cast("WriteFileResultSuccess", result).final_file_path)
+        success = cast("WriteFileResultSuccess", result)
+        self._alias_macro_spelling(success)
+        return Path(success.final_file_path)
 
     async def _awrite_content(
         self,
@@ -628,7 +631,27 @@ class File:
                 missing_variables=result.missing_variables,
             )
 
-        return Path(cast("WriteFileResultSuccess", result).final_file_path)
+        success = cast("WriteFileResultSuccess", result)
+        self._alias_macro_spelling(success)
+        return Path(success.final_file_path)
+
+    def _alias_macro_spelling(self, success: WriteFileResultSuccess) -> None:
+        """Mirror the absolute-path write tracker entry under the macro spelling.
+
+        ``OSManager.on_write_file_request`` already records the post-write
+        mtime under ``final_file_path`` (the resolved absolute path) for every
+        write that flows through the engine. ``UrlArtifact.value`` may instead
+        carry the macro template the caller originally wrote to
+        (``self.location``, e.g. ``{outputs}/foo.png``); this alias mirrors
+        the same token under that spelling so the cattrs hook resolves either
+        form to the same cache token without I/O at serialize time.
+        ``ProjectFileDestination`` adds a third spelling via
+        ``write_tracker.alias`` after its post-write project mapping. No-op
+        when ``self.location`` already equals the absolute path.
+        """
+        location = self.location
+        if location and location != success.final_file_path:
+            write_tracker.alias(location, success.final_file_path)
 
     def _build_file_metadata(self) -> SidecarContent | None:
         """Build SidecarContent from MacroPath variables and caller-provided metadata.

--- a/src/griptape_nodes/files/project_file.py
+++ b/src/griptape_nodes/files/project_file.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from griptape_nodes.common.macro_parser import ParsedMacro
 from griptape_nodes.common.project_templates.situation import SituationFilePolicy
+from griptape_nodes.files import write_tracker
 from griptape_nodes.files.file import File, FileDestination
 from griptape_nodes.files.path_utils import FilenameParts
 from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
@@ -71,11 +72,17 @@ class ProjectFileDestination(FileDestination):
         portable reference via ``file.as_macro()``.  Falls back to the original
         File (absolute path) if mapping is not possible.
         """
+        absolute_path = result_file.resolve()
         map_result = GriptapeNodes.handle_request(
-            AttemptMapAbsolutePathToProjectRequest(absolute_path=Path(result_file.resolve()))
+            AttemptMapAbsolutePathToProjectRequest(absolute_path=Path(absolute_path))
         )
         if isinstance(map_result, AttemptMapAbsolutePathToProjectResultSuccess) and map_result.mapped_path is not None:
-            return File(map_result.mapped_path)
+            mapped_file = File(map_result.mapped_path)
+            # Mirror the write tracker entry under the macro spelling so artifacts
+            # holding the portable form (e.g. {outputs}/foo.png) resolve to the
+            # same cache token recorded under the absolute path.
+            write_tracker.alias(mapped_file.location, absolute_path)
+            return mapped_file
         return result_file
 
     @classmethod

--- a/src/griptape_nodes/files/write_tracker.py
+++ b/src/griptape_nodes/files/write_tracker.py
@@ -26,7 +26,7 @@ import threading
 from collections import OrderedDict
 from datetime import UTC, datetime
 
-MAX_ENTRIES = 8192
+MAX_ENTRIES = 1024
 
 _cache: OrderedDict[str, str] = OrderedDict()
 _lock = threading.Lock()

--- a/src/griptape_nodes/files/write_tracker.py
+++ b/src/griptape_nodes/files/write_tracker.py
@@ -1,0 +1,77 @@
+"""In-memory registry of recent file writes, keyed by the artifact-facing path string.
+
+The artifact pipeline emits ``UrlArtifact(value=<path>)`` whenever a node saves
+output. The frontend keys its preview-cache invalidation on
+``meta.created_at`` (see ``hooks/useConvertFileUrl.ts``), so when a node
+overwrites a file at the same path the editor must see a fresh ``created_at``
+or its presigned URL stays cached and the preview never re-fetches.
+
+``OSManager.on_write_file_request`` records the post-write mtime under the
+resolved absolute path. Downstream layers (``File``, ``ProjectFileDestination``,
+``StaticFilesManager``) call ``alias`` to mirror that token under whatever
+spelling the artifact's ``.value`` will actually carry (macro template,
+project-mapped macro, signed download URL). The cattrs unstructure hook in
+``retained_mode.events.event_converter`` then stamps ``meta.created_at`` with
+a single in-memory dict lookup at serialization time -- no I/O, no macro
+resolution, no manager calls during serialize.
+
+Bounded LRU so a long-running engine doesn't accumulate every write forever.
+The cache only needs to outlive the round-trip from ``write_bytes`` to the
+ParameterValueUpdateEvent emit, typically well under a second.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import OrderedDict
+from datetime import UTC, datetime
+
+MAX_ENTRIES = 8192
+
+_cache: OrderedDict[str, str] = OrderedDict()
+_lock = threading.Lock()
+
+
+def record(key: str, mtime_ns: int) -> None:
+    """Record an mtime token for one spelling of a written path."""
+    token = datetime.fromtimestamp(mtime_ns / 1e9, tz=UTC).isoformat()
+    with _lock:
+        _set_locked(key, token)
+
+
+def alias(new_key: str, source_key: str) -> None:
+    """Copy the token recorded under ``source_key`` to ``new_key``.
+
+    Each write records under the resolved absolute path at the OSManager
+    chokepoint. Aliases cover the other spellings an artifact's ``.value``
+    may carry: the originating ``File.location`` macro template, the
+    ``ProjectFileDestination``-mapped portable form (``{outputs}/foo.png``),
+    and the signed download URL emitted by ``StaticFilesManager``. No-op if
+    ``source_key`` is unknown.
+    """
+    with _lock:
+        token = _cache.get(source_key)
+        if token is None:
+            return
+        _set_locked(new_key, token)
+
+
+def lookup(key: str) -> str | None:
+    """Return the recorded ISO8601 token for ``key`` or None."""
+    with _lock:
+        return _cache.get(key)
+
+
+def clear() -> None:
+    """Drop all entries. Test hook."""
+    with _lock:
+        _cache.clear()
+
+
+def _set_locked(key: str, token: str) -> None:
+    """Insert/refresh ``key`` and evict to ``MAX_ENTRIES``. Caller holds ``_lock``."""
+    if key in _cache:
+        _cache.move_to_end(key)
+    _cache[key] = token
+    while len(_cache) > MAX_ENTRIES:
+        _cache.popitem(last=False)

--- a/src/griptape_nodes/retained_mode/events/event_converter.py
+++ b/src/griptape_nodes/retained_mode/events/event_converter.py
@@ -10,12 +10,46 @@ from typing import Any, Union, get_args, get_origin
 from cattrs.gen import make_dict_structure_fn, make_dict_unstructure_fn, override
 from cattrs.preconf.json import make_converter
 from cattrs.strategies import use_class_methods
+from griptape.artifacts import UrlArtifact
 from griptape.mixins.serializable_mixin import SerializableMixin
 from pydantic import BaseModel
+
+from griptape_nodes.files import write_tracker
 
 logger = logging.getLogger(__name__)
 
 converter = make_converter()
+
+
+def _unstructure_serializable(obj: Any) -> dict[str, Any]:
+    """Unstructure a SerializableMixin, stamping freshly-written UrlArtifacts.
+
+    The frontend's preview cache invalidates on ``meta.created_at`` (see
+    ``griptape-vsl-gui/src/hooks/useConvertFileUrl.ts``). When a node
+    overwrites a file at the same path the artifact's ``.value`` is byte-
+    identical between writes, so without a fresh stamp the editor never
+    re-fetches the presigned URL and the preview stays frozen on the prior
+    content (issue #4663).
+
+    The write path records the post-write mtime in ``write_tracker`` under
+    every spelling the artifact value may take, so this hook does a single
+    in-memory dict lookup -- no I/O, no macro resolution, no manager calls.
+    """
+    data = obj.to_dict()
+    if not isinstance(obj, UrlArtifact) or not isinstance(obj.value, str):
+        return data
+
+    meta = data.get("meta") or {}
+    if meta.get("created_at"):
+        return data
+
+    token = write_tracker.lookup(obj.value)
+    if token is None:
+        return data
+
+    meta["created_at"] = token
+    data["meta"] = meta
+    return data
 
 
 # --- Unstructure hooks (serialization) ---
@@ -23,7 +57,7 @@ converter = make_converter()
 # SerializableMixin subclasses (BaseArtifact, BaseTool, Structure, etc.)
 converter.register_unstructure_hook_func(
     lambda cls: isinstance(cls, type) and issubclass(cls, SerializableMixin),
-    lambda obj: obj.to_dict(),
+    _unstructure_serializable,
 )
 
 # Pydantic BaseModel subclasses (WorkflowMetadata, WorkflowShape, etc.)

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import contextlib
 import ctypes
 import logging
 import mimetypes
@@ -23,6 +24,7 @@ from griptape_nodes.common.macro_parser.exceptions import MacroResolutionFailure
 from griptape_nodes.common.macro_parser.formats import NumericPaddingFormat
 from griptape_nodes.common.macro_parser.resolution import partial_resolve
 from griptape_nodes.common.macro_parser.segments import ParsedStaticValue, ParsedVariable
+from griptape_nodes.files import write_tracker
 from griptape_nodes.files.drivers.base64_file_driver import Base64FileDriver
 from griptape_nodes.files.drivers.data_uri_file_driver import DataUriFileDriver
 from griptape_nodes.files.drivers.griptape_cloud_file_driver import GriptapeCloudFileDriver
@@ -1973,6 +1975,17 @@ class OSManager:
         # Write sidecar metadata file if caller opted in by providing file_metadata
         if request.file_metadata is not None:
             write_sidecar(final_file_path, request.file_metadata)
+
+        # Record the post-write mtime under the resolved absolute path. The
+        # cattrs UrlArtifact unstructure hook reads this to stamp
+        # ``meta.created_at`` so the frontend preview cache invalidates on
+        # same-path overwrites (issue #4663). Recording at this universal
+        # chokepoint catches every engine-side write; callers that hand
+        # artifacts a different path spelling (macro template, signed URL)
+        # add aliases via ``write_tracker.alias``. ``stat()`` failures here
+        # are non-fatal -- the artifact pipeline simply skips stamping.
+        with contextlib.suppress(OSError):
+            write_tracker.record(str(final_file_path), Path(final_file_path).stat().st_mtime_ns)
 
         if used_indexed_fallback:
             msg = f"File written to indexed path: {final_file_path} (original path '{path_display}' already existed)"

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -12,6 +12,7 @@ from griptape_nodes.common.project_templates.situation import SituationFilePolic
 from griptape_nodes.drivers.storage import StorageBackend
 from griptape_nodes.drivers.storage.griptape_cloud_storage_driver import GriptapeCloudStorageDriver
 from griptape_nodes.drivers.storage.local_storage_driver import LocalStorageDriver
+from griptape_nodes.files import write_tracker
 from griptape_nodes.files.path_utils import FilenameParts
 from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
 from griptape_nodes.retained_mode.events.artifact_events import (
@@ -476,7 +477,14 @@ class StaticFilesManager:
             msg = f"Failed to save static file {file_name}: {e}"
             logger.error(msg)
             raise RuntimeError(msg) from e
-        return self.storage_driver.create_signed_download_url(Path(saved_path))
+        signed_url = self.storage_driver.create_signed_download_url(Path(saved_path))
+        # Callers (e.g. agent_manager, artifact_normalization) wrap this URL
+        # in an ImageUrlArtifact, so the artifact's ``.value`` is the URL --
+        # not the absolute path the OSManager recorded under. Alias them so
+        # the cattrs hook can stamp ``meta.created_at`` for same-path
+        # overwrites (issue #4663).
+        write_tracker.alias(signed_url, str(saved_path))
+        return signed_url
 
     def _resolve_static_file_path(
         self, file_name: str, situation_name: str = SAVE_STATIC_FILE_SITUATION

--- a/tests/unit/files/test_write_tracker.py
+++ b/tests/unit/files/test_write_tracker.py
@@ -1,0 +1,65 @@
+"""Tests for the in-memory write_tracker module used by the artifact-stamping pipeline."""
+
+import pytest
+
+from griptape_nodes.files import write_tracker
+
+
+class TestWriteTracker:
+    @pytest.fixture(autouse=True)
+    def _clear(self) -> None:
+        write_tracker.clear()
+
+    def test_record_then_lookup(self) -> None:
+        write_tracker.record("key-a", 1700000000000000000)
+        assert write_tracker.lookup("key-a") is not None
+
+    def test_lookup_missing_returns_none(self) -> None:
+        assert write_tracker.lookup("/nope") is None
+
+    def test_overwrite_replaces_token(self) -> None:
+        write_tracker.record("key-a", 1700000000000000000)
+        first = write_tracker.lookup("key-a")
+        write_tracker.record("key-a", 1700000001000000000)
+        second = write_tracker.lookup("key-a")
+        assert first != second
+
+    def test_alias_copies_token(self) -> None:
+        write_tracker.record("key-a", 1700000000000000000)
+        write_tracker.alias("key-mapped", "key-a")
+        assert write_tracker.lookup("key-mapped") == write_tracker.lookup("key-a")
+
+    def test_alias_unknown_source_is_noop(self) -> None:
+        write_tracker.alias("key-mapped", "/never-recorded")
+        assert write_tracker.lookup("key-mapped") is None
+
+    def test_lru_eviction_drops_oldest(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(write_tracker, "MAX_ENTRIES", 2)
+        write_tracker.record("a", 1)
+        write_tracker.record("b", 2)
+        write_tracker.record("c", 3)  # evicts "a"
+        assert write_tracker.lookup("a") is None
+        assert write_tracker.lookup("b") is not None
+        assert write_tracker.lookup("c") is not None
+
+    def test_record_refreshes_lru_position(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(write_tracker, "MAX_ENTRIES", 2)
+        write_tracker.record("a", 1)
+        write_tracker.record("b", 2)
+        # Re-recording "a" should make "b" the LRU candidate.
+        write_tracker.record("a", 10)
+        write_tracker.record("c", 3)
+        assert write_tracker.lookup("a") is not None
+        assert write_tracker.lookup("b") is None
+        assert write_tracker.lookup("c") is not None
+
+    def test_token_is_iso8601_utc(self) -> None:
+        write_tracker.record("/x", 1700000000000000000)
+        token = write_tracker.lookup("/x")
+        assert token is not None
+        assert token.endswith("+00:00")
+
+    def test_clear_drops_all_entries(self) -> None:
+        write_tracker.record("/x", 1)
+        write_tracker.clear()
+        assert write_tracker.lookup("/x") is None

--- a/tests/unit/retained_mode/events/test_event_converter.py
+++ b/tests/unit/retained_mode/events/test_event_converter.py
@@ -3,7 +3,9 @@
 from typing import Any
 
 import pytest
+from griptape.artifacts import ImageUrlArtifact, TextArtifact, UrlArtifact
 
+from griptape_nodes.files import write_tracker
 from griptape_nodes.retained_mode.events.base_events import EventRequest
 from griptape_nodes.retained_mode.events.event_converter import (
     _is_json_primitive_union,
@@ -145,3 +147,60 @@ class TestSetParameterValueRequestStructuring:
         assert event.request.value["type"] == "ImageUrlArtifact"
         expected_width = 3024
         assert event.request.value["width"] == expected_width
+
+
+class TestUrlArtifactMetaStamping:
+    """Tests for the cattrs UrlArtifact ``meta.created_at`` stamping pipeline.
+
+    The engine records each write's mtime into ``write_tracker``; the cattrs
+    unstructure hook reads it to refresh the frontend preview cache when a
+    node overwrites a file at the same path (issue #4663).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_tracker(self) -> None:
+        write_tracker.clear()
+
+    def test_local_path_with_recorded_write_gets_stamp(self) -> None:
+        write_tracker.record("/var/data/foo.png", 1700000000123456789)
+        out = converter.unstructure(ImageUrlArtifact("/var/data/foo.png"))
+        assert (out.get("meta") or {}).get("created_at")
+
+    def test_unwritten_path_not_stamped(self) -> None:
+        out = converter.unstructure(ImageUrlArtifact("/var/data/never-written.png"))
+        assert not (out.get("meta") or {}).get("created_at")
+
+    def test_remote_url_not_stamped(self) -> None:
+        # Remote URLs are never recorded, so even if a tracker entry exists for
+        # something else, a remote artifact must not receive a stamp.
+        write_tracker.record("/var/data/foo.png", 1700000000000000000)
+        out = converter.unstructure(ImageUrlArtifact("https://example.com/x.png"))
+        assert not (out.get("meta") or {}).get("created_at")
+
+    def test_existing_created_at_preserved(self) -> None:
+        write_tracker.record("/var/data/foo.png", 1700000000000000000)
+        existing = "2020-01-01T00:00:00+00:00"
+        out = converter.unstructure(ImageUrlArtifact("/var/data/foo.png", meta={"created_at": existing}))
+        assert out["meta"]["created_at"] == existing
+
+    def test_text_artifact_unaffected(self) -> None:
+        write_tracker.record("hello", 1700000000000000000)
+        out = converter.unstructure(TextArtifact("hello"))
+        assert not (out.get("meta") or {}).get("created_at")
+
+    def test_url_artifact_subclass_stamped(self) -> None:
+        # Surrogate for ThreeDUrlArtifact / GLTFUrlArtifact / SplatUrlArtifact:
+        # any UrlArtifact subclass must participate.
+        class _LocalUrl(UrlArtifact):
+            pass
+
+        write_tracker.record("/var/data/model.glb", 1700000000000000000)
+        out = converter.unstructure(_LocalUrl("/var/data/model.glb"))
+        assert (out.get("meta") or {}).get("created_at")
+
+    def test_overwrite_produces_distinct_token(self) -> None:
+        write_tracker.record("/var/data/foo.png", 1700000000000000000)
+        first = converter.unstructure(ImageUrlArtifact("/var/data/foo.png"))
+        write_tracker.record("/var/data/foo.png", 1700000000999999999)
+        second = converter.unstructure(ImageUrlArtifact("/var/data/foo.png"))
+        assert first["meta"]["created_at"] != second["meta"]["created_at"]


### PR DESCRIPTION
Closes https://github.com/griptape-ai/griptape-nodes/issues/4663

https://www.loom.com/share/b78b600e827045f5b2b1aab2d7cd57dc

When a node overwrites a file at the same path, the editor's preview stays frozen. The frontend's useConvertFileUrl keys cache invalidation on meta.created_at, but engine-emitted UrlArtifacts never set it so same-path overwrites produce a byte-identical artifact and the presigned URL stays cached. This change is kind of ugly but I didn't want to make a breaking change requiring library rewrites.

### Fix
A new in-memory write_tracker records each write's st_mtime_ns at the universal chokepoint (OSManager.on_write_file_request), keyed by absolute path. Downstream layers (File, ProjectFileDestination, StaticFilesManager) alias the same token under whatever spelling the artifact's .value actually carries (macro template, project-mapped macro, signed URL). The cattrs unstructure hook does a single dict lookup at serialize time and stamps meta.created_at.

### Why engine-only
The clean alternative of threading mtime directly into XxxUrlArtifact(saved.location, meta=...) constructors would require touching almost every node/library, and pushes a frontend caching detail onto every node author. The tracker keeps the fix in one PR, with no library changes, and any new or third-party node benefits automatically.

### Known gaps
GriptapeCloudStorageDriver.save_file uploads via HTTP and bypasses OSManager. Cloud URLs change per upload so that is fine.