### PR TITLE
ArtifactManager check for preview availability from ArtifactProvider

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/artifact_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_manager.py
@@ -339,7 +339,7 @@ class ArtifactManager:
             )
 
         # FAILURE CASE: Verify provider generates previews
-        if not provider_class.get_preview_formats():
+        if len(provider_class.get_preview_formats()) == 0:
             return GeneratePreviewResultFailure(
                 result_details=f"Attempted to generate preview for '{source_path}'. "
                 f"Failed due to: provider '{request.artifact_provider_name}' does not generate previews"
@@ -502,7 +502,7 @@ class ArtifactManager:
             )
 
         # FAILURE CASE: Verify provider generates previews
-        if not provider_class.get_preview_formats():
+        if len(provider_class.get_preview_formats()) == 0:
             return GeneratePreviewFromDefaultsResultFailure(
                 result_details=f"Attempted to generate preview using defaults. "
                 f"Failed due to: provider '{request.artifact_provider_name}' does not generate previews"
@@ -581,7 +581,7 @@ class ArtifactManager:
             )
 
         # FAILURE CASE: Verify provider generates previews
-        if not provider_class.get_preview_formats():
+        if len(provider_class.get_preview_formats()) == 0:
             return GetPreviewForArtifactResultFailure(
                 result_details=f"Attempted to get preview for '{source_path}'. "
                 f"Failed due to: provider '{request.artifact_provider_name}' does not generate previews"
@@ -1024,7 +1024,7 @@ class ArtifactManager:
 
         for provider_class in self._registry.get_all_provider_classes():
             # Providers that don't generate previews have no preview schema to publish.
-            if not provider_class.get_preview_formats():
+            if len(provider_class.get_preview_formats()) == 0:
                 continue
 
             provider_friendly_name = provider_class.get_friendly_name()
@@ -1094,7 +1094,7 @@ class ArtifactManager:
             settings registration entirely.
         """
         # Providers that don't generate previews have no preview settings to register.
-        if not provider_class.get_preview_formats():
+        if len(provider_class.get_preview_formats()) == 0:
             return
 
         # Validate and write provider-level settings (format, generator name)

--- a/src/griptape_nodes/retained_mode/managers/artifact_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_manager.py
@@ -338,6 +338,13 @@ class ArtifactManager:
                 f"Failed due to: provider '{request.artifact_provider_name}' not found"
             )
 
+        # FAILURE CASE: Verify provider generates previews
+        if not provider_class.get_preview_formats():
+            return GeneratePreviewResultFailure(
+                result_details=f"Attempted to generate preview for '{source_path}'. "
+                f"Failed due to: provider '{request.artifact_provider_name}' does not generate previews"
+            )
+
         # FAILURE CASE: Verify provider supports this file format
         if file_extension not in provider_class.get_supported_formats():
             return GeneratePreviewResultFailure(
@@ -494,6 +501,13 @@ class ArtifactManager:
                 f"Failed due to: provider '{request.artifact_provider_name}' not found"
             )
 
+        # FAILURE CASE: Verify provider generates previews
+        if not provider_class.get_preview_formats():
+            return GeneratePreviewFromDefaultsResultFailure(
+                result_details=f"Attempted to generate preview using defaults. "
+                f"Failed due to: provider '{request.artifact_provider_name}' does not generate previews"
+            )
+
         # Read settings from config with validation
         try:
             settings = self._get_preview_settings_from_config(provider_class, request.artifact_provider_name)
@@ -564,6 +578,13 @@ class ArtifactManager:
         if provider_class is None:
             return GetPreviewForArtifactResultFailure(
                 result_details=f"Attempted to get preview for '{source_path}'. Failed due to: provider '{request.artifact_provider_name}' not found"
+            )
+
+        # FAILURE CASE: Verify provider generates previews
+        if not provider_class.get_preview_formats():
+            return GetPreviewForArtifactResultFailure(
+                result_details=f"Attempted to get preview for '{source_path}'. "
+                f"Failed due to: provider '{request.artifact_provider_name}' does not generate previews"
             )
 
         # FAILURE CASE: Calculate metadata path using same logic as preview path (metadata uses .json extension)
@@ -1002,6 +1023,10 @@ class ArtifactManager:
         provider_schemas: dict[str, ProviderSchema] = {}
 
         for provider_class in self._registry.get_all_provider_classes():
+            # Providers that don't generate previews have no preview schema to publish.
+            if not provider_class.get_preview_formats():
+                continue
+
             provider_friendly_name = provider_class.get_friendly_name()
             provider_key = normalize_friendly_name_to_key(provider_friendly_name)
 

--- a/src/griptape_nodes/retained_mode/managers/artifact_providers/base_artifact_provider.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_providers/base_artifact_provider.py
@@ -80,36 +80,43 @@ class BaseArtifactProvider(ABC):
     def get_default_preview_generator(cls) -> str:
         """Default preview generator for this provider.
 
-        Override in subclasses that support preview generation.
+        Only valid for providers that generate previews. Callers must check
+        ``get_preview_formats()`` first; calling this on a provider that
+        does not generate previews raises ``NotImplementedError``.
 
         Returns:
-            Friendly name of the default preview generator, or empty string if unsupported.
+            Friendly name of the default preview generator.
         """
-        return ""
+        msg = f"{cls.__name__} does not generate previews; check get_preview_formats() before calling."
+        raise NotImplementedError(msg)
 
     @classmethod
     def get_default_preview_format(cls) -> str:
         """Default preview format for this provider.
 
-        Override in subclasses that support preview generation.
+        Only valid for providers that generate previews. Callers must check
+        ``get_preview_formats()`` first; calling this on a provider that
+        does not generate previews raises ``NotImplementedError``.
 
         Returns:
-            Default format extension WITHOUT leading dot (e.g., 'png', 'webp'),
-            or empty string if unsupported.
+            Default format extension WITHOUT leading dot (e.g., 'png', 'webp').
         """
-        return ""
+        msg = f"{cls.__name__} does not generate previews; check get_preview_formats() before calling."
+        raise NotImplementedError(msg)
 
     @classmethod
     def get_default_preview_generators(cls) -> list[type[BaseArtifactPreviewGenerator]]:
         """Get default preview generator classes for this provider.
 
-        Override in subclasses that support preview generation. The default
-        empty list indicates this provider does not generate previews.
+        Only valid for providers that generate previews. Callers must check
+        ``get_preview_formats()`` first; calling this on a provider that
+        does not generate previews raises ``NotImplementedError``.
 
         Returns:
-            List of default preview generator classes
+            List of default preview generator classes.
         """
-        return []
+        msg = f"{cls.__name__} does not generate previews; check get_preview_formats() before calling."
+        raise NotImplementedError(msg)
 
     @classmethod
     def get_config_key_prefix(cls) -> str:

--- a/tests/unit/retained_mode/managers/artifact_providers/test_base_artifact_provider.py
+++ b/tests/unit/retained_mode/managers/artifact_providers/test_base_artifact_provider.py
@@ -1,0 +1,49 @@
+"""Tests for BaseArtifactProvider's preview-default contract.
+
+A provider that does not generate previews advertises that by leaving
+``get_preview_formats()`` empty. The other three preview-default helpers
+(``get_default_preview_generator``, ``get_default_preview_format``,
+``get_default_preview_generators``) raise NotImplementedError on the base
+class so that callers who skip the ``get_preview_formats()`` gate fail
+loudly instead of silently consuming an empty sentinel value.
+"""
+
+import pytest
+
+from griptape_nodes.retained_mode.managers.artifact_providers.base_artifact_provider import (
+    BaseArtifactMetadata,
+    BaseArtifactProvider,
+)
+
+
+class _NonPreviewProvider(BaseArtifactProvider):
+    """Concrete provider that opts out of preview generation."""
+
+    @classmethod
+    def get_friendly_name(cls) -> str:
+        return "NonPreview"
+
+    @classmethod
+    def get_supported_formats(cls) -> set[str]:
+        return {"bin"}
+
+    @classmethod
+    def get_artifact_metadata(cls, source_path: str) -> BaseArtifactMetadata | None:  # noqa: ARG003
+        return None
+
+
+class TestBaseProviderPreviewContract:
+    def test_get_preview_formats_default_is_empty(self) -> None:
+        assert _NonPreviewProvider.get_preview_formats() == set()
+
+    def test_get_default_preview_generator_raises(self) -> None:
+        with pytest.raises(NotImplementedError, match="does not generate previews"):
+            _NonPreviewProvider.get_default_preview_generator()
+
+    def test_get_default_preview_format_raises(self) -> None:
+        with pytest.raises(NotImplementedError, match="does not generate previews"):
+            _NonPreviewProvider.get_default_preview_format()
+
+    def test_get_default_preview_generators_raises(self) -> None:
+        with pytest.raises(NotImplementedError, match="does not generate previews"):
+            _NonPreviewProvider.get_default_preview_generators()


### PR DESCRIPTION
Followup for https://github.com/griptape-ai/griptape-nodes/commit/9826e79c5ea02a0bed68db31d1ca1b1dcd93fdb7

explicit errors for unimplemented functions is better than magic empty values