### PR TITLE
feature: add estimated size to search results and GetModelInfoRequest for exact size

### DIFF
--- a/src/griptape_nodes/retained_mode/events/model_events.py
+++ b/src/griptape_nodes/retained_mode/events/model_events.py
@@ -62,7 +62,6 @@ class ModelInfo:
     model_id: str
     local_path: str | None = None
     size_bytes: int | None = None
-    estimated_size_bytes: int | None = None
     author: str | None = None
     downloads: int | None = None
     likes: int | None = None

--- a/src/griptape_nodes/retained_mode/events/model_events.py
+++ b/src/griptape_nodes/retained_mode/events/model_events.py
@@ -62,6 +62,7 @@ class ModelInfo:
     model_id: str
     local_path: str | None = None
     size_bytes: int | None = None
+    estimated_size_bytes: int | None = None
     author: str | None = None
     downloads: int | None = None
     likes: int | None = None
@@ -294,3 +295,54 @@ class SearchModelsResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
 @PayloadRegistry.register
 class SearchModelsResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     """Model search failed. Common causes: network error, invalid parameters, API limits."""
+
+
+@dataclass
+@PayloadRegistry.register
+class GetModelInfoRequest(RequestPayload):
+    """Fetch detailed information for a specific model from Hugging Face Hub.
+
+    Use when: Retrieving exact storage size before downloading, inspecting model
+    metadata after selecting a model from search results.
+
+    Args:
+        model_id: Model identifier (e.g., "microsoft/phi-2")
+
+    Results: GetModelInfoResultSuccess (with size and metadata) | GetModelInfoResultFailure (model not found)
+    """
+
+    model_id: str = ""
+
+
+@dataclass
+@PayloadRegistry.register
+class GetModelInfoResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """Model info retrieved successfully.
+
+    Args:
+        model_id: The model identifier
+        size_bytes: Exact storage size on Hugging Face in bytes
+        safetensors_parameters: Parameter count by dtype (e.g. {"F16": 2779683840})
+        author: Model author or organization
+        task: Pipeline tag / task type
+        library: Library name (e.g. "transformers")
+        tags: List of tags
+        downloads: Total download count
+        likes: Total like count
+    """
+
+    model_id: str
+    size_bytes: int | None
+    safetensors_parameters: dict[str, int] | None
+    author: str | None
+    task: str | None
+    library: str | None
+    tags: list[str] | None
+    downloads: int | None
+    likes: int | None
+
+
+@dataclass
+@PayloadRegistry.register
+class GetModelInfoResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Model info retrieval failed. Common causes: invalid model ID, network error, authentication required."""

--- a/src/griptape_nodes/retained_mode/events/model_events.py
+++ b/src/griptape_nodes/retained_mode/events/model_events.py
@@ -311,7 +311,7 @@ class GetModelInfoRequest(RequestPayload):
     Results: GetModelInfoResultSuccess (with size and metadata) | GetModelInfoResultFailure (model not found)
     """
 
