### PR TITLE
Feat/sequence events

### DIFF
--- a/docs/projects/sequences.md
+++ b/docs/projects/sequences.md
@@ -104,8 +104,19 @@ Sequence handling is built on [`fileseq`](https://github.com/justinfx/fileseq), 
 
 Scans are dispatched on the engine's event bus, not by importing a function. Send a `ScanSequencesRequest` (defined in `griptape_nodes.retained_mode.events.os_events`) and `await GriptapeNodes.ahandle_request(...)`; the handler runs the directory listing and fileseq parsing in a worker thread, so a long-running scan over a deep directory doesn't block the event loop.
 
-Success returns `ScanSequencesResultSuccess` carrying `sequences: list[Sequence]` and a `has_entries: bool` convenience flag (true iff at least one sequence has at least one entry). A scan that ran cleanly but found nothing is *success with `has_entries=False`*, not failure — callers that need to fail-fast on empty results check `has_entries` themselves.
+Success returns `ScanSequencesResultSuccess` carrying:
 
-Failure returns `ScanSequencesResultFailure` whose `failure_reason` is either a `SequenceScanFailureReason` (`INVALID_TEMPLATE`, `INVALID_BOUNDS`, `ABORTED_AT_GAP`) or an OS-layer `FileIOFailureReason`. Failures are reserved for cases where the scan couldn't proceed: bad bounds, bad template, or the `ABORT` policy hit a gap. Under `ABORTED_AT_GAP`, the failure also populates `missing_item_number` with the offending integer key.
+- **`sequences: list[Sequence]`** — the inferred sequences, post-policy.
+- **`has_entries: bool`** — true iff at least one Sequence has at least one entry. A scan that ran cleanly but found nothing is *success with `has_entries=False`*, not failure — callers that need to fail-fast on empty results check `has_entries` themselves.
+- **`directory_had_matching_files: bool`** — true iff the directory listing produced at least one file whose basename + extension matched the target shape (i.e. the prefilter accepted something). Combined with `has_entries`, it tells you *why* a scan came up empty: false means the path is wrong or the basename/extension doesn't match anything; true with `has_entries=False` means the files are there but the padding doesn't line up *or* the active subset clipped them all out.
+- **`discovered_first: int | None`** / **`discovered_last: int | None`** — the on-disk range of inferred numbers *before* subset clipping is applied. Populated whenever fileseq inferred at least one number from the directory; `None` if the listing yielded no padding-matching numbers. Lets the caller diagnose subset-clip cases without guessing — e.g. "asked for 90..100 but disk has 1..7" comes straight from these fields.
+
+These three diagnostic fields let consumers distinguish wrong-path / wrong-padding / wrong-range cases without inspecting `result_details` strings. Per-Sequence `discovered_first`/`discovered_last` (on each `Sequence` object) are still the right read when you have at least one sequence; the top-level fields are specifically for the empty-result diagnostic.
+
+Failure returns `ScanSequencesResultFailure` whose `failure_reason` is either a `SequenceScanFailureReason` (`INVALID_TEMPLATE`, `INVALID_BOUNDS`, `ABORTED_AT_GAP`) or an OS-layer `FileIOFailureReason`. Failures are reserved for cases where the scan couldn't proceed: bad bounds, bad template, the `ABORT` policy hit a gap, or the inner directory listing failed (directory not found, permission denied — these surface via `FileIOFailureReason`, not folded into empty success). Under `ABORTED_AT_GAP`, the failure also populates `missing_item_number` with the offending integer key.
+
+### Node-level: `fail_on_empty_result`
+
+The standard library's `ParseSequenceNode` and `ParseSplitSequenceNode` both expose a top-level `fail_on_empty_result: bool = True` parameter. When true (the default), an empty scan result routes the node through its Failure control-flow edge with a diagnostic-aware status message built from the fields above. When false, the node succeeds with empty outputs and a status noting the opt-out — for workflows that legitimately tolerate empty scans (e.g. a sweep that may find nothing).
 
 Library and node code should never import the underlying scanner directly — the request bus is the only public path.

--- a/docs/projects/sequences.md
+++ b/docs/projects/sequences.md
@@ -117,6 +117,6 @@ Failure returns `ScanSequencesResultFailure` whose `failure_reason` is either a 
 
 ### Node-level: `fail_on_empty_result`
 
-The standard library's `ParseSequenceNode` and `ParseSplitSequenceNode` both expose a top-level `fail_on_empty_result: bool = True` parameter. When true (the default), an empty scan result routes the node through its Failure control-flow edge with a diagnostic-aware status message built from the fields above. When false, the node succeeds with empty outputs and a status noting the opt-out — for workflows that legitimately tolerate empty scans (e.g. a sweep that may find nothing).
+The standard library's `ScanSequenceNode` and `ScanSplitSequenceNode` both expose a top-level `fail_on_empty_result: bool = True` parameter. When true (the default), an empty scan result routes the node through its Failure control-flow edge with a diagnostic-aware status message built from the fields above. When false, the node succeeds with empty outputs and a status noting the opt-out — for workflows that legitimately tolerate empty scans (e.g. a sweep that may find nothing).
 
 Library and node code should never import the underlying scanner directly — the request bus is the only public path.

--- a/docs/projects/sequences.md
+++ b/docs/projects/sequences.md
@@ -51,7 +51,7 @@ Real sequences often have gaps — a render that crashed on frame 47, a sparse e
 
 | Policy              | What you get                                                                                                                                                                                      |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ABORT`             | Fail fast. Raises `MissingItemError` (with the offending item number) on the first gap inside `[first, last]`. No Sequence is returned.                                                           |
+| `ABORT`             | Fail fast. Surfaces a failure carrying the offending item number on the first gap inside `[first, last]`. No Sequence is returned.                                                                |
 | `SPLIT` *(default)* | One sequence per **contiguous run** of present items. A sequence with items 1–5, 8–12, 15 produces three separate sequences.                                                                      |
 | `SKIP`              | One sequence containing only the present items. Gaps are absent from the output (but visible via the sequence's `missing_numbers` set).                                                           |
 | `FILL_NEAREST`      | One sequence covering the full `[first, last]` range. Each missing item is filled with the path of the nearest **earlier** present item (or the nearest later one if no earlier neighbor exists). |
@@ -99,3 +99,13 @@ A few cases are deliberately excluded:
 ## Where this comes from
 
 Sequence handling is built on [`fileseq`](https://github.com/justinfx/fileseq), the de facto Python library for VFX-style frame-range parsing. We use it as a parser and number-math library; all filesystem listings still flow through the engine's request bus, so the same workspace permissions, path normalization, and Windows-long-path handling that govern other file operations apply here too. fileseq itself uses "frame" terminology throughout — that's an implementation detail; the public API speaks "items" and "numbers" so the same code can serve any numbered-filename sequence, not just images.
+
+## Public entry point: `ScanSequencesRequest`
+
+Scans are dispatched on the engine's event bus, not by importing a function. Send a `ScanSequencesRequest` (defined in `griptape_nodes.retained_mode.events.os_events`) and `await GriptapeNodes.ahandle_request(...)`; the handler runs the directory listing and fileseq parsing in a worker thread, so a long-running scan over a deep directory doesn't block the event loop.
+
+Success returns `ScanSequencesResultSuccess` carrying `sequences: list[Sequence]` and a `has_entries: bool` convenience flag (true iff at least one sequence has at least one entry). A scan that ran cleanly but found nothing is *success with `has_entries=False`*, not failure — callers that need to fail-fast on empty results check `has_entries` themselves.
+
+Failure returns `ScanSequencesResultFailure` whose `failure_reason` is either a `SequenceScanFailureReason` (`INVALID_TEMPLATE`, `INVALID_BOUNDS`, `ABORTED_AT_GAP`) or an OS-layer `FileIOFailureReason`. Failures are reserved for cases where the scan couldn't proceed: bad bounds, bad template, or the `ABORT` policy hit a gap. Under `ABORTED_AT_GAP`, the failure also populates `missing_item_number` with the offending integer key.
+
+Library and node code should never import the underlying scanner directly — the request bus is the only public path.

--- a/src/griptape_nodes/common/sequences/__init__.py
+++ b/src/griptape_nodes/common/sequences/__init__.py
@@ -1,6 +1,12 @@
 """Sequence support built on `fileseq`.
 
-This module provides a thin wrapper over `fileseq.FileSequence` that:
+The public entry point for scanning is `ScanSequencesRequest` on the engine's
+event bus (see `griptape_nodes.retained_mode.events.os_events`). This module
+exports the data shapes (`Sequence`, `SequenceEntry`, `MissingItemPolicy`,
+`MissingItemError`) but not the scan function itself — that lives on the bus
+to keep disk I/O async-friendly and observable.
+
+The scanner provides a thin wrapper over `fileseq.FileSequence` that:
 
 - Routes all filesystem I/O through `ListDirectoryRequest` (no `os.scandir` calls).
 - Drops negative numbers at scan time (intentional — they're a footgun in
@@ -12,7 +18,7 @@ This module provides a thin wrapper over `fileseq.FileSequence` that:
 
 `fileseq` is used in `pad_style=PAD_STYLE_HASH1` mode throughout — this is
 mandatory for our use case because the default (HASH4) interprets `####` as
-16 zeros, not 4. Every public function in this module enforces that style.
+16 zeros, not 4. The internal scanner enforces that style.
 
 Sequence tokens inside directory components (e.g. `v_####_final/beauty.png`)
 are NOT supported — fileseq cannot parse them, and we don't reimplement that
@@ -20,17 +26,19 @@ case here.
 """
 
 from griptape_nodes.common.sequences.models import (
+    InvalidSubsetBoundsError,
+    InvalidTemplateError,
     MissingItemError,
     MissingItemPolicy,
     Sequence,
     SequenceEntry,
 )
-from griptape_nodes.common.sequences.scan import scan_sequences
 
 __all__ = [
+    "InvalidSubsetBoundsError",
+    "InvalidTemplateError",
     "MissingItemError",
     "MissingItemPolicy",
     "Sequence",
     "SequenceEntry",
-    "scan_sequences",
 ]

--- a/src/griptape_nodes/common/sequences/models.py
+++ b/src/griptape_nodes/common/sequences/models.py
@@ -43,6 +43,24 @@ class MissingItemError(Exception):
         self.number = number
 
 
+class InvalidSubsetBoundsError(ValueError):
+    """Raised when `scan_sequences`'s `start` / `end` bounds are unusable.
+
+    Subclasses `ValueError` so existing `except ValueError` clauses keep working,
+    but lets request handlers and other callers discriminate this failure mode
+    from invalid-template errors via `except InvalidSubsetBoundsError`.
+    """
+
+
+class InvalidTemplateError(ValueError):
+    """Raised when a template string can't be parsed as a single-token fileseq pattern.
+
+    Subclasses `ValueError` so existing `except ValueError` clauses keep working,
+    but lets request handlers and other callers discriminate this failure mode
+    from invalid-bounds errors via `except InvalidTemplateError`.
+    """
+
+
 class SequenceEntry(BaseModel):
     """One entry in a Sequence.
 

--- a/src/griptape_nodes/common/sequences/scan.py
+++ b/src/griptape_nodes/common/sequences/scan.py
@@ -31,6 +31,7 @@ from griptape_nodes.common.sequences.models import (
 )
 from griptape_nodes.common.sequences.policies import PolicyContext, apply_policy
 from griptape_nodes.retained_mode.events.os_events import (
+    FileIOFailureReason,
     ListDirectoryRequest,
     ListDirectoryResultSuccess,
 )
@@ -41,6 +42,34 @@ logger = logging.getLogger("griptape_nodes")
 # Mandatory pad style: each `#` = 1 zero, matching Nuke. fileseq's default
 # (HASH4) treats each `#` as 4 zeros, which would silently break templates.
 PAD_STYLE = PAD_STYLE_HASH1
+
+
+class _ScanOutcome(NamedTuple):
+    """The full result of a sequence scan, including diagnostics for empty results.
+
+    `directory_had_matching_files` and `discovered_first/last` let callers
+    distinguish "wrong path / template" from "right path, padding mismatch /
+    subset clipped out everything" without inspecting log strings.
+    """
+
+    sequences: list[Sequence]
+    directory_had_matching_files: bool
+    discovered_first: int | None
+    discovered_last: int | None
+
+
+class _DirectoryListingError(Exception):
+    """Raised when the inner `ListDirectoryRequest` returns a failure.
+
+    Carries the listing's own `FileIOFailureReason` and `result_details` so
+    the request handler can surface them through `ScanSequencesResultFailure`
+    without losing the OS-level diagnostic.
+    """
+
+    def __init__(self, failure_reason: FileIOFailureReason, result_details: str) -> None:
+        super().__init__(result_details)
+        self.failure_reason = failure_reason
+        self.result_details = result_details
 
 
 @dataclass(frozen=True)
@@ -65,7 +94,7 @@ def _scan_sequences(
     policy: MissingItemPolicy = MissingItemPolicy.SPLIT,
     start: int | None = None,
     end: int | None = None,
-) -> list[Sequence]:
+) -> _ScanOutcome:
     """Find sequences matching `pattern` inside `directory`.
 
     Module-private. The public entry point is `ScanSequencesRequest` on the
@@ -91,11 +120,17 @@ def _scan_sequences(
             supplied.
 
     Returns:
-        List of `Sequence` objects. Empty if the directory listing fails, the
-        directory contains no files matching the pattern, or the active
-        subset is empty.
+        `_ScanOutcome` carrying the inferred sequences plus diagnostic flags
+        (whether the directory had any files matching the basename/extension
+        shape, and the on-disk discovered range when sequences were inferred).
+        `sequences` is empty if the directory contains no matching files, the
+        padding doesn't line up, or the active subset clipped everything out;
+        the diagnostic fields tell the caller which case fired.
 
     Raises:
+        _DirectoryListingError: If the inner `ListDirectoryRequest` returns
+            a failure (directory not found, permission denied, etc.). Carries
+            the original `FileIOFailureReason`.
         InvalidSubsetBoundsError: If `start` < 0 or `end` < `start`.
         InvalidTemplateError: If `pattern` contains more than one sequence token.
         MissingItemError: If `policy` is ABORT and a gap is found inside the
@@ -108,20 +143,43 @@ def _scan_sequences(
     target = _coerce_target_pattern(pattern)
 
     relevant = _list_pattern_matching_filenames(directory, target)
+    directory_had_matching_files = bool(relevant)
     if not relevant:
-        return []
+        return _ScanOutcome(
+            sequences=[],
+            directory_had_matching_files=False,
+            discovered_first=None,
+            discovered_last=None,
+        )
 
     present = _collect_present_numbers(directory, target, relevant)
     if not present.by_number:
-        return []
+        # Directory had files matching the basename/extension shape, but
+        # fileseq grouped them at a different padding than the target's
+        # zfill. Surface the diagnostic flag so the caller can say "the
+        # padding is wrong" instead of a generic "no matches".
+        return _ScanOutcome(
+            sequences=[],
+            directory_had_matching_files=directory_had_matching_files,
+            discovered_first=None,
+            discovered_last=None,
+        )
 
     discovered_first = min(present.by_number)
     discovered_last = max(present.by_number)
     active = _compute_active_range(start, end, discovered_first, discovered_last)
     if active.first > active.last:
-        return []
+        # Active subset clipped every present item out. Surface the
+        # discovered range so the caller can show "asked for 90..100 but
+        # disk has 1..7".
+        return _ScanOutcome(
+            sequences=[],
+            directory_had_matching_files=directory_had_matching_files,
+            discovered_first=discovered_first,
+            discovered_last=discovered_last,
+        )
 
-    return apply_policy(
+    sequences = apply_policy(
         PolicyContext(
             fseq=target,
             present_numbers=present.by_number,
@@ -133,6 +191,12 @@ def _scan_sequences(
             discovered_last=discovered_last,
             dropped_negative_number_count=present.dropped_negatives,
         )
+    )
+    return _ScanOutcome(
+        sequences=sequences,
+        directory_had_matching_files=directory_had_matching_files,
+        discovered_first=discovered_first,
+        discovered_last=discovered_last,
     )
 
 
@@ -264,9 +328,13 @@ def _compute_active_range(
 def _list_directory_filenames(directory: str) -> list[str]:
     """List `directory` via ListDirectoryRequest, returning bare filenames.
 
