### PR TITLE
feat: expose GetNextVersionIndexRequest for O(1) version slot discovery

### DIFF
--- a/src/griptape_nodes/retained_mode/events/os_events.py
+++ b/src/griptape_nodes/retained_mode/events/os_events.py
@@ -850,3 +850,69 @@ class ResolveMacroPathResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailur
     """
 
     missing_variables: set[str] | None = None
+
+
+@dataclass
+@PayloadRegistry.register
+class GetNextVersionIndexRequest(RequestPayload):
+    """Find the next available version index for a versioned path pattern.
+
+    Use when: Allocating a new versioned output slot (e.g. ``v001``, ``v002``) without
+    creating any files. The caller passes a ``MacroPath`` whose template contains an
+    unresolved ``{_index}`` placeholder. The OS manager performs a single glob pass over
+    the parent directory to discover which indices are already taken and returns the
+    lowest unused one (gaps are filled first).
+
+    This is a read-only preview operation — no files or directories are created.
+
+    Args:
+        macro_path: MacroPath whose template contains ``{_index}`` (required or optional).
+            All variables other than ``_index`` must be resolved in ``macro_path.variables``
+            so the manager can build a concrete glob pattern.
+
+    Results: GetNextVersionIndexResultSuccess | GetNextVersionIndexResultFailure
+
+    Examples:
+        MacroPath with required ``{_index:03}``:
+            Template: ``"{outputs}/render_v{_index:03}"``
+            Variables: ``{"outputs": "/abs/path"}``
+            Existing dirs: ``render_v001``, ``render_v002``, ``render_v004``
+            Returns: ``GetNextVersionIndexResultSuccess(index=3)``  # fills the gap
+
+        MacroPath with no existing entries:
+            Returns: ``GetNextVersionIndexResultSuccess(index=1)``
+
+        MacroPath with optional ``{_index?:_}`` and base path free:
+            Returns: ``GetNextVersionIndexResultSuccess(index=None)``
+            (callers that always need an integer should treat ``None`` as ``1``)
+    """
+
+    macro_path: MacroPath
+
+
+@dataclass
+@PayloadRegistry.register
+class GetNextVersionIndexResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """Next available version index found (read-only preview — no files created).
+
+    Attributes:
+        index: The lowest unused version index (1-based), or ``None`` when the
+            ``{_index}`` placeholder is optional and the un-indexed base path is
+            still available. Callers that always require an integer (e.g. directory
+            versioning) should treat ``None`` as ``1``.
+    """
+
+    index: int | None
+
+
+@dataclass
+@PayloadRegistry.register
+class GetNextVersionIndexResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Failed to determine the next available version index.
+
+    Attributes:
+        failure_reason: Classification of why the operation failed
+        result_details: Human-readable error message (inherited from ResultPayloadFailure)
+    """
+
+    failure_reason: FileIOFailureReason

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -71,6 +71,9 @@ from griptape_nodes.retained_mode.events.os_events import (
     GetNextUnusedFilenameRequest,
     GetNextUnusedFilenameResultFailure,
     GetNextUnusedFilenameResultSuccess,
+    GetNextVersionIndexRequest,
+    GetNextVersionIndexResultFailure,
+    GetNextVersionIndexResultSuccess,
     ListDirectoryRequest,
     ListDirectoryResultFailure,
     ListDirectoryResultSuccess,
@@ -330,6 +333,14 @@ class OSManager:
 
             event_manager.assign_manager_to_request_type(
                 request_type=ResolveMacroPathRequest, callback=self.on_handle_resolve_macro_path_request
+            )
+
+            event_manager.assign_manager_to_request_type(
+                request_type=GetNextUnusedFilenameRequest, callback=self.on_get_next_unused_filename_request
+            )
+
+            event_manager.assign_manager_to_request_type(
+                request_type=GetNextVersionIndexRequest, callback=self.on_get_next_version_index_request
             )
 
             # Store event_manager for direct access during resource registration
@@ -1800,6 +1811,38 @@ class OSManager:
             result_details=f"Found available filename with index {next_index}"
             if next_index
             else "Found available filename (no index needed)",
+        )
+
+    def on_get_next_version_index_request(self, request: GetNextVersionIndexRequest) -> ResultPayload:
+        """Handle a request to find the next available version index via a single glob pass."""
+        parsed_macro = request.macro_path.parsed_macro
+        variables = request.macro_path.variables
+
+        try:
+            index_info = self._identify_index_variable(parsed_macro, variables)
+        except ValueError as e:
+            msg = str(e)
+            logger.error(msg)
+            return GetNextVersionIndexResultFailure(
+                failure_reason=FileIOFailureReason.INVALID_PATH,
+                result_details=msg,
+            )
+
+        if index_info is None:
+            msg = "Attempted to find next version index. Failed because no unresolved {_index} variable was found in the macro template."
+            logger.error(msg)
+            return GetNextVersionIndexResultFailure(
+                failure_reason=FileIOFailureReason.INVALID_PATH,
+                result_details=msg,
+            )
+
+        next_index = self._scan_for_next_available_index(parsed_macro, variables, index_info)
+
+        return GetNextVersionIndexResultSuccess(
+            index=next_index,
+            result_details=f"Next available version index is {next_index}"
+            if next_index is not None
+            else "Base path is available (no index needed)",
         )
 
     def on_write_file_request(self, request: WriteFileRequest) -> ResultPayload:  # noqa: PLR0911, PLR0912, PLR0915, C901

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -1768,7 +1768,7 @@ class OSManager:
         try:
             index_info = self._identify_index_variable(parsed_macro, variables)
         except ValueError as e:
-            msg = str(e)
+            msg = f"Failed to identify index variable in path template: {e}"
             logger.error(msg)
             return GetNextUnusedFilenameResultFailure(
                 failure_reason=FileIOFailureReason.INVALID_PATH,
@@ -1821,7 +1821,7 @@ class OSManager:
         try:
             index_info = self._identify_index_variable(parsed_macro, variables)
         except ValueError as e:
-            msg = str(e)
+            msg = f"Attempted to find next version index. Failed: {e}"
             logger.error(msg)
             return GetNextVersionIndexResultFailure(
                 failure_reason=FileIOFailureReason.INVALID_PATH,

--- a/tests/unit/retained_mode/managers/test_os_manager.py
+++ b/tests/unit/retained_mode/managers/test_os_manager.py
@@ -9,6 +9,7 @@ import anyio
 import pytest
 import send2trash
 
+from griptape_nodes.common.macro_parser import ParsedMacro
 from griptape_nodes.files.path_utils import normalize_path_for_platform, resolve_path_safely
 from griptape_nodes.retained_mode.events.base_events import ResultDetails
 from griptape_nodes.retained_mode.events.os_events import (
@@ -25,6 +26,12 @@ from griptape_nodes.retained_mode.events.os_events import (
     GetFileInfoRequest,
     GetFileInfoResultFailure,
     GetFileInfoResultSuccess,
+    GetNextUnusedFilenameRequest,
+    GetNextUnusedFilenameResultFailure,
+    GetNextUnusedFilenameResultSuccess,
+    GetNextVersionIndexRequest,
+    GetNextVersionIndexResultFailure,
+    GetNextVersionIndexResultSuccess,
     ListDirectoryRequest,
     ListDirectoryResultFailure,
     ListDirectoryResultSuccess,
@@ -38,6 +45,7 @@ from griptape_nodes.retained_mode.events.os_events import (
     WriteFileResultFailure,
     WriteFileResultSuccess,
 )
+from griptape_nodes.retained_mode.events.project_events import MacroPath
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.os_manager import OSManager, WindowsSpecialFolderError
 
@@ -1450,3 +1458,125 @@ class TestDiskSpaceProbe:
         # probe branch emits "Available:" numbers. We want the probe branch.
         assert "Available:" in message
         assert "Could not determine disk space" not in message
+
+
+class TestGetNextUnusedFilenameRequest:
+    """Test GetNextUnusedFilenameRequest preview behavior."""
+
+    @pytest.fixture
+    def temp_dir(self) -> Generator[Path, None, None]:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    @pytest.fixture(autouse=True)
+    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+        original_workspace = griptape_nodes.ConfigManager().workspace_path
+        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        yield
+        griptape_nodes.ConfigManager().workspace_path = original_workspace
+
+    def test_base_filename_available_returns_unindexed_path(
+        self, griptape_nodes: GriptapeNodes, temp_dir: Path
+    ) -> None:
+        """When the base filename is free, preview returns that path and no index."""
+        os_manager = griptape_nodes.OSManager()
+        requested_path = temp_dir / "render.png"
+
+        result = os_manager.on_get_next_unused_filename_request(
+            GetNextUnusedFilenameRequest(file_path=str(requested_path))
+        )
+
+        assert isinstance(result, GetNextUnusedFilenameResultSuccess)
+        assert Path(result.available_filename).resolve() == requested_path.resolve()
+        assert result.index_used is None
+        assert not requested_path.exists()
+
+    def test_existing_base_filename_returns_indexed_candidate(
+        self, griptape_nodes: GriptapeNodes, temp_dir: Path
+    ) -> None:
+        """When base exists, preview switches to indexed naming."""
+        os_manager = griptape_nodes.OSManager()
+        (temp_dir / "render.png").write_text("base")
+
+        result = os_manager.on_get_next_unused_filename_request(
+            GetNextUnusedFilenameRequest(file_path=str(temp_dir / "render.png"))
+        )
+
+        assert isinstance(result, GetNextUnusedFilenameResultSuccess)
+        assert result.index_used == 1
+        assert Path(result.available_filename).resolve() == (temp_dir / "render_1.png").resolve()
+
+    def test_macro_without_unresolved_index_fails(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+        """Macro path without an unresolved index variable cannot be auto-incremented."""
+        os_manager = griptape_nodes.OSManager()
+        macro_path = MacroPath(parsed_macro=ParsedMacro(f"{temp_dir}/render.png"), variables={})
+
+        result = os_manager.on_get_next_unused_filename_request(
+            GetNextUnusedFilenameRequest(file_path=macro_path)
+        )
+
+        assert isinstance(result, GetNextUnusedFilenameResultFailure)
+        assert result.failure_reason == FileIOFailureReason.INVALID_PATH
+
+
+class TestGetNextVersionIndexRequest:
+    """Test GetNextVersionIndexRequest index-preview behavior."""
+
+    @pytest.fixture
+    def temp_dir(self) -> Generator[Path, None, None]:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    @pytest.fixture(autouse=True)
+    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+        original_workspace = griptape_nodes.ConfigManager().workspace_path
+        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        yield
+        griptape_nodes.ConfigManager().workspace_path = original_workspace
+
+    def test_required_index_returns_one_when_no_matches(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+        """Required index templates start at index 1 when nothing exists yet."""
+        os_manager = griptape_nodes.OSManager()
+
+        request = GetNextVersionIndexRequest(
+            macro_path=MacroPath(
+                parsed_macro=ParsedMacro("{outputs}/render_v{_index:03}"),
+                variables={"outputs": str(temp_dir)},
+            )
+        )
+        result = os_manager.on_get_next_version_index_request(request)
+
+        assert isinstance(result, GetNextVersionIndexResultSuccess)
+        assert result.index == 1
+
+    def test_optional_index_is_rejected_as_invalid_path(
+        self, griptape_nodes: GriptapeNodes, temp_dir: Path
+    ) -> None:
+        """Optional index templates currently fail because no required unresolved index exists."""
+        os_manager = griptape_nodes.OSManager()
+
+        request = GetNextVersionIndexRequest(
+            macro_path=MacroPath(
+                parsed_macro=ParsedMacro("{outputs}/render{_index?:_}.png"),
+                variables={"outputs": str(temp_dir)},
+            )
+        )
+        result = os_manager.on_get_next_version_index_request(request)
+
+        assert isinstance(result, GetNextVersionIndexResultFailure)
+        assert result.failure_reason == FileIOFailureReason.INVALID_PATH
+
+    def test_missing_unresolved_index_returns_failure(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+        """Requests without an unresolved {_index} variable should fail as invalid path input."""
+        os_manager = griptape_nodes.OSManager()
+        request = GetNextVersionIndexRequest(
+            macro_path=MacroPath(
+                parsed_macro=ParsedMacro("{outputs}/render.png"),
+                variables={"outputs": str(temp_dir)},
+            )
+        )
+
+        result = os_manager.on_get_next_version_index_request(request)
+
+        assert isinstance(result, GetNextVersionIndexResultFailure)
+        assert result.failure_reason == FileIOFailureReason.INVALID_PATH

--- a/tests/unit/retained_mode/managers/test_os_manager.py
+++ b/tests/unit/retained_mode/managers/test_os_manager.py
@@ -1511,9 +1511,7 @@ class TestGetNextUnusedFilenameRequest:
         os_manager = griptape_nodes.OSManager()
         macro_path = MacroPath(parsed_macro=ParsedMacro(f"{temp_dir}/render.png"), variables={})
 
-        result = os_manager.on_get_next_unused_filename_request(
-            GetNextUnusedFilenameRequest(file_path=macro_path)
-        )
+        result = os_manager.on_get_next_unused_filename_request(GetNextUnusedFilenameRequest(file_path=macro_path))
 
         assert isinstance(result, GetNextUnusedFilenameResultFailure)
         assert result.failure_reason == FileIOFailureReason.INVALID_PATH
@@ -1549,9 +1547,7 @@ class TestGetNextVersionIndexRequest:
         assert isinstance(result, GetNextVersionIndexResultSuccess)
         assert result.index == 1
 
-    def test_optional_index_is_rejected_as_invalid_path(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    def test_optional_index_is_rejected_as_invalid_path(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
         """Optional index templates currently fail because no required unresolved index exists."""
         os_manager = griptape_nodes.OSManager()
 


### PR DESCRIPTION
## Summary

- Exposes `GetNextVersionIndexRequest` as a first-class event so callers can find the next free versioned directory slot in a single glob pass, rather than an O(N) IPC probe loop                                                                                                       
- Adds `GetNextVersionIndexResultSuccess` (returns `index: int | None`) and `GetNextVersionIndexResultFailure`                                                                                                                                                                           
- Fixes a pre-existing bug: `GetNextUnusedFilenameRequest` was imported but never registered in `OSManager.__init__`

## Why
                                                                                                                                                                                   
Two upcoming callers (in #4635) (`directory.py` and `file_sequence.py` in `feat/dir_sequence_output`) each need to find the lowest unused `_vNNN` index. There was already a `_scan_for_next_available_index` method which does this in a single `glob` pass — this PR surfaces it as a proper request type.