-    model_id: str = ""
+    model_id: str
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -680,6 +680,13 @@ class ModelManager:
         Returns:
             ResultPayload: Success with exact size and metadata, or failure with error details
         """
+        if get_token() is None:
+            error_msg = (
+                "No Hugging Face token found. Fetching info for gated models requires authentication. "
+                "Set your HF_TOKEN environment variable or log in with `huggingface-cli login`."
+            )
+            return GetModelInfoResultFailure(result_details=error_msg)
+
         try:
             info = await asyncio.to_thread(hf_model_info, request.model_id)
         except Exception as e:

--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -816,7 +816,7 @@ class ModelManager:
             "I16": 2,
             "I8": 1,
             "U8": 1,
-            "BOOL": 0.125,
+            "BOOL": 1,
         }
 
         total = 0

--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -751,8 +751,8 @@ class ModelManager:
         # Limit results (max 100 as per HF Hub API)
         limit = min(max(1, request.limit), 100)
 
-        # Perform the search, requesting safetensors metadata for size estimation
-        models_iterator = list_models(limit=limit, expand=["safetensors"], **search_params)
+        # Perform the search
+        models_iterator = list_models(limit=limit, **search_params)
 
         # Convert models to list and extract information
         models_list = []
@@ -770,7 +770,6 @@ class ModelManager:
                 task=getattr(model, "pipeline_tag", None),
                 library=getattr(model, "library_name", None),
                 tags=getattr(model, "tags", None),
-                estimated_size_bytes=self._estimate_size_from_safetensors(getattr(model, "safetensors", None)),
             )
             models_list.append(model_info)
 
@@ -791,40 +790,6 @@ class ModelManager:
             total_results=len(models_list),
             query_info=query_info,
         )
-
-    def _estimate_size_from_safetensors(self, safetensors_info: object | None) -> int | None:
-        """Estimate model download size in bytes from safetensors parameter metadata.
-
-        Uses parameter counts and dtype sizes as a rough approximation. The actual
-        download size may differ due to quantization, additional files, or metadata.
-        """
-        if safetensors_info is None:
-            return None
-
-        parameters = getattr(safetensors_info, "parameters", None)
-        if not parameters:
-            return None
-
-        # Bytes per parameter for common dtypes
-        dtype_bytes: dict[str, float] = {
-            "F64": 8,
-            "F32": 4,
-            "BF16": 2,
-            "F16": 2,
-            "I64": 8,
-            "I32": 4,
-            "I16": 2,
-            "I8": 1,
-            "U8": 1,
-            "BOOL": 1,
-        }
-
-        total = 0
-        for dtype, count in parameters.items():
-            bytes_per_param = dtype_bytes.get(dtype.upper(), 4)
-            total += int(count * bytes_per_param)
-
-        return total if total > 0 else None
 
     async def on_app_initialization_complete(self, _payload: AppInitializationComplete) -> None:
         """Handle app initialization complete event by downloading configured models and resuming unfinished downloads.

--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 from huggingface_hub import get_token, list_models, scan_cache_dir, snapshot_download
+from huggingface_hub import model_info as hf_model_info
 from huggingface_hub.utils.tqdm import tqdm
 from xdg_base_dirs import xdg_data_home
 
@@ -28,6 +29,9 @@ from griptape_nodes.retained_mode.events.model_events import (
     DownloadModelRequest,
     DownloadModelResultFailure,
     DownloadModelResultSuccess,
+    GetModelInfoRequest,
+    GetModelInfoResultFailure,
+    GetModelInfoResultSuccess,
     ListModelDownloadsRequest,
     ListModelDownloadsResultFailure,
     ListModelDownloadsResultSuccess,
@@ -234,6 +238,7 @@ class ModelManager:
             event_manager.assign_manager_to_request_type(ListModelsRequest, self.on_handle_list_models_request)
             event_manager.assign_manager_to_request_type(DeleteModelRequest, self.on_handle_delete_model_request)
             event_manager.assign_manager_to_request_type(SearchModelsRequest, self.on_handle_search_models_request)
+            event_manager.assign_manager_to_request_type(GetModelInfoRequest, self.on_handle_get_model_info_request)
             event_manager.assign_manager_to_request_type(
                 ListModelDownloadsRequest, self.on_handle_list_model_downloads_request
             )
@@ -666,6 +671,40 @@ class ModelManager:
                 result_details=result_details,
             )
 