-    Returns an empty list on any listing failure. Suppresses client toasts
-    via `broadcast_result=False` since "directory not found" is a normal
-    outcome of a user-supplied template.
+    Raises `_DirectoryListingError` on any listing failure, carrying the
+    underlying `FileIOFailureReason` so the request handler can surface
+    "directory not found" / "permission denied" / etc. through
+    `ScanSequencesResultFailure` without losing the OS-level diagnostic.
+
+    Suppresses client toasts via `broadcast_result=False` since "directory
+    not found" is a normal outcome of a user-supplied template.
     """
     result = GriptapeNodes.handle_request(
         ListDirectoryRequest(
@@ -281,6 +349,9 @@ def _list_directory_filenames(directory: str) -> list[str]:
         )
     )
     if not isinstance(result, ListDirectoryResultSuccess):
-        return []
+        raise _DirectoryListingError(
+            failure_reason=result.failure_reason,  # pyright: ignore[reportAttributeAccessIssue]
+            result_details=str(result.result_details),
+        )
     # Skip directories — we want files only.
     return [entry.name for entry in result.entries if not entry.is_dir]

--- a/src/griptape_nodes/common/sequences/scan.py
+++ b/src/griptape_nodes/common/sequences/scan.py
@@ -1,7 +1,7 @@
 """Directory scanning for sequences.
 
