### PR TITLE
Unresolvable projects are now FLAWED

### DIFF
--- a/src/griptape_nodes/common/project_templates/project_path.py
+++ b/src/griptape_nodes/common/project_templates/project_path.py
@@ -53,7 +53,7 @@ class ResolvedProjectPath(NamedTuple):
     """Outcome of resolving a declared project path field to an absolute path.
 
     Exactly one of these states holds:
-    - `path` is set, both lists are empty, and neither flag is set: the field resolved.
+    - `path` is set, both lists are empty, and no flag is set: the field resolved.
     - `path` is None and at least one list is non-empty: the field declares a variable nothing
       supplied a value for, so there IS no answer. Callers must report this rather than substitute a
       guess -- a wrong path labelled "declared" is worse for users than an honest "unknown".
@@ -64,6 +64,13 @@ class ResolvedProjectPath(NamedTuple):
     - `path` is None and `quoted_expansion` is set: a variable's value carried quotes that expansion
       moved into the middle of the path. The lists are empty for the same reason as a cycle -- every
       variable IS set, the value they produced just is not usable as a path.
+    - `path` is None and `platform_gap` is set: the field is a per-platform mapping with no entry for
+      this platform and no `default`, so the declaration names no value here at all.
+
+    A `path` of None with nothing else set is NOT one of this type's states -- it is the shape
+    `ProjectManager._resolve_template_path_field` returns for a field that was never declared, so
+    ladder callers can fall through. `is_unresolvable` is the property that separates the two:
+    "declared but no answer" (this type's failure states) versus "nothing declared".
 
     Attributes:
         path: Canonical absolute path, or None when the field could not be resolved.
@@ -75,6 +82,8 @@ class ResolvedProjectPath(NamedTuple):
             to each other in a cycle.
         quoted_expansion: True when expansion introduced quote characters the author did not write,
             per `expansion_introduced_quoting`.
+        platform_gap: True when a per-platform mapping has no entry for this platform and no
+            `default`.
     """
 
     path: Path | None
@@ -83,6 +92,28 @@ class ResolvedProjectPath(NamedTuple):
     needs_anchor: bool = False
     reference_cycle: bool = False
     quoted_expansion: bool = False
+    platform_gap: bool = False
+
+    @property
+    def is_unresolvable(self) -> bool:
+        """True when the field was DECLARED but no path could be produced from it.
+
+        False both for a resolved field (`path` is set) and for a field that was never declared
+        (`path` is None with no failure state recorded). Callers on the resolution ladders fall
+        through on "nothing declared" but must refuse on unresolvable -- substituting the next
+        source for a declaration the engine failed to honor would relocate the user's files
+        behind their back.
+        """
+        if self.path is not None:
+            return False
+        return (
+            bool(self.unresolved_variables)
+            or bool(self.macro_tokens)
+            or self.needs_anchor
+            or self.reference_cycle
+            or self.quoted_expansion
+            or self.platform_gap
+        )
 
 
 def resolve_project_path_field(selected: str, anchor_dir: Path | None) -> ResolvedProjectPath:

--- a/src/griptape_nodes/common/project_templates/validation.py
+++ b/src/griptape_nodes/common/project_templates/validation.py
@@ -99,6 +99,30 @@ class ProjectValidationInfo:
         )
         self.status = ProjectValidationStatus.UNUSABLE
 
+    def add_recoverable_error(self, field_path: str, message: str, line_number: int | None = None) -> None:
+        """Add an error that leaves the template loadable, downgrading status to FLAWED at most.
+
+        For problems that block USING the project but not representing it -- e.g. a declared
+        workspace_dir/libraries_dir that cannot be resolved. Recording these as ERROR severity while
+        keeping the template usable is what lets the project load, appear in listings, and be edited
+        (so the user can fix the bad value in the app) while activation refuses it. Does not upgrade
+        a status that is already UNUSABLE; early returns if status is MISSING.
+        """
+        if self.status == ProjectValidationStatus.MISSING:
+            return
+
+        self.problems.append(
+            ProjectValidationProblem(
+                line_number=line_number,
+                field_path=field_path,
+                message=message,
+                severity=ProjectValidationProblemSeverity.ERROR,
+            ),
+        )
+
+        if self.status == ProjectValidationStatus.GOOD:
+            self.status = ProjectValidationStatus.FLAWED
+
     def add_warning(self, field_path: str, message: str, line_number: int | None = None) -> None:
         """Add a warning to the problems list.
 

--- a/src/griptape_nodes/retained_mode/events/project_events.py
+++ b/src/griptape_nodes/retained_mode/events/project_events.py
@@ -192,8 +192,12 @@ class ResolveProjectWorkspaceResultSuccess(WorkflowNotAlteredMixin, ResultPayloa
     """Resolved workspace directory for a project.
 
     Args:
