### PR TITLE
feat(mcp): add node info + param list + save workflow + source location

### DIFF
--- a/src/griptape_nodes/retained_mode/events/library_events.py
+++ b/src/griptape_nodes/retained_mode/events/library_events.py
@@ -1250,3 +1250,71 @@ class InspectLibraryRepoResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSucc
 @PayloadRegistry.register
 class InspectLibraryRepoResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     """Library repository inspection failed. Common causes: invalid git URL, network error, no library JSON found, invalid JSON format."""
+
+
+@dataclass
+@PayloadRegistry.register
+class GetLibrarySourceInfoRequest(RequestPayload):
+    """Get filesystem paths for a registered library's source code.
+
+    Use when: Locating library source files on disk, reading node source code.
+
+    Args:
+        library: Name of the registered library (e.g. "Griptape Nodes Library")
+
+    Results: GetLibrarySourceInfoResultSuccess (with paths) | GetLibrarySourceInfoResultFailure (library not found)
+    """
+
+    library: str
+
+
+@dataclass
+@PayloadRegistry.register
+class GetLibrarySourceInfoResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """Library source info retrieved successfully.
+
+    Args:
+        library_name: Echo of the requested library name
+        library_json_path: Absolute path to the library's griptape_nodes_library.json
+        library_directory: Absolute path to the directory containing the JSON file
+    """
+
+    library_name: str
+    library_json_path: str
+    library_directory: str
+
+
+@dataclass
+@PayloadRegistry.register
+class GetLibrarySourceInfoResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Library source info retrieval failed. Common causes: library not found, library not yet loaded."""
+
+
+@dataclass
+@PayloadRegistry.register
+class GetEngineSourceInfoRequest(RequestPayload):
+    """Get the filesystem path of the griptape_nodes engine source tree.
+
+    Use when: Reading engine base class definitions (e.g. exe_types/node_types.py),
+    inspecting engine internals, locating engine source code on disk.
+
+    Results: GetEngineSourceInfoResultSuccess (with path) | GetEngineSourceInfoResultFailure (resolution error)
+    """
+
+
+@dataclass
+@PayloadRegistry.register
+class GetEngineSourceInfoResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """Engine source info retrieved successfully.
+
+    Args:
+        package_directory: Absolute path to the griptape_nodes package root
+    """
+
+    package_directory: str
+
+
+@dataclass
+@PayloadRegistry.register
+class GetEngineSourceInfoResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Engine source info retrieval failed. Common causes: package path could not be resolved."""

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -86,9 +86,15 @@ from griptape_nodes.retained_mode.events.library_events import (
     GetAllInfoForLibraryRequest,
     GetAllInfoForLibraryResultFailure,
     GetAllInfoForLibraryResultSuccess,
+    GetEngineSourceInfoRequest,
+    GetEngineSourceInfoResultFailure,
+    GetEngineSourceInfoResultSuccess,
     GetLibraryMetadataRequest,
     GetLibraryMetadataResultFailure,
     GetLibraryMetadataResultSuccess,
+    GetLibrarySourceInfoRequest,
+    GetLibrarySourceInfoResultFailure,
+    GetLibrarySourceInfoResultSuccess,
     GetNodeMetadataFromLibraryRequest,
     GetNodeMetadataFromLibraryResultFailure,
     GetNodeMetadataFromLibraryResultSuccess,
@@ -451,6 +457,10 @@ class LibraryManager:
         )
         event_manager.assign_manager_to_request_type(SyncLibrariesRequest, self.sync_libraries_request)
         event_manager.assign_manager_to_request_type(InspectLibraryRepoRequest, self.inspect_library_repo_request)
+        event_manager.assign_manager_to_request_type(
+            GetLibrarySourceInfoRequest, self.on_get_library_source_info_request
+        )
+        event_manager.assign_manager_to_request_type(GetEngineSourceInfoRequest, self.on_get_engine_source_info_request)
 
         event_manager.add_listener_to_app_event(
             LibraryLoadedNotification,
@@ -736,6 +746,74 @@ class LibraryManager:
             result_details=details,
         )
         return result