-Single public function: `scan_sequences()`. Takes a directory + a fileseq
-pattern (either as a string like `render.####.exr` or a pre-constructed
+Module-private worker behind `ScanSequencesRequest`. Takes a directory + a
+fileseq pattern (either as a string like `render.####.exr` or a pre-constructed
 `FileSequence`), lists the directory via `ListDirectoryRequest`, hands the
 filenames to `fileseq.findSequencesInList`, applies subset clipping and the
 chosen missing-item policy, and returns a list of `Sequence` objects.
@@ -24,6 +24,8 @@ from fileseq.constants import PAD_STYLE_HASH1
 from fileseq.filesequence import FileSequence
 
 from griptape_nodes.common.sequences.models import (
+    InvalidSubsetBoundsError,
+    InvalidTemplateError,
     MissingItemPolicy,
     Sequence,
 )
@@ -56,7 +58,7 @@ class _ActiveRange(NamedTuple):
     last: int
 
 
-def scan_sequences(
+def _scan_sequences(
     directory: str,
     pattern: str | FileSequence,
     *,
@@ -65,6 +67,11 @@ def scan_sequences(
     end: int | None = None,
 ) -> list[Sequence]:
     """Find sequences matching `pattern` inside `directory`.
+
+    Module-private. The public entry point is `ScanSequencesRequest` on the
+    engine's event bus; that request's handler invokes this function via
+    `asyncio.to_thread()` so neither the directory listing nor fileseq parsing
+    blocks the event loop.
 
     Args:
         directory: Absolute directory path to scan. Listed via
@@ -75,7 +82,8 @@ def scan_sequences(
             HASH1 mode regardless of pattern syntax.
         policy: How to handle gaps within the matched range. SPLIT yields one
             Sequence per contiguous run; the others yield exactly one
-            Sequence with policy-driven gap fills (or omissions for ERROR).
+            Sequence with policy-driven gap fills (or omissions for SKIP, or
+            a `MissingItemError` for ABORT).
         start: Optional lower bound (inclusive) for the active subset. Items
             below this are dropped from output. Must be >= 0 if supplied.
         end: Optional upper bound (inclusive) for the active subset. Items
@@ -86,6 +94,12 @@ def scan_sequences(
         List of `Sequence` objects. Empty if the directory listing fails, the
         directory contains no files matching the pattern, or the active
         subset is empty.
+
+    Raises:
+        InvalidSubsetBoundsError: If `start` < 0 or `end` < `start`.
+        InvalidTemplateError: If `pattern` contains more than one sequence token.
+        MissingItemError: If `policy` is ABORT and a gap is found inside the
+            active range.
 
     Negative numbers on disk are filtered out before policy is applied;
     `Sequence.dropped_negative_number_count` records how many were skipped.
@@ -125,11 +139,14 @@ def scan_sequences(
 def _validate_subset_bounds(start: int | None, end: int | None) -> None:
     """Reject negative start values and end < start ranges before any work."""
     if start is not None and start < 0:
-        msg = f"`start` must be >= 0; got {start}"
-        raise ValueError(msg)
+        msg = f"Attempted to validate sequence subset bounds with start={start}. Failed because start must be >= 0."
+        raise InvalidSubsetBoundsError(msg)
     if start is not None and end is not None and end < start:
-        msg = f"`end` ({end}) must be >= `start` ({start})"
-        raise ValueError(msg)
+        msg = (
+            f"Attempted to validate sequence subset bounds with start={start}, end={end}. "
+            f"Failed because end must be >= start."
+        )
+        raise InvalidSubsetBoundsError(msg)
 
 
 def _coerce_target_pattern(pattern: str | FileSequence) -> FileSequence:
@@ -146,10 +163,11 @@ def _coerce_target_pattern(pattern: str | FileSequence) -> FileSequence:
     token_count = _count_sequence_tokens(pattern)
     if token_count > 1:
         msg = (
-            f"Pattern {pattern!r} contains {token_count} sequence tokens; only one is supported. "
+            f"Attempted to parse fileseq template {pattern!r}. "
+            f"Failed because it contains {token_count} sequence tokens; only one is supported. "
             f"Multi-token templates like 'v##_f####.exr' are not handled correctly by fileseq."
         )
-        raise ValueError(msg)
+        raise InvalidTemplateError(msg)
     return FileSequence(pattern, pad_style=PAD_STYLE)
 
 

--- a/src/griptape_nodes/common/sequences/scan.py
+++ b/src/griptape_nodes/common/sequences/scan.py
@@ -1,10 +1,14 @@
 """Directory scanning for sequences.
 
-Module-private worker behind `ScanSequencesRequest`. Takes a directory + a
-fileseq pattern (either as a string like `render.####.exr` or a pre-constructed
+Worker behind `ScanSequencesRequest`. Takes a directory + a fileseq pattern
+(either as a string like `render.####.exr` or a pre-constructed
 `FileSequence`), lists the directory via `ListDirectoryRequest`, hands the
 filenames to `fileseq.findSequencesInList`, applies subset clipping and the
-chosen missing-item policy, and returns a list of `Sequence` objects.
+chosen missing-item policy, and returns a `ScanOutcome` carrying the
+inferred sequences plus diagnostic flags. The intended caller is
+`OSManager.on_scan_sequences_request`; other callers are welcome but should
+prefer dispatching the bus request unless they have a strong reason to
+bypass the worker-thread / async-dispatch path.
 
 All filesystem I/O is routed through the engine's request bus — this module
 never calls `os.scandir`, `os.walk`, or `pathlib.Path.glob` directly.
@@ -44,7 +48,7 @@ logger = logging.getLogger("griptape_nodes")
 PAD_STYLE = PAD_STYLE_HASH1
 
 
-class _ScanOutcome(NamedTuple):
+class ScanOutcome(NamedTuple):
     """The full result of a sequence scan, including diagnostics for empty results.
 
     `directory_had_matching_files` and `discovered_first/last` let callers
@@ -58,7 +62,7 @@ class _ScanOutcome(NamedTuple):
     discovered_last: int | None
 
 
-class _DirectoryListingError(Exception):
+class DirectoryListingError(Exception):
     """Raised when the inner `ListDirectoryRequest` returns a failure.
 
     Carries the listing's own `FileIOFailureReason` and `result_details` so
@@ -87,20 +91,21 @@ class _ActiveRange(NamedTuple):
     last: int
 
 
-def _scan_sequences(
+def scan_sequences(
     directory: str,
     pattern: str | FileSequence,
     *,
     policy: MissingItemPolicy = MissingItemPolicy.SPLIT,
     start: int | None = None,
     end: int | None = None,
-) -> _ScanOutcome:
+) -> ScanOutcome:
     """Find sequences matching `pattern` inside `directory`.
 
-    Module-private. The public entry point is `ScanSequencesRequest` on the
-    engine's event bus; that request's handler invokes this function via
-    `asyncio.to_thread()` so neither the directory listing nor fileseq parsing
-    blocks the event loop.
+    The intended entry point is `ScanSequencesRequest` on the engine's event
+    bus; that request's handler invokes this function via `asyncio.to_thread()`
+    so neither the directory listing nor fileseq parsing blocks the event loop.
+    Callers that bypass the request lose the worker-thread offload — only do so
+    if you've already taken the I/O off the event loop yourself.
 
     Args:
         directory: Absolute directory path to scan. Listed via
@@ -120,7 +125,7 @@ def _scan_sequences(
             supplied.
 
     Returns:
-        `_ScanOutcome` carrying the inferred sequences plus diagnostic flags
+        `ScanOutcome` carrying the inferred sequences plus diagnostic flags
         (whether the directory had any files matching the basename/extension
         shape, and the on-disk discovered range when sequences were inferred).
         `sequences` is empty if the directory contains no matching files, the
@@ -128,7 +133,7 @@ def _scan_sequences(
         the diagnostic fields tell the caller which case fired.
 
     Raises:
-        _DirectoryListingError: If the inner `ListDirectoryRequest` returns
+        DirectoryListingError: If the inner `ListDirectoryRequest` returns
             a failure (directory not found, permission denied, etc.). Carries
             the original `FileIOFailureReason`.
         InvalidSubsetBoundsError: If `start` < 0 or `end` < `start`.
@@ -145,7 +150,7 @@ def _scan_sequences(
     relevant = _list_pattern_matching_filenames(directory, target)
     directory_had_matching_files = bool(relevant)
     if not relevant:
-        return _ScanOutcome(
+        return ScanOutcome(
             sequences=[],
             directory_had_matching_files=False,
             discovered_first=None,
@@ -158,7 +163,7 @@ def _scan_sequences(
         # fileseq grouped them at a different padding than the target's
         # zfill. Surface the diagnostic flag so the caller can say "the
         # padding is wrong" instead of a generic "no matches".
-        return _ScanOutcome(
+        return ScanOutcome(
             sequences=[],
             directory_had_matching_files=directory_had_matching_files,
             discovered_first=None,
@@ -172,7 +177,7 @@ def _scan_sequences(
         # Active subset clipped every present item out. Surface the
         # discovered range so the caller can show "asked for 90..100 but
         # disk has 1..7".
-        return _ScanOutcome(
+        return ScanOutcome(
             sequences=[],
             directory_had_matching_files=directory_had_matching_files,
             discovered_first=discovered_first,
@@ -192,7 +197,7 @@ def _scan_sequences(
             dropped_negative_number_count=present.dropped_negatives,
         )
     )
-    return _ScanOutcome(
+    return ScanOutcome(
         sequences=sequences,
         directory_had_matching_files=directory_had_matching_files,
         discovered_first=discovered_first,
@@ -328,7 +333,7 @@ def _compute_active_range(
 def _list_directory_filenames(directory: str) -> list[str]:
     """List `directory` via ListDirectoryRequest, returning bare filenames.
 
-    Raises `_DirectoryListingError` on any listing failure, carrying the
+    Raises `DirectoryListingError` on any listing failure, carrying the
     underlying `FileIOFailureReason` so the request handler can surface
     "directory not found" / "permission denied" / etc. through
     `ScanSequencesResultFailure` without losing the OS-level diagnostic.
@@ -349,7 +354,7 @@ def _list_directory_filenames(directory: str) -> list[str]:
         )
     )
     if not isinstance(result, ListDirectoryResultSuccess):
-        raise _DirectoryListingError(
+        raise DirectoryListingError(
             failure_reason=result.failure_reason,  # pyright: ignore[reportAttributeAccessIssue]
             result_details=str(result.result_details),
         )

--- a/src/griptape_nodes/retained_mode/events/os_events.py
+++ b/src/griptape_nodes/retained_mode/events/os_events.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import StrEnum
 
+from griptape_nodes.common.sequences.models import MissingItemPolicy, Sequence
 from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultPayloadFailure,
@@ -54,6 +55,23 @@ class FileIOFailureReason(StrEnum):
 
     # Recycle bin errors
     RECYCLE_BIN_UNAVAILABLE = "recycle_bin_unavailable"  # Recycle bin unavailable and behavior was RECYCLE_BIN_ONLY
+
+
+class SequenceScanFailureReason(StrEnum):
+    """Sequence-semantic failure reasons returned by `ScanSequencesRequest`.
+
+    OS-layer failures (directory not found, permission denied, etc.) are reported
+    using `FileIOFailureReason` instead; the request's failure payload accepts
+    either enum so the handler can pick the right taxonomy per layer.
+
+    A successful scan that simply found nothing is NOT a failure — it returns
+    `ScanSequencesResultSuccess` with `sequences=[]` and `has_entries=False`.
+    Failures are reserved for cases where the scan couldn't proceed.
+    """
+
+    INVALID_TEMPLATE = "invalid_template"  # Multi-token templates or fileseq parse errors.
+    INVALID_BOUNDS = "invalid_bounds"  # `start_number` < 0, or `end_number` < `start_number`.
+    ABORTED_AT_GAP = "aborted_at_gap"  # `MissingItemPolicy.ABORT` hit a gap; payload carries the offending number.
 
 
 class DeletionBehavior(StrEnum):
@@ -177,6 +195,84 @@ class ListDirectoryResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     """
 
     failure_reason: FileIOFailureReason
+
+
+@dataclass
+@PayloadRegistry.register
+class ScanSequencesRequest(RequestPayload):
+    """Scan a directory for files matching a fileseq template; produce typed Sequence(s).
+
+    Use when: A node or workflow needs to discover frame/item sequences on disk
+    (e.g. a render output, a directory of dialogue takes). Mediates fileseq parsing
+    and the underlying directory listing through the engine's request bus so callers
+    don't import the engine's sequence helpers directly.
+
+    Args:
+        directory: Absolute directory path to scan. Listed via `ListDirectoryRequest`
+            internally (no direct filesystem access). Macro-form paths must be
+            resolved by the caller before dispatching this request.
+        pattern: A fileseq pattern (e.g. `render.####.exr`, `take_%02d.wav`). Sequence
+            tokens are interpreted in HASH1 mode regardless of pattern syntax. Multi-token
+            templates are rejected up-front with `INVALID_TEMPLATE`.
+        policy: How to handle gaps within the matched range. Defaults to `SPLIT`.
+        start_number: Optional lower bound (inclusive) for the active subset. Items
+            below this are dropped. Must be >= 0 if supplied; rejected with
+            `INVALID_BOUNDS` otherwise.
+        end_number: Optional upper bound (inclusive). Items above this are dropped.
+            Must be >= `start_number` if both supplied; rejected with `INVALID_BOUNDS`
+            otherwise.
+
+    Results: ScanSequencesResultSuccess (with sequences) | ScanSequencesResultFailure
+    (sequence-semantic or OS-layer failure).
+    """
+
+    directory: str
+    pattern: str
+    policy: MissingItemPolicy = MissingItemPolicy.SPLIT
+    start_number: int | None = None
+    end_number: int | None = None
+
+
+@dataclass
+@PayloadRegistry.register
+class ScanSequencesResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """Sequence scan completed successfully.
+
+    A successful scan may legitimately return zero sequences (the directory
+    had no files matching the template, or the active subset clipped them
+    all out). Callers that need to fail-fast on empty results can check
+    `has_entries`.
+
+    Attributes:
+        sequences: Zero or more `Sequence` objects produced by the scan.
+            Under `SPLIT` policy this may contain multiple sub-sequences;
+            under all other policies it has at most one. May be empty.
+        has_entries: True iff at least one Sequence in `sequences` has at
+            least one entry. Convenience for callers that just want to
+            branch on "did the scan produce anything?" without iterating.
+    """
+
+    sequences: list[Sequence]
+    has_entries: bool
+
+
+@dataclass
+@PayloadRegistry.register
+class ScanSequencesResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Sequence scan failed.
+
+    Attributes:
+        failure_reason: Either a sequence-semantic reason (`SequenceScanFailureReason`)
+            or an OS-layer reason (`FileIOFailureReason`) when the underlying
+            directory listing failed.
+        missing_item_number: Populated only when `failure_reason` is
+            `SequenceScanFailureReason.ABORTED_AT_GAP`. Carries the integer key
+            of the first slot the scan aborted on.
+        result_details: Human-readable error message (inherited from ResultPayloadFailure).
+    """
+
+    failure_reason: SequenceScanFailureReason | FileIOFailureReason
+    missing_item_number: int | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/os_events.py
+++ b/src/griptape_nodes/retained_mode/events/os_events.py
@@ -239,9 +239,17 @@ class ScanSequencesResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     """Sequence scan completed successfully.
 
     A successful scan may legitimately return zero sequences (the directory
-    had no files matching the template, or the active subset clipped them
-    all out). Callers that need to fail-fast on empty results can check
-    `has_entries`.
+    had no files matching the template, the padding didn't line up, or the
+    active subset clipped them all out). The diagnostic fields let consumers
+    distinguish those cases without inspecting `result_details` strings:
+
+    - `directory_had_matching_files=False` → wrong path / wrong template /
+      empty directory: nothing on disk matched the basename + extension.
+    - `directory_had_matching_files=True`, `has_entries=False` → right path,
+      but either the padding didn't line up with the template's zfill, or
+      the active subset (`start_number`/`end_number`) clipped everything out.
+      `discovered_first`/`discovered_last` give the on-disk range so callers
+      can show "asked for 90..100 but disk has 1..7."
 
     Attributes:
         sequences: Zero or more `Sequence` objects produced by the scan.
@@ -250,10 +258,22 @@ class ScanSequencesResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
         has_entries: True iff at least one Sequence in `sequences` has at
             least one entry. Convenience for callers that just want to
             branch on "did the scan produce anything?" without iterating.
+        directory_had_matching_files: True iff the directory listing
+            produced ≥1 file matching the target's basename + extension
+            (before fileseq parsing or subset clipping).
+        discovered_first: Lowest item number actually found on disk that
+            matched the target's full shape (basename + extension + zfill),
+            ignoring any subset bounds. None when no sequences were inferred.
+        discovered_last: Highest item number actually found on disk that
+            matched the target's full shape, ignoring any subset bounds.
+            None when no sequences were inferred.
     """
 
     sequences: list[Sequence]
     has_entries: bool
+    directory_had_matching_files: bool
+    discovered_first: int | None = None
+    discovered_last: int | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -16,6 +16,7 @@ from typing import Any, ClassVar, NamedTuple
 import anyio
 import portalocker
 import send2trash
+from fileseq.exceptions import FileSeqException
 from rich.console import Console
 
 from griptape_nodes.common.macro_parser import MacroResolutionError, MacroResolutionFailure, MacroVariables, ParsedMacro
@@ -23,6 +24,12 @@ from griptape_nodes.common.macro_parser.exceptions import MacroResolutionFailure
 from griptape_nodes.common.macro_parser.formats import NumericPaddingFormat
 from griptape_nodes.common.macro_parser.resolution import partial_resolve
 from griptape_nodes.common.macro_parser.segments import ParsedStaticValue, ParsedVariable
+from griptape_nodes.common.sequences import (
+    InvalidSubsetBoundsError,
+    InvalidTemplateError,
+    MissingItemError,
+)
+from griptape_nodes.common.sequences.scan import _scan_sequences
 from griptape_nodes.files.drivers.base64_file_driver import Base64FileDriver
 from griptape_nodes.files.drivers.data_uri_file_driver import DataUriFileDriver
 from griptape_nodes.files.drivers.griptape_cloud_file_driver import GriptapeCloudFileDriver
@@ -79,6 +86,10 @@ from griptape_nodes.retained_mode.events.os_events import (
     ResolveMacroPathRequest,
     ResolveMacroPathResultFailure,
     ResolveMacroPathResultSuccess,
+    ScanSequencesRequest,
+    ScanSequencesResultFailure,
+    ScanSequencesResultSuccess,
+    SequenceScanFailureReason,
     WriteFileRequest,
     WriteFileResultFailure,
     WriteFileResultSuccess,
@@ -279,6 +290,10 @@ class OSManager:
             )
             event_manager.assign_manager_to_request_type(
                 request_type=ListDirectoryRequest, callback=self.on_list_directory_request
+            )
+
+            event_manager.assign_manager_to_request_type(
+                request_type=ScanSequencesRequest, callback=self.on_scan_sequences_request
             )
 
             event_manager.assign_manager_to_request_type(
@@ -1437,6 +1452,72 @@ class OSManager:
             msg = f"Unexpected error in list_directory: {type(e).__name__}: {e}"
             logger.error(msg)
             return ListDirectoryResultFailure(failure_reason=FileIOFailureReason.UNKNOWN, result_details=msg)
+
+    async def on_scan_sequences_request(self, request: ScanSequencesRequest) -> ResultPayload:
+        """Handle a request to scan a directory for sequences matching a fileseq template.
+
+        The handler runs `_scan_sequences` in a worker thread (`asyncio.to_thread`)
+        so neither the directory listing (via `ListDirectoryRequest`, performed
+        inside `_scan_sequences`) nor fileseq parsing blocks the event loop.
+
+        Routes failures to the appropriate taxonomy: typed exceptions raised by
+        the scanner map to `SequenceScanFailureReason`; OS-layer failures from
+        the inner listing surface via `FileIOFailureReason` (today's
+        `_scan_sequences` swallows them into an empty list, which becomes
+        `NO_MATCHES`).
+        """
+        try:
+            sequences = await asyncio.to_thread(
+                _scan_sequences,
+                request.directory,
+                request.pattern,
+                policy=request.policy,
+                start=request.start_number,
+                end=request.end_number,
+            )
+        except InvalidSubsetBoundsError as e:
+            return ScanSequencesResultFailure(
+                failure_reason=SequenceScanFailureReason.INVALID_BOUNDS,
+                result_details=str(e),
+            )
+        except InvalidTemplateError as e:
+            return ScanSequencesResultFailure(
+                failure_reason=SequenceScanFailureReason.INVALID_TEMPLATE,
+                result_details=str(e),
+            )
+        except FileSeqException as e:
+            return ScanSequencesResultFailure(
+                failure_reason=SequenceScanFailureReason.INVALID_TEMPLATE,
+                result_details=(
+                    f"Attempted to scan sequences with pattern={request.pattern!r}. "
+                    f"Failed because fileseq could not parse the template: {e}"
+                ),
+            )
+        except MissingItemError as e:
+            return ScanSequencesResultFailure(
+                failure_reason=SequenceScanFailureReason.ABORTED_AT_GAP,
+                missing_item_number=e.number,
+                result_details=(
+                    f"Attempted to scan sequences with pattern={request.pattern!r}, policy=ABORT. "
+                    f"Failed because the sequence has a gap at item {e.number}."
+                ),
+            )
+
+        # An empty result is a successful scan that simply found nothing —
+        # not a failure. Callers that need to fail-fast can check `has_entries`.
+        has_entries = any(seq.entries for seq in sequences)
+        if has_entries:
+            details = f"Found {len(sequences)} sequence(s)."
+        else:
+            details = (
+                f"Scanned directory={request.directory!r} with pattern={request.pattern!r}; "
+                f"no matching sequence entries found."
+            )
+        return ScanSequencesResultSuccess(
+            sequences=sequences,
+            has_entries=has_entries,
+            result_details=details,
+        )
 
     def _detect_mime_type_from_location(self, location: str) -> str:
         """Detect MIME type from location string.

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -29,7 +29,7 @@ from griptape_nodes.common.sequences import (
     InvalidTemplateError,
     MissingItemError,
 )
-from griptape_nodes.common.sequences.scan import _DirectoryListingError, _scan_sequences
+from griptape_nodes.common.sequences.scan import DirectoryListingError, scan_sequences
 from griptape_nodes.files.drivers.base64_file_driver import Base64FileDriver
 from griptape_nodes.files.drivers.data_uri_file_driver import DataUriFileDriver
 from griptape_nodes.files.drivers.griptape_cloud_file_driver import GriptapeCloudFileDriver
@@ -1456,26 +1456,26 @@ class OSManager:
     async def on_scan_sequences_request(self, request: ScanSequencesRequest) -> ResultPayload:
         """Handle a request to scan a directory for sequences matching a fileseq template.
 
-        The handler runs `_scan_sequences` in a worker thread (`asyncio.to_thread`)
+        The handler runs `scan_sequences` in a worker thread (`asyncio.to_thread`)
         so neither the directory listing (via `ListDirectoryRequest`, performed
-        inside `_scan_sequences`) nor fileseq parsing blocks the event loop.
+        inside `scan_sequences`) nor fileseq parsing blocks the event loop.
 
         Routes failures to the appropriate taxonomy: typed exceptions raised by
         the scanner map to `SequenceScanFailureReason`; OS-layer listing
         failures (directory not found, permission denied) propagate via
-        `_DirectoryListingError` and map to `FileIOFailureReason` so the
+        `DirectoryListingError` and map to `FileIOFailureReason` so the
         underlying OS diagnostic isn't lost.
         """
         try:
             outcome = await asyncio.to_thread(
-                _scan_sequences,
+                scan_sequences,
                 request.directory,
                 request.pattern,
                 policy=request.policy,
                 start=request.start_number,
                 end=request.end_number,
             )
-        except _DirectoryListingError as e:
+        except DirectoryListingError as e:
             return ScanSequencesResultFailure(
                 failure_reason=e.failure_reason,
                 result_details=e.result_details,

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -29,7 +29,7 @@ from griptape_nodes.common.sequences import (
     InvalidTemplateError,
     MissingItemError,
 )
-from griptape_nodes.common.sequences.scan import _scan_sequences
+from griptape_nodes.common.sequences.scan import _DirectoryListingError, _scan_sequences
 from griptape_nodes.files.drivers.base64_file_driver import Base64FileDriver
 from griptape_nodes.files.drivers.data_uri_file_driver import DataUriFileDriver
 from griptape_nodes.files.drivers.griptape_cloud_file_driver import GriptapeCloudFileDriver
@@ -1461,19 +1461,24 @@ class OSManager:
         inside `_scan_sequences`) nor fileseq parsing blocks the event loop.
 
         Routes failures to the appropriate taxonomy: typed exceptions raised by
-        the scanner map to `SequenceScanFailureReason`; OS-layer failures from
-        the inner listing surface via `FileIOFailureReason` (today's
-        `_scan_sequences` swallows them into an empty list, which becomes
-        `NO_MATCHES`).
+        the scanner map to `SequenceScanFailureReason`; OS-layer listing
+        failures (directory not found, permission denied) propagate via
+        `_DirectoryListingError` and map to `FileIOFailureReason` so the
+        underlying OS diagnostic isn't lost.
         """
         try:
-            sequences = await asyncio.to_thread(
+            outcome = await asyncio.to_thread(
                 _scan_sequences,
                 request.directory,
                 request.pattern,
                 policy=request.policy,
                 start=request.start_number,
                 end=request.end_number,
+            )
+        except _DirectoryListingError as e:
+            return ScanSequencesResultFailure(
+                failure_reason=e.failure_reason,
+                result_details=e.result_details,
             )
         except InvalidSubsetBoundsError as e:
             return ScanSequencesResultFailure(
@@ -1505,17 +1510,20 @@ class OSManager:
 
         # An empty result is a successful scan that simply found nothing —
         # not a failure. Callers that need to fail-fast can check `has_entries`.
-        has_entries = any(seq.entries for seq in sequences)
+        has_entries = any(seq.entries for seq in outcome.sequences)
         if has_entries:
-            details = f"Found {len(sequences)} sequence(s)."
+            details = f"Found {len(outcome.sequences)} sequence(s)."
         else:
             details = (
                 f"Scanned directory={request.directory!r} with pattern={request.pattern!r}; "
                 f"no matching sequence entries found."
             )
         return ScanSequencesResultSuccess(
-            sequences=sequences,
+            sequences=outcome.sequences,
             has_entries=has_entries,
+            directory_had_matching_files=outcome.directory_had_matching_files,
+            discovered_first=outcome.discovered_first,
+            discovered_last=outcome.discovered_last,
             result_details=details,
         )
 

--- a/tests/unit/common/test_sequences.py
+++ b/tests/unit/common/test_sequences.py
@@ -102,6 +102,9 @@ class TestBasicScanning:
             result = await _scan(directory, "render.####.png", policy=MissingItemPolicy.SPLIT)
         assert isinstance(result, ScanSequencesResultSuccess)
         assert result.has_entries is True
+        assert result.directory_had_matching_files is True
+        assert result.discovered_first == 1
+        assert result.discovered_last == 5
         seqs = result.sequences
         assert len(seqs) == 1
         assert seqs[0].first == 1
@@ -111,27 +114,35 @@ class TestBasicScanning:
 
     @pytest.mark.asyncio
     async def test_no_files_returns_empty_success(self) -> None:
-        """An empty directory yields a success with no sequences and `has_entries=False`."""
+        """An empty directory yields a success with no sequences and `has_entries=False`.
+
+        The `directory_had_matching_files` flag is False because nothing in
+        the listing matched the basename/extension shape.
+        """
         with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing("/work/in", [])):
             result = await _scan("/work/in", "render.####.png")
         assert isinstance(result, ScanSequencesResultSuccess)
         assert result.sequences == []
         assert result.has_entries is False
+        assert result.directory_had_matching_files is False
+        assert result.discovered_first is None
+        assert result.discovered_last is None
 
     @pytest.mark.asyncio
-    async def test_directory_listing_failure_returns_empty_success(self) -> None:
-        """A failed listing is currently swallowed by `_scan_sequences` and surfaces as an empty success.
+    async def test_directory_listing_failure_surfaces_file_io_failure(self) -> None:
+        """A failed listing propagates the OS-level `FileIOFailureReason` to the caller.
 
-        TODO: a future iteration may have the handler dispatch its own
-        `ListDirectoryRequest` first and surface OS-layer failures via
-        `FileIOFailureReason` instead of folding them into empty success.
+        `_scan_sequences` raises `_DirectoryListingError` when the inner
+        `ListDirectoryRequest` fails; the handler maps that to a
+        `ScanSequencesResultFailure` carrying the underlying reason. This
+        replaces the prior behavior where listing failures were silently
+        folded into empty success.
         """
-        # Stub always returns failure
+        # Stub always returns failure for /work/in (only /other is recognized)
         with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing("/other", [])):
             result = await _scan("/work/in", "render.####.png")
-        assert isinstance(result, ScanSequencesResultSuccess)
-        assert result.sequences == []
-        assert result.has_entries is False
+        assert isinstance(result, ScanSequencesResultFailure)
+        assert result.failure_reason is FileIOFailureReason.FILE_NOT_FOUND
 
     @pytest.mark.asyncio
     async def test_unrelated_files_filtered_out(self) -> None:
@@ -332,7 +343,14 @@ class TestSubsetClipping:
         assert [e.number for e in seqs[0].entries] == [2, 3, 4]
 
     @pytest.mark.asyncio
-    async def test_subset_outside_discovered_range_yields_empty_success(self) -> None:
+    async def test_subset_outside_discovered_range_reports_discovered_range(self) -> None:
+        """Subset clip drops every present item — diagnostic flags expose the on-disk range.
+
+        The directory has 1..3 on disk but the caller asked for 10..20.
+        `directory_had_matching_files=True` and `discovered_first/last` carry
+        the on-disk bounds so the caller can show "asked for 10..20 but disk
+        has 1..3" instead of a generic "no matches".
+        """
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 3]]
         with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
@@ -342,6 +360,9 @@ class TestSubsetClipping:
         assert isinstance(result, ScanSequencesResultSuccess)
         assert result.sequences == []
         assert result.has_entries is False
+        assert result.directory_had_matching_files is True
+        assert result.discovered_first == 1
+        assert result.discovered_last == 3
 
     @pytest.mark.asyncio
     async def test_negative_start_rejected(self) -> None:
@@ -373,8 +394,15 @@ class TestPatternVariants:
         assert [e.number for e in seqs[0].entries] == [1, 2, 3]
 
     @pytest.mark.asyncio
-    async def test_mismatched_padding_returns_empty_success(self) -> None:
-        """Disk has 3-digit numbers; user declared #### (4 digits). No match — empty success."""
+    async def test_mismatched_padding_reports_files_present(self) -> None:
+        """Disk has 3-digit numbers; user declared #### (4 digits). No match — empty success.
+
+        The basename/extension prefilter accepts these files (so
+        `directory_had_matching_files=True`), but fileseq groups them at
+        zfill=3 which doesn't match the target's zfill=4 — so no inferred
+        numbers and `discovered_first/last` stay None. The flag combination
+        tells the caller the cause is padding mismatch, not wrong path.
+        """
         directory = "/work/in"
         filenames = [f"render.{n:03d}.png" for n in [1, 2, 3]]
         with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
@@ -382,6 +410,9 @@ class TestPatternVariants:
         assert isinstance(result, ScanSequencesResultSuccess)
         assert result.sequences == []
         assert result.has_entries is False
+        assert result.directory_had_matching_files is True
+        assert result.discovered_first is None
+        assert result.discovered_last is None
 
     @pytest.mark.asyncio
     async def test_unpadded_printf_round_trip(self) -> None:

--- a/tests/unit/common/test_sequences.py
+++ b/tests/unit/common/test_sequences.py
@@ -1,8 +1,13 @@
-"""Tests for `griptape_nodes.common.sequences`.
+"""Tests for `griptape_nodes.common.sequences` via the public `ScanSequencesRequest`.
 
-Filesystem listings are stubbed via `GriptapeNodes.handle_request` so the
-tests don't depend on real on-disk state. fileseq's parsing/math is exercised
-indirectly through `scan_sequences`.
+The public entry point is the bus request, not the (now module-private)
+`_scan_sequences` function. Each test dispatches via `GriptapeNodes.ahandle_request(...)`
+and asserts on the typed result payload.
+
+Filesystem listings are stubbed by patching `GriptapeNodes.handle_request` so the
+inner `ListDirectoryRequest` returns canned filenames; this leaves the real
+`OSManager.on_scan_sequences_request` handler in place to exercise the full
+async dispatch path.
 """
 
 # ruff: noqa: PLR2004
@@ -15,17 +20,17 @@ from unittest.mock import patch
 
 import pytest
 
-from griptape_nodes.common.sequences import (
-    MissingItemError,
-    MissingItemPolicy,
-    scan_sequences,
-)
+from griptape_nodes.common.sequences import MissingItemPolicy
 from griptape_nodes.retained_mode.events.os_events import (
     FileIOFailureReason,
     FileSystemEntry,
     ListDirectoryRequest,
     ListDirectoryResultFailure,
     ListDirectoryResultSuccess,
+    ScanSequencesRequest,
+    ScanSequencesResultFailure,
+    ScanSequencesResultSuccess,
+    SequenceScanFailureReason,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
@@ -60,36 +65,76 @@ def _stub_listing(directory: str, filenames: list[str]) -> Any:
     return handle_request
 
 
+async def _scan(
+    directory: str,
+    pattern: str,
+    *,
+    policy: MissingItemPolicy = MissingItemPolicy.SPLIT,
+    start_number: int | None = None,
+    end_number: int | None = None,
+) -> ScanSequencesResultSuccess | ScanSequencesResultFailure:
+    """Dispatch a ScanSequencesRequest and narrow the result type for assertions."""
+    result = await GriptapeNodes.ahandle_request(
+        ScanSequencesRequest(
+            directory=directory,
+            pattern=pattern,
+            policy=policy,
+            start_number=start_number,
+            end_number=end_number,
+        )
+    )
+    assert isinstance(result, (ScanSequencesResultSuccess, ScanSequencesResultFailure)), (
+        f"unexpected result type: {type(result).__name__}"
+    )
+    return result
+
+
 # --- Basic scanning -----------------------------------------------------
 
 
 class TestBasicScanning:
-    def test_contiguous_sequence_split(self) -> None:
+    @pytest.mark.asyncio
+    async def test_contiguous_sequence_split(self) -> None:
         """SPLIT on a contiguous sequence yields one sub-sequence."""
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 3, 4, 5]]
         with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            seqs = scan_sequences(directory, "render.####.png", policy=MissingItemPolicy.SPLIT)
+            result = await _scan(directory, "render.####.png", policy=MissingItemPolicy.SPLIT)
+        assert isinstance(result, ScanSequencesResultSuccess)
+        assert result.has_entries is True
+        seqs = result.sequences
         assert len(seqs) == 1
         assert seqs[0].first == 1
         assert seqs[0].last == 5
         assert [e.number for e in seqs[0].entries] == [1, 2, 3, 4, 5]
         assert [e.padded_number for e in seqs[0].entries] == ["0001", "0002", "0003", "0004", "0005"]
 
-    def test_no_files_returns_empty(self) -> None:
-        """An empty directory yields an empty list."""
+    @pytest.mark.asyncio
+    async def test_no_files_returns_empty_success(self) -> None:
+        """An empty directory yields a success with no sequences and `has_entries=False`."""
         with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing("/work/in", [])):
-            seqs = scan_sequences("/work/in", "render.####.png")
-        assert seqs == []
+            result = await _scan("/work/in", "render.####.png")
+        assert isinstance(result, ScanSequencesResultSuccess)
+        assert result.sequences == []
+        assert result.has_entries is False
 
-    def test_directory_listing_failure_returns_empty(self) -> None:
-        """A failed listing yields an empty list (no exception)."""
+    @pytest.mark.asyncio
+    async def test_directory_listing_failure_returns_empty_success(self) -> None:
+        """A failed listing is currently swallowed by `_scan_sequences` and surfaces as an empty success.
+
+        TODO: a future iteration may have the handler dispatch its own
+        `ListDirectoryRequest` first and surface OS-layer failures via
+        `FileIOFailureReason` instead of folding them into empty success.
+        """
         # Stub always returns failure
         with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing("/other", [])):
-            seqs = scan_sequences("/work/in", "render.####.png")
-        assert seqs == []
+            result = await _scan("/work/in", "render.####.png")
+        assert isinstance(result, ScanSequencesResultSuccess)
+        assert result.sequences == []
+        assert result.has_entries is False
 
-    def test_unrelated_files_filtered_out(self) -> None:
+    @pytest.mark.asyncio
+    async def test_unrelated_files_filtered_out(self) -> None:
         """Files not matching basename/extension are ignored."""
         directory = "/work/in"
         filenames = [
@@ -100,7 +145,9 @@ class TestBasicScanning:
             "notes.txt",  # totally unrelated
         ]
         with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            seqs = scan_sequences(directory, "render.####.png", policy=MissingItemPolicy.SPLIT)
+            result = await _scan(directory, "render.####.png", policy=MissingItemPolicy.SPLIT)
+        assert isinstance(result, ScanSequencesResultSuccess)
+        seqs = result.sequences
         assert len(seqs) == 1
         assert [e.number for e in seqs[0].entries] == [1, 2]
 
@@ -109,48 +156,58 @@ class TestBasicScanning:
 
 
 class TestSplitPolicy:
-    def test_three_runs(self) -> None:
+    @pytest.mark.asyncio
+    async def test_three_runs(self) -> None:
         """Numbers 1-2, 4, 6-7 split into three sub-sequences."""
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 4, 6, 7]]
         with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            seqs = scan_sequences(directory, "render.####.png", policy=MissingItemPolicy.SPLIT)
+            result = await _scan(directory, "render.####.png", policy=MissingItemPolicy.SPLIT)
+        assert isinstance(result, ScanSequencesResultSuccess)
+        seqs = result.sequences
         assert len(seqs) == 3
         assert (seqs[0].first, seqs[0].last) == (1, 2)
         assert (seqs[1].first, seqs[1].last) == (4, 4)
         assert (seqs[2].first, seqs[2].last) == (6, 7)
 
-    def test_split_records_discovered_range_on_each(self) -> None:
+    @pytest.mark.asyncio
+    async def test_split_records_discovered_range_on_each(self) -> None:
         """All sub-sequences carry the same discovered_first/discovered_last."""
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 4, 6, 7]]
         with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            seqs = scan_sequences(directory, "render.####.png", policy=MissingItemPolicy.SPLIT)
-        for s in seqs:
+            result = await _scan(directory, "render.####.png", policy=MissingItemPolicy.SPLIT)
+        assert isinstance(result, ScanSequencesResultSuccess)
+        for s in result.sequences:
             assert s.discovered_first == 1
             assert s.discovered_last == 7
 
 
 class TestSkipPolicy:
-    def test_skip_omits_gaps(self) -> None:
+    @pytest.mark.asyncio
+    async def test_skip_omits_gaps(self) -> None:
         """SKIP yields one sequence with only present numbers; gaps absent from entries."""
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 4, 6, 7]]
         with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            seqs = scan_sequences(directory, "render.####.png", policy=MissingItemPolicy.SKIP)
+            result = await _scan(directory, "render.####.png", policy=MissingItemPolicy.SKIP)
+        assert isinstance(result, ScanSequencesResultSuccess)
+        seqs = result.sequences
         assert len(seqs) == 1
         assert [e.number for e in seqs[0].entries] == [1, 2, 4, 6, 7]
         assert seqs[0].missing_numbers == {3, 5}
 
 
 class TestFillNearestPolicy:
-    def test_fill_nearest_backward_first(self) -> None:
+    @pytest.mark.asyncio
+    async def test_fill_nearest_backward_first(self) -> None:
         """FILL_NEAREST fills gaps with the backward-first present number."""
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 4, 6, 7]]
         with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            seqs = scan_sequences(directory, "render.####.png", policy=MissingItemPolicy.FILL_NEAREST)
-        s = seqs[0]
+            result = await _scan(directory, "render.####.png", policy=MissingItemPolicy.FILL_NEAREST)
+        assert isinstance(result, ScanSequencesResultSuccess)
+        s = result.sequences[0]
         # Gap at 3 -> backward to 2
         entry_3 = next(e for e in s.entries if e.number == 3)
         assert Path(entry_3.path).name == "render.0002.png"
@@ -166,23 +223,26 @@ class TestFillNearestPolicy:
 
 
 class TestAbortPolicy:
-    def test_abort_raises_at_first_gap(self) -> None:
-        """ABORT raises MissingItemError on the first missing slot."""
+    @pytest.mark.asyncio
+    async def test_abort_surfaces_failure_at_first_gap(self) -> None:
+        """ABORT surfaces a ScanSequencesResultFailure with the offending number."""
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 4, 5]]
-        with (
-            patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)),
-            pytest.raises(MissingItemError) as exc_info,
-        ):
-            scan_sequences(directory, "render.####.png", policy=MissingItemPolicy.ABORT)
-        assert exc_info.value.number == 3
+        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
+            result = await _scan(directory, "render.####.png", policy=MissingItemPolicy.ABORT)
+        assert isinstance(result, ScanSequencesResultFailure)
+        assert result.failure_reason is SequenceScanFailureReason.ABORTED_AT_GAP
+        assert result.missing_item_number == 3
 
-    def test_abort_succeeds_when_dense(self) -> None:
+    @pytest.mark.asyncio
+    async def test_abort_succeeds_when_dense(self) -> None:
         """ABORT returns one Sequence with all entries when there are no gaps."""
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 3]]
         with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            seqs = scan_sequences(directory, "render.####.png", policy=MissingItemPolicy.ABORT)
+            result = await _scan(directory, "render.####.png", policy=MissingItemPolicy.ABORT)
+        assert isinstance(result, ScanSequencesResultSuccess)
+        seqs = result.sequences
         assert len(seqs) == 1
         assert [e.number for e in seqs[0].entries] == [1, 2, 3]
 
@@ -191,7 +251,8 @@ class TestAbortPolicy:
 
 
 class TestNegativeNumbers:
-    def test_negatives_with_different_padding_filter_out_silently(self) -> None:
+    @pytest.mark.asyncio
+    async def test_negatives_with_different_padding_filter_out_silently(self) -> None:
         """Negative numbers at a different padding width are filtered by the padding match.
 
         When `-0005.png` has 5 total chars (sign + 4 digits), fileseq groups
@@ -201,19 +262,24 @@ class TestNegativeNumbers:
         directory = "/work/in"
         filenames = ["render.-0005.png", "render.0001.png", "render.0002.png"]
         with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            seqs = scan_sequences(directory, "render.####.png", policy=MissingItemPolicy.SPLIT)
+            result = await _scan(directory, "render.####.png", policy=MissingItemPolicy.SPLIT)
+        assert isinstance(result, ScanSequencesResultSuccess)
+        seqs = result.sequences
         assert len(seqs) == 1
         assert [e.number for e in seqs[0].entries] == [1, 2]
         # Negatives never entered our loop; the counter sees zero.
         assert seqs[0].dropped_negative_number_count == 0
 
-    def test_negatives_with_matching_padding_dropped_with_counter(self) -> None:
+    @pytest.mark.asyncio
+    async def test_negatives_with_matching_padding_dropped_with_counter(self) -> None:
         """When padding matches, negatives DO enter the loop and get filtered out."""
         directory = "/work/in"
         # Width-5 pattern: `-0005` and `00005` both have 5 digits in their slot.
         filenames = ["render.-0005.png", "render.00005.png", "render.00010.png"]
         with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            seqs = scan_sequences(directory, "render.#####.png", policy=MissingItemPolicy.SPLIT)
+            result = await _scan(directory, "render.#####.png", policy=MissingItemPolicy.SPLIT)
+        assert isinstance(result, ScanSequencesResultSuccess)
+        seqs = result.sequences
         # The negative is dropped; positives 5 and 10 are in the same sequence
         # under SPLIT but they aren't contiguous, so they split into two runs.
         assert len(seqs) == 2
@@ -226,72 +292,99 @@ class TestNegativeNumbers:
 
 
 class TestSubsetClipping:
-    def test_start_only(self) -> None:
+    @pytest.mark.asyncio
+    async def test_start_only(self) -> None:
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 3, 4, 5]]
         with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            seqs = scan_sequences(directory, "render.####.png", policy=MissingItemPolicy.SPLIT, start=3)
+            result = await _scan(directory, "render.####.png", policy=MissingItemPolicy.SPLIT, start_number=3)
+        assert isinstance(result, ScanSequencesResultSuccess)
+        seqs = result.sequences
         assert len(seqs) == 1
         assert [e.number for e in seqs[0].entries] == [3, 4, 5]
         assert seqs[0].discovered_first == 1
         assert seqs[0].first == 3
 
-    def test_end_only(self) -> None:
+    @pytest.mark.asyncio
+    async def test_end_only(self) -> None:
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 3, 4, 5]]
         with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            seqs = scan_sequences(directory, "render.####.png", policy=MissingItemPolicy.SPLIT, end=3)
