### PR TITLE
perf(boot): silence internal ListRegisteredLibrariesRequest broadcasts

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -3066,7 +3066,7 @@ class LibraryManager:
         to sys.path so relative imports work when the workflow is loaded.
         """
         workflow_files: list[str] = []
-        library_result = await GriptapeNodes.ahandle_request(ListRegisteredLibrariesRequest())
+        library_result = await GriptapeNodes.ahandle_request(ListRegisteredLibrariesRequest(broadcast_result=False))
         if not isinstance(library_result, ListRegisteredLibrariesResultSuccess):
             return workflow_files
         for library_name in library_result.libraries:
@@ -3854,7 +3854,7 @@ class LibraryManager:
             return ReloadAllLibrariesResultFailure(result_details=details)
 
         # Unload all libraries now.
-        all_libraries_request = ListRegisteredLibrariesRequest()
+        all_libraries_request = ListRegisteredLibrariesRequest(broadcast_result=False)
         all_libraries_result = await GriptapeNodes.ahandle_request(all_libraries_request)
         if not isinstance(all_libraries_result, ListRegisteredLibrariesResultSuccess):
             details = "When preparing to reload all libraries, failed to get registered libraries."
@@ -4865,7 +4865,7 @@ class LibraryManager:
 
         # Phase 3: Check and update all registered libraries
         # Get all registered libraries
-        list_result = await GriptapeNodes.ahandle_request(ListRegisteredLibrariesRequest())
+        list_result = await GriptapeNodes.ahandle_request(ListRegisteredLibrariesRequest(broadcast_result=False))
         if not isinstance(list_result, ListRegisteredLibrariesResultSuccess):
             details = "Failed to list registered libraries for sync"
             return SyncLibrariesResultFailure(result_details=details)

--- a/src/griptape_nodes/retained_mode/managers/version_compatibility_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/version_compatibility_manager.py
@@ -269,7 +269,7 @@ class VersionCompatibilityManager:
         """
         issues: list[WorkflowVersionCompatibilityIssue] = []
 
-        list_result = await GriptapeNodes.ahandle_request(ListRegisteredLibrariesRequest())
+        list_result = await GriptapeNodes.ahandle_request(ListRegisteredLibrariesRequest(broadcast_result=False))
 
         if not isinstance(list_result, ListRegisteredLibrariesResultSuccess):
             return issues

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -1621,7 +1621,9 @@ class WorkflowManager:
             workflow_metadata.last_modified_date = WorkflowManager.EPOCH_START
             problems.append(MissingLastModifiedDateProblem(default_date=str(WorkflowManager.EPOCH_START)))
 
-        list_libraries_result = await GriptapeNodes.ahandle_request(ListRegisteredLibrariesRequest())
+        list_libraries_result = await GriptapeNodes.ahandle_request(
+            ListRegisteredLibrariesRequest(broadcast_result=False)
+        )
 
         if not isinstance(list_libraries_result, ListRegisteredLibrariesResultSuccess):
             registered_libraries = []


### PR DESCRIPTION
Closes #4700.

The five sites changed here are all engine-internal manager-to-manager calls; none of them have a caller waiting on the result, and `ListRegisteredLibrariesResultSuccess` is not in the GUI bridge's type-keyed subscriber set, so the broadcasts produced no observable effect beyond serialization and wire pressure. Profiling a clean boot shows the change drops `ListRegisteredLibrariesResultSuccess` frames from 337 to 4 (the 4 remaining are the GUI's own externally driven calls, which still broadcast). Total outbound boot frames in the first 20s drop from 625 to 340.