-        workspace_dir: Absolute path string the project would use, or None when the id resolves to
-            no readable project file (matches the resolver's "nothing to resolve" contract).
+        workspace_dir: Absolute path string the project would use, or None when there is no honest
+            answer: the id resolves to no readable project file (the resolver's "nothing to
+            resolve" contract), or the project declares a workspace_dir that cannot currently be
+            resolved (a FLAWED project -- e.g. an unset environment variable -- whose activation
+            would be refused). Clients treat null as "no hint to show"; the project's validation
+            problems carry the reason for the FLAWED case.
     """
 
     workspace_dir: str | None = None
@@ -231,15 +235,19 @@ class ProjectTemplateInfo:
             resolved through the same ladder activation uses (the project's own
             `workspace_dir`, the `project_workspaces` mapping, an environment or
             project-adjacent setting, inheritance from the parent chain, or the
-            global default). None ONLY when the entry is not file-backed (e.g. the
-            system defaults) or its template failed to load -- never because
-            resolution was attempted and gave up. A project whose declared path
-            fields cannot be resolved does not load at all; see `validation` for
-            the field and line at fault.
+            global default). None when the entry is not file-backed (e.g. the
+            system defaults), its template failed to load, or the project DECLARES
+            a `workspace_dir` that cannot currently be resolved (a FLAWED project
+            -- e.g. an unset environment variable). In the FLAWED case activation
+            refuses the project, so there is no real path to report; `validation`
+            carries the field, reason, and line number so the value can be
+            corrected in the app.
         libraries_root: Absolute path where this project's libraries install and
             resolve from -- its own `libraries_dir`, else the nearest ancestor that
             declares one, else the workspace-relative `libraries_directory`
-            setting. None under the same conditions as `workspace_dir`.
+            setting. None under the same conditions as `workspace_dir`, plus one
+            more: the fallback cannot be computed when `libraries_dir` is
+            undeclared and `workspace_dir` is unresolvable.
     """
 
     project_id: ProjectID

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -3744,6 +3744,18 @@ class LibraryManager(EngineScoped):
         if request.project_id == SYSTEM_DEFAULTS_KEY:
             merged = config_mgr.compute_system_defaults_provisioning_config()
         else:
+            # Mirror the activation gate: a project whose declared workspace_dir/libraries_dir
+            # cannot be resolved will be refused by activation, so previewing a plan built from
+            # fallback locations would show the user changes that can never be applied.
+            project_info = self.engine.project_manager.project_info_for_request(request.project_id)
+            if project_info is not None:
+                unresolvable = self.engine.project_manager.unresolvable_declared_path_messages(project_info)
+                if unresolvable:
+                    return PreviewProjectProvisioningResultFailure(
+                        result_details=f"Attempted to preview provisioning for project '{request.project_id}'. "
+                        f"Failed because its declared paths cannot be resolved, so activation would refuse it. "
+                        f"{' '.join(unresolvable)}",
+                    )
             dirs = await self.engine.project_manager.resolve_provisioning_config_dirs(request.project_id)
             if dirs is None:
                 return PreviewProjectProvisioningResultFailure(

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -457,10 +457,34 @@ class WorkspaceDecision(NamedTuple):
     parent-chain inheritance, and the global-default branches. It is False when env
     vars or the project-adjacent config supply workspace_directory, because activation
     then leaves the override unset so the workspace config layer can re-point it.
+
+    `blocked_reason` is set when the parent-chain walk found an ancestor whose DECLARED
+    workspace_dir cannot be resolved (a FLAWED ancestor). The carried workspace_dir is then the
+    fallback the ladder would otherwise use -- callers that only display may show nothing, but
+    activation must refuse rather than apply it, or a child would adopt a workspace its chain never
+    named. Environmental chain breaks (moved/unreadable ancestor files, cycles) do NOT set this;
+    those keep the long-standing warn-and-fall-back behavior.
     """
 
     workspace_dir: Path
     apply_override: bool
+    blocked_reason: str | None = None
+
+
+class LibrariesRootDecision(NamedTuple):
+    """The libraries root a project resolves to from disk, or why no answer can be trusted.
+
+    `libraries_root` is the project's own or nearest ancestor's declared libraries_dir, or None when
+    nothing in the chain declares one (callers fall back to the workspace-relative default).
+    `blocked_reason` is set when an ancestor DECLARES a libraries_dir that cannot be resolved (a
+    FLAWED ancestor): the chain names a location the engine cannot honor, so activation refuses the
+    descendant instead of installing into the fallback -- the exact substitution the load-time
+    validation exists to prevent. Environmental chain breaks (moved/unreadable ancestor files,
+    cycles) do NOT set this and keep the warn-and-fall-back behavior.
+    """
+
+    libraries_root: Path | None
+    blocked_reason: str | None = None
 
 
 class AncestorValueLookup(NamedTuple):
@@ -477,14 +501,25 @@ class AncestorValueLookup(NamedTuple):
       cycles. A usable value may be hiding behind that break, so the caller logs the fall-through
       rather than treating "nothing declared" as established.
 
+    `unresolvable_declaration` further splits the incomplete state. True means an ancestor DECLARED
+    a value the engine cannot resolve (a FLAWED ancestor, e.g. an unset variable) -- the value the
+    chain would supply is known to exist and known to be broken, so activation refuses the
+    descendant rather than substitute a fallback for it. False covers the environmental breaks (a
+    moved or unreadable ancestor file, a missing parent, a cycle), where activation keeps the
+    long-standing warn-and-fall-back behavior: it has to pick something to run with, and the break
+    is not a declaration being dishonored.
+
     Attributes:
         value: The nearest ancestor's resolved value, or None if there was no hit.
         incomplete_reason: Artist-readable phrase describing why the walk came away incomplete, or
             None when the whole chain was seen and nothing in it declared a value.
+        unresolvable_declaration: True when the break is an ancestor's declared-but-unresolvable
+            path field, the one incomplete state activation must refuse rather than fall back from.
     """
 
     value: str | None
     incomplete_reason: str | None
+    unresolvable_declaration: bool = False
 
 
 class ParentLinkLookup(NamedTuple):
@@ -508,13 +543,17 @@ class ParentLinkLookup(NamedTuple):
 class EffectiveProjectPaths(NamedTuple):
     """The two paths a project activates with, as reported on the project listing.
 
-    Both are absolute and both are always present: each resolution ladder bottoms out in an
-    unconditional default, and a project whose declared path fields could not be resolved fails to
-    load rather than reaching here.
+    A path is None when the project DECLARES it but the declaration cannot currently be resolved (a
+    FLAWED load -- e.g. an unset environment variable in workspace_dir/libraries_dir). The listing
+    shows "unknown" for it and the entry's validation problems say why; activation refuses such a
+    project, so no real path exists to report. A resolvable project always gets absolute paths:
+    each resolution ladder bottoms out in an unconditional default. libraries_root is also None
+    when it is undeclared AND workspace_dir is unresolvable, because the workspace-relative default
+    cannot be computed without a workspace decision.
     """
 
-    workspace_dir: Path
-    libraries_root: Path
+    workspace_dir: Path | None
+    libraries_root: Path | None
 
 
 class _ProvisioningConfigDirs(NamedTuple):
@@ -895,10 +934,15 @@ class ProjectManager(EngineScoped):
         surfaces as failed_to_load. Read-only probes (e.g. resolve_workspace_dir_for_project_id)
         pass record_status=False so a transient lookup does not inject phantom failed-load entries.
 
-        This is also where a declared path field that cannot produce a path is refused
-        (_validate_declared_path_fields). Every consumer funnels through here -- the boot load,
-        activation, the offline ancestor walks and the read-only probes -- so one check means none of
-        them can substitute a different location behind the user's back.
+        This is also where declared path fields are validated (_validate_declared_path_fields).
+        Every consumer funnels through here -- the boot load, activation, the offline ancestor walks
+        and the read-only probes -- so one check means they cannot disagree about what is broken. A
+        broken parent_project_path refuses the overlay (nothing coherent can be merged without the
+        base); a broken workspace_dir/libraries_dir is recorded as a recoverable FLAWED problem and
+        the read proceeds, so the project stays loadable and editable. The refusal to substitute a
+        different location behind the user's back moves to the consumers: the activation gate
+        (_apply_workspace_and_libraries_layers), the provisioning preview, and the ancestor walks
+        each check `is_unresolvable` before falling through to another source.
         """
         read_request = ReadFileRequest(
             file_path=str(project_file_path),
@@ -940,7 +984,12 @@ class ProjectManager(EngineScoped):
             )
 
         unresolvable_fields = self._validate_declared_path_fields(overlay, project_file_path, validation)
-        if unresolvable_fields:
+        if not validation.is_usable():
+            # Only parent_project_path lands here: without the parent there is no base to merge, so
+            # the overlay is genuinely unrepresentable. A broken workspace_dir/libraries_dir is
+            # recorded as a recoverable (FLAWED) problem instead and the read proceeds -- the project
+            # stays loadable and editable while activation refuses it, so the user can fix the bad
+            # value in the app rather than hand-editing YAML.
             return self._overlay_read_failure(
                 project_file_path,
                 validation,
@@ -982,9 +1031,15 @@ class ProjectManager(EngineScoped):
         the next source, which is the documented behavior. A field that is PRESENT but cannot produce
         a path -- an unset `${VAR}` / `%VAR%`, a `{macro}` token, or a per-platform mapping with no
         entry for this OS and no `default` -- is an error, because the only alternative is to discard
-        what the user wrote and put their workspace or their libraries somewhere else. A project that
-        installs libraries into a directory it never named is worse than a project that refuses to
-        open and says which line is wrong.
+        what the user wrote and put their workspace or their libraries somewhere else.
+
+        The error's blast radius differs by field. A broken `parent_project_path` is UNUSABLE: the
+        template cannot be merged with a base that cannot be found, so there is nothing coherent to
+        load. A broken `workspace_dir` or `libraries_dir` is a RECOVERABLE error (FLAWED): the
+        template itself is perfectly representable, only activation must refuse it
+        (_apply_workspace_and_libraries_layers). Keeping such a project loadable is what lets the
+        user see the problem in the app and fix the bad value there, instead of hand-editing the
+        YAML and restarting the engine.
 
         All three fields are checked even after the first error, so one load reports every broken
         field instead of making the user fix them one restart at a time.
@@ -995,7 +1050,7 @@ class ProjectManager(EngineScoped):
         file that names it.
 
         Returns the names of the fields that failed, in declaration order; empty means the overlay's
-        paths are all resolvable and the caller may proceed.
+        paths are all resolvable.
         """
         declarations: dict[str, str | PerPlatformProjectPath | None] = {
             "workspace_dir": overlay.workspace_dir,
@@ -1005,29 +1060,73 @@ class ProjectManager(EngineScoped):
 
         unresolvable_fields: list[str] = []
         for field_name, declared in declarations.items():
-            if declared is None:
+            message = self._declared_path_field_problem(field_name, declared, project_file_path)
+            if message is None:
                 continue
 
-            selected = select_project_path(declared)
-            if selected is None:
-                unresolvable_fields.append(field_name)
+            unresolvable_fields.append(field_name)
+            if field_name == "parent_project_path":
                 validation.add_error(
                     field_path=field_name,
-                    message=self._platform_gap_message(field_name),
+                    message=message,
                     line_number=overlay.line_info.get_line(field_name),
                 )
-                continue
-
-            resolution = resolve_project_path_field(selected, project_file_path.parent)
-            if resolution.path is None:
-                unresolvable_fields.append(field_name)
-                validation.add_error(
+            else:
+                validation.add_recoverable_error(
                     field_path=field_name,
-                    message=self._unresolvable_field_message(field_name, selected, resolution),
+                    message=message,
                     line_number=overlay.line_info.get_line(field_name),
                 )
 
         return unresolvable_fields
+
+    def _declared_path_field_problem(
+        self, field_name: str, declared: str | PerPlatformProjectPath | None, project_file_path: Path
+    ) -> str | None:
+        """Phrase why a DECLARED path field cannot produce a path, or None when it can (or is unset).
+
+        The single check behind every consumer that must refuse an unresolvable declaration rather
+        than substitute another source: load-time validation (_validate_declared_path_fields), the
+        activation gate, and the provisioning preview (via unresolvable_declared_path_messages) all
+        call this, so they cannot disagree about what counts as broken. Resolves fresh on every call
+        -- the environment can change between load and activation, so a load-time verdict is not
+        reusable.
+        """
+        if declared is None:
+            return None
+
+        selected = select_project_path(declared)
+        if selected is None:
+            return self._platform_gap_message(field_name)
+
+        resolution = resolve_project_path_field(selected, project_file_path.parent)
+        if resolution.path is None:
+            return self._unresolvable_field_message(field_name, selected, resolution)
+        return None
+
+    def unresolvable_declared_path_messages(self, project_info: ProjectInfo) -> list[str]:
+        """Phrase every workspace_dir/libraries_dir declaration that cannot currently be resolved.
+
+        Empty means the project's own declared paths all resolve (or it declares none) and it is
+        safe to activate or preview. Non-empty is the activation gate's and provisioning preview's
+        refusal reason: a FLAWED project (or one whose environment changed since load) must not have
+        its declared locations silently replaced with fallbacks. parent_project_path is not checked
+        here because a project with a broken parent link never loads (UNUSABLE), so no ProjectInfo
+        exists to hand in.
+        """
+        if project_info.project_file_path is None:
+            return []
+
+        declarations: dict[str, str | PerPlatformProjectPath | None] = {
+            "workspace_dir": project_info.template.workspace_dir,
+            "libraries_dir": project_info.template.libraries_dir,
+        }
+        messages: list[str] = []
+        for field_name, declared in declarations.items():
+            message = self._declared_path_field_problem(field_name, declared, project_info.project_file_path)
+            if message is not None:
+                messages.append(message)
+        return messages
 
     async def _resolve_parent_chain(  # noqa: C901, PLR0911
         self,
@@ -1332,12 +1431,19 @@ class ProjectManager(EngineScoped):
         engine_version_reason = engine_version_failure_detail(required_engine_version)
 
         # Where this project's files and libraries actually land. Both stay None for an entry with no
-        # backing file (the system defaults), which declares nothing and is never activated.
-        effective_paths: EffectiveProjectPaths | None = None
+        # backing file (the system defaults), which declares nothing and is never activated. A path
+        # is also None when the project declares it but the declaration cannot be resolved (a FLAWED
+        # load) -- the validation problems on this entry carry the reason.
+        workspace_dir: str | None = None
+        libraries_root: str | None = None
         if project_info.project_file_path is not None:
             effective_paths = await self._effective_paths_for_project(
                 project_info.project_file_path, project_info.template, id_index
             )
+            if effective_paths.workspace_dir is not None:
+                workspace_dir = str(effective_paths.workspace_dir)
+            if effective_paths.libraries_root is not None:
+                libraries_root = str(effective_paths.libraries_root)
 
         return ProjectTemplateInfo(
             project_id=project_id,
@@ -1351,8 +1457,8 @@ class ProjectManager(EngineScoped):
             required_engine_version=required_engine_version,
             current_engine_version=engine_version,
             engine_version_reason=engine_version_reason,
-            workspace_dir=str(effective_paths.workspace_dir) if effective_paths is not None else None,
-            libraries_root=str(effective_paths.libraries_root) if effective_paths is not None else None,
+            workspace_dir=workspace_dir,
+            libraries_root=libraries_root,
         )
 
     def on_get_situation_request(
@@ -1712,7 +1818,9 @@ class ProjectManager(EngineScoped):
         resolver activation uses -- so the previewed workspace cannot diverge from what
         activation applies even when an ancestor is registered but not loaded. Returns
         None when the project is not loaded or has no backing file, mirroring
-        get_loaded_project_dir's "nothing to preview" contract. Mutates no config state.
+        get_loaded_project_dir's "nothing to preview" contract -- and when the workspace decision is
+        blocked by an ancestor's unresolvable declared workspace_dir, since a preview computed from
+        the fallback would describe a plan activation refuses. Mutates no config state.
         """
         project_info = self._successfully_loaded_project_templates.get(project_id)
         if project_info is None:
@@ -1731,6 +1839,8 @@ class ProjectManager(EngineScoped):
         decision = await self._decide_workspace_from_disk(
             project_file_path, project_config, env_config, template_workspace_dir, id_index
         )
+        if decision.blocked_reason is not None:
+            return None
         return _ProvisioningConfigDirs(
             project_dir=project_dir,
             workspace_dir=decision.workspace_dir,
@@ -1745,7 +1855,10 @@ class ProjectManager(EngineScoped):
         registry and falls back to a read-only disk scan of projects_to_register (see
         _build_unloaded_id_index); a legacy id that is itself a canonical project file path is
         accepted directly. Returns None when the id resolves to no readable project file, matching
-        resolve_provisioning_config_dirs' "nothing to resolve" contract.
+        resolve_provisioning_config_dirs' "nothing to resolve" contract -- and also when the
+        project's own workspace_dir is declared but cannot be resolved (a FLAWED project), because
+        the fall-through answer would be a location the project never named and activation will
+        refuse. The GUI treats null as "no hint to show", which is the honest display for both.
 
         Branches 0-3 and 4-result/5 are computed by the same _decide_workspace_pre/post_inheritance
         helpers decide_workspace uses, so they cannot drift. The template's own workspace_dir (branch
@@ -1776,11 +1889,19 @@ class ProjectManager(EngineScoped):
         own_overlay_load = await self._read_overlay(project_file_path, record_status=False)
         if not isinstance(own_overlay_load, LoadProjectTemplateResultFailure):
             _, own_overlay = own_overlay_load
-            template_workspace_dir = self._resolve_template_workspace_dir(own_overlay.workspace_dir, project_file_path)
+            workspace_resolution = self._resolve_template_path_field(
+                own_overlay.workspace_dir, project_file_path, "workspace_dir"
+            )
+            if workspace_resolution.is_unresolvable:
+                return None
+            if workspace_resolution.path is not None:
+                template_workspace_dir = str(workspace_resolution.path)
 
         decision = await self._decide_workspace_from_disk(
             project_file_path, project_config, env_config, template_workspace_dir, id_index
         )
+        if decision.blocked_reason is not None:
+            return None
         return self._resolve_workspace_dir(decision.workspace_dir)
 
     async def _decide_workspace_from_disk(
@@ -1820,29 +1941,42 @@ class ProjectManager(EngineScoped):
                 project_file_path,
                 lookup.incomplete_reason,
             )
-        return self._decide_workspace_post_inheritance(project_file_path, lookup.value)
+        decision = self._decide_workspace_post_inheritance(project_file_path, lookup.value)
+        if lookup.unresolvable_declaration:
+            # An ancestor DECLARED a workspace the engine cannot resolve. The fallback decision is
+            # still carried for display-only callers, but activation must refuse it (blocked_reason)
+            # rather than adopt a workspace the chain never named.
+            return WorkspaceDecision(
+                workspace_dir=decision.workspace_dir,
+                apply_override=decision.apply_override,
+                blocked_reason=lookup.incomplete_reason,
+            )
+        return decision
 
     async def _decide_libraries_root_from_disk(
         self, project_file_path: Path, template_libraries_dir: str | None, id_index: dict[str, Path]
-    ) -> Path | None:
+    ) -> LibrariesRootDecision:
         """Decide a project's libraries root, resolving parent inheritance from disk.
 
         Disk-walking analogue of decide_libraries_root: branch 0 (own libraries_dir, passed in
         already resolved) is unchanged, and branch 1 (nearest ancestor's libraries_dir) walks the
         chain offline via _inherit_libraries_dir_from_parents_offline rather than the live registry,
-        so a child's shared libraries/ tree is identical whether or not its parent is loaded. Returns
-        None when no libraries_dir is declared anywhere in the chain (caller falls back to the
-        workspace-relative default).
+        so a child's shared libraries/ tree is identical whether or not its parent is loaded. A None
+        libraries_root means no libraries_dir is declared anywhere in the chain (caller falls back
+        to the workspace-relative default).
 
-        A chain that could not be fully walked still falls back to the workspace-relative default --
-        activation has to pick SOMETHING to run with -- but it says so in the log. That break is rare
-        by construction: a project whose parent link or path fields do not resolve fails its own load,
-        so a chain normally breaks only if an ancestor file was moved or made unreadable after the
-        descendants were registered.
+        An ENVIRONMENTAL chain break (an ancestor file moved or made unreadable after the
+        descendants were registered, a missing parent, a cycle) still falls back to the
+        workspace-relative default -- activation has to pick SOMETHING to run with -- but it says so
+        in the log. A FLAWED ancestor whose DECLARED libraries_dir cannot be resolved instead sets
+        `blocked_reason`: the chain names a location the engine cannot honor, so activation refuses
+        the descendant rather than install into a fallback the chain never named.
         """
         if template_libraries_dir is not None:
-            return Path(template_libraries_dir)
+            return LibrariesRootDecision(libraries_root=Path(template_libraries_dir))
         lookup = await self._inherit_libraries_dir_from_parents_offline(project_file_path, id_index)
+        if lookup.unresolvable_declaration:
+            return LibrariesRootDecision(libraries_root=None, blocked_reason=lookup.incomplete_reason)
         if lookup.incomplete_reason is not None:
             logger.warning(
                 "Could not inherit a libraries root for project '%s' from its parent chain (%s). "
@@ -1851,8 +1985,8 @@ class ProjectManager(EngineScoped):
                 lookup.incomplete_reason,
             )
         if lookup.value is not None:
-            return Path(lookup.value)
-        return None
+            return LibrariesRootDecision(libraries_root=Path(lookup.value))
+        return LibrariesRootDecision(libraries_root=None)
 
     def _resolve_workspace_dir(self, workspace_dir: Path) -> Path:
         """Expand and resolve a decided workspace dir the way ConfigManager.set_workspace_override does."""
@@ -1927,11 +2061,12 @@ class ProjectManager(EngineScoped):
             # The ancestor's workspace_dir template field (branch 0) wins, mirroring how the ancestor
             # would resolve its own workspace as the active project; the overlay was already read by
             # the walker to follow the parent link, so the field is free to read here. Falls through
-            # to the ancestor's project_workspaces override / adjacent config when the field is
-            # unset. (It cannot be set-but-unresolvable: _read_overlay would have refused the
-            # ancestor, and the walker reports that as a break in the chain.)
+            # to the ancestor's project_workspaces override / adjacent config only when the field is
+            # genuinely UNSET. A set-but-unresolvable field (a FLAWED ancestor) is returned as-is so
+            # the walker reports a break in the chain: falling through would inherit a
+            # lower-precedence source in place of the workspace the ancestor actually named.
             template_resolution = self._resolve_template_path_field(overlay.workspace_dir, node_path, "workspace_dir")
-            if template_resolution.path is not None:
+            if template_resolution.path is not None or template_resolution.is_unresolvable:
                 return template_resolution
             explicit_workspace = self._resolve_node_explicit_workspace(node_path, project_workspaces)
             if explicit_workspace is not None:
@@ -1977,8 +2112,10 @@ class ProjectManager(EngineScoped):
         matching what activation reconciles. _effective_paths_for_project is the caller that wants the
         fully-defaulted answer.
 
-        A declared value that cannot be resolved does not reach here: _read_overlay rejects an
-        unresolvable path field, so such a project is UNUSABLE and never gets walked.
+        None ALSO covers a project whose own libraries_dir is declared but cannot be resolved (a
+        FLAWED load): reporting the inherited or default location for it would substitute a place
+        the project never named. A caller for whom that distinction matters must gate first, the way
+        the provisioning preview gates on unresolvable_declared_path_messages before calling this.
 
         Builds its own id -> path index. The listing does NOT come through here (it goes through
         _effective_paths_for_project, which wants the fully-defaulted answer), so there is no caller
@@ -1997,8 +2134,18 @@ class ProjectManager(EngineScoped):
             return None
         _, own_overlay = own_overlay_load
 
-        template_libraries_dir = self._resolve_template_libraries_dir(own_overlay.libraries_dir, project_file_path)
-        return await self._decide_libraries_root_from_disk(project_file_path, template_libraries_dir, id_index)
+        libraries_resolution = self._resolve_template_path_field(
+            own_overlay.libraries_dir, project_file_path, "libraries_dir"
+        )
+        if libraries_resolution.is_unresolvable:
+            return None
+        template_libraries_dir = str(libraries_resolution.path) if libraries_resolution.path is not None else None
+        libraries_decision = await self._decide_libraries_root_from_disk(
+            project_file_path, template_libraries_dir, id_index
+        )
+        if libraries_decision.blocked_reason is not None:
+            return None
+        return libraries_decision.libraries_root
 
     async def _effective_paths_for_project(
         self, project_file_path: Path, template: ProjectTemplate, id_index: dict[str, Path]
@@ -2017,26 +2164,46 @@ class ProjectManager(EngineScoped):
         them from the base (see merged_workspace_dir / merged_libraries_dir), so the loaded value is
         this project's own declaration and anchoring it to this project's directory is correct.
 
-        Both values are always a real path: each ladder bottoms out in an unconditional default, and
-        a project whose declarations could not be resolved would have failed to load.
+        A value is a real path for every resolvable project: each ladder bottoms out in an
+        unconditional default. A DECLARED-but-unresolvable field (a FLAWED load) reports None
+        instead -- activation refuses such a project, so any path shown for it would be one it will
+        never use. The entry's validation problems carry the reason.
         """
-        project_config = self._config_manager.read_config_file(project_file_path.parent / "griptape_nodes_config.json")
-        env_config = self._config_manager.read_env_config()
-        template_workspace_dir = self._resolve_template_workspace_dir(template.workspace_dir, project_file_path)
-        template_libraries_dir = self._resolve_template_libraries_dir(template.libraries_dir, project_file_path)
+        workspace_resolution = self._resolve_template_path_field(
+            template.workspace_dir, project_file_path, "workspace_dir"
+        )
+        libraries_resolution = self._resolve_template_path_field(
+            template.libraries_dir, project_file_path, "libraries_dir"
+        )
 
-        decision = await self._decide_workspace_from_disk(
-            project_file_path, project_config, env_config, template_workspace_dir, id_index
-        )
-        libraries_root = await self._decide_libraries_root_from_disk(
-            project_file_path, template_libraries_dir, id_index
-        )
-        if libraries_root is None:
-            libraries_root = self._workspace_relative_libraries_root(project_file_path, decision)
+        workspace_dir: Path | None = None
+        decision: WorkspaceDecision | None = None
+        if not workspace_resolution.is_unresolvable:
+            project_config = self._config_manager.read_config_file(
+                project_file_path.parent / "griptape_nodes_config.json"
+            )
+            env_config = self._config_manager.read_env_config()
+            template_workspace_dir = str(workspace_resolution.path) if workspace_resolution.path is not None else None
+            decision = await self._decide_workspace_from_disk(
+                project_file_path, project_config, env_config, template_workspace_dir, id_index
+            )
+            if decision.blocked_reason is None:
+                workspace_dir = self._resolve_workspace_dir(decision.workspace_dir)
 
-        return EffectiveProjectPaths(
-            workspace_dir=self._resolve_workspace_dir(decision.workspace_dir), libraries_root=libraries_root
-        )
+        libraries_root: Path | None = None
+        if not libraries_resolution.is_unresolvable:
+            template_libraries_dir = str(libraries_resolution.path) if libraries_resolution.path is not None else None
+            libraries_decision = await self._decide_libraries_root_from_disk(
+                project_file_path, template_libraries_dir, id_index
+            )
+            if libraries_decision.blocked_reason is None:
+                libraries_root = libraries_decision.libraries_root
+                # The workspace-relative default needs the workspace decision; with an unresolvable
+                # workspace_dir there is none, so an undeclared libraries root stays unknown too.
+                if libraries_root is None and decision is not None and decision.blocked_reason is None:
+                    libraries_root = self._workspace_relative_libraries_root(project_file_path, decision)
+
+        return EffectiveProjectPaths(workspace_dir=workspace_dir, libraries_root=libraries_root)
 
     def _workspace_relative_libraries_root(self, project_file_path: Path, decision: WorkspaceDecision) -> Path:
         """Compute the nothing-declared libraries default for a target project, offline.
@@ -2092,7 +2259,7 @@ class ProjectManager(EngineScoped):
 
         return await self._nearest_ancestor_value_offline(project_file_path, id_index, probe)
 
-    async def _nearest_ancestor_value_offline(
+    async def _nearest_ancestor_value_offline(  # noqa: PLR0911 — each terminal walk state returns its own lookup
         self,
         project_file_path: Path,
         id_index: dict[str, Path],
@@ -2116,11 +2283,10 @@ class ProjectManager(EngineScoped):
         None, which callers read as "no ancestor declares one, so use the default" -- turning an
         unreadable ancestor into a confident wrong answer. Now only a chain walked all the way to its
         root reports `incomplete_reason=None`; an ancestor that could not be loaded, a parent id that
-        maps to no file, and a cycle each say why they stopped.
-
-        A probe that comes back unresolved cannot occur: _read_overlay rejects an overlay whose path
-        fields do not resolve, so such an ancestor fails the read above and is reported as a break in
-        the chain rather than silently stepped past.
+        maps to no file, a cycle, and an ancestor whose DECLARED value cannot be resolved (a FLAWED
+        overlay reads fine, so the probe sees the broken declaration) each say why they stopped.
+        Stepping past an unresolvable declaration would inherit a lower-precedence source in place of
+        the one the ancestor actually named.
         """
         file_path_to_id: dict[Path, ProjectID] = {path: pid for pid, path in id_index.items()}
 
@@ -2149,6 +2315,15 @@ class ProjectManager(EngineScoped):
                 probed = probe(current_path, overlay)
                 if probed.path is not None:
                     return AncestorValueLookup(value=str(probed.path), incomplete_reason=None)
+                if probed.is_unresolvable:
+                    return AncestorValueLookup(
+                        value=None,
+                        incomplete_reason=(
+                            f"parent project '{current_path}' declares a path that cannot be resolved "
+                            f"({self._describe_unresolved_path(probed)})"
+                        ),
+                        unresolvable_declaration=True,
+                    )
             is_start = False
 
             parent_id = self._reduce_parent_link_to_id(overlay, current_path, file_path_to_id)
@@ -2197,10 +2372,12 @@ class ProjectManager(EngineScoped):
         `template_workspace_dir` is the highest-priority source: a project that declares its own
         workspace_dir beats the per-user project_workspaces mapping and the env var. The caller
         resolves the (possibly per-platform, possibly relative) raw field to an absolute path before
-        passing it, so this method and the offline resolver share the branch verbatim. For a project
-        that loaded, None means the field was ABSENT and nothing more: a declared value that cannot
-        produce a path is refused by _read_overlay, so the project is UNUSABLE and never reaches this
-        ladder. Branch 0 is skipped only when the project genuinely declares no workspace of its own.
+        passing it, so this method and the offline resolver share the branch verbatim. None must mean
+        the field was ABSENT and nothing more: a declared value that cannot produce a path loads as
+        FLAWED, and every path to this ladder gates on that first (activation via
+        unresolvable_declared_path_messages, the offline resolvers and the listing via
+        `is_unresolvable`), so branch 0 is skipped only when the project genuinely declares no
+        workspace of its own.
 
         Branch 4 walks the project's explicit parent chain (parent_project_id / legacy
         parent_project_path, resolved through the registry) and inherits the first ancestor that
@@ -2256,21 +2433,24 @@ class ProjectManager(EngineScoped):
         _resolve_template_libraries_dir are `str | None` projections of it for the resolution
         ladders, which only need "is there a usable value?".
 
-        An unset field resolves to a None path with empty reason lists -- "nothing declared", so the
+        An unset field resolves to a None path with no failure state -- "nothing declared", so the
         ladder falls through to the next source.
 
         A field that IS declared but cannot produce a path (no entry for this platform and no
-        'default', an unset variable, a macro token) cannot reach here for a project that loaded:
-        _read_overlay validates all three path fields and refuses the overlay, so the project is
-        UNUSABLE and never gets activated or listed. The warn-and-fall-through below is therefore
-        defense in depth rather than a normal outcome, and it keeps the resolvers total for callers
-        that hand them a value from somewhere other than an overlay read.
+        'default', an unset variable, a macro token) comes back with `is_unresolvable` set. A
+        project in that state loads as FLAWED (_read_overlay records the problem instead of refusing
+        the overlay), so this outcome IS reachable for loaded projects: activation refuses it
+        (_apply_workspace_and_libraries_layers), the ancestor walks report it as a break in the
+        chain, and the listing shows the affected path as unknown. Only the `str | None` projections
+        collapse it to "nothing" -- their callers must gate on `is_unresolvable` first when a
+        substitute location would be user-visible.
 
         One window where load-time and activation-time answers can differ: a project registered
         WHILE another project's `environment:` block is applied validates against that mutated
-        os.environ, whereas activation restores the launch environment before resolving. A value that
-        depends on a variable only some other project sets can therefore pass validation and then
-        fail to resolve here.
+        os.environ, whereas activation restores the launch environment before resolving. A value
+        that depends on a variable only some other project sets can therefore load as GOOD and
+        still be refused at activation, or vice versa; both re-resolve rather than trusting the
+        load-time verdict.
         """
         if raw is None:
             return ResolvedProjectPath(path=None, unresolved_variables=[], macro_tokens=[])
@@ -2278,18 +2458,16 @@ class ProjectManager(EngineScoped):
         selected = select_project_path(raw)
         if selected is None:
             logger.warning(
-                "Project '%s' declares %s as a per-platform mapping with no entry for this platform "
-                "and no 'default'. Ignoring it and falling back to the next source.",
+                "Project '%s' declares %s as a per-platform mapping with no entry for this platform and no 'default'.",
                 project_file_path,
                 field_name,
             )
-            return ResolvedProjectPath(path=None, unresolved_variables=[], macro_tokens=[])
+            return ResolvedProjectPath(path=None, unresolved_variables=[], macro_tokens=[], platform_gap=True)
 
         resolution = resolve_project_path_field(selected, project_file_path.parent)
         if resolution.path is None:
             logger.warning(
-                "Project '%s' declares %s as %r, which cannot be resolved (%s). Ignoring it and "
-                "falling back to the next source.",
+                "Project '%s' declares %s as %r, which cannot be resolved (%s).",
                 project_file_path,
                 field_name,
                 selected,
@@ -2363,6 +2541,8 @@ class ProjectManager(EngineScoped):
                 "a variable it references expanded to a quoted value, which is not a usable path "
                 "(remove the quotes from the variable's value, not from this field)"
             )
+        if resolution.platform_gap:
+            reasons.append("it lists no path for this platform and no 'default'")
         if not reasons:
             return "it could not be turned into a usable path"
         return "; ".join(reasons)
@@ -2373,9 +2553,11 @@ class ProjectManager(EngineScoped):
         """Resolve a template's raw workspace_dir field to an absolute path string, or None.
 
         Thin projection of _resolve_template_path_field for the workspace resolution ladder. Returns
-        None when the field is unset -- and, defensively, for the declared-but-unresolvable cases that
-        _read_overlay already refuses at load time. Both mean the same thing to the ladder: fall
-        through to the next workspace source.
+        None both when the field is unset and when it is declared but unresolvable (a FLAWED
+        project), which the ladder cannot tell apart -- so callers for whom the difference is
+        user-visible must gate on the full resolution's `is_unresolvable` (or
+        unresolvable_declared_path_messages) BEFORE consulting the ladder, as activation and the
+        listing do.
         """
         resolution = self._resolve_template_path_field(raw, project_file_path, "workspace_dir")
         if resolution.path is None:
@@ -2531,11 +2713,12 @@ class ProjectManager(EngineScoped):
         library declared on the parent is downloaded once and reused via SKIP. See
         _inherit_libraries_dir_from_parents.
 
-        For a project that loaded, `template_libraries_dir` is None only because the field was ABSENT.
-        A declared value that cannot produce a path (unset variable, macro token, no entry for this
-        platform and no 'default') is refused by _read_overlay, so such a project is UNUSABLE and
-        never reaches this ladder -- branch 2's legacy default is never a substitute for a declaration
-        the engine failed to honor.
+        `template_libraries_dir` must be None only because the field was ABSENT. A declared value
+        that cannot produce a path (unset variable, macro token, no entry for this platform and no
+        'default') loads as FLAWED, and every path to this ladder gates on that first (activation
+        via unresolvable_declared_path_messages, the offline resolvers and the listing via
+        `is_unresolvable`) -- branch 2's legacy default is never a substitute for a declaration the
+        engine failed to honor.
         """
         if template_libraries_dir is not None:
             return Path(template_libraries_dir)
@@ -2549,11 +2732,11 @@ class ProjectManager(EngineScoped):
     ) -> str | None:
         """Resolve a template's raw libraries_dir field to an absolute path string, or None.
 
-        Thin projection of _resolve_template_path_field, mirroring _resolve_template_workspace_dir.
-        Returns None when the field is unset -- and, defensively, for the declared-but-unresolvable
-        cases _read_overlay already refuses at load time. This doubles as the per-node leaf primitive
-        for the parent-chain walks, so an inherited value resolves against the DECLARING node's
-        directory.
+        Thin projection of _resolve_template_path_field, mirroring _resolve_template_workspace_dir --
+        including its caveat: None covers both "unset" and "declared but unresolvable", so callers
+        for whom the difference is user-visible gate on the full resolution first. This doubles as
+        the per-node leaf primitive for the LIVE parent-chain walk, so an inherited value resolves
+        against the DECLARING node's directory.
         """
         resolution = self._resolve_template_path_field(raw, project_file_path, "libraries_dir")
         if resolution.path is None:
@@ -2891,7 +3074,11 @@ class ProjectManager(EngineScoped):
             project_dir = project_file_path.parent
             self._config_manager.load_project_config(project_dir)
 
-            await self._apply_workspace_and_libraries_layers(project_info, project_file_path)
+            apply_failure = await self._apply_workspace_and_libraries_layers(project_info, project_file_path)
+            if apply_failure is not None:
+                # The gate refused an unresolvable declared path. The caller's rollback
+                # re-activates the previous project, which re-establishes its layers and env.
+                return _ProjectActivationOutcome(failure=apply_failure, workspace_changed=False)
 
             # Load workspace config layer from the resolved workspace directory.
             self._config_manager.load_workspace_config(self._config_manager.workspace_path)
@@ -2952,8 +3139,19 @@ class ProjectManager(EngineScoped):
 
         return _ProjectActivationOutcome(failure=None, workspace_changed=workspace_changed)
 
-    async def _apply_workspace_and_libraries_layers(self, project_info: ProjectInfo, project_file_path: Path) -> None:
+    async def _apply_workspace_and_libraries_layers(
+        self, project_info: ProjectInfo, project_file_path: Path
+    ) -> SetCurrentProjectResultFailure | None:
         """Resolve and apply a project's workspace override + libraries-root override during activation.
+
+        This is also the activation gate for unresolvable declared paths: a project whose own
+        workspace_dir or libraries_dir is declared but cannot produce a path (a FLAWED load, or an
+        environment change since load) is refused here, before any config layer is applied, rather
+        than having the ladders silently substitute the next source for a location the user named.
+        Returns the failure for _activate_project to propagate (the caller's rollback restores the
+        previous project), or None when the layers were applied. The gate runs AFTER
+        _restore_project_env, so a variable only the OUTGOING project's `environment:` block set
+        cannot make a broken declaration look resolvable.
 
         Branch 4 (workspace) and branch 1 (libraries) inherit from the parent chain, which is the ONLY
         part of the decision that can vary with what is currently loaded. A project that declares a
@@ -2969,6 +3167,16 @@ class ProjectManager(EngineScoped):
         libraries root clears the override so a stale one from a previously-active sharing project is
         dropped and resolved_libraries_root() falls back to the workspace-relative default.
         """
+        unresolvable_messages = self.unresolvable_declared_path_messages(project_info)
+        if unresolvable_messages:
+            return SetCurrentProjectResultFailure(
+                result_details=(
+                    f"Attempted to activate project '{project_info.project_id}'. Failed because its "
+                    f"declared paths cannot be resolved. Fix the value in the project's settings (or "
+                    f"the project file) and try again. {' '.join(unresolvable_messages)}"
+                ),
+            )
+
         template_workspace_dir = self._resolve_template_workspace_dir(
             project_info.template.workspace_dir, project_file_path
         )
@@ -2989,9 +3197,21 @@ class ProjectManager(EngineScoped):
                 template_workspace_dir,
                 id_index,
             )
-            libraries_root = await self._decide_libraries_root_from_disk(
+            libraries_decision = await self._decide_libraries_root_from_disk(
                 project_file_path, template_libraries_dir, id_index
             )
+            blocked_reasons = [
+                reason for reason in (decision.blocked_reason, libraries_decision.blocked_reason) if reason is not None
+            ]
+            if blocked_reasons:
+                return SetCurrentProjectResultFailure(
+                    result_details=(
+                        f"Attempted to activate project '{project_info.project_id}'. Failed because "
+                        f"its parent chain declares paths that cannot be resolved. Fix the value in "
+                        f"the parent project and try again. {'; '.join(blocked_reasons)}"
+                    ),
+                )
+            libraries_root = libraries_decision.libraries_root
         else:
             decision = self.decide_workspace(
                 project_file_path,
@@ -3004,6 +3224,7 @@ class ProjectManager(EngineScoped):
         if decision.apply_override:
             self._config_manager.set_workspace_override(decision.workspace_dir)
         self._config_manager.set_libraries_root_override(libraries_root)
+        return None
 
     async def ensure_project_loaded(self, project_id: ProjectID) -> bool:
         """Ensure a project id is present in the in-memory registry, re-deriving if absent.

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -941,7 +941,7 @@ class ProjectManager(EngineScoped):
         base); a broken workspace_dir/libraries_dir is recorded as a recoverable FLAWED problem and
         the read proceeds, so the project stays loadable and editable. The refusal to substitute a
         different location behind the user's back moves to the consumers: the activation gate
-        (_apply_workspace_and_libraries_layers), the provisioning preview, and the ancestor walks
+        (the top of _activate_project), the provisioning preview, and the ancestor walks
         each check `is_unresolvable` before falling through to another source.
         """
         read_request = ReadFileRequest(
@@ -1037,7 +1037,7 @@ class ProjectManager(EngineScoped):
         template cannot be merged with a base that cannot be found, so there is nothing coherent to
         load. A broken `workspace_dir` or `libraries_dir` is a RECOVERABLE error (FLAWED): the
         template itself is perfectly representable, only activation must refuse it
-        (_apply_workspace_and_libraries_layers). Keeping such a project loadable is what lets the
+        (the gate at the top of _activate_project). Keeping such a project loadable is what lets the
         user see the problem in the app and fix the bad value there, instead of hand-editing the
         YAML and restarting the engine.
 
@@ -2440,7 +2440,7 @@ class ProjectManager(EngineScoped):
         'default', an unset variable, a macro token) comes back with `is_unresolvable` set. A
         project in that state loads as FLAWED (_read_overlay records the problem instead of refusing
         the overlay), so this outcome IS reachable for loaded projects: activation refuses it
-        (_apply_workspace_and_libraries_layers), the ancestor walks report it as a break in the
+        (the gate at the top of _activate_project), the ancestor walks report it as a break in the
         chain, and the listing shows the affected path as unknown. Only the `str | None` projections
         collapse it to "nothing" -- their callers must gate on `is_unresolvable` first when a
         substitute location would be user-visible.
@@ -2955,11 +2955,14 @@ class ProjectManager(EngineScoped):
         """Set which project user has selected.
 
         Establishes the target project's config/workspace/env layers and reloads
-        libraries. When the reload fails (e.g. an engine_version mismatch or a
-        failed provisioning), the previously active project is re-established so
-        the engine is never left adopting a broken project: the user can keep
-        working in the project they had. Re-establishment runs only after startup
-        (interactive switches); during boot the failure is returned as-is.
+        libraries. When the activation fails (e.g. an engine_version mismatch, a
+        failed provisioning, or the gate refusing an unresolvable declared path),
+        the previously active project is re-established so the engine is never
+        left adopting a broken project: the user can keep working in the project
+        they had. During boot the previous project is the system-defaults rest
+        state (or one a CLI executor explicitly selected), so a failed boot
+        activation lands back on the fallback on_app_initialization_complete
+        expects; the failure is still returned to the caller.
         """
         # Remember the project that was active before this switch so a failed
         # activation can roll back to it. SYSTEM_DEFAULTS_KEY is a valid target.
@@ -3002,11 +3005,13 @@ class ProjectManager(EngineScoped):
 
         outcome = await self._activate_project(resolved_project_id)
         if outcome.failure is not None:
-            # During boot, leave the failure to the caller (soft handling); there is
-            # no prior interactive project to fall back to. After startup, restore the
-            # previously active project so the engine stays in a working state, then
-            # surface the original failure to the GUI.
-            if self._initialization_complete and previous_project_id != resolved_project_id:
+            # Restore the previously active project so the engine stays in a working
+            # state, then surface the original failure to the caller. This runs during
+            # boot too: the previous project is then the system-defaults rest state (or
+            # a project a CLI executor explicitly selected), and rolling back to it is
+            # what keeps _current_project_id off the refused project so
+            # on_app_initialization_complete still reaches its system-defaults fallback.
+            if previous_project_id != resolved_project_id:
                 rollback = await self._activate_project(previous_project_id)
                 if rollback.failure is not None:
                     logger.error(
@@ -3034,6 +3039,38 @@ class ProjectManager(EngineScoped):
             self._event_manager.broadcast_app_event(CurrentProjectChanged(project_id=resolved_project_id))
         return result
 
+    def _refuse_unresolvable_declared_paths(
+        self, project_info: ProjectInfo | None
+    ) -> SetCurrentProjectResultFailure | None:
+        """Activation gate for a project's OWN declared paths, or None when activation may proceed.
+
+        A workspace_dir or libraries_dir that is declared but cannot produce a path (a FLAWED
+        load, or an environment change since load) is refused rather than having the ladders
+        silently substitute the next source for a location the user named. _activate_project
+        calls this before _current_project_id or any config layer changes, so a refusal is a
+        no-op: a boot-time refusal leaves the engine on the state it had, and
+        on_app_initialization_complete still reaches its system-defaults fallback. It also runs
+        AFTER _restore_project_env, so a variable only the OUTGOING project's `environment:`
+        block set cannot make a broken declaration look resolvable. Parent-chain breaks are
+        gated later, in _apply_workspace_and_libraries_layers, because deciding them needs the
+        NEW project's config layer; the caller's rollback restores state for that refusal.
+
+        System defaults and unknown ids have no file-backed template, hence no declared paths
+        to gate.
+        """
+        if project_info is None or project_info.project_file_path is None:
+            return None
+        unresolvable_messages = self.unresolvable_declared_path_messages(project_info)
+        if not unresolvable_messages:
+            return None
+        return SetCurrentProjectResultFailure(
+            result_details=(
+                f"Attempted to activate project '{project_info.project_id}'. Failed because its "
+                f"declared paths cannot be resolved. Fix the value in the project's settings (or "
+                f"the project file) and try again. {' '.join(unresolvable_messages)}"
+            ),
+        )
+
     async def _activate_project(self, resolved_project_id: ProjectID) -> _ProjectActivationOutcome:
         """Establish a project's config/workspace/env layers and reload libraries.
 
@@ -3053,6 +3090,12 @@ class ProjectManager(EngineScoped):
         # project's values must not leak into the new project's workspace decision.
         self._restore_project_env()
 
+        project_info = self._successfully_loaded_project_templates.get(resolved_project_id)
+
+        gate_failure = self._refuse_unresolvable_declared_paths(project_info)
+        if gate_failure is not None:
+            return _ProjectActivationOutcome(failure=gate_failure, workspace_changed=False)
+
         # Capture workspace and library-affecting config BEFORE config changes for comparison after
         old_workspace = self._config_manager.workspace_path
         old_library_config = self._snapshot_library_config()
@@ -3068,7 +3111,6 @@ class ProjectManager(EngineScoped):
         # below remerge via load_project_config()/load_workspace_config()/load_configs().
         self._config_manager.clear_project_layers()
 
-        project_info = self._successfully_loaded_project_templates.get(resolved_project_id)
         if project_info is not None and project_info.project_file_path is not None:
             project_file_path = project_info.project_file_path
             project_dir = project_file_path.parent
@@ -3076,21 +3118,19 @@ class ProjectManager(EngineScoped):
 
             apply_failure = await self._apply_workspace_and_libraries_layers(project_info, project_file_path)
             if apply_failure is not None:
-                # The gate refused an unresolvable declared path. The caller's rollback
-                # re-activates the previous project, which re-establishes its layers and env.
+                # The gate refused an unresolvable parent-chain declaration. The config
+                # layers above have already changed, so the caller's rollback re-activates
+                # the previous project, which re-establishes its layers and env.
                 return _ProjectActivationOutcome(failure=apply_failure, workspace_changed=False)
 
             # Load workspace config layer from the resolved workspace directory.
             self._config_manager.load_workspace_config(self._config_manager.workspace_path)
-        elif project_info is not None and project_info.project_file_path is None:
-            # Switching to system defaults: clear_project_layers() above already dropped
-            # the prior project's override and config-file paths, so reloading configs now
-            # resolves workspace_path and all config layers from defaults only.
-            self._config_manager.load_configs()
         else:
-            # Unknown project id (no loaded template): clear_project_layers() above already
-            # dropped the prior project's layers, so remerge from defaults rather than leave
-            # config in the cleared, unmerged state.
+            # Switching to system defaults (a loaded template with no backing file) or an
+            # unknown project id (no loaded template): clear_project_layers() above already
+            # dropped the prior project's override and config-file paths, so reloading
+            # configs now resolves workspace_path and all config layers from defaults only,
+            # rather than leaving config in the cleared, unmerged state.
             self._config_manager.load_configs()
 
         # Apply the new project's environment variables to os.environ. Happens after
@@ -3144,14 +3184,17 @@ class ProjectManager(EngineScoped):
     ) -> SetCurrentProjectResultFailure | None:
         """Resolve and apply a project's workspace override + libraries-root override during activation.
 
-        This is also the activation gate for unresolvable declared paths: a project whose own
-        workspace_dir or libraries_dir is declared but cannot produce a path (a FLAWED load, or an
-        environment change since load) is refused here, before any config layer is applied, rather
-        than having the ladders silently substitute the next source for a location the user named.
-        Returns the failure for _activate_project to propagate (the caller's rollback restores the
-        previous project), or None when the layers were applied. The gate runs AFTER
-        _restore_project_env, so a variable only the OUTGOING project's `environment:` block set
-        cannot make a broken declaration look resolvable.
+        This also hosts the parent-chain half of the activation gate: an ancestor whose DECLARED
+        workspace_dir or libraries_dir cannot be resolved blocks the descendant (blocked_reason)
+        rather than having the ladders silently substitute a location the chain never named. The
+        project's OWN declarations are gated earlier, at the top of _activate_project, before any
+        state changes; the parent-chain decision cannot run there because it reads the NEW
+        project's config layers (the project-adjacent workspace_directory short-circuit and the
+        registered-projects index), which _activate_project swaps in just before calling this. A
+        refusal here therefore leaves changed config layers behind, and the caller of
+        _activate_project rolls back to the previous project (system defaults during boot) to
+        restore a consistent state. Returns the failure for _activate_project to propagate, or
+        None when the layers were applied.
 
         Branch 4 (workspace) and branch 1 (libraries) inherit from the parent chain, which is the ONLY
         part of the decision that can vary with what is currently loaded. A project that declares a
@@ -3167,16 +3210,6 @@ class ProjectManager(EngineScoped):
         libraries root clears the override so a stale one from a previously-active sharing project is
         dropped and resolved_libraries_root() falls back to the workspace-relative default.
         """
-        unresolvable_messages = self.unresolvable_declared_path_messages(project_info)
-        if unresolvable_messages:
-            return SetCurrentProjectResultFailure(
-                result_details=(
-                    f"Attempted to activate project '{project_info.project_id}'. Failed because its "
-                    f"declared paths cannot be resolved. Fix the value in the project's settings (or "
-                    f"the project file) and try again. {' '.join(unresolvable_messages)}"
-                ),
-            )
-
         template_workspace_dir = self._resolve_template_workspace_dir(
             project_info.template.workspace_dir, project_file_path
         )

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -2570,6 +2570,9 @@ class TestPreviewProjectProvisioning:
         mock_project_manager = MagicMock()
         mock_project_manager.resolve_provisioning_config_dirs = AsyncMock(return_value=dirs)
         mock_project_manager.resolve_libraries_root_for_project_id = AsyncMock(return_value=libraries_root)
+        # The gate that mirrors activation: these projects declare nothing unresolvable, so the
+        # preview must proceed past it to the plan under test.
+        mock_project_manager.unresolvable_declared_path_messages.return_value = []
         mock_config_manager = MagicMock()
         mock_config_manager.compute_project_provisioning_config.return_value = merged
         TestPreviewProjectProvisioning._use_real_libraries_root_formula(mock_config_manager)
@@ -2766,6 +2769,9 @@ class TestPreviewProjectProvisioning:
         mock_project_manager = MagicMock()
         mock_project_manager.resolve_provisioning_config_dirs = AsyncMock(return_value=MagicMock())
         mock_project_manager.resolve_libraries_root_for_project_id = AsyncMock(return_value=None)
+        # This project declares nothing unresolvable, so the preview must proceed past the
+        # activation-mirroring gate to the fallback probe under test.
+        mock_project_manager.unresolvable_declared_path_messages.return_value = []
         with (
             patch.object(griptape_nodes, "_project_manager", mock_project_manager),
             patch.object(griptape_nodes, "_config_manager", live_config),

--- a/tests/unit/retained_mode/managers/test_project_effective_paths.py
+++ b/tests/unit/retained_mode/managers/test_project_effective_paths.py
@@ -203,27 +203,28 @@ class TestEffectiveProjectPathsThroughEngine:
         assert CHAIN_INNER_ENV_VAR not in libraries_root
         assert CHAIN_OUTER_ENV_VAR not in libraries_root
 
-    def test_a_reference_cycle_fails_the_load_as_a_cycle_not_as_a_missing_value(
+    def test_a_reference_cycle_loads_flawed_as_a_cycle_not_as_a_missing_value(
         self, engine: Engine, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """Mutually referencing variables refuse the load, and say so as a cycle.
+        """Mutually referencing variables load FLAWED, and say so as a cycle.
 
         Both variables ARE set, so "no value is set for A" would be false. Expansion cannot finish,
         which is a different problem with a different fix, and the artist needs to be told which.
+        The project stays loadable (so the field can be fixed in the app) with no libraries root
+        reported for it.
         """
         monkeypatch.setenv(CYCLE_A_ENV_VAR, f"${{{CYCLE_B_ENV_VAR}}}")
         monkeypatch.setenv(CYCLE_B_ENV_VAR, f"${{{CYCLE_A_ENV_VAR}}}")
         cyclic_path = write_project(tmp_path / "cyclic", CYCLIC_LIBRARIES_YAML)
 
-        assert isinstance(self.load(engine, cyclic_path), LoadProjectTemplateResultFailure)
+        assert isinstance(self.load(engine, cyclic_path), LoadProjectTemplateResultSuccess)
         listing = self.listing(engine)
 
-        assert self.loaded_by_path(listing) == {}
-        failed = [info for info in listing.failed_to_load if info.project_id == str(cyclic_path)]
-        assert len(failed) == 1
-        assert failed[0].libraries_root is None
+        assert listing.failed_to_load == []
+        info = self.loaded_by_path(listing)[str(cyclic_path)]
+        assert info.libraries_root is None
 
-        problems = [p for p in failed[0].validation.problems if p.field_path == "libraries_dir"]
+        problems = [p for p in info.validation.problems if p.field_path == "libraries_dir"]
         assert len(problems) == 1
         assert "cycle" in problems[0].message or "each other" in problems[0].message
         assert "no value is set" not in problems[0].message
@@ -312,6 +313,25 @@ class TestEffectiveProjectPathsThroughEngine:
         assert isinstance(preview, PreviewProjectProvisioningResultFailure)
         assert "not loaded" in str(preview.result_details)
 
+    def test_provisioning_declines_to_preview_a_flawed_project(
+        self, engine: Engine, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The preview mirrors the activation gate rather than planning against a fallback root.
+
+        A FLAWED project's activation will be refused, so a plan computed from the workspace-default
+        libraries root would show the user changes that can never be applied.
+        """
+        monkeypatch.delenv(LIBS_ENV_VAR, raising=False)
+        base_path = write_project(tmp_path / "base", DECLARED_LIBRARIES_YAML)
+        load_result = self.load(engine, base_path)
+        assert isinstance(load_result, LoadProjectTemplateResultSuccess)
+
+        preview = engine.handle_request(PreviewProjectProvisioningRequest(project_id=load_result.project_id))
+
+        assert isinstance(preview, PreviewProjectProvisioningResultFailure)
+        assert "declared paths cannot be resolved" in str(preview.result_details)
+        assert LIBS_ENV_VAR in str(preview.result_details)
+
     @pytest.mark.asyncio
     async def test_resolver_answers_nothing_for_an_id_that_is_not_a_loadable_project(
         self, engine: Engine, tmp_path: Path
@@ -329,27 +349,28 @@ class TestEffectiveProjectPathsThroughEngine:
         assert await engine.project_manager.resolve_libraries_root_for_project_id("no-such-project") is None
         assert await engine.project_manager.resolve_libraries_root_for_project_id(str(unparsable)) is None
 
-    def test_unresolvable_declaration_fails_the_load_with_the_field_and_its_line(
+    def test_unresolvable_declaration_loads_flawed_with_the_field_and_its_line(
         self, engine: Engine, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """With the variable unset the project refuses to load instead of substituting a path.
+        """With the variable unset the project loads FLAWED instead of substituting a path.
 
-        The listing reports it under failed_to_load with no paths at all, so the GUI can tell "here is
-        where the libraries live" apart from "this project is broken."
+        The listing reports it as loaded -- so the GUI can open it and the bad value can be fixed in
+        the app -- but with no libraries root, so "here is where the libraries live" stays distinct
+        from "this project is broken." The workspace, which the project does not declare, still
+        resolves normally.
         """
         monkeypatch.delenv(LIBS_ENV_VAR, raising=False)
         base_path = write_project(tmp_path / "base", DECLARED_LIBRARIES_YAML)
 
-        assert isinstance(self.load(engine, base_path), LoadProjectTemplateResultFailure)
+        assert isinstance(self.load(engine, base_path), LoadProjectTemplateResultSuccess)
         listing = self.listing(engine)
 
-        assert self.loaded_by_path(listing) == {}
-        failed = [info for info in listing.failed_to_load if info.project_id == str(base_path)]
-        assert len(failed) == 1
-        assert failed[0].workspace_dir is None
-        assert failed[0].libraries_root is None
+        assert listing.failed_to_load == []
+        info = self.loaded_by_path(listing)[str(base_path)]
+        assert info.workspace_dir is not None
+        assert info.libraries_root is None
 
-        problems = [p for p in failed[0].validation.problems if p.field_path == "libraries_dir"]
+        problems = [p for p in info.validation.problems if p.field_path == "libraries_dir"]
         assert len(problems) == 1
         assert LIBS_ENV_VAR in problems[0].message
         # The scalar's line is tracked from its key's position in the parent mapping; before that,
@@ -358,14 +379,39 @@ class TestEffectiveProjectPathsThroughEngine:
         cited_line = base_path.read_text(encoding="utf-8").splitlines()[problems[0].line_number - 1]
         assert "libraries_dir" in cited_line
 
-    def test_a_broken_parent_takes_its_child_down_but_not_an_unrelated_project(
+    def test_activation_refuses_a_flawed_project_end_to_end(
+        self, engine: Engine, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The whole point of loading FLAWED: the project opens, but switching to it is refused.
+
+        Drives SetCurrentProjectRequest through the real event system so the gate, not a mock, is
+        what says no. The failure names the field's problem so the GUI can point at it.
+        """
+        from griptape_nodes.retained_mode.events.project_events import (
+            SetCurrentProjectRequest,
+            SetCurrentProjectResultFailure,
+        )
+
+        monkeypatch.delenv(LIBS_ENV_VAR, raising=False)
+        base_path = write_project(tmp_path / "base", DECLARED_LIBRARIES_YAML)
+        load_result = self.load(engine, base_path)
+        assert isinstance(load_result, LoadProjectTemplateResultSuccess)
+
+        result = engine.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
+
+        assert isinstance(result, SetCurrentProjectResultFailure)
+        assert "declared paths cannot be resolved" in str(result.result_details)
+        assert LIBS_ENV_VAR in str(result.result_details)
+
+    def test_a_broken_parent_blocks_its_child_but_not_an_unrelated_project(
         self, engine: Engine, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, workspace: Path
     ) -> None:
-        """Failing closed cascades along the parent chain and stops there.
+        """A FLAWED base no longer bricks its family, but nothing inherits around it either.
 
-        A shared base pinning an unset variable stops loading for everything derived from it -- the
-        accepted cost, since the alternative is each child quietly installing libraries elsewhere. A
-        project that never referenced the variable is untouched and still reports its paths.
+        The base and its child both LOAD (so the family stays visible and the base's value can be
+        fixed in the app), and neither reports a libraries root: the base's declaration is
+        unresolvable and the child's inheritance is blocked on it, never quietly replaced with the
+        workspace default. A project that never referenced the variable is untouched.
         """
         monkeypatch.delenv(LIBS_ENV_VAR, raising=False)
         base_dir = tmp_path / "base"
@@ -373,19 +419,15 @@ class TestEffectiveProjectPathsThroughEngine:
         child_path = write_project(base_dir / "shots" / "sc010", CHILD_OF_BASE_YAML)
         solo_path = write_project(tmp_path / "solo", DECLARES_NOTHING_YAML)
 
-        assert isinstance(self.load(engine, base_path), LoadProjectTemplateResultFailure)
-        assert isinstance(self.load(engine, child_path), LoadProjectTemplateResultFailure)
+        assert isinstance(self.load(engine, base_path), LoadProjectTemplateResultSuccess)
+        assert isinstance(self.load(engine, child_path), LoadProjectTemplateResultSuccess)
         assert isinstance(self.load(engine, solo_path), LoadProjectTemplateResultSuccess)
         listing = self.listing(engine)
 
-        failed_ids = {info.project_id for info in listing.failed_to_load}
-        assert {str(base_path), str(child_path)} <= failed_ids
-        assert all(info.libraries_root is None for info in listing.failed_to_load)
+        assert listing.failed_to_load == []
+        by_path = self.loaded_by_path(listing)
+        assert by_path[str(base_path)].libraries_root is None
+        assert by_path[str(child_path)].libraries_root is None
 
-        child_problems = [
-            p for info in listing.failed_to_load if info.project_id == str(child_path) for p in info.validation.problems
-        ]
-        assert any(p.field_path == "parent_project_path" for p in child_problems)
-
-        solo_info = self.loaded_by_path(listing)[str(solo_path)]
+        solo_info = by_path[str(solo_path)]
         assert solo_info.libraries_root == str(canonicalize_for_identity(workspace / "libraries"))

--- a/tests/unit/retained_mode/managers/test_project_effective_paths.py
+++ b/tests/unit/retained_mode/managers/test_project_effective_paths.py
@@ -391,6 +391,7 @@ class TestEffectiveProjectPathsThroughEngine:
             SetCurrentProjectRequest,
             SetCurrentProjectResultFailure,
         )
+        from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY
 
         monkeypatch.delenv(LIBS_ENV_VAR, raising=False)
         base_path = write_project(tmp_path / "base", DECLARED_LIBRARIES_YAML)
@@ -402,6 +403,9 @@ class TestEffectiveProjectPathsThroughEngine:
         assert isinstance(result, SetCurrentProjectResultFailure)
         assert "declared paths cannot be resolved" in str(result.result_details)
         assert LIBS_ENV_VAR in str(result.result_details)
+        # The refusal must not half-take: the engine stays on the project it had
+        # (system defaults here), with the refused project nowhere in its state.
+        assert engine.project_manager._current_project_id == SYSTEM_DEFAULTS_KEY
 
     def test_a_broken_parent_blocks_its_child_but_not_an_unrelated_project(
         self, engine: Engine, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, workspace: Path

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -5712,8 +5712,15 @@ class TestProjectManagerProjectWorkspaces:
         assert "engine_version mismatch" in str(result.result_details)
 
     @pytest.mark.asyncio
-    async def test_failed_activation_during_boot_does_not_roll_back(self, tmp_path: Path) -> None:
-        """A failure before startup completes returns as-is without re-activating anything."""
+    async def test_failed_activation_during_boot_rolls_back_to_the_rest_state(self, tmp_path: Path) -> None:
+        """A failure before startup completes re-activates the previous project, the boot rest state.
+
+        During boot the previous project is SYSTEM_DEFAULTS_KEY, and rolling back to it is what
+        keeps _current_project_id off the refused project: on_app_initialization_complete reads
+        it to decide whether an explicit project was selected, and a leftover id would make it
+        skip the system-defaults fallback and finish boot with the failed project current, its
+        config layers half-applied. The original failure is still surfaced to the caller.
+        """
         from unittest.mock import patch
 
         from griptape_nodes.retained_mode.events.project_events import (
@@ -5743,14 +5750,18 @@ class TestProjectManagerProjectWorkspaces:
 
         async def fake_activate(project_id: str) -> _ProjectActivationOutcome:
             calls.append(project_id)
-            return _ProjectActivationOutcome(failure=failure, workspace_changed=False)
+            # First call (the requested target) fails; the rollback to the rest state succeeds.
+            if len(calls) == 1:
+                return _ProjectActivationOutcome(failure=failure, workspace_changed=False)
+            return _ProjectActivationOutcome(failure=None, workspace_changed=False)
 
         with patch.object(pm, "_activate_project", side_effect=fake_activate):
             result = await pm.on_set_current_project_request(SetCurrentProjectRequest(project_id=str(target_file)))
 
-        # Only the target activation runs; no rollback during boot.
-        assert len(calls) == 1
+        target_id = str(canonicalize_for_identity(str(target_file)))
+        assert calls == [target_id, SYSTEM_DEFAULTS_KEY]
         assert isinstance(result, SetCurrentProjectResultFailure)
+        assert "boot failure" in str(result.result_details)
 
 
 class TestRegisterProjectPath:
@@ -8795,7 +8806,7 @@ class TestProjectPathFieldValidation:
     the template cannot be merged without its base. A broken `workspace_dir`/`libraries_dir` loads
     FLAWED with an ERROR problem: the project stays loadable and editable -- so the user can fix the
     bad value in the app instead of hand-editing YAML and restarting -- while activation refuses it
-    (the gate in _apply_workspace_and_libraries_layers).
+    (the gate at the top of _activate_project).
 
     These tests drive the REAL `_read_overlay` through `on_load_project_template_request` with YAML on
     disk, because `_read_overlay` is where the check lives -- the `_build_pm` harness used by the
@@ -9254,8 +9265,11 @@ class TestProjectPathFieldValidation:
 
         Loading FLAWED is what keeps the project editable; this is the other half of the contract --
         the broken declaration is never silently replaced with a fallback location at activation.
-        The gate returns before any config layer is touched, so a refusal leaves no half-applied
-        state for the caller's rollback to fight.
+        Drives _activate_project (not the gate helper) because the ORDERING is part of the
+        contract: the refusal must land before _current_project_id moves or any config layer is
+        touched. Otherwise a boot-time refusal (where the caller's rollback used not to run)
+        strands the engine on the refused project with its layers cleared but never reloaded, and
+        on_app_initialization_complete skips the system-defaults fallback.
         """
         from griptape_nodes.retained_mode.events.project_events import (
             LoadProjectTemplateResultSuccess,
@@ -9271,13 +9285,21 @@ class TestProjectPathFieldValidation:
         )
         result = await self._load(pm, {project_path: project_yaml}, project_path)
         assert isinstance(result, LoadProjectTemplateResultSuccess)
-        project_info = pm._successfully_loaded_project_templates[result.project_id]
 
-        failure = await pm._apply_workspace_and_libraries_layers(project_info, project_path)
+        config = cast("Mock", pm._config_manager)
+        config.clear_project_layers.reset_mock()
+        config.load_project_config.reset_mock()
+        current_before = pm._current_project_id
 
-        assert isinstance(failure, SetCurrentProjectResultFailure)
-        assert "declared paths cannot be resolved" in str(failure.result_details)
-        assert "no value is set for GTN_TEST_LIBS" in str(failure.result_details)
+        outcome = await pm._activate_project(result.project_id)
+
+        assert isinstance(outcome.failure, SetCurrentProjectResultFailure)
+        assert "declared paths cannot be resolved" in str(outcome.failure.result_details)
+        assert "no value is set for GTN_TEST_LIBS" in str(outcome.failure.result_details)
+        # The refusal is a no-op: nothing became current and no config layer was touched.
+        assert pm._current_project_id == current_before
+        config.clear_project_layers.assert_not_called()
+        config.load_project_config.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_activation_gate_re_resolves_after_the_environment_breaks(
@@ -9305,13 +9327,12 @@ class TestProjectPathFieldValidation:
         result = await self._load(pm, {project_path: project_yaml}, project_path)
         assert isinstance(result, LoadProjectTemplateResultSuccess)
         assert result.validation.status is ProjectValidationStatus.GOOD
-        project_info = pm._successfully_loaded_project_templates[result.project_id]
 
         monkeypatch.delenv("GTN_TEST_LIBS")
-        failure = await pm._apply_workspace_and_libraries_layers(project_info, project_path)
+        outcome = await pm._activate_project(result.project_id)
 
-        assert isinstance(failure, SetCurrentProjectResultFailure)
-        assert "no value is set for GTN_TEST_LIBS" in str(failure.result_details)
+        assert isinstance(outcome.failure, SetCurrentProjectResultFailure)
+        assert "no value is set for GTN_TEST_LIBS" in str(outcome.failure.result_details)
 
 
 class TestListProjectTemplatesEffectivePaths:
@@ -9774,6 +9795,57 @@ situations:
         assert isinstance(result, ActivateWorkspaceProjectResultFailure)
         assert str(workspace_project_path) in str(result.result_details)
         assert "Failed because" in str(result.result_details)
+
+    @pytest.mark.asyncio
+    async def test_flawed_workspace_project_refused_at_boot_stays_on_system_defaults(
+        self, pm: ProjectManager, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A boot-time gate refusal leaves the engine exactly where it was: on system defaults.
+
+        The workspace project loads FLAWED (unresolvable libraries_dir) and the activation gate
+        refuses it before _current_project_id or any config layer moves. If the refusal landed
+        after those mutations instead, boot would finish with the refused project current --
+        on_app_initialization_complete reads _current_project_id to decide whether an explicit
+        project was selected, and a leftover id makes it skip the system-defaults fallback.
+        """
+        from griptape_nodes.retained_mode.events.project_events import (
+            ActivateWorkspaceProjectRequest,
+            ActivateWorkspaceProjectResultFailure,
+        )
+        from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY, WORKSPACE_PROJECT_FILE
+
+        self._setup_system_defaults(pm, str(tmp_path))
+        monkeypatch.delenv("GTN_BOOT_LIBS", raising=False)
+
+        flawed_yaml = (
+            'project_template_schema_version: "0.3.3"\n'
+            "name: Broken Boot Project\n"
+            'libraries_dir: "${GTN_BOOT_LIBS}/shared-libraries"\n'
+        )
+        workspace_project_path = tmp_path / WORKSPACE_PROJECT_FILE
+        workspace_project_path.write_text(flawed_yaml)
+
+        def get_config_value_side_effect(key: str, **_: object) -> str | dict | None:
+            if key == "project_file":
+                return None
+            if "project_workspaces" in key:
+                return {}
+            return str(tmp_path)
+
+        cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
+        cast("Mock", pm._config_manager).workspace_path = tmp_path
+
+        with patch("griptape_nodes.retained_mode.managers.project_manager.File") as mock_file_cls:
+            mock_file_instance = Mock()
+            mock_file_instance.aread_text = AsyncMock(return_value=flawed_yaml)
+            mock_file_cls.return_value = mock_file_instance
+
+            result = await pm.on_activate_workspace_project_request(ActivateWorkspaceProjectRequest())
+
+        assert isinstance(result, ActivateWorkspaceProjectResultFailure)
+        assert "declared paths cannot be resolved" in str(result.result_details)
+        assert "no value is set for GTN_BOOT_LIBS" in str(result.result_details)
+        assert pm._current_project_id == SYSTEM_DEFAULTS_KEY
 
     @pytest.mark.asyncio
     async def test_activate_child_seed_resolves_id_parent_registered_only_in_config(

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -4230,14 +4230,16 @@ class TestResolveWorkspaceDirForProjectId:
         assert "GTN_TEST_WS" not in str(result)
 
     @pytest.mark.asyncio
-    async def test_unloaded_workspace_dir_with_unset_env_var_falls_through(
+    async def test_unloaded_workspace_dir_with_unset_env_var_answers_nothing(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """An unset env var in workspace_dir falls through to the next ladder source, not a literal path.
+        """An unset env var in workspace_dir answers None -- not a fallback, not a literal path.
 
-        The value cannot be resolved, so the ladder behaves as if the project declared nothing --
-        which is what activation does -- rather than creating a directory named `${GTN_TEST_WS}`
-        under the project.
+        The value cannot be resolved, so there is no honest workspace to report: activation refuses
+        such a project rather than falling through, so answering the global default here would name
+        a path the project will never use. (Creating a directory literally named `${GTN_TEST_WS}`
+        under the project would be even worse.) None is the "no hint to show" signal the workspace
+        event already defines.
         """
         project_file = tmp_path / "c" / "griptape-nodes-project.yml"
         project_file.parent.mkdir(parents=True)
@@ -4251,7 +4253,7 @@ class TestResolveWorkspaceDirForProjectId:
         )
         result = await pm.resolve_workspace_dir_for_project_id("C")
 
-        assert result == self._resolved("/global/ws")
+        assert result is None
 
     @pytest.mark.asyncio
     async def test_unloaded_parent_link_expands_env_var(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -8781,13 +8783,19 @@ directories:
 
 
 class TestProjectPathFieldValidation:
-    """A declared path field that cannot produce a path fails the load, naming field, line and cause.
+    """A declared path field that cannot produce a path is recorded, naming field, line and cause.
 
     The rule, uniform across `workspace_dir`, `libraries_dir` and `parent_project_path`: ABSENT means
     "fall through to the next source", PRESENT-but-unresolvable means the project is broken. The only
     alternative is to discard what the user wrote and put their workspace or their libraries somewhere
     they never named, which is how a shared project ends up silently installing a second copy of every
     library on a teammate's machine.
+
+    What "broken" costs differs by field. A broken `parent_project_path` fails the load (UNUSABLE):
+    the template cannot be merged without its base. A broken `workspace_dir`/`libraries_dir` loads
+    FLAWED with an ERROR problem: the project stays loadable and editable -- so the user can fix the
+    bad value in the app instead of hand-editing YAML and restarting -- while activation refuses it
+    (the gate in _apply_workspace_and_libraries_layers).
 
     These tests drive the REAL `_read_overlay` through `on_load_project_template_request` with YAML on
     disk, because `_read_overlay` is where the check lives -- the `_build_pm` harness used by the
@@ -8844,16 +8852,19 @@ class TestProjectPathFieldValidation:
             return await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=project_path))
 
     @pytest.mark.asyncio
-    async def test_unset_variable_in_libraries_dir_fails_the_load(
+    async def test_unset_variable_in_libraries_dir_loads_flawed(
         self, pm: ProjectManager, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """`${GTN_TEST_LIBS}/libraries` with the variable unset is an error, not a fallback.
+        """`${GTN_TEST_LIBS}/libraries` with the variable unset is a recorded error, not a fallback.
 
-        An unresolvable declaration is never quietly replaced with `<workspace>/libraries`:
-        installing libraries somewhere the project never named is worse than refusing to open.
+        An unresolvable declaration is never quietly replaced with `<workspace>/libraries` --
+        activation refuses the project. But the project still LOADS (FLAWED, with the field, cause
+        and line on the validation) so the bad value can be seen and fixed in the app instead of
+        hand-editing YAML and restarting the engine.
         """
         from griptape_nodes.common.project_templates import ProjectValidationStatus
-        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultFailure
+        from griptape_nodes.common.project_templates.validation import ProjectValidationProblemSeverity
+        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultSuccess
 
         monkeypatch.delenv("GTN_TEST_LIBS", raising=False)
         project_path = (tmp_path / "griptape-nodes-project.yml").resolve()
@@ -8865,22 +8876,24 @@ class TestProjectPathFieldValidation:
 
         result = await self._load(pm, {project_path: project_yaml}, project_path)
 
-        assert isinstance(result, LoadProjectTemplateResultFailure)
-        assert result.validation.status is ProjectValidationStatus.UNUSABLE
+        assert isinstance(result, LoadProjectTemplateResultSuccess)
+        assert result.validation.status is ProjectValidationStatus.FLAWED
         problems = [p for p in result.validation.problems if p.field_path == "libraries_dir"]
         assert len(problems) == 1
+        assert problems[0].severity is ProjectValidationProblemSeverity.ERROR
         assert "no value is set for GTN_TEST_LIBS" in problems[0].message
         assert problems[0].line_number == _line_of(project_yaml, "libraries_dir:")
 
     @pytest.mark.asyncio
-    async def test_macro_token_in_workspace_dir_fails_the_load(self, pm: ProjectManager, tmp_path: Path) -> None:
+    async def test_macro_token_in_workspace_dir_loads_flawed(self, pm: ProjectManager, tmp_path: Path) -> None:
         """A `{macro}` token in a path field is refused rather than becoming a folder of that name.
 
         Macros resolve against runtime state that does not exist yet when these fields are read, so
-        `{outputs}` here can only ever mean a directory literally called `{outputs}`.
+        `{outputs}` here can only ever mean a directory literally called `{outputs}`. The project
+        still loads (FLAWED) so the field can be corrected in the app; activation refuses it.
         """
         from griptape_nodes.common.project_templates import ProjectValidationStatus
-        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultFailure
+        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultSuccess
 
         project_path = (tmp_path / "griptape-nodes-project.yml").resolve()
         project_yaml = (
@@ -8889,8 +8902,8 @@ class TestProjectPathFieldValidation:
 
         result = await self._load(pm, {project_path: project_yaml}, project_path)
 
-        assert isinstance(result, LoadProjectTemplateResultFailure)
-        assert result.validation.status is ProjectValidationStatus.UNUSABLE
+        assert isinstance(result, LoadProjectTemplateResultSuccess)
+        assert result.validation.status is ProjectValidationStatus.FLAWED
         problems = [p for p in result.validation.problems if p.field_path == "workspace_dir"]
         assert len(problems) == 1
         assert "macro tokens are not supported" in problems[0].message
@@ -8898,17 +8911,17 @@ class TestProjectPathFieldValidation:
         assert problems[0].line_number == _line_of(project_yaml, "workspace_dir:")
 
     @pytest.mark.asyncio
-    async def test_percent_reference_in_libraries_dir_fails_the_load(
+    async def test_percent_reference_in_libraries_dir_loads_flawed(
         self, pm: ProjectManager, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A `%NAME%` reference that expands to nothing fails the load on every platform.
+        """A `%NAME%` reference that expands to nothing is a recorded error on every platform.
 
         `%NAME%` expands only on Windows, so elsewhere it never resolves at all. Either way the value
         has no answer, and a real directory whose name happens to contain `%SHOT_CODE%` is now refused
         rather than used literally -- the deliberate cost of treating the form as a variable.
         """
         from griptape_nodes.common.project_templates import ProjectValidationStatus
-        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultFailure
+        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultSuccess
 
         monkeypatch.delenv("SHOT_CODE", raising=False)
         project_path = (tmp_path / "griptape-nodes-project.yml").resolve()
@@ -8918,24 +8931,24 @@ class TestProjectPathFieldValidation:
 
         result = await self._load(pm, {project_path: project_yaml}, project_path)
 
-        assert isinstance(result, LoadProjectTemplateResultFailure)
-        assert result.validation.status is ProjectValidationStatus.UNUSABLE
+        assert isinstance(result, LoadProjectTemplateResultSuccess)
+        assert result.validation.status is ProjectValidationStatus.FLAWED
         problems = [p for p in result.validation.problems if p.field_path == "libraries_dir"]
         assert len(problems) == 1
         assert "no value is set for SHOT_CODE" in problems[0].message
 
     @pytest.mark.asyncio
-    async def test_platform_gap_in_libraries_dir_fails_the_load(
+    async def test_platform_gap_in_libraries_dir_loads_flawed(
         self, pm: ProjectManager, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A per-platform mapping with no entry for this OS and no `default` fails the load.
+        """A per-platform mapping with no entry for this OS and no `default` is a recorded error.
 
         `default` exists precisely to say what the platforms you did not name should get. A mapping
         that names only Windows says nothing about a Linux teammate, so there is nothing to honor and
-        nothing to guess.
+        nothing to guess -- the project loads FLAWED and activation refuses it.
         """
         from griptape_nodes.common.project_templates import ProjectValidationStatus
-        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultFailure
+        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultSuccess
 
         monkeypatch.setattr("sys.platform", "linux")
         project_path = (tmp_path / "griptape-nodes-project.yml").resolve()
@@ -8949,8 +8962,8 @@ class TestProjectPathFieldValidation:
 
         result = await self._load(pm, {project_path: project_yaml}, project_path)
 
-        assert isinstance(result, LoadProjectTemplateResultFailure)
-        assert result.validation.status is ProjectValidationStatus.UNUSABLE
+        assert isinstance(result, LoadProjectTemplateResultSuccess)
+        assert result.validation.status is ProjectValidationStatus.FLAWED
         problems = [p for p in result.validation.problems if p.field_path == "libraries_dir"]
         assert len(problems) == 1
         assert "no path for this platform (linux) and no 'default'" in problems[0].message
@@ -8959,7 +8972,7 @@ class TestProjectPathFieldValidation:
         assert problems[0].line_number == _line_of(project_yaml, "darwin:")
 
     @pytest.mark.asyncio
-    async def test_quoted_variable_value_fails_the_load_instead_of_anchoring_under_the_project(
+    async def test_quoted_variable_value_loads_flawed_instead_of_anchoring_under_the_project(
         self, pm: ProjectManager, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A variable whose value carries quotes is refused, not quietly relocated.
@@ -8970,7 +8983,7 @@ class TestProjectPathFieldValidation:
         libraries installing somewhere the project never named, reported as a clean resolve.
         """
         from griptape_nodes.common.project_templates import ProjectValidationStatus
-        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultFailure
+        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultSuccess
 
         monkeypatch.setenv("GTN_TEST_QUOTED_ROOT", '"/mnt/studio"')
         project_path = (tmp_path / "griptape-nodes-project.yml").resolve()
@@ -8982,8 +8995,8 @@ class TestProjectPathFieldValidation:
 
         result = await self._load(pm, {project_path: project_yaml}, project_path)
 
-        assert isinstance(result, LoadProjectTemplateResultFailure)
-        assert result.validation.status is ProjectValidationStatus.UNUSABLE
+        assert isinstance(result, LoadProjectTemplateResultSuccess)
+        assert result.validation.status is ProjectValidationStatus.FLAWED
         problems = [p for p in result.validation.problems if p.field_path == "libraries_dir"]
         assert len(problems) == 1
         assert "expanded to a quoted value" in problems[0].message
@@ -9031,7 +9044,7 @@ class TestProjectPathFieldValidation:
         `sys.platform` of `win32` OR `linux` must be absent from the message, and neither is the
         value being reported.
         """
-        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultFailure
+        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultSuccess
 
         monkeypatch.setattr(
             "griptape_nodes.common.project_templates.directory.active_platform_key",
@@ -9048,7 +9061,7 @@ class TestProjectPathFieldValidation:
 
         result = await self._load(pm, {project_path: project_yaml}, project_path)
 
-        assert isinstance(result, LoadProjectTemplateResultFailure)
+        assert isinstance(result, LoadProjectTemplateResultSuccess)
         problems = [p for p in result.validation.problems if p.field_path == "libraries_dir"]
         assert len(problems) == 1
         assert "no path for this platform (windows) and no 'default'" in problems[0].message
@@ -9065,7 +9078,7 @@ class TestProjectPathFieldValidation:
         a fix that fails validation, which is the same confidently-wrong-cause failure this whole
         field-resolution path exists to avoid. `default` is the only way out, and the message says so.
         """
-        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultFailure
+        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultSuccess
 
         monkeypatch.setattr(
             "griptape_nodes.common.project_templates.directory.active_platform_key",
@@ -9083,7 +9096,7 @@ class TestProjectPathFieldValidation:
 
         result = await self._load(pm, {project_path: project_yaml}, project_path)
 
-        assert isinstance(result, LoadProjectTemplateResultFailure)
+        assert isinstance(result, LoadProjectTemplateResultSuccess)
         problems = [p for p in result.validation.problems if p.field_path == "libraries_dir"]
         assert len(problems) == 1
         assert f"no path for this platform (unsupported ({sys.platform})) and no 'default'" in problems[0].message
@@ -9152,17 +9165,18 @@ class TestProjectPathFieldValidation:
         assert result.template.libraries_dir == "${GTN_TEST_LIBS}/libraries"
 
     @pytest.mark.asyncio
-    async def test_child_of_project_with_unresolvable_libraries_dir_also_fails(
+    async def test_child_of_project_with_unresolvable_libraries_dir_loads_but_cannot_inherit(
         self, pm: ProjectManager, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A broken parent brings its descendants down, with the error on the child's parent link.
+        """A FLAWED parent no longer bricks its descendants, but they cannot activate around it.
 
-        This is the accepted cost of failing closed: a shared base project pinning an unset variable
-        stops loading for every project derived from it. The alternative is each of those children
-        quietly installing libraries somewhere the base never named.
+        The child loads (its own fields are fine, and the parent's overlay is readable), so the
+        family stays visible and fixable in the app. What is preserved from the old fail-closed
+        behavior is the guarantee that mattered: the libraries decision comes back BLOCKED rather
+        than falling back to the workspace default, so no descendant quietly installs libraries
+        somewhere the base never named.
         """
-        from griptape_nodes.common.project_templates import ProjectValidationStatus
-        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultFailure
+        from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultSuccess
 
         monkeypatch.delenv("GTN_TEST_LIBS", raising=False)
         base_path = (tmp_path / "base.yml").resolve()
@@ -9173,25 +9187,36 @@ class TestProjectPathFieldValidation:
         child_yaml = (
             f'project_template_schema_version: "0.3.3"\nname: Child\nparent_project_path: "{base_path.as_posix()}"\n'
         )
+        # The offline walk locates an unregistered legacy parent by checking the real filesystem
+        # (_resolve_parent_id_to_path), so the files must exist on disk as well as in the router.
+        base_path.write_text(base_yaml, encoding="utf-8")
+        child_path.write_text(child_yaml, encoding="utf-8")
+        files = {base_path: base_yaml, child_path: child_yaml}
 
-        result = await self._load(pm, {base_path: base_yaml, child_path: child_yaml}, child_path)
+        result = await self._load(pm, files, child_path)
 
-        assert isinstance(result, LoadProjectTemplateResultFailure)
-        assert result.validation.status is ProjectValidationStatus.UNUSABLE
-        problems = [p for p in result.validation.problems if p.field_path == "parent_project_path"]
-        assert len(problems) == 1
-        assert "could not be loaded" in problems[0].message
-        assert problems[0].line_number == _line_of(child_yaml, "parent_project_path:")
+        assert isinstance(result, LoadProjectTemplateResultSuccess)
+
+        mock_engine = MagicMock()
+        with patch.object(pm, "_engine", mock_engine):
+            mock_engine.ahandle_request = self._file_router(files)
+            libraries_decision = await pm._decide_libraries_root_from_disk(child_path, None, {})
+
+        assert libraries_decision.libraries_root is None
+        assert libraries_decision.blocked_reason is not None
+        assert "cannot be resolved" in libraries_decision.blocked_reason
+        assert "no value is set for GTN_TEST_LIBS" in libraries_decision.blocked_reason
 
     @pytest.mark.asyncio
-    async def test_failed_project_is_listed_as_failed_with_no_paths(
+    async def test_flawed_project_is_listed_as_loaded_with_no_libraries_root(
         self, pm: ProjectManager, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A refused project surfaces in failed_to_load, and reports no paths at all.
+        """A FLAWED project surfaces in successfully_loaded, with no answer for the broken path.
 
-        The GUI needs to distinguish "here is where this project's libraries live" from "this project
-        is broken" -- so a failed entry carries its validation problems and nothing that looks like an
-        answer.
+        The GUI needs both halves: the project appears in the list (so it can be opened and the bad
+        value fixed in the app), and its libraries_root is None rather than a fallback path it will
+        never use -- the validation problems on the entry say why. The workspace, which the project
+        does not declare, still resolves normally.
         """
         from griptape_nodes.retained_mode.events.project_events import (
             ListProjectTemplatesRequest,
@@ -9214,13 +9239,79 @@ class TestProjectPathFieldValidation:
             )
 
         assert isinstance(listing, ListProjectTemplatesResultSuccess)
-        assert listing.successfully_loaded == []
-        assert len(listing.failed_to_load) == 1
-        failed = listing.failed_to_load[0]
-        assert failed.project_id == str(project_path)
-        assert failed.workspace_dir is None
-        assert failed.libraries_root is None
-        assert any(p.field_path == "libraries_dir" for p in failed.validation.problems)
+        assert listing.failed_to_load == []
+        assert len(listing.successfully_loaded) == 1
+        entry = listing.successfully_loaded[0]
+        assert entry.workspace_dir is not None
+        assert entry.libraries_root is None
+        assert any(p.field_path == "libraries_dir" for p in entry.validation.problems)
+
+    @pytest.mark.asyncio
+    async def test_activation_gate_refuses_a_flawed_project(
+        self, pm: ProjectManager, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A loadable FLAWED project is refused at activation, naming the field and cause.
+
+        Loading FLAWED is what keeps the project editable; this is the other half of the contract --
+        the broken declaration is never silently replaced with a fallback location at activation.
+        The gate returns before any config layer is touched, so a refusal leaves no half-applied
+        state for the caller's rollback to fight.
+        """
+        from griptape_nodes.retained_mode.events.project_events import (
+            LoadProjectTemplateResultSuccess,
+            SetCurrentProjectResultFailure,
+        )
+
+        monkeypatch.delenv("GTN_TEST_LIBS", raising=False)
+        project_path = (tmp_path / "griptape-nodes-project.yml").resolve()
+        project_yaml = (
+            'project_template_schema_version: "0.3.3"\n'
+            "name: Studio Project\n"
+            'libraries_dir: "${GTN_TEST_LIBS}/libraries"\n'
+        )
+        result = await self._load(pm, {project_path: project_yaml}, project_path)
+        assert isinstance(result, LoadProjectTemplateResultSuccess)
+        project_info = pm._successfully_loaded_project_templates[result.project_id]
+
+        failure = await pm._apply_workspace_and_libraries_layers(project_info, project_path)
+
+        assert isinstance(failure, SetCurrentProjectResultFailure)
+        assert "declared paths cannot be resolved" in str(failure.result_details)
+        assert "no value is set for GTN_TEST_LIBS" in str(failure.result_details)
+
+    @pytest.mark.asyncio
+    async def test_activation_gate_re_resolves_after_the_environment_breaks(
+        self, pm: ProjectManager, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The gate re-resolves at activation time instead of trusting the load-time verdict.
+
+        A project can load GOOD and then have its variable deleted (or the reverse); the environment
+        the declaration resolves against is live state. Activating on the stale verdict would apply
+        a workspace/libraries layer built from a value that no longer exists.
+        """
+        from griptape_nodes.common.project_templates import ProjectValidationStatus
+        from griptape_nodes.retained_mode.events.project_events import (
+            LoadProjectTemplateResultSuccess,
+            SetCurrentProjectResultFailure,
+        )
+
+        monkeypatch.setenv("GTN_TEST_LIBS", str(tmp_path / "studio"))
+        project_path = (tmp_path / "griptape-nodes-project.yml").resolve()
+        project_yaml = (
+            'project_template_schema_version: "0.3.3"\n'
+            "name: Studio Project\n"
+            'libraries_dir: "${GTN_TEST_LIBS}/libraries"\n'
+        )
+        result = await self._load(pm, {project_path: project_yaml}, project_path)
+        assert isinstance(result, LoadProjectTemplateResultSuccess)
+        assert result.validation.status is ProjectValidationStatus.GOOD
+        project_info = pm._successfully_loaded_project_templates[result.project_id]
+
+        monkeypatch.delenv("GTN_TEST_LIBS")
+        failure = await pm._apply_workspace_and_libraries_layers(project_info, project_path)
+
+        assert isinstance(failure, SetCurrentProjectResultFailure)
+        assert "no value is set for GTN_TEST_LIBS" in str(failure.result_details)
 
 
 class TestListProjectTemplatesEffectivePaths:


### PR DESCRIPTION
Closes https://github.com/griptape-ai/griptape-nodes-engine/issues/5297

```
What I built
Load side — unresolvable workspace_dir/libraries_dir is now FLAWED, not fatal. ProjectValidationInfo.add_recoverable_error records an ERROR-severity problem (field, cause, line number) while downgrading status only to FLAWED. _read_overlay now refuses an overlay only when validation is genuinely UNUSABLE — which in practice means a broken parent_project_path, since without the parent there's no base to merge. So Jason's misspelled-variable project loads, appears in the listing, opens in the Project Management UI, and carries the exact problem to display. Case 2 (save-from-UI) is fixed by the same mechanism: the post-save reload keeps the project registered instead of evicting it.

Use side — four gates enforce "never substitute a location the user named":

Activation: _apply_workspace_and_libraries_layers re-resolves both fields fresh (env can change between load and activation) and refuses with an artist-readable message naming the variable. Runs after env restore, so the outgoing project's environment: can't mask a break.
Provisioning preview mirrors the gate, so the GUI never shows an install plan activation would refuse.
Parent chains: the offline walker now distinguishes an ancestor with an unresolvable declaration (blocks the descendant's activation — preserving the old "a broken base never lets children silently install elsewhere" guarantee) from environmental breaks like a moved file (which keep the long-standing warn-and-fall-back).
Listing/resolvers: EffectiveProjectPaths fields are now optional; a broken path reports None (GUI shows "unknown", validation says why) instead of a confident fallback path. Same for ResolveProjectWorkspaceRequest.
The tri-state itself lives on ResolvedProjectPath as a new platform_gap flag plus an is_unresolvable property separating "declared but broken" from "nothing declared".

Tests: updated the ~10 tests that pinned the old fail-the-load behavior (same assertions on problems/messages/line numbers, new FLAWED expectations), rewrote the child-of-broken-parent and listing tests to the new contract, and added: activation-gate refusal (unit + end-to-end through a real Engine), gate re-resolution after the env breaks post-load, preview refusal, and blocked-inheritance coverage.

One scope note: parent_project_path deliberately stays load-blocking — that's a structural failure (no template to merge), not a recoverable field, and its in-app repair would need a different mechanism.
```