+            result = await _scan(directory, "render.####.png", policy=MissingItemPolicy.SPLIT, end_number=3)
+        assert isinstance(result, ScanSequencesResultSuccess)
+        seqs = result.sequences
         assert len(seqs) == 1
         assert [e.number for e in seqs[0].entries] == [1, 2, 3]
         assert seqs[0].discovered_last == 5
         assert seqs[0].last == 3
 
-    def test_start_and_end(self) -> None:
+    @pytest.mark.asyncio
+    async def test_start_and_end(self) -> None:
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 3, 4, 5]]
         with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            seqs = scan_sequences(directory, "render.####.png", policy=MissingItemPolicy.SPLIT, start=2, end=4)
+            result = await _scan(
+                directory, "render.####.png", policy=MissingItemPolicy.SPLIT, start_number=2, end_number=4
+            )
+        assert isinstance(result, ScanSequencesResultSuccess)
+        seqs = result.sequences
         assert len(seqs) == 1
         assert [e.number for e in seqs[0].entries] == [2, 3, 4]
 
-    def test_subset_outside_discovered_range_yields_empty(self) -> None:
+    @pytest.mark.asyncio
+    async def test_subset_outside_discovered_range_yields_empty_success(self) -> None:
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 3]]
         with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            seqs = scan_sequences(directory, "render.####.png", policy=MissingItemPolicy.SPLIT, start=10, end=20)
