### PR TITLE
fix(init): mirror library settings to workspace config when one exists

### DIFF
--- a/src/griptape_nodes/cli/commands/init.py
+++ b/src/griptape_nodes/cli/commands/init.py
@@ -246,11 +246,14 @@ def _handle_additional_library_config(config: InitConfig) -> bool | None:
         # If a workspace config exists at the configured workspace directory, mirror
         # the library settings there. The workspace config layer has higher precedence
         # than the user config and would otherwise silently override the values above.
-        config_manager.set_workspace_config_value(
+        # Snapshot existence now so a False return can be read as "write failed" vs "no file".
+        workspace_config_path = config_manager.workspace_path / "griptape_nodes_config.json"
+        workspace_config_existed = workspace_config_path.exists()
+        download_mirrored = config_manager.set_workspace_config_value(
             LIBRARIES_TO_DOWNLOAD_KEY,
             libraries_config.libraries_to_download,
         )
-        config_manager.set_workspace_config_value(
+        register_mirrored = config_manager.set_workspace_config_value(
             LIBRARIES_TO_REGISTER_KEY,
             libraries_config.libraries_to_register,
         )
@@ -261,6 +264,11 @@ def _handle_additional_library_config(config: InitConfig) -> bool | None:
         console.print(
             f"[bold green]Libraries to register: {', '.join(libraries_config.libraries_to_register)}[/bold green]"
         )
+        if workspace_config_existed and not (download_mirrored and register_mirrored):
+            console.print(
+                f"[bold yellow]Warning: library settings were saved to your user config but could not be "
+                f"mirrored to {workspace_config_path}. Your workspace config may override them on next launch.[/bold yellow]"
+            )
 
     return register_advanced_library
 

--- a/src/griptape_nodes/cli/commands/init.py
+++ b/src/griptape_nodes/cli/commands/init.py
@@ -243,6 +243,17 @@ def _handle_additional_library_config(config: InitConfig) -> bool | None:
             LIBRARIES_TO_REGISTER_KEY,
             libraries_config.libraries_to_register,
         )
+        # If a workspace config exists at the configured workspace directory, mirror
+        # the library settings there. The workspace config layer has higher precedence
+        # than the user config and would otherwise silently override the values above.
+        config_manager.set_workspace_config_value(
+            LIBRARIES_TO_DOWNLOAD_KEY,
+            libraries_config.libraries_to_download,
+        )
+        config_manager.set_workspace_config_value(
+            LIBRARIES_TO_REGISTER_KEY,
+            libraries_config.libraries_to_register,
+        )
         download_git_urls = [
             download.git_url for download in normalize_library_downloads(libraries_config.libraries_to_download)
         ]

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -657,6 +657,10 @@ class ConfigManager:
             logger.warning("set_workspace_config_value: failed to write workspace config: %s", e)
             return False
 
+        # Re-merge so the live merged_config reflects the updated workspace file.
+        # Only meaningful when _workspace_config_path is set (engine runtime path);
+        # during gtn init _workspace_config_path is None so the workspace layer is
+        # not re-read, but the call is harmless and mirrors set_config_value's pattern.
         self.load_configs()
         return True
 

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -645,11 +645,7 @@ class ConfigManager:
             return False
 
         delta = set_dot_value({}, key, value)
-        try:
-            current = json.loads(workspace_config_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError) as e:
-            logger.warning("set_workspace_config_value: failed to read workspace config: %s", e)
-            return False
+        current = self._load_config_from_file(workspace_config_path, "workspace")
 
         merged = merge_dicts(current, delta)
         try:

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -587,6 +587,41 @@ class ConfigManager:
 
         return write_succeeded
 
+    def set_workspace_config_value(self, key: str, value: Any) -> bool:
+        """Write a value to the workspace config file.
+
+        A no-op when the resolved workspace config file does not yet exist on
+        disk — in those cases the user config layer is sufficient.
+        Returns True on success, False otherwise.
+        """
+        # Prefer the explicitly loaded workspace config path (set by load_workspace_config
+        # during engine startup). Fall back to the current workspace_path so that callers
+        # such as `gtn init` (which never calls load_workspace_config) can still reach the
+        # workspace config when the user passes --workspace-directory.
+        workspace_config_path = self._workspace_config_path
+        if workspace_config_path is None:
+            workspace_config_path = self.workspace_path / "griptape_nodes_config.json"
+
+        if not workspace_config_path.exists():
+            return False
+
+        delta = set_dot_value({}, key, value)
+        try:
+            current = json.loads(workspace_config_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning("set_workspace_config_value: failed to read workspace config: %s", e)
+            return False
+
+        merged = merge_dicts(current, delta)
+        try:
+            workspace_config_path.write_text(json.dumps(merged, indent=2), encoding="utf-8")
+        except OSError as e:
+            logger.warning("set_workspace_config_value: failed to write workspace config: %s", e)
+            return False
+
+        self.load_configs()
+        return True
+
     def on_handle_get_config_category_request(self, request: GetConfigCategoryRequest) -> ResultPayload:
         if request.category is None or request.category == "":
             # Return the whole shebang. Start with the defaults and then layer on the user config.

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -625,8 +625,13 @@ class ConfigManager:
         """Write a value to the workspace config file.
 
         A no-op when the resolved workspace config file does not yet exist on
-        disk — in those cases the user config layer is sufficient.
+        disk; in those cases the user config layer is sufficient.
         Returns True on success, False otherwise.
+
+        No ConfigChanged event is broadcast. This method is a file-only mirror
+        intended for callers such as ``gtn init`` where no workers are listening;
+        callers that need event-driven side-effects should use ``set_config_value``
+        instead.
         """
         # Prefer the explicitly loaded workspace config path (set by load_workspace_config
         # during engine startup). Fall back to the current workspace_path so that callers

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -648,9 +648,12 @@ class ConfigManager:
         current = self._load_config_from_file(workspace_config_path, "workspace")
 
         merged = merge_dicts(current, delta)
+        tmp_path = workspace_config_path.with_suffix(".tmp")
         try:
-            workspace_config_path.write_text(json.dumps(merged, indent=2), encoding="utf-8")
+            tmp_path.write_text(json.dumps(merged, indent=2), encoding="utf-8")
+            tmp_path.replace(workspace_config_path)
         except OSError as e:
+            tmp_path.unlink(missing_ok=True)
             logger.warning("set_workspace_config_value: failed to write workspace config: %s", e)
             return False
 

--- a/tests/unit/cli/commands/test_init.py
+++ b/tests/unit/cli/commands/test_init.py
@@ -1,0 +1,107 @@
+"""Tests for gtn init workspace config mirroring."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import griptape_nodes.retained_mode.managers.config_manager as config_manager_module
+from griptape_nodes.cli.commands import init as init_module
+from griptape_nodes.cli.commands.init import _run_init
+from griptape_nodes.cli.shared import InitConfig
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+_STALE_LIBRARIES_CONFIG = {
+    "app_events": {
+        "on_app_initialization_complete": {
+            "libraries_to_register": ["/stale/lib"],
+        }
+    }
+}
+
+
+class TestInitWorkspaceConfigMirroring:
+    """Integration tests: _run_init writes library settings to the workspace config when one exists."""
+
+    def _fresh_config_manager(self) -> config_manager_module.ConfigManager:
+        # SingletonMeta._instances was cleared by the isolate_user_config autouse fixture,
+        # so this creates a fresh ConfigManager that reads from the patched USER_CONFIG_PATH.
+        return GriptapeNodes.ConfigManager()
+
+    def test_workspace_config_updated_when_exists(self, tmp_path: Path) -> None:
+        workspace_config = tmp_path / "griptape_nodes_config.json"
+        workspace_config.write_text(json.dumps(_STALE_LIBRARIES_CONFIG, indent=2))
+
+        fresh_config_manager = self._fresh_config_manager()
+        with (
+            patch.object(init_module, "config_manager", fresh_config_manager),
+            patch.object(init_module, "console"),
+            patch.object(init_module, "_init_system_config"),
+        ):
+            _run_init(
+                InitConfig(
+                    interactive=False,
+                    workspace_directory=str(tmp_path),
+                    register_advanced_library=False,
+                )
+            )
+
+        workspace_result = json.loads(workspace_config.read_text())
+        workspace_libs = workspace_result["app_events"]["on_app_initialization_complete"]["libraries_to_register"]
+
+        user_result = json.loads(config_manager_module.USER_CONFIG_PATH.read_text())
+        user_libs = user_result["app_events"]["on_app_initialization_complete"]["libraries_to_register"]
+
+        assert "/stale/lib" not in workspace_libs
+        assert workspace_libs == user_libs
+
+    def test_no_workspace_config_no_file_created(self, tmp_path: Path) -> None:
+        workspace_config = tmp_path / "griptape_nodes_config.json"
+        assert not workspace_config.exists()
+
+        fresh_config_manager = self._fresh_config_manager()
+        with (
+            patch.object(init_module, "config_manager", fresh_config_manager),
+            patch.object(init_module, "console"),
+            patch.object(init_module, "_init_system_config"),
+        ):
+            _run_init(
+                InitConfig(
+                    interactive=False,
+                    workspace_directory=str(tmp_path),
+                    register_advanced_library=False,
+                )
+            )
+
+        assert not workspace_config.exists()
+
+        user_result = json.loads(config_manager_module.USER_CONFIG_PATH.read_text())
+        user_libs = user_result["app_events"]["on_app_initialization_complete"]["libraries_to_register"]
+        assert isinstance(user_libs, list)
+
+
+class TestSetWorkspaceConfigValue:
+    """Unit tests for ConfigManager.set_workspace_config_value."""
+
+    def test_file_exists_returns_true_and_updates(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "workspace_config.json"
+        config_file.write_text(json.dumps({"foo": "old"}))
+
+        fresh_config_manager = GriptapeNodes.ConfigManager()
+        fresh_config_manager._workspace_config_path = config_file
+
+        result = fresh_config_manager.set_workspace_config_value("foo", "new")
+
+        assert result is True
+        written = json.loads(config_file.read_text())
+        assert written["foo"] == "new"
+
+    def test_no_file_returns_false_and_no_file_created(self, tmp_path: Path) -> None:
+        non_existent = tmp_path / "does_not_exist.json"
+
+        fresh_config_manager = GriptapeNodes.ConfigManager()
+        fresh_config_manager._workspace_config_path = non_existent
+
+        result = fresh_config_manager.set_workspace_config_value("foo", "bar")
+
+        assert result is False
+        assert not non_existent.exists()


### PR DESCRIPTION
## Summary

Closes [#337](https://github.com/griptape-ai/griptape-nodes-desktop/issues/337)

- Adds `ConfigManager.set_workspace_config_value()`, which writes a key/value to the workspace config file. When `_workspace_config_path` is not set (e.g. during `gtn init`), it falls back to `workspace_path / "griptape_nodes_config.json"`. Returns `False` and is a no-op if the file does not exist.
- In `_handle_additional_library_config()`, calls `set_workspace_config_value()` for `libraries_to_download` and `libraries_to_register` immediately after the corresponding `set_config_value()` calls. This ensures that when a workspace already has a `griptape_nodes_config.json` (which takes precedence over the user config), the Desktop's `gtn init` library choices are not silently discarded.
- Adds four unit/integration tests in `tests/unit/cli/commands/test_init.py` covering both the happy path and the no-op case.

## Test plan

- [ ] Run `uv run pytest tests/unit/cli/commands/test_init.py -v` — all 4 tests pass
- [ ] Run `uv run pytest tests/unit/ -v` — full unit suite passes (2970 tests)
- [ ] Manually: run `gtn init --workspace-directory <dir-with-existing-config> --no-register-advanced-library` and confirm the workspace `griptape_nodes_config.json` is updated with the new library list
- [ ] Manually: run `gtn init --workspace-directory <fresh-dir>` and confirm no `griptape_nodes_config.json` is created in the workspace directory