+    async def on_handle_get_model_info_request(self, request: GetModelInfoRequest) -> ResultPayload:
+        """Fetch detailed info for a specific model from Hugging Face Hub.
+
+        Args:
+            request: The request containing the model_id to look up
+
+        Returns:
+            ResultPayload: Success with exact size and metadata, or failure with error details
+        """
+        try:
+            info = await asyncio.to_thread(hf_model_info, request.model_id)
+        except Exception as e:
+            error_msg = f"Attempted to get model info for '{request.model_id}'. Failed because: {e}"
+            return GetModelInfoResultFailure(
+                result_details=error_msg,
+                exception=e,
+            )
+
+        safetensors = getattr(info, "safetensors", None)
+        safetensors_parameters = dict(safetensors.parameters) if safetensors else None
+
+        return GetModelInfoResultSuccess(
+            model_id=request.model_id,
+            size_bytes=getattr(info, "used_storage", None),
+            safetensors_parameters=safetensors_parameters,
+            author=getattr(info, "author", None),
+            task=getattr(info, "pipeline_tag", None),
+            library=getattr(info, "library_name", None),
+            tags=getattr(info, "tags", None),
+            downloads=getattr(info, "downloads", None),
+            likes=getattr(info, "likes", None),
+            result_details=f"Retrieved info for '{request.model_id}'",
+        )
+
     def _search_models(self, request: SearchModelsRequest) -> SearchResultsData:
         """Synchronous model search implementation.
 
@@ -705,8 +744,8 @@ class ModelManager:
         # Limit results (max 100 as per HF Hub API)
         limit = min(max(1, request.limit), 100)
 
-        # Perform the search
-        models_iterator = list_models(limit=limit, **search_params)
+        # Perform the search, requesting safetensors metadata for size estimation
+        models_iterator = list_models(limit=limit, expand=["safetensors"], **search_params)
 
         # Convert models to list and extract information
         models_list = []
@@ -724,6 +763,7 @@ class ModelManager:
                 task=getattr(model, "pipeline_tag", None),
                 library=getattr(model, "library_name", None),
                 tags=getattr(model, "tags", None),
+                estimated_size_bytes=self._estimate_size_from_safetensors(getattr(model, "safetensors", None)),
             )
             models_list.append(model_info)
 
@@ -744,6 +784,40 @@ class ModelManager:
             total_results=len(models_list),
             query_info=query_info,
         )
+
+    def _estimate_size_from_safetensors(self, safetensors_info: object | None) -> int | None:
+        """Estimate model download size in bytes from safetensors parameter metadata.
+
+        Uses parameter counts and dtype sizes as a rough approximation. The actual
+        download size may differ due to quantization, additional files, or metadata.
+        """
+        if safetensors_info is None:
+            return None
+
+        parameters = getattr(safetensors_info, "parameters", None)
+        if not parameters:
+            return None
+
+        # Bytes per parameter for common dtypes
+        dtype_bytes: dict[str, float] = {
+            "F64": 8,
+            "F32": 4,
+            "BF16": 2,
+            "F16": 2,
+            "I64": 8,
+            "I32": 4,
+            "I16": 2,
+            "I8": 1,
+            "U8": 1,
+            "BOOL": 0.125,
+        }
+
+        total = 0
+        for dtype, count in parameters.items():
+            bytes_per_param = dtype_bytes.get(dtype.upper(), 4)
+            total += int(count * bytes_per_param)
+
+        return total if total > 0 else None
 
     async def on_app_initialization_complete(self, _payload: AppInitializationComplete) -> None:
         """Handle app initialization complete event by downloading configured models and resuming unfinished downloads.

--- a/tests/unit/retained_mode/managers/test_model_manager.py
+++ b/tests/unit/retained_mode/managers/test_model_manager.py
@@ -1,13 +1,12 @@
 """Tests for ModelManager methods added for model size support.
 
 Covers:
-- `_estimate_size_from_safetensors` — pure size estimation logic
 - `on_handle_get_model_info_request` — token guard and HF API delegation
-- `on_handle_search_models_request` — estimated_size_bytes propagation
+- `on_handle_search_models_request` — search result handling
 """
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -26,57 +25,6 @@ from griptape_nodes.retained_mode.managers.model_manager import ModelManager
 def model_manager() -> ModelManager:
     """Bare ModelManager without event wiring."""
     return ModelManager.__new__(ModelManager)