-        assert seqs == []
+            result = await _scan(
+                directory, "render.####.png", policy=MissingItemPolicy.SPLIT, start_number=10, end_number=20
+            )
+        assert isinstance(result, ScanSequencesResultSuccess)
+        assert result.sequences == []
+        assert result.has_entries is False
 
-    def test_negative_start_rejected(self) -> None:
-        with pytest.raises(ValueError, match=">= 0"):
-            scan_sequences("/work/in", "render.####.png", start=-1)
+    @pytest.mark.asyncio
+    async def test_negative_start_rejected(self) -> None:
+        result = await _scan("/work/in", "render.####.png", start_number=-1)
+        assert isinstance(result, ScanSequencesResultFailure)
+        assert result.failure_reason is SequenceScanFailureReason.INVALID_BOUNDS
 
-    def test_inverted_bounds_rejected(self) -> None:
-        with pytest.raises(ValueError, match=">= `start`"):
-            scan_sequences("/work/in", "render.####.png", start=10, end=5)
+    @pytest.mark.asyncio
+    async def test_inverted_bounds_rejected(self) -> None:
+        result = await _scan("/work/in", "render.####.png", start_number=10, end_number=5)
+        assert isinstance(result, ScanSequencesResultFailure)
+        assert result.failure_reason is SequenceScanFailureReason.INVALID_BOUNDS
 
 
 # --- Pattern variants ---------------------------------------------------
 
 
 class TestPatternVariants:
