### PR TITLE
Add gtn-editor://editor to domain allowlist

### DIFF
--- a/src/griptape_nodes/servers/static.py
+++ b/src/griptape_nodes/servers/static.py
@@ -288,6 +288,7 @@ def start_static_server(sock: socket.socket) -> None:
         "https://editor-nightly.nodes.griptape.ai",
         "http://localhost:5173",
         "http://localhost:5174",
+        "gtn-editor://editor",
         GriptapeNodes.StaticFilesManager().static_server_base_url,
     ]
 


### PR DESCRIPTION
Custom widgets are failing CORS in desktop app because they are now served via `gtn-editor://editor` which is not allowlisted