-
-
-# ---------------------------------------------------------------------------
-# _estimate_size_from_safetensors
-# ---------------------------------------------------------------------------
-
-
-class TestEstimateSizeFromSafetensors:
-    def _make_safetensors(self, parameters: dict) -> object:
-        return SimpleNamespace(parameters=parameters)
-
-    def test_returns_none_when_no_safetensors_info(self, model_manager: ModelManager) -> None:
-        assert model_manager._estimate_size_from_safetensors(None) is None
-
-    def test_returns_none_when_parameters_empty(self, model_manager: ModelManager) -> None:
-        info = self._make_safetensors({})
-        assert model_manager._estimate_size_from_safetensors(info) is None
-
-    def test_f16_two_bytes_per_param(self, model_manager: ModelManager) -> None:
-        info = self._make_safetensors({"F16": 1_000_000})
-        assert model_manager._estimate_size_from_safetensors(info) == 2_000_000
-
-    def test_f32_four_bytes_per_param(self, model_manager: ModelManager) -> None:
-        info = self._make_safetensors({"F32": 1_000_000})
-        assert model_manager._estimate_size_from_safetensors(info) == 4_000_000
-
-    def test_bf16_two_bytes_per_param(self, model_manager: ModelManager) -> None:
-        info = self._make_safetensors({"BF16": 1_000_000})
-        assert model_manager._estimate_size_from_safetensors(info) == 2_000_000
-
-    def test_i8_one_byte_per_param(self, model_manager: ModelManager) -> None:
-        info = self._make_safetensors({"I8": 1_000_000})
-        assert model_manager._estimate_size_from_safetensors(info) == 1_000_000
-
-    def test_bool_one_byte_per_element(self, model_manager: ModelManager) -> None:
-        # safetensors stores bools as uint8 (1 byte), not bitpacked
-        info = self._make_safetensors({"BOOL": 1_000_000})
-        assert model_manager._estimate_size_from_safetensors(info) == 1_000_000
-
-    def test_mixed_dtypes_summed(self, model_manager: ModelManager) -> None:
-        info = self._make_safetensors({"F32": 500_000, "F16": 500_000})
-        # 500k × 4 + 500k × 2 = 3_000_000
-        assert model_manager._estimate_size_from_safetensors(info) == 3_000_000
-
-    def test_unknown_dtype_defaults_to_four_bytes(self, model_manager: ModelManager) -> None:
-        info = self._make_safetensors({"EXOTIC": 1_000_000})
-        assert model_manager._estimate_size_from_safetensors(info) == 4_000_000
-
-    def test_dtype_matching_is_case_insensitive(self, model_manager: ModelManager) -> None:
-        info = self._make_safetensors({"f16": 1_000_000})
-        assert model_manager._estimate_size_from_safetensors(info) == 2_000_000
 
 
 # ---------------------------------------------------------------------------
@@ -147,9 +95,7 @@ class TestOnHandleGetModelInfoRequest:
                 side_effect=ValueError("model not found"),
             ),
         ):
-            result = await model_manager.on_handle_get_model_info_request(
-                GetModelInfoRequest(model_id="bad/model")
-            )
+            result = await model_manager.on_handle_get_model_info_request(GetModelInfoRequest(model_id="bad/model"))
 
         assert isinstance(result, GetModelInfoResultFailure)
         assert "bad/model" in str(result.result_details)
@@ -177,9 +123,7 @@ class TestOnHandleGetModelInfoRequest:
                 return_value=fake_info,
             ),
         ):
-            result = await model_manager.on_handle_get_model_info_request(
-                GetModelInfoRequest(model_id="some/model")
-            )
+            result = await model_manager.on_handle_get_model_info_request(GetModelInfoRequest(model_id="some/model"))
 
         assert isinstance(result, GetModelInfoResultSuccess)
         assert result.size_bytes is None