+
+    async def on_get_library_source_info_request(self, request: GetLibrarySourceInfoRequest) -> ResultPayload:
+        """Return the filesystem paths for a registered library's source files.
+
+        Waits for all libraries to finish loading before resolving the request,
+        ensuring the library registry is in a consistent state.
+
+        The response provides two path variants for the named library:
+        - ``library_json_path``: the absolute path to the library's
+          ``griptape_nodes_library.json`` manifest file.
+        - ``library_directory``: the absolute path to the directory that contains the
+          manifest file (i.e. the library root folder).
+
+        Args:
+            request: A :class:`GetLibrarySourceInfoRequest` carrying the ``library``
+              field — the registered name of the library whose source paths are being
+              queried (e.g. ``"Griptape Nodes Library"``).
+
+        Returns:
+            :class:`GetLibrarySourceInfoResultSuccess` containing ``library_name``,
+              ``library_json_path``, and ``library_directory`` when the library is
+              found.
+
+            :class:`GetLibrarySourceInfoResultFailure` when no library with the
+              requested name has been registered.
+        """
+        await self._libraries_loading_complete.wait()
+        lib_info = self.get_library_info_by_library_name(request.library)
+        if lib_info is None:
+            return GetLibrarySourceInfoResultFailure(
+                result_details=f"Library '{request.library}' not found.",
+            )
+        library_dir = str(Path(lib_info.library_path).parent.absolute())
+        return GetLibrarySourceInfoResultSuccess(
+            library_name=request.library,
+            library_json_path=lib_info.library_path,
+            library_directory=library_dir,
+            result_details=f"Source info for library '{request.library}'.",
+        )
+
+    def on_get_engine_source_info_request(self, _request: GetEngineSourceInfoRequest) -> ResultPayload:
+        """Return the filesystem path of the installed ``griptape_nodes`` package.
+
+        Resolves the location of the ``griptape_nodes`` package on disk. The returned
+        directory is the package root.
+
+        This is useful for tools that need to read engine source files directly, for
+        example to inspect base-class definitions in ``exe_types/node_types.py`` or
+        locate built-in node implementations.
+
+        Args:
+            _request: A :class:`GetEngineSourceInfoRequest` (no fields required; the
+                argument is accepted for handler-dispatch consistency).
+
+        Returns:
+            :class:`GetEngineSourceInfoResultSuccess` containing ``package_directory`` —
+                the absolute path to the ``griptape_nodes`` package root directory.
+        """
+        spec = importlib.util.find_spec("griptape_nodes")
+        if spec is None or spec.origin is None:
+            return GetEngineSourceInfoResultFailure(
+                result_details="Attempted to resolve engine source path. Failed because the griptape_nodes package spec could not be located.",
+            )
+        package_dir = str(Path(spec.origin).parent.absolute())
+        return GetEngineSourceInfoResultSuccess(
+            package_directory=package_dir,
+            result_details="Engine source info.",
+        )
 
     def on_list_node_types_in_library_request(self, request: ListNodeTypesInLibraryRequest) -> ResultPayload:
         # Does this library exist?