-    def test_printf_pattern(self) -> None:
+    @pytest.mark.asyncio
+    async def test_printf_pattern(self) -> None:
         """%04d works the same as ####."""
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 3]]
         with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            seqs = scan_sequences(directory, "render.%04d.png", policy=MissingItemPolicy.SPLIT)
+            result = await _scan(directory, "render.%04d.png", policy=MissingItemPolicy.SPLIT)
+        assert isinstance(result, ScanSequencesResultSuccess)
+        seqs = result.sequences
         assert len(seqs) == 1
         assert [e.number for e in seqs[0].entries] == [1, 2, 3]
 
-    def test_mismatched_padding_returns_empty(self) -> None:
-        """Disk has 3-digit numbers; user declared #### (4 digits). No match."""
+    @pytest.mark.asyncio
+    async def test_mismatched_padding_returns_empty_success(self) -> None:
+        """Disk has 3-digit numbers; user declared #### (4 digits). No match — empty success."""
         directory = "/work/in"
         filenames = [f"render.{n:03d}.png" for n in [1, 2, 3]]
         with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            seqs = scan_sequences(directory, "render.####.png", policy=MissingItemPolicy.SPLIT)
-        assert seqs == []
+            result = await _scan(directory, "render.####.png", policy=MissingItemPolicy.SPLIT)
+        assert isinstance(result, ScanSequencesResultSuccess)
+        assert result.sequences == []
+        assert result.has_entries is False
 