@@ -187,12 +131,12 @@ class TestOnHandleGetModelInfoRequest:
 
 
 # ---------------------------------------------------------------------------
-# on_handle_search_models_request — estimated_size_bytes propagation
+# on_handle_search_models_request
 # ---------------------------------------------------------------------------
 
 
-class TestOnHandleSearchModelsRequestEstimatedSize:
-    def _make_hf_model(self, model_id: str, safetensors=None) -> object:
+class TestOnHandleSearchModelsRequest:
+    def _make_hf_model(self, model_id: str) -> object:
         return SimpleNamespace(
             id=model_id,
             author=None,
@@ -203,54 +147,28 @@ class TestOnHandleSearchModelsRequestEstimatedSize:
             pipeline_tag=None,
             library_name=None,
             tags=None,
-            safetensors=safetensors,
         )
 
     @pytest.mark.asyncio
-    async def test_estimated_size_populated_when_safetensors_present(
-        self, model_manager: ModelManager
-    ) -> None:
-        safetensors = SimpleNamespace(parameters={"F16": 1_000_000})
-        fake_model = self._make_hf_model("org/model", safetensors=safetensors)
+    async def test_returns_success_with_model_list(self, model_manager: ModelManager) -> None:
+        fake_model = self._make_hf_model("org/model")
 
         with patch(
             "griptape_nodes.retained_mode.managers.model_manager.list_models",
             return_value=[fake_model],
         ):
-            result = await model_manager.on_handle_search_models_request(
-                SearchModelsRequest(query="model")
-            )
+            result = await model_manager.on_handle_search_models_request(SearchModelsRequest(query="model"))
 
         assert isinstance(result, SearchModelsResultSuccess)
-        assert result.models[0].estimated_size_bytes == 2_000_000  # 1M × 2 bytes (F16)
+        assert len(result.models) == 1
+        assert result.models[0].model_id == "org/model"
 
     @pytest.mark.asyncio
-    async def test_estimated_size_is_none_when_no_safetensors(
-        self, model_manager: ModelManager
-    ) -> None:
-        fake_model = self._make_hf_model("org/model", safetensors=None)
-
-        with patch(
-            "griptape_nodes.retained_mode.managers.model_manager.list_models",
-            return_value=[fake_model],
-        ):
-            result = await model_manager.on_handle_search_models_request(
-                SearchModelsRequest(query="model")
-            )
-
-        assert isinstance(result, SearchModelsResultSuccess)
-        assert result.models[0].estimated_size_bytes is None
-
-    @pytest.mark.asyncio
-    async def test_returns_failure_when_list_models_raises(
-        self, model_manager: ModelManager
-    ) -> None:
+    async def test_returns_failure_when_list_models_raises(self, model_manager: ModelManager) -> None:
         with patch(
             "griptape_nodes.retained_mode.managers.model_manager.list_models",
             side_effect=RuntimeError("network error"),
         ):
-            result = await model_manager.on_handle_search_models_request(
-                SearchModelsRequest(query="model")
-            )
+            result = await model_manager.on_handle_search_models_request(SearchModelsRequest(query="model"))
 
         assert isinstance(result, SearchModelsResultFailure)

