### PR TITLE
ci: dispatch downstream repo on engine release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,6 +51,39 @@ jobs:
       - name: uv Publish
         run: uv publish --token ${{ secrets.PYPI_TOKEN }}
 
+  notify-app-release:
+    # Fan out to griptape-nodes-app once the engine wheel is on PyPI so the
+    # app can re-pin and ship a matching release. The downstream receiver
+    # waits on the version becoming visible to `pip index`, but we wait here
+    # too so a same-second app job doesn't race the index update.
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve published version
+        id: ver
+        run: |
+          TAG="${{ inputs.tag || github.ref_name }}"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+      - name: Wait for griptape-nodes-engine ${{ steps.ver.outputs.version }} on PyPI
+        run: |
+          for i in $(seq 1 30); do
+            if pip index versions griptape-nodes-engine 2>/dev/null \
+                | grep -qE "\b${{ steps.ver.outputs.version }}\b"; then
+              echo "Visible on PyPI"; exit 0
+            fi
+            echo "Not visible yet (attempt $i); sleeping 30s"
+            sleep 30
+          done
+          echo "::error::griptape-nodes-engine ${{ steps.ver.outputs.version }} not visible on PyPI after 15 minutes"
+          exit 1
+      - name: Dispatch engine-released to griptape-nodes-app
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.RELEASE_PAT }}
+          repository: griptape-ai/griptape-nodes-app
+          event-type: engine-released
+          client-payload: '{"engine_version": "${{ steps.ver.outputs.version }}"}'
+
   push_cpu_image:
     needs: pre-publish-checks
     name: Push CPU Docker image


### PR DESCRIPTION
Today an engine release stops at PyPI and a maintainer hand-bumps the engine pin in `griptape-nodes-app`, hand-bumps the app version, and re-tags. After this lands, `publish.yml` fans out to `griptape-nodes-app` once the engine wheel is visible on PyPI, carrying the version in the dispatch payload so the app's receiver can re-pin and tag without intervention.

The dispatch waits on `pip index versions` because the registry can lag a minute or two behind `uv publish`; a same-second app job would otherwise resolve a stale index and fail. The dispatch uses `RELEASE_PAT` rather than `GITHUB_TOKEN` because tag pushes from `GITHUB_TOKEN` do not retrigger workflows, which would break the next leg of the chain.

This is the head of a four-repo chain. The downstream pieces live in PRs against `griptape-nodes-app`, `griptape-nodes-desktop`, and `griptape-vsl-gui` on the same `ci/release-fan-out` branch name. The chain is safe to land out of order: each leg only fires after the previous repo's `publish-pypi` (or editor npm publish) succeeds, and each receiver is no-ops when its target version is already current.

Closes #4687.