-    def test_unpadded_printf_round_trip(self) -> None:
+    @pytest.mark.asyncio
+    async def test_unpadded_printf_round_trip(self) -> None:
         """`%d` matches an unpadded directory and yields bare integer padded_numbers.
 
         fileseq treats `%d` as zfill=1 (same as a single `#`). The Sequence's
@@ -300,7 +393,9 @@ class TestPatternVariants:
         directory = "/work/in"
         filenames = ["render.5.png", "render.42.png", "render.123.png"]
         with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            seqs = scan_sequences(directory, "render.%d.png", policy=MissingItemPolicy.SPLIT)
+            result = await _scan(directory, "render.%d.png", policy=MissingItemPolicy.SPLIT)
+        assert isinstance(result, ScanSequencesResultSuccess)
+        seqs = result.sequences
         # 5, 42, 123 aren't contiguous, so SPLIT yields three sequences.
         assert len(seqs) == 3
         all_entries = [e for s in seqs for e in s.entries]
@@ -315,40 +410,52 @@ class TestPatternVariants:
 
 
 class TestPatternValidation:
-    """Multi-token templates raise before any work happens."""
+    """Multi-token templates surface as INVALID_TEMPLATE failures."""
 
-    def test_multi_token_dot_separator(self) -> None:
+    @pytest.mark.asyncio
+    async def test_multi_token_dot_separator(self) -> None:
         """`render.##.##.exr` — fileseq accepts this and silently misparses."""
-        with pytest.raises(ValueError, match="2 sequence tokens"):
-            scan_sequences("/work/in", "render.##.##.exr")
+        result = await _scan("/work/in", "render.##.##.exr")
+        assert isinstance(result, ScanSequencesResultFailure)
+        assert result.failure_reason is SequenceScanFailureReason.INVALID_TEMPLATE
+        assert "2 sequence tokens" in str(result.result_details or "")
 
-    def test_multi_token_underscore_separator(self) -> None:
+    @pytest.mark.asyncio
+    async def test_multi_token_underscore_separator(self) -> None:
         """`render.####_v####.exr` — two distinct hash tokens."""
-        with pytest.raises(ValueError, match="2 sequence tokens"):
-            scan_sequences("/work/in", "render.####_v####.exr")
+        result = await _scan("/work/in", "render.####_v####.exr")
+        assert isinstance(result, ScanSequencesResultFailure)
+        assert result.failure_reason is SequenceScanFailureReason.INVALID_TEMPLATE
+        assert "2 sequence tokens" in str(result.result_details or "")
 
-    def test_multi_token_mixed_syntax(self) -> None:
+    @pytest.mark.asyncio
+    async def test_multi_token_mixed_syntax(self) -> None:
         """A printf token AND a hash token in the same template."""
-        with pytest.raises(ValueError, match="2 sequence tokens"):
-            scan_sequences("/work/in", "foo_%04d_bar_####.exr")
+        result = await _scan("/work/in", "foo_%04d_bar_####.exr")
+        assert isinstance(result, ScanSequencesResultFailure)
+        assert result.failure_reason is SequenceScanFailureReason.INVALID_TEMPLATE
+        assert "2 sequence tokens" in str(result.result_details or "")
 
-    def test_zero_token_pattern_left_to_fileseq(self) -> None:
-        """A pattern with no token doesn't raise our error.
+    @pytest.mark.asyncio
+    async def test_zero_token_pattern_left_to_fileseq(self) -> None:
+        """A pattern with no token returns empty success.
 
-        fileseq itself will report an empty result (or its own error) for a
-        non-sequence pattern; we don't second-guess that here.
+        fileseq itself accepts non-sequence patterns silently; either way, no
+        result-set means a successful scan with `has_entries=False`.
         """
         directory = "/work/in"
         with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, [])):