--- a/tests/unit/retained_mode/managers/test_model_manager.py
+++ b/tests/unit/retained_mode/managers/test_model_manager.py
@@ -1,0 +1,256 @@
+"""Tests for ModelManager methods added for model size support.
+
+Covers:
+- `_estimate_size_from_safetensors` — pure size estimation logic
+- `on_handle_get_model_info_request` — token guard and HF API delegation
+- `on_handle_search_models_request` — estimated_size_bytes propagation
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from griptape_nodes.retained_mode.events.model_events import (
+    GetModelInfoRequest,
+    GetModelInfoResultFailure,
+    GetModelInfoResultSuccess,
+    SearchModelsRequest,
+    SearchModelsResultFailure,
+    SearchModelsResultSuccess,
+)
+from griptape_nodes.retained_mode.managers.model_manager import ModelManager
+
+
+@pytest.fixture
+def model_manager() -> ModelManager:
+    """Bare ModelManager without event wiring."""
+    return ModelManager.__new__(ModelManager)
+
+
+# ---------------------------------------------------------------------------
+# _estimate_size_from_safetensors
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateSizeFromSafetensors:
+    def _make_safetensors(self, parameters: dict) -> object:
+        return SimpleNamespace(parameters=parameters)
+
+    def test_returns_none_when_no_safetensors_info(self, model_manager: ModelManager) -> None:
+        assert model_manager._estimate_size_from_safetensors(None) is None
+
+    def test_returns_none_when_parameters_empty(self, model_manager: ModelManager) -> None:
+        info = self._make_safetensors({})
+        assert model_manager._estimate_size_from_safetensors(info) is None
+
+    def test_f16_two_bytes_per_param(self, model_manager: ModelManager) -> None:
+        info = self._make_safetensors({"F16": 1_000_000})
+        assert model_manager._estimate_size_from_safetensors(info) == 2_000_000
+
+    def test_f32_four_bytes_per_param(self, model_manager: ModelManager) -> None:
+        info = self._make_safetensors({"F32": 1_000_000})
+        assert model_manager._estimate_size_from_safetensors(info) == 4_000_000
+
+    def test_bf16_two_bytes_per_param(self, model_manager: ModelManager) -> None:
+        info = self._make_safetensors({"BF16": 1_000_000})
+        assert model_manager._estimate_size_from_safetensors(info) == 2_000_000
+
+    def test_i8_one_byte_per_param(self, model_manager: ModelManager) -> None:
+        info = self._make_safetensors({"I8": 1_000_000})
+        assert model_manager._estimate_size_from_safetensors(info) == 1_000_000
+
+    def test_bool_one_byte_per_element(self, model_manager: ModelManager) -> None:
+        # safetensors stores bools as uint8 (1 byte), not bitpacked
+        info = self._make_safetensors({"BOOL": 1_000_000})
+        assert model_manager._estimate_size_from_safetensors(info) == 1_000_000
+
+    def test_mixed_dtypes_summed(self, model_manager: ModelManager) -> None:
+        info = self._make_safetensors({"F32": 500_000, "F16": 500_000})
+        # 500k × 4 + 500k × 2 = 3_000_000
+        assert model_manager._estimate_size_from_safetensors(info) == 3_000_000
+
+    def test_unknown_dtype_defaults_to_four_bytes(self, model_manager: ModelManager) -> None:
+        info = self._make_safetensors({"EXOTIC": 1_000_000})
+        assert model_manager._estimate_size_from_safetensors(info) == 4_000_000
+
+    def test_dtype_matching_is_case_insensitive(self, model_manager: ModelManager) -> None:
+        info = self._make_safetensors({"f16": 1_000_000})
+        assert model_manager._estimate_size_from_safetensors(info) == 2_000_000
+
+
+# ---------------------------------------------------------------------------
+# on_handle_get_model_info_request
+# ---------------------------------------------------------------------------
+
+
+class TestOnHandleGetModelInfoRequest:
+    @pytest.mark.asyncio
+    async def test_returns_failure_when_no_hf_token(self, model_manager: ModelManager) -> None:
+        with patch(
+            "griptape_nodes.retained_mode.managers.model_manager.get_token",
+            return_value=None,
+        ):
+            result = await model_manager.on_handle_get_model_info_request(
+                GetModelInfoRequest(model_id="microsoft/phi-2")
+            )
+
+        assert isinstance(result, GetModelInfoResultFailure)
+        assert "No Hugging Face token found" in str(result.result_details)
+
+    @pytest.mark.asyncio
+    async def test_returns_success_with_size_and_metadata(self, model_manager: ModelManager) -> None:
+        fake_info = SimpleNamespace(
+            used_storage=11_125_567_216,
+            safetensors=SimpleNamespace(parameters={"F16": 2_779_683_840}),
+            author="microsoft",
+            pipeline_tag="text-generation",
+            library_name="transformers",
+            tags=["pytorch"],
+            downloads=123_456,
+            likes=789,
+        )
+
+        with (
+            patch(
+                "griptape_nodes.retained_mode.managers.model_manager.get_token",
+                return_value="hf_token",
+            ),
+            patch(
+                "griptape_nodes.retained_mode.managers.model_manager.hf_model_info",
+                return_value=fake_info,
+            ),
+        ):
+            result = await model_manager.on_handle_get_model_info_request(
+                GetModelInfoRequest(model_id="microsoft/phi-2")
+            )
+
+        assert isinstance(result, GetModelInfoResultSuccess)
+        assert result.model_id == "microsoft/phi-2"
+        assert result.size_bytes == 11_125_567_216
+        assert result.safetensors_parameters == {"F16": 2_779_683_840}
+        assert result.author == "microsoft"
+        assert result.task == "text-generation"
+        assert result.library == "transformers"
+        assert result.downloads == 123_456
+        assert result.likes == 789
+
+    @pytest.mark.asyncio
+    async def test_returns_failure_when_hf_api_raises(self, model_manager: ModelManager) -> None:
+        with (
+            patch(
+                "griptape_nodes.retained_mode.managers.model_manager.get_token",
+                return_value="hf_token",
+            ),
+            patch(
+                "griptape_nodes.retained_mode.managers.model_manager.hf_model_info",
+                side_effect=ValueError("model not found"),
+            ),
+        ):
+            result = await model_manager.on_handle_get_model_info_request(
+                GetModelInfoRequest(model_id="bad/model")
+            )
+
+        assert isinstance(result, GetModelInfoResultFailure)
+        assert "bad/model" in str(result.result_details)
+
+    @pytest.mark.asyncio
+    async def test_handles_missing_safetensors_gracefully(self, model_manager: ModelManager) -> None:
+        fake_info = SimpleNamespace(
+            used_storage=None,
+            safetensors=None,
+            author=None,
+            pipeline_tag=None,
+            library_name=None,
+            tags=None,
+            downloads=None,
+            likes=None,
+        )
+
+        with (
+            patch(
+                "griptape_nodes.retained_mode.managers.model_manager.get_token",
+                return_value="hf_token",
+            ),
+            patch(
+                "griptape_nodes.retained_mode.managers.model_manager.hf_model_info",
+                return_value=fake_info,
+            ),
+        ):
+            result = await model_manager.on_handle_get_model_info_request(
+                GetModelInfoRequest(model_id="some/model")
+            )
+
+        assert isinstance(result, GetModelInfoResultSuccess)
+        assert result.size_bytes is None
+        assert result.safetensors_parameters is None
+
+
+# ---------------------------------------------------------------------------
+# on_handle_search_models_request — estimated_size_bytes propagation
+# ---------------------------------------------------------------------------
+
+
+class TestOnHandleSearchModelsRequestEstimatedSize:
+    def _make_hf_model(self, model_id: str, safetensors=None) -> object:
+        return SimpleNamespace(
+            id=model_id,
+            author=None,
+            downloads=None,
+            likes=None,
+            created_at=None,
+            last_modified=None,
+            pipeline_tag=None,
+            library_name=None,
+            tags=None,
+            safetensors=safetensors,
+        )
+
+    @pytest.mark.asyncio
+    async def test_estimated_size_populated_when_safetensors_present(
+        self, model_manager: ModelManager
+    ) -> None:
+        safetensors = SimpleNamespace(parameters={"F16": 1_000_000})
+        fake_model = self._make_hf_model("org/model", safetensors=safetensors)
+
+        with patch(
+            "griptape_nodes.retained_mode.managers.model_manager.list_models",
+            return_value=[fake_model],
+        ):
+            result = await model_manager.on_handle_search_models_request(
+                SearchModelsRequest(query="model")
+            )
+
+        assert isinstance(result, SearchModelsResultSuccess)
+        assert result.models[0].estimated_size_bytes == 2_000_000  # 1M × 2 bytes (F16)
+
+    @pytest.mark.asyncio
+    async def test_estimated_size_is_none_when_no_safetensors(
+        self, model_manager: ModelManager
+    ) -> None:
+        fake_model = self._make_hf_model("org/model", safetensors=None)
+
+        with patch(
+            "griptape_nodes.retained_mode.managers.model_manager.list_models",
+            return_value=[fake_model],
+        ):
+            result = await model_manager.on_handle_search_models_request(
+                SearchModelsRequest(query="model")
+            )
+
+        assert isinstance(result, SearchModelsResultSuccess)
+        assert result.models[0].estimated_size_bytes is None
+
+    @pytest.mark.asyncio
+    async def test_returns_failure_when_list_models_raises(
+        self, model_manager: ModelManager
+    ) -> None:
+        with patch(
+            "griptape_nodes.retained_mode.managers.model_manager.list_models",
+            side_effect=RuntimeError("network error"),
+        ):
+            result = await model_manager.on_handle_search_models_request(
+                SearchModelsRequest(query="model")
+            )
+
+        assert isinstance(result, SearchModelsResultFailure)

--- a/tests/unit/retained_mode/managers/test_model_manager.py
+++ b/tests/unit/retained_mode/managers/test_model_manager.py
@@ -48,15 +48,18 @@ class TestOnHandleGetModelInfoRequest:
 
     @pytest.mark.asyncio
     async def test_returns_success_with_size_and_metadata(self, model_manager: ModelManager) -> None:
+        expected_size = 11_125_567_216
+        expected_downloads = 123_456
+        expected_likes = 789
         fake_info = SimpleNamespace(
-            used_storage=11_125_567_216,
+            used_storage=expected_size,
             safetensors=SimpleNamespace(parameters={"F16": 2_779_683_840}),
             author="microsoft",
             pipeline_tag="text-generation",
             library_name="transformers",
             tags=["pytorch"],
-            downloads=123_456,
-            likes=789,
+            downloads=expected_downloads,
+            likes=expected_likes,
         )
 
         with (
@@ -75,13 +78,13 @@ class TestOnHandleGetModelInfoRequest:
 
         assert isinstance(result, GetModelInfoResultSuccess)
         assert result.model_id == "microsoft/phi-2"
-        assert result.size_bytes == 11_125_567_216
+        assert result.size_bytes == expected_size
         assert result.safetensors_parameters == {"F16": 2_779_683_840}
         assert result.author == "microsoft"
         assert result.task == "text-generation"
         assert result.library == "transformers"
-        assert result.downloads == 123_456
-        assert result.likes == 789
+        assert result.downloads == expected_downloads
+        assert result.likes == expected_likes
 
     @pytest.mark.asyncio
     async def test_returns_failure_when_hf_api_raises(self, model_manager: ModelManager) -> None:


### PR DESCRIPTION
Fixes https://github.com/griptape-ai/griptape-nodes/issues/4644

## Summary

- New `GetModelInfoRequest(model_id)` fetches detailed info for a specific model via `hf_model_info()`, returning the exact `size_bytes` (HuggingFace `used_storage`) along with author, task, library, tags, downloads, and likes.

## Recommended frontend flow

1. **Pre-download detail panel** — call `GetModelInfoRequest` after the user selects a model; show exact `size_bytes` (e.g. "11.1 GB") before they confirm the download.

## Test plan

- [ ] Run `GetModelInfoRequest` for a known model (e.g. `microsoft/phi-2`) and verify `size_bytes` matches the value shown on the HuggingFace model page
- [ ] Run `GetModelInfoRequest` for an invalid model ID and verify a `GetModelInfoResultFailure` is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)