--- a/src/griptape_nodes/servers/mcp.py
+++ b/src/griptape_nodes/servers/mcp.py
@@ -49,6 +49,8 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.library_events import (
     DescribeNodeTypeRequest,
+    GetEngineSourceInfoRequest,
+    GetLibrarySourceInfoRequest,
     ListCategoriesInLibraryRequest,
     ListNodeTypesInLibraryRequest,
     ListRegisteredLibrariesRequest,
@@ -57,6 +59,7 @@ from griptape_nodes.retained_mode.events.library_events import (
 from griptape_nodes.retained_mode.events.node_events import (
     CreateNodeRequest,
     DeleteNodeRequest,
+    GetAllNodeInfoRequest,
     GetNodeMetadataRequest,
     GetNodeResolutionStateRequest,
     ListParametersOnNodeRequest,
@@ -69,6 +72,7 @@ from griptape_nodes.retained_mode.events.object_events import (
     RenameObjectRequest,
 )
 from griptape_nodes.retained_mode.events.parameter_events import (
+    AddParameterToNodeRequest,
     GetConnectionsForParameterRequest,
     GetParameterDetailsRequest,
     GetParameterValueRequest,
@@ -77,6 +81,7 @@ from griptape_nodes.retained_mode.events.parameter_events import (
 from griptape_nodes.retained_mode.events.workflow_events import (
     ListAllWorkflowsRequest,
     RunWorkflowWithCurrentStateRequest,
+    SaveWorkflowRequest,
 )
 from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
 from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
@@ -130,6 +135,17 @@ SUPPORTED_REQUEST_EVENTS: dict[str, type[RequestPayload]] = {
     "SetParameterValueRequest": SetParameterValueRequest,
     "GetParameterDetailsRequest": GetParameterDetailsRequest,
     "GetConnectionsForParameterRequest": GetConnectionsForParameterRequest,
+    # Expander-style ParameterList parameters (e.g. input_images on OpenAiImageGeneration) require
+    # a slot to be created before a connection can be made. AddParameterToNodeRequest creates that
+    # slot and returns its UUID name, which can then be used as the target of CreateConnectionRequest.
+    "AddParameterToNodeRequest": AddParameterToNodeRequest,
+    # Batch node info (metadata + state + connections + params in one call)
+    "GetAllNodeInfoRequest": GetAllNodeInfoRequest,
+    # Workflow persistence
+    "SaveWorkflowRequest": SaveWorkflowRequest,
+    # Library / engine source discovery (read-only)
+    "GetLibrarySourceInfoRequest": GetLibrarySourceInfoRequest,
+    "GetEngineSourceInfoRequest": GetEngineSourceInfoRequest,
 }
 
 # Synthetic MCP tool name for the batch envelope. Not a request payload (and so not a member of

--- a/tests/unit/retained_mode/managers/test_library_manager_source_info.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_source_info.py
@@ -1,0 +1,174 @@
+import asyncio
+from importlib.machinery import ModuleSpec
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from griptape_nodes.retained_mode.events.library_events import (
+    GetEngineSourceInfoRequest,
+    GetEngineSourceInfoResultFailure,
+    GetEngineSourceInfoResultSuccess,
+    GetLibrarySourceInfoRequest,
+    GetLibrarySourceInfoResultFailure,
+    GetLibrarySourceInfoResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
+
+# Compute the filesystem root once at import time so async test bodies don't
+# call Path methods (ASYNC240 forbids Path I/O inside async functions).
+_FS_ROOT = Path("/").resolve()
+
+
+class TestGetLibrarySourceInfoRequest:
+    @pytest.mark.asyncio
+    async def test_returns_success_with_correct_paths(self, griptape_nodes: GriptapeNodes) -> None:
+        library_manager = griptape_nodes.LibraryManager()
+
+        root = _FS_ROOT
+        json_path = str(root / "some" / "dir" / "griptape_nodes_library.json")
+        dir_path = str(root / "some" / "dir")
+
+        mock_lib_info = LibraryManager.LibraryInfo(
+            lifecycle_state=LibraryManager.LibraryLifecycleState.LOADED,
+            fitness=LibraryManager.LibraryFitness.GOOD,
+            library_path=json_path,
+            is_sandbox=False,
+            library_name="Test Library",
+        )
+
+        with patch.object(
+            library_manager, "get_library_info_by_library_name", return_value=mock_lib_info, autospec=True
+        ) as get_library_info_by_library_name:
+            request = GetLibrarySourceInfoRequest(library="Test Library")
+            result = await library_manager.on_get_library_source_info_request(request)
+
+        get_library_info_by_library_name.assert_called_once_with("Test Library")
+        assert isinstance(result, GetLibrarySourceInfoResultSuccess)
+        assert result.library_name == "Test Library"
+        assert result.library_json_path == json_path
+        assert result.library_directory == dir_path
+
+    @pytest.mark.asyncio
+    async def test_library_directory_is_parent_of_json_path(self, griptape_nodes: GriptapeNodes) -> None:
+        library_manager = griptape_nodes.LibraryManager()
+
+        root = _FS_ROOT
+        json_path = str(root / "libs" / "my_lib" / "griptape_nodes_library.json")
+
+        mock_lib_info = LibraryManager.LibraryInfo(
+            lifecycle_state=LibraryManager.LibraryLifecycleState.LOADED,
+            fitness=LibraryManager.LibraryFitness.GOOD,
+            library_path=json_path,
+            is_sandbox=False,
+            library_name="My Lib",
+        )
+
+        with patch.object(
+            library_manager, "get_library_info_by_library_name", return_value=mock_lib_info, autospec=True
+        ) as get_library_info_by_library_name:
+            request = GetLibrarySourceInfoRequest(library="My Lib")
+            result = await library_manager.on_get_library_source_info_request(request)
+
+        get_library_info_by_library_name.assert_called_once_with("My Lib")
+        assert isinstance(result, GetLibrarySourceInfoResultSuccess)
+        assert Path(result.library_directory) == Path(result.library_json_path).parent
+
+    @pytest.mark.asyncio
+    async def test_returns_failure_when_library_not_found(self, griptape_nodes: GriptapeNodes) -> None:
+        library_manager = griptape_nodes.LibraryManager()
+
+        with patch.object(
+            library_manager, "get_library_info_by_library_name", return_value=None, autospec=True
+        ) as get_library_info_by_library_name:
+            request = GetLibrarySourceInfoRequest(library="NonexistentLib")
+            result = await library_manager.on_get_library_source_info_request(request)
+
+        get_library_info_by_library_name.assert_called_once_with("NonexistentLib")
+        assert isinstance(result, GetLibrarySourceInfoResultFailure)
+
+    @pytest.mark.asyncio
+    async def test_waits_for_libraries_loading_complete(self, griptape_nodes: GriptapeNodes) -> None:
+        library_manager = griptape_nodes.LibraryManager()
+
+        loading_event = asyncio.Event()
+        root = _FS_ROOT
+        json_path = str(root / "some" / "dir" / "griptape_nodes_library.json")
+        mock_lib_info = LibraryManager.LibraryInfo(
+            lifecycle_state=LibraryManager.LibraryLifecycleState.LOADED,
+            fitness=LibraryManager.LibraryFitness.GOOD,
+            library_path=json_path,
+            is_sandbox=False,
+            library_name="Test Library",
+        )
+
+        with (
+            patch.object(library_manager, "_libraries_loading_complete", loading_event),
+            patch.object(
+                library_manager,
+                "get_library_info_by_library_name",
+                return_value=mock_lib_info,
+                autospec=True,
+            ) as get_library_info_by_library_name,
+        ):
+            request = GetLibrarySourceInfoRequest(library="Test Library")
+            task = asyncio.create_task(library_manager.on_get_library_source_info_request(request))
+
+            await asyncio.sleep(0)
+            assert not task.done()
+
+            loading_event.set()
+            result = await task
+
+        get_library_info_by_library_name.assert_called_once_with("Test Library")
+        assert isinstance(result, GetLibrarySourceInfoResultSuccess)
+
+
+class TestGetEngineSourceInfoRequest:
+    def test_returns_success_with_valid_directory(self, griptape_nodes: GriptapeNodes) -> None:
+        library_manager = griptape_nodes.LibraryManager()
+
+        request = GetEngineSourceInfoRequest()
+        result = library_manager.on_get_engine_source_info_request(request)
+
+        assert isinstance(result, GetEngineSourceInfoResultSuccess)
+        assert Path(result.package_directory).is_dir()
+
+    def test_package_directory_contains_init(self, griptape_nodes: GriptapeNodes) -> None:
+        library_manager = griptape_nodes.LibraryManager()
+
+        request = GetEngineSourceInfoRequest()
+        result = library_manager.on_get_engine_source_info_request(request)
+
+        assert isinstance(result, GetEngineSourceInfoResultSuccess)
+        assert (Path(result.package_directory) / "__init__.py").exists()
+
+    def test_package_directory_contains_exe_types(self, griptape_nodes: GriptapeNodes) -> None:
+        library_manager = griptape_nodes.LibraryManager()
+
+        request = GetEngineSourceInfoRequest()
+        result = library_manager.on_get_engine_source_info_request(request)
+
+        assert isinstance(result, GetEngineSourceInfoResultSuccess)
+        assert (Path(result.package_directory) / "exe_types" / "node_types.py").exists()
+
+    def test_returns_failure_when_spec_not_found(self, griptape_nodes: GriptapeNodes) -> None:
+        library_manager = griptape_nodes.LibraryManager()
+
+        with patch("importlib.util.find_spec", return_value=None):
+            request = GetEngineSourceInfoRequest()
+            result = library_manager.on_get_engine_source_info_request(request)
+
+        assert isinstance(result, GetEngineSourceInfoResultFailure)
+
+    def test_returns_failure_when_spec_origin_is_none(self, griptape_nodes: GriptapeNodes) -> None:
+        library_manager = griptape_nodes.LibraryManager()
+
+        spec_without_origin = ModuleSpec(name="griptape_nodes", loader=None, origin=None)
+
+        with patch("importlib.util.find_spec", return_value=spec_without_origin):
+            request = GetEngineSourceInfoRequest()
+            result = library_manager.on_get_engine_source_info_request(request)
+
+        assert isinstance(result, GetEngineSourceInfoResultFailure)


### PR DESCRIPTION
Closes #4683.  

Don't add AppStartSessionRequest nor RunWorkflowFromScratchRequest (mentioned in the issue) - they are potentially dangerous and probably unnecessary. In particular, RunWorkflowFromScratchRequest can be accomplished by ClearAllObjectStateRequest + RunWorkflowWithCurrentStateRequest.

Expose existing requests through MCP server:

- AddParameterToNodeRequest - required for agents to make connections to expandable list parameters.
- GetAllNodeInfoRequest - useful to gather information on a node that would otherwise take multiple MCP calls (which the agent may not know to do).
- SaveWorkflowRequest - necessary when you want an agent to autonomously create a workflow, save it, and start creating another workflow.

Add new request types to the MCP server to help agent-based node inspection via node and engine source code:

- GetLibrarySourceInfoRequest: returns the filesystem path of a registered library's griptape_nodes_library.json and its parent directory, so callers can locate node source files on disk.
- GetEngineSourceInfoRequest: returns the filesystem path of the griptape_nodes package root, so callers can read engine base class definitions (e.g. exe_types/node_types.py).