-            # Should NOT raise from our validator. fileseq's FileSequence may
-            # accept it silently; either way, no result-set means empty.
-            seqs = scan_sequences(directory, "photo.png")
-        assert seqs == []
+            result = await _scan(directory, "photo.png")
+        assert isinstance(result, ScanSequencesResultSuccess)
+        assert result.sequences == []
+        assert result.has_entries is False
 
-    def test_single_token_passes(self) -> None:
+    @pytest.mark.asyncio
+    async def test_single_token_passes(self) -> None:
         """Sanity: a normal single-token pattern survives the validator."""
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 3]]
         with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            seqs = scan_sequences(directory, "render.####.png")
-        assert len(seqs) == 1
+            result = await _scan(directory, "render.####.png")
+        assert isinstance(result, ScanSequencesResultSuccess)
+        assert len(result.sequences) == 1

--- a/tests/unit/common/test_sequences.py
+++ b/tests/unit/common/test_sequences.py
@@ -1,8 +1,8 @@
 """Tests for `griptape_nodes.common.sequences` via the public `ScanSequencesRequest`.
 
-The public entry point is the bus request, not the (now module-private)
-`_scan_sequences` function. Each test dispatches via `GriptapeNodes.ahandle_request(...)`
-and asserts on the typed result payload.
+The intended entry point is the bus request, not the underlying
+`scan_sequences` function. Each test dispatches via
+`GriptapeNodes.ahandle_request(...)` and asserts on the typed result payload.
 
 Filesystem listings are stubbed by patching `GriptapeNodes.handle_request` so the
 inner `ListDirectoryRequest` returns canned filenames; this leaves the real
@@ -132,7 +132,7 @@ class TestBasicScanning:
     async def test_directory_listing_failure_surfaces_file_io_failure(self) -> None:
         """A failed listing propagates the OS-level `FileIOFailureReason` to the caller.
 
-        `_scan_sequences` raises `_DirectoryListingError` when the inner
+        `scan_sequences` raises `DirectoryListingError` when the inner
         `ListDirectoryRequest` fails; the handler maps that to a
         `ScanSequencesResultFailure` carrying the underlying reason. This
         replaces the prior behavior where listing failures were silently


### PR DESCRIPTION
Fixes #4710.

Moves sequence scanning off the synchronous direct-call path and onto the engine's event bus, then layers diagnostic upgrades on top so empty results — the most common failure mode in real-world use — actually tell the artist what went wrong.

## What changed

### Scanning is now a request

The intended entry point for scanning is `ScanSequencesRequest` (defined in `griptape_nodes.retained_mode.events.os_events`). The handler (`OSManager.on_scan_sequences_request`) runs the directory listing and fileseq parsing in a worker thread via `asyncio.to_thread`, so neither I/O nor parsing blocks the event loop. The underlying `scan_sequences` worker in `griptape_nodes.common.sequences.scan` is public — direct callers are allowed, but lose the worker-thread offload unless they take the I/O off the event loop themselves.

### Failure taxonomy

`ScanSequencesResultFailure.failure_reason` is a union of `SequenceScanFailureReason | FileIOFailureReason`:

- **`SequenceScanFailureReason`** (new enum): `INVALID_TEMPLATE`, `INVALID_BOUNDS`, `ABORTED_AT_GAP` — sequence-semantic problems the scanner itself raises. `ABORTED_AT_GAP` also carries `missing_item_number`.
- **`FileIOFailureReason`** (existing enum): surfaces OS-layer listing failures (directory not found, permission denied) when the inner `ListDirectoryRequest` fails. These no longer fold silently into "empty success."

To make the handler discriminate cleanly without string-matching, two new typed exceptions live alongside `MissingItemError` in `models.py`:

- `InvalidSubsetBoundsError(ValueError)` — `start < 0` or `end < start`.
- `InvalidTemplateError(ValueError)` — multi-token templates (e.g. `v##_f####.exr`, `render.##.##.exr`) that fileseq accepts but silently misparses.

Both subclass `ValueError` so existing broad clauses keep working.

### Empty-result diagnostics

Empty scan results have three indistinguishable causes in practice — wrong path, wrong padding, or a subset that clipped everything out. `ScanSequencesResultSuccess` now carries the diagnostic data needed to tell them apart:

- **`has_entries: bool`** — true iff at least one Sequence has at least one entry.
- **`directory_had_matching_files: bool`** — true iff the directory listing produced at least one file matching the target's basename + extension.
- **`discovered_first: int | None`** / **`discovered_last: int | None`** — on-disk range pre-subset, populated whenever fileseq inferred any numbers.

Internally, `scan_sequences` returns a `ScanOutcome` NamedTuple carrying all of this; the handler is now a thin translator. One listing per scan, no duplicated logic.

### Listing failures propagate

`DirectoryListingError` carries the underlying `FileIOFailureReason` and `result_details` from the inner `ListDirectoryRequest` up to the handler, which maps it onto `ScanSequencesResultFailure`. Previously, listing failures (directory not found, permission denied) were silently swallowed into empty-success — those now correctly surface as `ScanSequencesResultFailure(failure_reason=FileIOFailureReason.FILE_NOT_FOUND, …)`.

## Tests

26 unit tests in `tests/unit/common/test_sequences.py`, all dispatching via the bus (`GriptapeNodes.ahandle_request(ScanSequencesRequest(...))`) so the full async path is exercised. New/updated coverage:

- `test_directory_listing_failure_surfaces_file_io_failure` — inverted: listing failure now maps to a typed `ScanSequencesResultFailure`, not empty success.
- `test_mismatched_padding_reports_files_present` — 3-digit-on-disk vs 4-digit template; asserts `directory_had_matching_files=True`, `has_entries=False`, `discovered_first/last=None`.
- `test_subset_outside_discovered_range_reports_discovered_range` — confirms `discovered_first/last` populate even when `sequences=[]` due to subset clipping.
- Existing happy-path tests updated to assert on the new diagnostic fields.

## Docs

`docs/projects/sequences.md` documents the success-payload diagnostic fields and their consumer use case (distinguishing wrong-path / wrong-padding / wrong-range without inspecting `result_details` strings), plus a note about the standard library's node-level `fail_on_empty_result: bool = True` parameter that ships in the companion library PR.

<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--4711.org.readthedocs.build/en/4711/

<!-- readthedocs-preview griptape-nodes end -->