### PR TITLE
feat(libraries): notify a library after the engine handles a request

### DIFF
--- a/docs/development/custom_nodes/advanced_libraries.md
+++ b/docs/development/custom_nodes/advanced_libraries.md
@@ -2,9 +2,10 @@
 
 Most libraries are fully described by their `griptape_nodes_library.json` manifest: the
 engine reads it, imports the node modules it names, and registers those classes. An
-**advanced library** is an optional Python class that lets your library run code at four
+**advanced library** is an optional Python class that lets your library run code at five
 points in its own lifecycle: before its nodes load, after they load, before it is
-unregistered, and when the engine collects request handlers.
+unregistered, when the engine collects request handlers, and when it collects
+post-dispatch hooks.
 
 This page is the author's reference for that class. For the manifest itself (metadata,
 categories, declarations, dependency management) see
@@ -24,6 +25,9 @@ list in the manifest. That is the common case and it needs no Python beyond the 
     [Registering node types without listing them](#registering-node-types-without-listing-them-in-the-manifest).
 - **Serve a request type** your library owns, so other libraries and nodes can call into
     it. See [`get_request_handlers`](#get_request_handlers).
+- **React after the engine handles a request** it already owns, such as running your own
+    step every time a workflow is saved. See
+    [`get_post_dispatch_hooks`](#get_post_dispatch_hooks).
 - **Register a competing provider** for an engine request type, such as a workflow
     publisher. See [Publishing](../../guides/publishing.md).
 
@@ -85,7 +89,8 @@ that silently does nothing. Registering a library runs, in order:
 | 8    | Registers the manifest's widgets                                    |
 | 9    | **Calls `after_library_nodes_loaded`**                              |
 | 10   | **Calls `get_request_handlers`** and registers what it returns      |
-| 11   | Computes library fitness and marks the library `LOADED`             |
+| 11   | **Calls `get_post_dispatch_hooks`** and registers what it returns   |
+| 12   | Computes library fitness and marks the library `LOADED`             |
 
 Two consequences worth internalizing:
 
@@ -96,13 +101,13 @@ Two consequences worth internalizing:
 
 Unregistering runs in the reverse spirit:
 
-| Step | What the engine does                                             |
-| ---- | ---------------------------------------------------------------- |
-| 1    | **Calls `before_library_unregistered`**                          |
-| 2    | Removes the library's app event listeners and pre-dispatch hooks |
-| 3    | Removes the request handlers it registered                       |
-| 4    | Unregisters the library's widgets                                |
-| 5    | Removes the library from the `LibraryRegistry`                   |
+| Step | What the engine does                                                            |
+| ---- | ------------------------------------------------------------------------------- |
+| 1    | **Calls `before_library_unregistered`**                                         |
+| 2    | Removes the library's app event listeners, pre-dispatch and post-dispatch hooks |
+| 3    | Removes the request handlers it registered                                      |
+| 4    | Unregisters the library's widgets                                               |
+| 5    | Removes the library from the `LibraryRegistry`                                  |
 
 ## The hooks
 
@@ -254,6 +259,79 @@ Constraints on the mechanism:
 Other code can discover what a loaded library exposes with
 `library.get_registered_request_handler_types()`, then inspect each type with
 `dataclasses.fields()` and `typing.get_type_hints()`.
+
+### `get_post_dispatch_hooks`
+
+```python
+def get_post_dispatch_hooks(self) -> list[tuple[type[RequestPayload], Callable]]: ...
+```
+
+Returns `(request_type, callback)` pairs the engine registers on your behalf, and
+deregisters when your library unloads. After the engine's own handler for that request
+type produces a result, your callback is invoked with `(request, result)`. This is how a
+library runs its own step when something happens in the engine — appending to an audit
+log, posting to a chat channel, kicking off an export — for a request type it does not
+own.
+
+It is the mirror image of [`get_request_handlers`](#get_request_handlers), and the
+difference is ownership:
+
+|                         | `get_request_handlers`         | `get_post_dispatch_hooks`                           |
+| ----------------------- | ------------------------------ | --------------------------------------------------- |
+| Claims the request type | Yes — one handler engine-wide  | No — any number of libraries may hook the same type |
+| When it runs            | *Instead of* an engine handler | *After* the engine's handler produced a result      |
+| Can change the outcome  | It **is** the outcome          | No, notification only                               |
+
+That is why you can hook `SaveWorkflowRequest`, which `WorkflowManager` already owns and
+which `get_request_handlers` would fail to claim.
+
+Both sync and async callbacks work. Return the pairs from the hook:
+
+```python
+def get_post_dispatch_hooks(self):
+    return [(SaveWorkflowRequest, self._on_workflow_saved)]
+
+
+async def _on_workflow_saved(self, request: RequestPayload, result: ResultPayload) -> None:
+    if not isinstance(result, SaveWorkflowResultSuccess):
+        return
+    await self._append_audit_line(result.file_path)
+```
+
+Constraints on the mechanism:
+
+- **Notification only.** The return value is ignored, and the callback cannot alter the
+    result or fail the operation. One that raises is logged and otherwise ignored, and it
+    does not stop other hooks on the same request.
+- **Both outcomes.** The callback fires for successes and failures alike, including a
+    failure synthesized from an exception that escaped the handler. Branch on the result
+    type to filter, as the example above does.
+- **Usually detached, sometimes not.** Whenever the engine has a live event loop the hook
+    is scheduled as a detached task, so the result reaches the editor without waiting for
+    it. Some paths have no such loop — CLI commands, bootstrap workflow runs, worker
+    threads — and there the hook runs inline and **blocks the caller until it returns**.
+    Keep hooks quick, or move slow work off-process, if they may fire on those paths.
+- **Exact type matching.** A hook registered for a request type fires for that exact type
+    only, never for its subclasses.
+- **Read-only arguments.** Do not mutate the request or the result; both are still
+    referenced by the result event the engine is about to serialize. Fields marked
+    `omit_from_result` have already been cleared on the request you receive, so a hook is
+    not a way to read them.
+- **Do not issue engine requests from a hook.** The engine's operation-depth and
+    node-execution state is process-wide, so a request sent from a hook can perturb an
+    operation that is still in flight. Do external work — HTTP, file writes — instead.
+- **Orchestrator only.** Hooks are registered on the event manager of whichever process
+    loads the library, so a worker-mode library's hooks never see requests the
+    orchestrator handled. The engine flags that combination with a
+    `PostDispatchHooksWorkerIncompatibleProblem` at load. See
+    [Node Isolation with Workers](node_isolation_with_workers.md).
+- **Not durable.** Hooks still in flight when the process exits are abandoned. Do not use
+    them where delivery has to be guaranteed.
+
+A malformed pair — a callback that is not callable, or a key that is not a request type —
+is reported as a `PostDispatchHookRegistrationProblem` and stops the rest of the list from
+registering, leaving the library `FLAWED`. Pairs registered before the bad one stay
+active, and are still removed when the library unloads.
 
 ## Registering node types without listing them in the manifest
 

--- a/src/griptape_nodes/node_library/advanced_node_library.py
+++ b/src/griptape_nodes/node_library/advanced_node_library.py
@@ -57,7 +57,8 @@ class AdvancedNodeLibrary:
         """Called before the library is unregistered from the engine.
 
         Called before the engine deregisters any event listeners, pre-dispatch hooks,
-        or request handlers, and before the library is removed from LibraryRegistry.
+        post-dispatch hooks, or request handlers, and before the library is removed
+        from LibraryRegistry.
         Use it to release external resources acquired during load — Python bindings,
         GPU contexts, background threads, connection pools, etc.
 
@@ -122,6 +123,72 @@ class AdvancedNodeLibrary:
             def get_request_handlers(self):
                 return [
                     (ConvertColorspaceRequest, self._handle_convert_colorspace),
+                ]
+        """
+        return []
+
+    def get_post_dispatch_hooks(
+        self,
+    ) -> list[
+        tuple[
+            type[RequestPayload],
+            Callable[[RequestPayload, ResultPayload], None]
+            | Callable[[RequestPayload, ResultPayload], Awaitable[None]],
+        ]
+    ]:
+        """Return post-dispatch hooks to register with the engine.
+
+        Each entry is a (request_type, callback) pair. After the engine's own
+        handler for that request type produces a result, the callback is invoked
+        with (request, result). Unlike get_request_handlers(), this does not claim
+        the request type — any number of libraries may hook the same type, and the
+        engine's handler still runs normally.
+
+        The engine registers all returned hooks after after_library_nodes_loaded()
+        and deregisters them automatically when the library is unloaded.
+
+        Both sync and async callbacks are supported. Sync callbacks run in a worker
+        thread; async callbacks run on the engine's event loop and must not block it.
+
+        **Notification only.** The callback's return value is ignored and it cannot
+        alter the result or fail the operation. A callback that raises is logged and
+        otherwise ignored.
+
+        **Usually detached.** Whenever the engine has a live event loop the hook is
+        scheduled as a detached task, so the result reaches the client without waiting
+        for it. Some paths have no such loop — CLI commands, bootstrap workflow runs,
+        worker threads — and there the hook runs inline and blocks the caller until it
+        returns, on a transient loop rather than the engine's. Keep hooks quick, or move
+        slow work off-process, if they may fire on those paths.
+
+        **Both outcomes.** The callback is invoked for successes and failures alike,
+        including failures produced by an exception escaping the handler. Branch on
+        the result type to filter.
+
+        **Exact type matching.** A hook registered for a request type fires only for
+        that exact type, not for its subclasses.
+
+        **Read-only arguments.** Do not mutate the request or the result: both are
+        still referenced by the result event the engine is about to serialize. Fields
+        marked ``omit_from_result`` have already been cleared on the request the hook
+        receives.
+
+        **Do not issue engine requests from a hook.** The engine's operation-depth and
+        node-execution state is process-wide, so a request issued from a hook can
+        perturb an in-flight operation. Do external work (HTTP, file writes) instead.
+
+        **Orchestrator process only.** Hooks are registered on the event manager of
+        whichever process loads the library, so a worker-mode library's hooks never
+        observe requests handled by the orchestrator. Cross-worker hook support is
+        tracked in GH#4748.
+
+        **Not durable.** In-flight hooks are abandoned at process exit. Do not use
+        them where delivery must be guaranteed.
+
+        Example:
+            def get_post_dispatch_hooks(self):
+                return [
+                    (SaveWorkflowRequest, self._on_workflow_saved),
                 ]
         """
         return []

--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -336,7 +336,17 @@ class LibraryRegistry:
                 )
                 # Continue — a failing teardown must not prevent unregistration.
 
-        # Deregister tracked handlers.
+        cls._deregister_tracked_handlers(library, event_manager=event_manager)
+
+        # Clean up registered widgets for this library
+        cls.unregister_widgets_for_library(library_name)
+
+        # Now delete the library from the registry.
+        del cls._libraries[library_name]
+
+    @classmethod
+    def _deregister_tracked_handlers(cls, library: Library, *, event_manager: EventManager) -> None:
+        """Remove everything the engine registered on the library's behalf at load time."""
         if library._registered_app_event_listeners:
             for event_type, listener in library._registered_app_event_listeners:
                 event_manager.remove_listener_for_app_event(event_type, listener)
@@ -347,16 +357,15 @@ class LibraryRegistry:
                 event_manager.remove_pre_dispatch_hook(hook)
             library._registered_pre_dispatch_hooks.clear()
 
+        if library._registered_post_dispatch_hooks:
+            for request_type, hook in library._registered_post_dispatch_hooks:
+                event_manager.remove_post_dispatch_hook(request_type, hook)
+            library._registered_post_dispatch_hooks.clear()
+
         if library._registered_request_handler_types:
             for request_type in library._registered_request_handler_types:
                 event_manager.remove_manager_from_request_type(request_type)
             library._registered_request_handler_types.clear()
-
-        # Clean up registered widgets for this library
-        cls.unregister_widgets_for_library(library_name)
-
-        # Now delete the library from the registry.
-        del cls._libraries[library_name]
 
     @classmethod
     def get_library(cls, name: str) -> Library:
@@ -581,6 +590,7 @@ class Library:
     # deregistered automatically when the library is unloaded.
     _registered_app_event_listeners: list[tuple[type, Callable]]
     _registered_pre_dispatch_hooks: list[Callable]
+    _registered_post_dispatch_hooks: list[tuple[type, Callable]]
     _registered_request_handler_types: list[type]
 
     def __init__(
@@ -603,6 +613,7 @@ class Library:
         self._advanced_library = advanced_library
         self._registered_app_event_listeners = []
         self._registered_pre_dispatch_hooks = []
+        self._registered_post_dispatch_hooks = []
         self._registered_request_handler_types = []
 
     def get_registered_app_event_listeners(self) -> list[tuple[type, Callable]]:
@@ -610,6 +621,14 @@ class Library:
 
     def get_registered_pre_dispatch_hooks(self) -> list[Callable]:
         return list(self._registered_pre_dispatch_hooks)
+
+    def get_registered_post_dispatch_hooks(self) -> list[tuple[type, Callable]]:
+        """Return the (request_type, callback) pairs this library has registered as post-dispatch hooks.
+
+        The request type is tracked alongside the callback because removal is
+        per-request-type. Returns a copy; mutating the returned list has no effect.
+        """
+        return list(self._registered_post_dispatch_hooks)
 
     def get_registered_request_handler_types(self) -> list[type]:
         """Return the request payload types whose handlers this library has registered.

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextvars
 import inspect
 import logging
 import threading
@@ -17,7 +18,7 @@ from griptape_nodes.common.strict_mode import STRICT_MODE
 from griptape_nodes.common.strict_mode_checks import RULES
 from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.node_library.library_registry import LibraryRegistry
-from griptape_nodes.retained_mode.engine import EngineScoped
+from griptape_nodes.retained_mode.engine import EngineScoped, engine_scope
 from griptape_nodes.retained_mode.events.base_events import (
     AppPayload,
     BaseEvent,
@@ -40,7 +41,7 @@ from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
     CheckpointDenial,
     CheckpointFailure,
 )
-from griptape_nodes.utils.async_utils import call_function
+from griptape_nodes.utils.async_utils import call_function, to_thread
 
 if TYPE_CHECKING:
     import types
@@ -48,6 +49,10 @@ if TYPE_CHECKING:
 
     from griptape_nodes.api_client.request_client import RequestClient
     from griptape_nodes.retained_mode.engine import Engine
+
+    # A post-dispatch hook observes a completed request. It may be sync or async;
+    # its return value is ignored because nothing awaits the notification.
+    PostDispatchHook = Callable[[Any, ResultPayload], None] | Callable[[Any, ResultPayload], Awaitable[None]]
 
 
 RP = TypeVar("RP", bound=RequestPayload, default=RequestPayload)
@@ -58,6 +63,39 @@ EP = TypeVar("EP", bound=ExecutionPayload, default=ExecutionPayload)
 _active_request_type: ContextVar[type[RequestPayload] | None] = ContextVar(
     "_event_manager_active_request_type", default=None
 )
+
+# (request_type, callback) pairs for the post-dispatch hooks running above this point
+# in the current logical chain. A hook task is created with this marker set, and every
+# request the hook issues inherits it, so any hook already running further up the chain
+# is skipped on a re-entrant dispatch instead of re-triggering without bound. That covers
+# both a hook re-issuing the type it subscribes to and a cycle between hooks on different
+# types. The chain is threaded explicitly into `_run_post_dispatch_hook` rather than read
+# from the context there, because each hook starts from a *fresh* context (see that
+# method) which would otherwise reset the marker to empty and make every generation
+# look like the first. Scoped to the chain rather than to the process, so it cannot
+# suppress unrelated dispatches and has no state that can leak.
+_active_post_dispatch_hooks: ContextVar[tuple[tuple[type[RequestPayload], Any], ...]] = ContextVar(
+    "_event_manager_active_post_dispatch_hooks", default=()
+)
+
+# Post-dispatch hooks are deliberately unbounded -- every result gets its own task so a
+# notification hook never misses a request. This is purely a "something is wrong" signal
+# for a hook that runs slower than requests arrive.
+POST_DISPATCH_HOOK_INFLIGHT_WARNING_THRESHOLD = 100
+
+
+def _is_async_callable(callback: Any) -> bool:
+    """Whether calling `callback` returns a coroutine.
+
+    `inspect.iscoroutinefunction` alone misses callable objects whose `__call__` is
+    async (worker_routing.RemoteHandler is one), which would otherwise be handed to a
+    thread where the coroutine it returns is never awaited.
+    """
+    if inspect.iscoroutinefunction(callback):
+        return True
+    if not callable(callback):
+        return False
+    return inspect.iscoroutinefunction(type(callback).__call__)
 
 
 def current_request_type() -> type[RequestPayload] | None:
@@ -170,6 +208,15 @@ class EventManager(EngineScoped):
         # handle_request runs on arbitrary threads, so guard the list and snapshot
         # it before iteration.
         self._pre_dispatch_hooks_lock = threading.Lock()
+        # Post-dispatch hooks, keyed by exact request type. Notification-only: they run
+        # after the result exists and cannot change it. Lists rather than sets because a
+        # callback need not be hashable -- a callable dataclass (RemoteHandler) has
+        # __hash__ set to None and would raise on set.add.
+        self._post_dispatch_hooks: dict[type[RequestPayload], list[PostDispatchHook]] = {}
+        self._post_dispatch_hooks_lock = threading.Lock()
+        # Strong references to in-flight hook tasks; asyncio only holds weak ones, so a
+        # task that is not retained here can be garbage collected mid-run (also RUF006).
+        self._inflight_post_dispatch_hook_tasks: set[asyncio.Task] = set()
         # Thread-local flags: if a hook re-enters an engine operation on this
         # thread, the corresponding chain is skipped so the hook can't keep
         # re-triggering itself into unbounded recursion. `active` guards the
@@ -385,6 +432,307 @@ class EventManager(EngineScoped):
             return None
         finally:
             self._hook_evaluation.active = False
+
+    def add_post_dispatch_hook(self, request_type: type[RP], callback: PostDispatchHook) -> None:
+        """Register a callback to run after `request_type`'s handler has produced a result.
+
+        The callback receives `(request, result)`. Whenever the engine has a live event
+        loop it is scheduled as a detached task, so it does not delay the result reaching
+        the caller and may run as long as it needs. On paths with no live engine loop --
+        CLI commands, bootstrap workflow runs, worker threads -- there is nothing to
+        detach onto, so the hook runs inline and *does* block the dispatching caller
+        until it finishes. Sync and async callbacks are both accepted. Registering the
+        same callback object twice for the same request type is a no-op.
+
+        The callback is notification-only -- it cannot alter the result or fail the
+        operation, because the result has already been returned. Specifically:
+
+        - It fires for both success and failure results, including when the handler
+          raised (in that case the payload is an equivalent `GenericResultFailure`, not
+          the identical object the client received).
+        - `request` and `result` must be treated as read-only. The same `request` object
+          is referenced by the result event still queued for the client, so mutating it
+          corrupts what the client sees.
+        - Fields marked `omit_from_result` are already `None` on the request the callback
+          sees. That scrub exists to keep sensitive and bulky values out of results, so
+          it is deliberately not undone for hooks.
+        - Matching is on the exact request type; subclasses of `request_type` do not
+          fire it.
+        - There is no ordering guarantee relative to the result reaching the client, nor
+          between separate invocations of the same hook.
+        - Hooks run regardless of `request.broadcast_result` or event suppression.
+        - A raising callback is logged and ignored; it does not stop sibling callbacks.
+        - Callbacks must not issue engine requests. Any hook already running further up
+          the same chain is skipped rather than recursing, but requests from a hook also
+          perturb operation-depth tracking for concurrent requests.
+
+        Async callbacks run on the engine event loop (or, on the inline path, a transient
+        loop that may itself be on another thread) and must not block it. Sync callbacks are handed to a
+        worker thread, so blocking in one cannot stall the loop -- but that thread comes
+        from the loop's default executor, which is shared with every other `to_thread`
+        caller in the engine. Because hook tasks are unbounded, a slow sync hook firing on
+        a high-frequency request type can occupy the pool and make unrelated engine work
+        that also needs a thread queue behind it. Keep sync callbacks quick.
+        """
+        with self._post_dispatch_hooks_lock:
+            hooks = self._post_dispatch_hooks.setdefault(request_type, [])
+            # Identity, not `in`: `in` runs `__eq__`, and a callable `@dataclass` compares
+            # by field value, so two separate libraries registering field-equal hook
+            # objects would collapse into one silently registered hook.
+            if not any(hook is callback for hook in hooks):
+                hooks.append(callback)
+
+    def remove_post_dispatch_hook(self, request_type: type[RP], callback: PostDispatchHook) -> None:
+        """Unregister a callback previously registered with `add_post_dispatch_hook`.
+
+        Removing a callback that was never registered is a no-op. Because hooks run
+        detached, an already-scheduled invocation still runs to completion -- callbacks
+        must tolerate firing once after removal.
+
+        Only the object that was registered is removed. `list.remove` would match by
+        `__eq__` and could unregister a different, field-equal hook belonging to another
+        library.
+        """
+        with self._post_dispatch_hooks_lock:
+            hooks = self._post_dispatch_hooks.get(request_type)
+            if hooks is None:
+                return
+            remaining = [hook for hook in hooks if hook is not callback]
+            if len(remaining) == len(hooks):
+                return
+            if not remaining:
+                del self._post_dispatch_hooks[request_type]
+                return
+            self._post_dispatch_hooks[request_type] = remaining
+
+    def _fire_post_dispatch_hooks(self, request: RequestPayload, result: ResultPayload) -> None:
+        """Schedule every hook registered for this request's exact type."""
+        request_type = type(request)
+
+        # Snapshot under the lock so a concurrent add/remove on another thread cannot
+        # mutate the list mid-iteration.
+        with self._post_dispatch_hooks_lock:
+            hooks = list(self._post_dispatch_hooks.get(request_type, ()))
+
+        if not hooks:
+            return
+
+        active = _active_post_dispatch_hooks.get()
+        for callback in hooks:
+            # Identity, not `(request_type, callback) in active`: membership compares with
+            # `__eq__`, and a callable `@dataclass` compares by field value, so a hook
+            # running up-chain would suppress a *different* field-equal hook belonging to
+            # another library. Same reason `add_post_dispatch_hook` dedupes by identity.
+            if any(active_type is request_type and active_cb is callback for active_type, active_cb in active):
+                logging.getLogger("griptape_nodes").debug(
+                    "Skipping post-dispatch hook '%s' for %s: it is already running further up this chain.",
+                    getattr(callback, "__name__", callback),
+                    request_type.__name__,
+                )
+                continue
+            self._schedule_post_dispatch_hook(request_type, callback, request, result, active)
+
+    def _fire_post_dispatch_hooks_for_handler_exception(self, request: RequestPayload, exception: Exception) -> None:
+        """Notify hooks that no result event will be built for this request.
+
+        Neither dispatch method catches handler exceptions -- they propagate to
+        `Engine.handle_request`, which logs and returns a synthesized failure. Without
+        this the most interesting failure mode would be invisible to hooks. The payload is
+        equivalent to the one the client receives, not the identical object, which is why
+        `add_post_dispatch_hook` says so explicitly.
+
+        The caller's `try` covers the parameter-change flush as well as the handler, so a
+        handler that returned a result and then had `_flush_tracked_parameter_changes`
+        raise also lands here. That is deliberate: the exception escapes either way, the
+        client gets a synthesized failure either way, and hooks reporting success for a
+        request the client saw fail would be worse than the coarser attribution.
+        """
+        result_details = f"Unhandled exception while processing {type(request).__name__}: {exception}"
+        # `_handle_request_core` scrubs the request on its way to building the result event,
+        # but a raising handler never gets there. Without this, hooks would be the one place
+        # an omitted field still surfaces -- and those fields are omitted precisely because
+        # they are sensitive or bulky.
+        self._scrub_omitted_request_fields(request)
+        self._fire_post_dispatch_hooks(
+            request, GenericResultFailure(exception=exception, result_details=result_details)
+        )
+
+    def _scrub_omitted_request_fields(self, request: RequestPayload) -> None:
+        """Null out the request fields marked `omit_from_result`, in place.
+
+        Mutates the request rather than copying it: the result event carries this same
+        object, so the scrub has to be visible through every reference to it.
+        """
+        for field in fields(request):
+            if field.metadata.get("omit_from_result", False):
+                setattr(request, field.name, None)
+
+    def _schedule_post_dispatch_hook(
+        self,
+        request_type: type[RequestPayload],
+        callback: PostDispatchHook,
+        request: RequestPayload,
+        result: ResultPayload,
+        inherited_chain: tuple[tuple[type[RequestPayload], Any], ...],
+    ) -> None:
+        """Hand one hook to the engine loop, or run it inline if there is no live loop.
+
+        Always targets `self._event_loop` rather than the running loop. The sync
+        `handle_request` drives async handlers on a transient `ThreadRunner` side loop
+        that stops as soon as the handler returns, so a task detached onto the *running*
+        loop can silently never run (see the ThreadRunner regression test in
+        tests/unit/app/test_app_worker.py).
+
+        `is_running()` is as load-bearing as `is_closed()`: `create_task` on an open but
+        undriven loop succeeds, returns a pending task, and never executes it. Executors
+        re-`initialize_queue` per run and nothing ever clears `_event_loop`, so a stale
+        loop from a finished `asyncio.run` is a real possibility here.
+        """
+        loop = self._event_loop
+        if loop is not None and not loop.is_closed() and loop.is_running():
+            try:
+                # call_soon_threadsafe is legal from the loop's own thread as well as
+                # from any other, so this is one path instead of two. The task itself is
+                # created on the loop thread by _spawn_post_dispatch_hook_task.
+                loop.call_soon_threadsafe(
+                    self._spawn_post_dispatch_hook_task,
+                    loop,
+                    request_type,
+                    callback,
+                    request,
+                    result,
+                    inherited_chain,
+                )
+            except RuntimeError:
+                # Lost the race with loop shutdown between the check and the call; fall
+                # through and run inline rather than dropping the notification.
+                pass
+            else:
+                return
+
+        self._run_post_dispatch_hook_inline(request_type, callback, request, result, inherited_chain)
+
+    def _spawn_post_dispatch_hook_task(  # noqa: PLR0913, PLR0917
+        self,
+        loop: asyncio.AbstractEventLoop,
+        request_type: type[RequestPayload],
+        callback: PostDispatchHook,
+        request: RequestPayload,
+        result: ResultPayload,
+        inherited_chain: tuple[tuple[type[RequestPayload], Any], ...],
+    ) -> None:
+        """Create the detached hook task. Runs on `loop`'s own thread."""
+        task = loop.create_task(
+            self._run_post_dispatch_hook(request_type, callback, request, result, inherited_chain),
+            context=contextvars.Context(),
+        )
+        self._inflight_post_dispatch_hook_tasks.add(task)
+        task.add_done_callback(self._on_post_dispatch_hook_done)
+
+        inflight = len(self._inflight_post_dispatch_hook_tasks)
+        if inflight > POST_DISPATCH_HOOK_INFLIGHT_WARNING_THRESHOLD:
+            logging.getLogger("griptape_nodes").warning(
+                "%d post-dispatch hooks are still running. Hooks are never dropped, so a hook "
+                "that runs slower than requests arrive will keep accumulating. Most recent: '%s' for %s.",
+                inflight,
+                getattr(callback, "__name__", callback),
+                request_type.__name__,
+            )
+
+    def _on_post_dispatch_hook_done(self, task: asyncio.Task) -> None:
+        """Release the task reference and surface anything the wrapper did not catch."""
+        self._inflight_post_dispatch_hook_tasks.discard(task)
+        if task.cancelled():
+            return
+        exception = task.exception()
+        if exception is not None:
+            logging.getLogger("griptape_nodes").error("Post-dispatch hook task failed.", exc_info=exception)
+
+    async def _run_post_dispatch_hook(
+        self,
+        request_type: type[RequestPayload],
+        callback: PostDispatchHook,
+        request: RequestPayload,
+        result: ResultPayload,
+        inherited_chain: tuple[tuple[type[RequestPayload], Any], ...],
+    ) -> None:
+        """Invoke one hook, isolated from the context that dispatched the request.
+
+        The task is created with a *fresh* context rather than a copy of the caller's, so
+        the hook cannot inherit the dispatching task's strict-mode scope stack. That
+        stack holds mutable scope objects: a hook that reported a violation into an
+        inherited RUNTIME_EXECUTE scope could append to `scope.violations` after (or
+        while) the node's own scope is being evaluated, and on a worker an ERROR-severity
+        violation promotes a node's success to a failure. A library's telemetry hook must
+        not be able to fail a user's node. The fresh context also keeps
+        `current_request_type()` from reporting the dispatching request inside the hook.
+
+        A fresh context drops the engine binding too, so it is re-established here from
+        the manager's own engine reference. It also drops the re-entrancy marker, which is
+        why the chain is passed in explicitly rather than read from the context here.
+        """
+        _active_post_dispatch_hooks.set((*inherited_chain, (request_type, callback)))
+
+        with engine_scope(self.engine):
+            try:
+                if _is_async_callable(callback):
+                    await callback(request, result)  # type: ignore[misc]
+                else:
+                    # Sync callbacks go to a thread: they would otherwise run inline on
+                    # the engine loop, where blocking stalls the event queue and every
+                    # in-flight request.
+                    await to_thread(callback, request, result)
+            except Exception:
+                # Fail open. The result has already been returned, so there is nothing
+                # to fail; the only correct response is to log and move on.
+                logging.getLogger("griptape_nodes").exception(
+                    "Post-dispatch hook '%s' for %s raised. The request result is unaffected.",
+                    getattr(callback, "__name__", callback),
+                    request_type.__name__,
+                )
+
+    def _run_post_dispatch_hook_inline(
+        self,
+        request_type: type[RequestPayload],
+        callback: PostDispatchHook,
+        request: RequestPayload,
+        result: ResultPayload,
+        inherited_chain: tuple[tuple[type[RequestPayload], Any], ...],
+    ) -> None:
+        """Run a hook synchronously, blocking the caller's thread until it finishes.
+
+        Blocking the caller is the guarantee; running *on* the caller's thread is not. A
+        sync callback always lands in a threadpool worker via `to_thread`, and when this
+        is reached from inside a running loop the coroutine is driven by a `ThreadRunner`
+        on a thread of its own.
+
+        The fallback for paths with no live engine loop -- CLI commands, bootstrap
+        workflow runs, worker threads. Blocking is the lesser evil: no editor is waiting
+        on those paths, and dropping the hook would make the feature "fires, except
+        sometimes."
+        """
+        coro = self._run_post_dispatch_hook(request_type, callback, request, result, inherited_chain)
+        try:
+            if _running_loop() is not None:
+                # Both branches must start the hook from an empty context, for the
+                # strict-mode reason in `_run_post_dispatch_hook`. Running on another
+                # thread is not enough on its own: ThreadRunner.run hands the coroutine
+                # over with `run_coroutine_threadsafe`, which has no `context=` parameter
+                # and whose underlying `call_soon_threadsafe` captures
+                # `copy_context()` on *this* thread. Entering a fresh context first is
+                # what makes the copy it takes an empty one.
+                with ThreadRunner() as runner:
+                    contextvars.Context().run(runner.run, coro)
+            else:
+                contextvars.Context().run(asyncio.run, coro)
+        except Exception:
+            # _run_post_dispatch_hook swallows callback errors, so reaching here means the
+            # scheduling machinery itself failed. Still fail open.
+            logging.getLogger("griptape_nodes").exception(
+                "Failed to run post-dispatch hook '%s' for %s inline.",
+                getattr(callback, "__name__", callback),
+                request_type.__name__,
+            )
 
     def add_authorization_hook(
         self,
@@ -709,9 +1057,7 @@ class EventManager(EngineScoped):
                 retained_mode_str = depth_manager.request_retained_mode_translation(request)
 
             # Some requests have fields marked as "omit_from_result" which should be removed from the request
-            for field in fields(request):
-                if field.metadata.get("omit_from_result", False):
-                    setattr(request, field.name, None)
+            self._scrub_omitted_request_fields(request)
             if callback_result.succeeded():
                 result_event = EventResultSuccess(
                     request=request,
@@ -728,6 +1074,12 @@ class EventManager(EngineScoped):
                     retained_mode=retained_mode_str,
                     response_topic=context.get("response_topic"),
                 )
+
+        # Fired here rather than in the two dispatch methods because every path that
+        # produces a result event -- sync, async, and pre-dispatch short-circuit -- runs
+        # through this method. Deliberately outside the operation-depth context above, so
+        # a hook that does issue a request nests cleanly instead of inflating the depth.
+        self._fire_post_dispatch_hooks(request, callback_result)
 
         return result_event
 
@@ -769,13 +1121,17 @@ class EventManager(EngineScoped):
         # Expose the dispatching request type to detectors (see current_request_type).
         token = _active_request_type.set(request_type)
         try:
-            # Actually make the handler callback (support both sync and async):
-            result_payload: ResultPayload = await call_function(callback, request)
+            try:
+                # Actually make the handler callback (support both sync and async):
+                result_payload: ResultPayload = await call_function(callback, request)
 
-            # Queue flush request for async context (unless result type should skip flush)
-            with operation_depth_mgr:
-                if type(result_payload) not in RESULT_TYPES_THAT_SKIP_FLUSH:
-                    self._flush_tracked_parameter_changes()
+                # Queue flush request for async context (unless result type should skip flush)
+                with operation_depth_mgr:
+                    if type(result_payload) not in RESULT_TYPES_THAT_SKIP_FLUSH:
+                        self._flush_tracked_parameter_changes()
+            except Exception as exc:
+                self._fire_post_dispatch_hooks_for_handler_exception(request, exc)
+                raise
 
             return self._handle_request_core(
                 request,
@@ -785,7 +1141,7 @@ class EventManager(EngineScoped):
         finally:
             _active_request_type.reset(token)
 
-    def handle_request(  # noqa: PLR0912
+    def handle_request(
         self,
         request: RP,
         *,
@@ -823,51 +1179,16 @@ class EventManager(EngineScoped):
         # Expose the dispatching request type to detectors (see current_request_type).
         token = _active_request_type.set(request_type)
         try:
-            # Worker-side RemoteHandler callbacks are async but safe to invoke from a
-            # running loop: forward_to_orchestrator dispatches onto the WS loop via
-            # run_coroutine_threadsafe, which runs on a different thread than the caller's
-            # loop, so no primitives are shared and the #4469 deadlock shape does not apply.
-            # Hop the callback onto the WS loop here and block the caller's thread on the
-            # concurrent.futures.Future so RemoteHandler itself stays a plain async callable.
-            #
-            # Lazy import: worker_routing imports ResultContext from this module at
-            # runtime, so a top-level import here would cycle through event_manager
-            # -> worker_routing -> event_manager during module load.
-            from griptape_nodes.app.worker_routing import RemoteHandler
+            try:
+                result_payload = self._invoke_handler_from_sync(callback, request)
 
-            if isinstance(callback, RemoteHandler):
-                if _running_loop() is not None:
-                    if self._websocket_event_loop is None:
-                        msg = (
-                            f"Cannot forward '{type(request).__name__}' from a running event loop: "
-                            "the websocket event loop is not configured. This indicates a bootstrap order bug."
-                        )
-                        raise RuntimeError(msg)
-                    future = asyncio.run_coroutine_threadsafe(callback(request), self._websocket_event_loop)
-                    result_payload: ResultPayload = future.result()
-                else:
-                    result_payload: ResultPayload = asyncio.run(callback(request))
-            # Support async callbacks invoked from sync code. If no loop is running
-            # (bootstrap, worker threads) asyncio.run drives the coroutine directly.
-            # If a loop IS running (pre-#4449 workflow files exec'd from inside the
-            # engine loop), dispatch onto a side loop via ThreadRunner. The #4469
-            # deadlock shape is specific to callbacks whose coroutines share
-            # primitives with the caller's loop; RemoteHandler is the only such case
-            # and is handled above via run_coroutine_threadsafe onto the WS loop.
-            # For all other async handlers the side-loop path is safe.
-            elif inspect.iscoroutinefunction(callback):
-                if _running_loop() is not None:
-                    with ThreadRunner() as runner:
-                        result_payload: ResultPayload = runner.run(callback(request))
-                else:
-                    result_payload = asyncio.run(callback(request))
-            else:
-                result_payload = callback(request)
-
-            # Queue flush request for sync context (unless result type should skip flush)
-            with operation_depth_mgr:
-                if type(result_payload) not in RESULT_TYPES_THAT_SKIP_FLUSH:
-                    self._flush_tracked_parameter_changes()
+                # Queue flush request for sync context (unless result type should skip flush)
+                with operation_depth_mgr:
+                    if type(result_payload) not in RESULT_TYPES_THAT_SKIP_FLUSH:
+                        self._flush_tracked_parameter_changes()
+            except Exception as exc:
+                self._fire_post_dispatch_hooks_for_handler_exception(request, exc)
+                raise
 
             return self._handle_request_core(
                 request,
@@ -876,6 +1197,48 @@ class EventManager(EngineScoped):
             )
         finally:
             _active_request_type.reset(token)
+
+    def _invoke_handler_from_sync(self, callback: Callable, request: RequestPayload) -> ResultPayload:
+        """Call a request handler from sync code, bridging async handlers onto a loop."""
+        # Worker-side RemoteHandler callbacks are async but safe to invoke from a
+        # running loop: forward_to_orchestrator dispatches onto the WS loop via
+        # run_coroutine_threadsafe, which runs on a different thread than the caller's
+        # loop, so no primitives are shared and the #4469 deadlock shape does not apply.
+        # Hop the callback onto the WS loop here and block the caller's thread on the
+        # concurrent.futures.Future so RemoteHandler itself stays a plain async callable.
+        #
+        # Lazy import: worker_routing imports ResultContext from this module at
+        # runtime, so a top-level import here would cycle through event_manager
+        # -> worker_routing -> event_manager during module load.
+        from griptape_nodes.app.worker_routing import RemoteHandler
+
+        if isinstance(callback, RemoteHandler):
+            if _running_loop() is None:
+                return asyncio.run(callback(request))
+            if self._websocket_event_loop is None:
+                msg = (
+                    f"Cannot forward '{type(request).__name__}' from a running event loop: "
+                    "the websocket event loop is not configured. This indicates a bootstrap order bug."
+                )
+                raise RuntimeError(msg)
+            future = asyncio.run_coroutine_threadsafe(callback(request), self._websocket_event_loop)
+            return future.result()
+
+        # Support async callbacks invoked from sync code. If no loop is running
+        # (bootstrap, worker threads) asyncio.run drives the coroutine directly.
+        # If a loop IS running (pre-#4449 workflow files exec'd from inside the
+        # engine loop), dispatch onto a side loop via ThreadRunner. The #4469
+        # deadlock shape is specific to callbacks whose coroutines share
+        # primitives with the caller's loop; RemoteHandler is the only such case
+        # and is handled above via run_coroutine_threadsafe onto the WS loop.
+        # For all other async handlers the side-loop path is safe.
+        if inspect.iscoroutinefunction(callback):
+            if _running_loop() is None:
+                return asyncio.run(callback(request))
+            with ThreadRunner() as runner:
+                return runner.run(callback(request))
+
+        return callback(request)
 
     def add_listener_to_app_event(
         self, app_event_type: type[AP], callback: Callable[[AP], None] | Callable[[AP], Awaitable[None]]

--- a/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/__init__.py
+++ b/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/__init__.py
@@ -30,6 +30,8 @@ from .node_module_import_problem import NodeModuleImportProblem
 from .node_permission_denied_problem import NodePermissionDeniedProblem
 from .old_xdg_location_warning_problem import OldXdgLocationWarningProblem
 from .permission_denied_problem import PermissionDeniedProblem
+from .post_dispatch_hook_registration_problem import PostDispatchHookRegistrationProblem
+from .post_dispatch_hooks_worker_incompatible_problem import PostDispatchHooksWorkerIncompatibleProblem
 from .pre_dispatch_hook_registration_problem import PreDispatchHookRegistrationProblem
 from .request_handler_registration_problem import RequestHandlerRegistrationProblem
 from .request_handlers_worker_incompatible_problem import RequestHandlersWorkerIncompatibleProblem
@@ -74,6 +76,8 @@ __all__ = [
     "NodePermissionDeniedProblem",
     "OldXdgLocationWarningProblem",
     "PermissionDeniedProblem",
+    "PostDispatchHookRegistrationProblem",
+    "PostDispatchHooksWorkerIncompatibleProblem",
     "PreDispatchHookRegistrationProblem",
     "RequestHandlerRegistrationProblem",
     "RequestHandlersWorkerIncompatibleProblem",

--- a/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/post_dispatch_hook_registration_problem.py
+++ b/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/post_dispatch_hook_registration_problem.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from griptape_nodes.retained_mode.managers.fitness_problems.libraries.library_problem import LibraryProblem
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PostDispatchHookRegistrationProblem(LibraryProblem):
+    """Problem indicating a failure registering post-dispatch hooks for a library."""
+
+    error_message: str
+
+    @classmethod
+    def collate_problems_for_display(cls, instances: list[PostDispatchHookRegistrationProblem]) -> str:
+        if len(instances) > 1:
+            logger.error(
+                "PostDispatchHookRegistrationProblem: Expected 1 instance but got %s.",
+                len(instances),
+            )
+        messages = "; ".join(p.error_message for p in instances)
+        return f"Error registering post-dispatch hooks: {messages}"

--- a/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/post_dispatch_hooks_worker_incompatible_problem.py
+++ b/src/griptape_nodes/retained_mode/managers/fitness_problems/libraries/post_dispatch_hooks_worker_incompatible_problem.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from griptape_nodes.retained_mode.managers.fitness_problems.libraries.library_problem import LibraryProblem
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PostDispatchHooksWorkerIncompatibleProblem(LibraryProblem):
+    """Problem raised when a worker-mode library declares post-dispatch hooks.
+
+    Hooks registered via get_post_dispatch_hooks() are registered on the event
+    manager of whichever process loads the library. For worker-mode libraries
+    that is the worker process, which only ever dispatches the requests forwarded
+    to it, so hooks on requests handled by the orchestrator never fire.
+
+    Tracked in: https://github.com/griptape-ai/griptape-nodes-engine/issues/4748
+    """
+
+    library_name: str
+    hook_count: int
+
+    @classmethod
+    def collate_problems_for_display(cls, instances: list[PostDispatchHooksWorkerIncompatibleProblem]) -> str:
+        if len(instances) > 1:
+            logger.error(
+                "PostDispatchHooksWorkerIncompatibleProblem: Expected 1 instance but got %s.",
+                len(instances),
+            )
+        p = instances[0]
+        return (
+            f"Library '{p.library_name}' declares {p.hook_count} post-dispatch hook(s) "
+            f"via get_post_dispatch_hooks() but is configured to run in worker mode. "
+            f"Hooks registered in the worker process do not observe requests handled by the orchestrator. "
+            f"Cross-worker hook support is tracked in "
+            f"https://github.com/griptape-ai/griptape-nodes-engine/issues/4748"
+        )

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -227,6 +227,8 @@ from griptape_nodes.retained_mode.managers.fitness_problems.libraries import (
     NodePermissionDeniedProblem,
     OldXdgLocationWarningProblem,
     PermissionDeniedProblem,
+    PostDispatchHookRegistrationProblem,
+    PostDispatchHooksWorkerIncompatibleProblem,
     RequestHandlerRegistrationProblem,
     RequestHandlersWorkerIncompatibleProblem,
     SandboxDirectoryMissingProblem,
@@ -4843,6 +4845,63 @@ class LibraryManager(EngineScoped):
                 library_info.problems.append(RequestHandlerRegistrationProblem(error_message=str(err)))
                 logger.error(
                     "Failed to register request handlers for library '%s': %s",
+                    library_data.name,
+                    err,
+                )
+
+        # Register post-dispatch hooks declared by the library
+        if advanced_library:
+            try:
+                hooks = advanced_library.get_post_dispatch_hooks()
+                if hooks and library_info.requires_worker:
+                    library_info.problems.append(
+                        PostDispatchHooksWorkerIncompatibleProblem(
+                            library_name=library_data.name,
+                            hook_count=len(hooks),
+                        )
+                    )
+                    logger.warning(
+                        "Library '%s' declares %d post-dispatch hook(s) via get_post_dispatch_hooks() but "
+                        "requires worker mode. Hooks are only registered in the worker process and do not "
+                        "observe requests handled by the orchestrator. "
+                        "See https://github.com/griptape-ai/griptape-nodes-engine/issues/4748",
+                        library_data.name,
+                        len(hooks),
+                    )
+                for request_type, callback in hooks:
+                    # Hooks match on the exact request type, so a key that is not a class can
+                    # never equal `type(request)`: the hook would register cleanly and then
+                    # never fire, with nothing in the log to explain why. Fail loudly instead,
+                    # the same way the callable check below does.
+                    if not isinstance(request_type, type):
+                        msg = (
+                            f"Attempted to register a post-dispatch hook from library "
+                            f"'{library_data.name}'. Failed because '{request_type}' is not a request type. "
+                            f"Each entry from get_post_dispatch_hooks() must pair a request type with a "
+                            f"function to run."
+                        )
+                        raise TypeError(msg)  # noqa: TRY301
+                    if not callable(callback):
+                        msg = (
+                            f"Attempted to register a post-dispatch hook for '{request_type.__name__}' "
+                            f"from library '{library_data.name}'. Failed because the hook is not something "
+                            f"that can be called. Each entry from get_post_dispatch_hooks() must pair a "
+                            f"request type with a function to run."
+                        )
+                        raise TypeError(msg)  # noqa: TRY301
+                    event_manager = self.engine.event_manager
+                    event_manager.add_post_dispatch_hook(request_type, callback)
+                    library._registered_post_dispatch_hooks.append((request_type, callback))
+                if hooks:
+                    logger.debug(
+                        "Registered %d post-dispatch hook(s) for library '%s'",
+                        len(hooks),
+                        library_data.name,
+                    )
+            except Exception as err:
+                library_info.problems.append(PostDispatchHookRegistrationProblem(error_message=str(err)))
+                logger.error(
+                    "Failed to register post-dispatch hooks for library '%s': %s",
                     library_data.name,
                     err,
                 )

--- a/tests/unit/node_library/test_library_tracking_fields.py
+++ b/tests/unit/node_library/test_library_tracking_fields.py
@@ -23,6 +23,10 @@ class TestLibraryTrackingFields:
         lib = _make_library()
         assert lib.get_registered_pre_dispatch_hooks() == []
 
+    def test_registered_post_dispatch_hooks_starts_empty(self) -> None:
+        lib = _make_library()
+        assert lib.get_registered_post_dispatch_hooks() == []
+
     def test_registered_request_handler_types_starts_empty(self) -> None:
         lib = _make_library()
         assert lib.get_registered_request_handler_types() == []

--- a/tests/unit/node_library/test_unregister_library.py
+++ b/tests/unit/node_library/test_unregister_library.py
@@ -90,11 +90,41 @@ class TestUnregisterLibraryEventManagerCleanup:
 
         event_manager.remove_pre_dispatch_hook.assert_called_once_with(hook)
 
+    def test_post_dispatch_hooks_are_deregistered(self) -> None:
+        hook = MagicMock()
+        library = _register_library()
+        library._registered_post_dispatch_hooks.append((str, hook))
+
+        event_manager = MagicMock()
+        LibraryRegistry.unregister_library("TestLib", event_manager=event_manager)
+
+        # Removal is per request type, so both halves of the pair are needed.
+        event_manager.remove_post_dispatch_hook.assert_called_once_with(str, hook)
+
+    def test_every_post_dispatch_hook_is_deregistered(self) -> None:
+        """A library may hook several request types; leaving any behind leaks a live callback.
+
+        The single-hook test above cannot see a teardown that stops after the first pair,
+        and a leaked hook keeps calling into a module the unload was supposed to retire.
+        """
+        first_hook = MagicMock()
+        second_hook = MagicMock()
+        library = _register_library()
+        library._registered_post_dispatch_hooks.append((str, first_hook))
+        library._registered_post_dispatch_hooks.append((int, second_hook))
+
+        event_manager = MagicMock()
+        LibraryRegistry.unregister_library("TestLib", event_manager=event_manager)
+
+        removed = [(c.args[0], c.args[1]) for c in event_manager.remove_post_dispatch_hook.call_args_list]
+        assert removed == [(str, first_hook), (int, second_hook)]
+
     def test_tracking_fields_cleared_after_deregistration(self) -> None:
         library = _register_library()
         library._registered_request_handler_types.append(str)
         library._registered_app_event_listeners.append((str, MagicMock()))
         library._registered_pre_dispatch_hooks.append(MagicMock())
+        library._registered_post_dispatch_hooks.append((str, MagicMock()))
 
         event_manager = MagicMock()
         LibraryRegistry.unregister_library("TestLib", event_manager=event_manager)
@@ -103,6 +133,7 @@ class TestUnregisterLibraryEventManagerCleanup:
         assert library._registered_request_handler_types == []
         assert library._registered_app_event_listeners == []
         assert library._registered_pre_dispatch_hooks == []
+        assert library._registered_post_dispatch_hooks == []
 
     def test_unregister_raises_for_unknown_library(self) -> None:
         with pytest.raises(KeyError):

--- a/tests/unit/retained_mode/managers/fitness_problems/test_registration_problems.py
+++ b/tests/unit/retained_mode/managers/fitness_problems/test_registration_problems.py
@@ -1,4 +1,4 @@
-"""Tests for registration fitness problem classes."""
+"""Tests for the library registration and worker-compatibility fitness problem classes."""
 
 from __future__ import annotations
 
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 
 from griptape_nodes.retained_mode.managers.fitness_problems.libraries import (
     AppEventListenerRegistrationProblem,
+    PostDispatchHookRegistrationProblem,
+    PostDispatchHooksWorkerIncompatibleProblem,
     PreDispatchHookRegistrationProblem,
     RequestHandlerRegistrationProblem,
 )
@@ -28,6 +30,43 @@ class TestAppEventListenerRegistrationProblem:
         with caplog.at_level("ERROR"):
             AppEventListenerRegistrationProblem.collate_problems_for_display(problems)
         assert caplog.records  # warning/error was logged
+
+
+class TestPostDispatchHookRegistrationProblem:
+    def test_collate_single_problem(self) -> None:
+        problem = PostDispatchHookRegistrationProblem(error_message="hook boom")
+        result = PostDispatchHookRegistrationProblem.collate_problems_for_display([problem])
+        assert "hook boom" in result
+
+    def test_collate_multiple_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        problems = [
+            PostDispatchHookRegistrationProblem(error_message="err1"),
+            PostDispatchHookRegistrationProblem(error_message="err2"),
+        ]
+        with caplog.at_level("ERROR"):
+            result = PostDispatchHookRegistrationProblem.collate_problems_for_display(problems)
+        assert caplog.records
+        assert "err1" in result
+        assert "err2" in result
+
+
+class TestPostDispatchHooksWorkerIncompatibleProblem:
+    """The collated string is the only explanation an artist gets for a silent hook."""
+
+    def test_collate_names_the_library_and_the_hook_count(self) -> None:
+        problem = PostDispatchHooksWorkerIncompatibleProblem(library_name="My Library", hook_count=3)
+        result = PostDispatchHooksWorkerIncompatibleProblem.collate_problems_for_display([problem])
+        assert "My Library" in result
+        assert "3" in result
+
+    def test_collate_multiple_logs_error(self, caplog: pytest.LogCaptureFixture) -> None:
+        problems = [
+            PostDispatchHooksWorkerIncompatibleProblem(library_name="LibA", hook_count=1),
+            PostDispatchHooksWorkerIncompatibleProblem(library_name="LibB", hook_count=2),
+        ]
+        with caplog.at_level("ERROR"):
+            PostDispatchHooksWorkerIncompatibleProblem.collate_problems_for_display(problems)
+        assert caplog.records
 
 
 class TestPreDispatchHookRegistrationProblem:

--- a/tests/unit/retained_mode/managers/test_event_manager.py
+++ b/tests/unit/retained_mode/managers/test_event_manager.py
@@ -1,14 +1,17 @@
 """Test EventManager functionality including sync/async event broadcasting."""
 
 import asyncio
+import inspect
 import logging
 import threading
-from dataclasses import dataclass
+from collections.abc import Callable
+from dataclasses import dataclass, field
 from unittest.mock import AsyncMock
 
 import pytest
 
 from griptape_nodes.app.worker_routing import RemoteHandler
+from griptape_nodes.retained_mode.engine import Engine, current_engine
 from griptape_nodes.retained_mode.events.app_events import ConfigChanged
 from griptape_nodes.retained_mode.events.base_events import (
     EventResultSuccess,
@@ -19,6 +22,7 @@ from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultDetail,
     ResultDetails,
+    ResultPayload,
     ResultPayloadFailure,
     ResultPayloadSuccess,
     StrictModeViolationDetail,
@@ -659,6 +663,839 @@ class TestPreDispatchHooks:
 
         assert event.result.failed()
         assert handler_calls == []
+
+
+@dataclass(kw_only=True)
+class _SubProbeRequest(_ProbeRequest):
+    """Subclass of the probe request, for asserting hooks match the exact type only."""
+
+
+@dataclass(kw_only=True)
+class _CycleProbeRequest(RequestPayload):
+    """A second request type, for hooks that issue each other's requests."""
+
+
+@dataclass(kw_only=True)
+class _OmitFieldProbeRequest(RequestPayload):
+    """Carries a field the engine must null out before any hook sees the request."""
+
+    secret: str | None = field(default=None, metadata={"omit_from_result": True})
+
+
+@dataclass
+class _RecordingHook:
+    """A callable object rather than a function.
+
+    Deliberately an ordinary ``@dataclass``, which sets ``__hash__ = None``, so
+    registering it would raise if the hook store were a set. ``RemoteHandler`` has
+    exactly this shape.
+    """
+
+    seen: list[ResultPayload]
+
+    def __call__(self, _request: RequestPayload, result: ResultPayload) -> None:
+        self.seen.append(result)
+
+
+@dataclass
+class _AsyncRecordingHook:
+    """A callable object whose ``__call__`` is async, as ``RemoteHandler``'s is.
+
+    ``inspect.iscoroutinefunction`` returns False for an *instance* of this class, so it
+    is the shape that distinguishes a correct async-callable check from a naive one.
+    """
+
+    seen: list[ResultPayload]
+
+    async def __call__(self, _request: RequestPayload, result: ResultPayload) -> None:
+        self.seen.append(result)
+
+
+# The re-entrancy guard is what actually bounds _ReissuingHook; this only keeps a
+# regression from wedging the test run.
+_REISSUE_SAFETY_CAP = 20
+
+
+@dataclass
+class _ReissuingHook:
+    """A hook that re-dispatches its own request type, and can be field-equal to a peer.
+
+    Both fields hold shared objects, so two instances compare equal while staying
+    distinct registrations. That is the shape that tells an identity-based re-entrancy
+    guard apart from an equality-based one.
+    """
+
+    event_manager: EventManager
+    seen: list[ResultPayload]
+
+    def __call__(self, _request: RequestPayload, result: ResultPayload) -> None:
+        self.seen.append(result)
+        if len(self.seen) > _REISSUE_SAFETY_CAP:
+            return
+        self.event_manager.handle_request(_ProbeRequest())
+
+
+# Hooks reach the loop via call_soon_threadsafe, so the asyncio.Task does not exist yet
+# when the dispatch call returns. Ticking the loop creates it; gathering waits it out.
+_HOOK_DRAIN_TICKS = 50
+
+
+async def _drain_post_dispatch_hooks(event_manager: EventManager) -> None:
+    """Run the loop until every detached hook task has finished."""
+    for _ in range(_HOOK_DRAIN_TICKS):
+        await asyncio.sleep(0)
+        pending = list(event_manager._inflight_post_dispatch_hook_tasks)
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+
+
+class TestPostDispatchHooks:
+    """Post-dispatch hooks observe a completed request without being able to affect it.
+
+    Most cases run against a bare ``EventManager``, whose ``_event_loop`` is None, so
+    hooks take the inline fallback and complete before the dispatch call returns. That
+    keeps the assertions deterministic. The loop path -- where the hook is detached and
+    the result comes back first -- has its own tests below.
+    """
+
+    @staticmethod
+    def _manager_with_handler(handler: Callable[[_ProbeRequest], ResultPayload]) -> EventManager:
+        event_manager = EventManager()
+        event_manager.assign_manager_to_request_type(_ProbeRequest, handler)
+        return event_manager
+
+    def test_reentrancy_guard_skips_only_the_hook_that_is_actually_up_chain(self) -> None:
+        """The guard scans by identity, so it must not suppress a field-equal peer.
+
+        Two libraries can register field-equal hook objects on one request type. With an
+        equality-based scan, one of them running up-chain silently swallows the other's
+        re-entrant invocation, and that library's telemetry just goes missing.
+
+        Registration order is [a, b], so with the guard scanning by identity: a fires,
+        re-issues, and inside that nested dispatch a is skipped while b fires; then b
+        fires at the outer level, re-issues, and inside *that* nesting a fires while b is
+        skipped. Four invocations. An equality-based scan skips a's field-equal peer in
+        both nestings and yields two.
+        """
+
+        def handler(_request: _ProbeRequest) -> _ProbeResult:
+            return _ProbeResult(result_details="ok")
+
+        event_manager = self._manager_with_handler(handler)
+
+        shared_seen: list[ResultPayload] = []
+        hook_a = _ReissuingHook(event_manager, shared_seen)
+        hook_b = _ReissuingHook(event_manager, shared_seen)
+        assert hook_a == hook_b
+        assert hook_a is not hook_b
+
+        event_manager.add_post_dispatch_hook(_ProbeRequest, hook_a)
+        event_manager.add_post_dispatch_hook(_ProbeRequest, hook_b)
+
+        event_manager.handle_request(_ProbeRequest())
+
+        assert len(shared_seen) == 4  # noqa: PLR2004
+
+    def test_hook_fires_for_a_result_a_pre_dispatch_hook_short_circuited(self) -> None:
+        """Hooks fire from `_handle_request_core`, which is also the short-circuit's exit.
+
+        A request a pre-dispatch hook denied never reaches the manager callback, and a
+        denial is exactly what a library's audit hook wants to see. Moving the fire site
+        into the two dispatch methods would silence this path.
+        """
+        handler_calls: list[RequestPayload] = []
+
+        def handler(request: _ProbeRequest) -> _ProbeResult:
+            handler_calls.append(request)
+            return _ProbeResult(result_details="ok")
+
+        event_manager = self._manager_with_handler(handler)
+
+        def pre_dispatch(_request: RequestPayload, _context: object) -> _DeniedResult:
+            return _DeniedResult(result_details="denied")
+
+        event_manager.add_pre_dispatch_hook(pre_dispatch)
+
+        seen: list[ResultPayload] = []
+        event_manager.add_post_dispatch_hook(_ProbeRequest, _RecordingHook(seen))
+
+        event = event_manager.handle_request(_ProbeRequest())
+
+        assert event.result.failed()
+        assert handler_calls == []
+        assert len(seen) == 1
+        assert isinstance(seen[0], _DeniedResult)
+
+    def test_hook_receives_the_request_and_result_after_the_handler(self) -> None:
+        order: list[str] = []
+
+        def handler(_request: _ProbeRequest) -> _ProbeResult:
+            order.append("handler")
+            return _ProbeResult(result_details="ok")
+
+        event_manager = self._manager_with_handler(handler)
+
+        seen_requests: list[RequestPayload] = []
+        seen_results: list[ResultPayload] = []
+
+        def hook(request: RequestPayload, result: ResultPayload) -> None:
+            order.append("hook")
+            seen_requests.append(request)
+            seen_results.append(result)
+
+        event_manager.add_post_dispatch_hook(_ProbeRequest, hook)
+
+        request = _ProbeRequest()
+        event = event_manager.handle_request(request)
+
+        assert event.result.succeeded()
+        assert order == ["handler", "hook"]
+        assert seen_requests == [request]
+        assert seen_results == [event.result]
+
+    def test_hook_fires_for_a_failure_result(self) -> None:
+        def handler(_request: _ProbeRequest) -> _DeniedResult:
+            return _DeniedResult(result_details="denied")
+
+        event_manager = self._manager_with_handler(handler)
+
+        seen: list[ResultPayload] = []
+        event_manager.add_post_dispatch_hook(_ProbeRequest, _RecordingHook(seen))
+
+        event = event_manager.handle_request(_ProbeRequest())
+
+        assert event.result.failed()
+        assert len(seen) == 1
+        assert seen[0].failed()
+
+    def test_hook_fires_when_the_handler_raises(self) -> None:
+        def handler(_request: _ProbeRequest) -> _ProbeResult:
+            msg = "handler exploded"
+            raise RuntimeError(msg)
+
+        event_manager = self._manager_with_handler(handler)
+
+        seen: list[ResultPayload] = []
+        event_manager.add_post_dispatch_hook(_ProbeRequest, _RecordingHook(seen))
+
+        # The exception propagates to Engine.handle_request, which synthesizes the
+        # failure the client sees. Hooks get an equivalent payload rather than that one.
+        with pytest.raises(RuntimeError, match="handler exploded"):
+            event_manager.handle_request(_ProbeRequest())
+
+        assert len(seen) == 1
+        failure = seen[0]
+        assert failure.failed()
+        assert isinstance(failure, GenericResultFailure)
+        assert isinstance(failure.exception, RuntimeError)
+
+    @pytest.mark.asyncio
+    async def test_hook_fires_when_an_async_handler_raises(self) -> None:
+        event_manager = EventManager()
+
+        async def handler(_request: _ProbeRequest) -> _ProbeResult:
+            msg = "async handler exploded"
+            raise RuntimeError(msg)
+
+        event_manager.assign_manager_to_request_type(_ProbeRequest, handler)
+
+        seen: list[ResultPayload] = []
+        event_manager.add_post_dispatch_hook(_ProbeRequest, _RecordingHook(seen))
+
+        with pytest.raises(RuntimeError, match="async handler exploded"):
+            await event_manager.ahandle_request(_ProbeRequest())
+
+        assert len(seen) == 1
+        assert seen[0].failed()
+
+    def test_hook_is_not_invoked_for_a_subclass_of_its_request_type(self) -> None:
+        def handler(_request: _ProbeRequest) -> _ProbeResult:
+            return _ProbeResult(result_details="ok")
+
+        event_manager = self._manager_with_handler(handler)
+        event_manager.assign_manager_to_request_type(_SubProbeRequest, handler)
+
+        seen: list[ResultPayload] = []
+        event_manager.add_post_dispatch_hook(_ProbeRequest, _RecordingHook(seen))
+
+        event_manager.handle_request(_SubProbeRequest())
+
+        assert seen == []
+
+    def test_async_hook_is_awaited(self) -> None:
+        def handler(_request: _ProbeRequest) -> _ProbeResult:
+            return _ProbeResult(result_details="ok")
+
+        event_manager = self._manager_with_handler(handler)
+
+        seen: list[ResultPayload] = []
+
+        async def hook(_request: RequestPayload, result: ResultPayload) -> None:
+            await asyncio.sleep(0)
+            seen.append(result)
+
+        event_manager.add_post_dispatch_hook(_ProbeRequest, hook)
+
+        event_manager.handle_request(_ProbeRequest())
+
+        assert len(seen) == 1
+
+    def test_raising_hook_leaves_the_result_intact_and_siblings_still_run(self) -> None:
+        def handler(_request: _ProbeRequest) -> _ProbeResult:
+            return _ProbeResult(result_details="ok")
+
+        event_manager = self._manager_with_handler(handler)
+
+        def boom(_request: RequestPayload, _result: ResultPayload) -> None:
+            msg = "hook exploded"
+            raise RuntimeError(msg)
+
+        seen: list[ResultPayload] = []
+        event_manager.add_post_dispatch_hook(_ProbeRequest, boom)
+        event_manager.add_post_dispatch_hook(_ProbeRequest, _RecordingHook(seen))
+
+        event = event_manager.handle_request(_ProbeRequest())
+
+        assert event.result.succeeded()
+        assert len(seen) == 1
+
+    def test_unhashable_callable_registers_and_fires(self) -> None:
+        def handler(_request: _ProbeRequest) -> _ProbeResult:
+            return _ProbeResult(result_details="ok")
+
+        event_manager = self._manager_with_handler(handler)
+
+        seen: list[ResultPayload] = []
+        hook = _RecordingHook(seen)
+        with pytest.raises(TypeError):
+            hash(hook)  # Guards the premise: a set-backed store could not hold this.
+
+        event_manager.add_post_dispatch_hook(_ProbeRequest, hook)
+        event_manager.handle_request(_ProbeRequest())
+
+        assert len(seen) == 1
+
+        event_manager.remove_post_dispatch_hook(_ProbeRequest, hook)
+        event_manager.handle_request(_ProbeRequest())
+
+        assert len(seen) == 1
+
+    def test_add_post_dispatch_hook_dedupes(self) -> None:
+        def handler(_request: _ProbeRequest) -> _ProbeResult:
+            return _ProbeResult(result_details="ok")
+
+        event_manager = self._manager_with_handler(handler)
+
+        seen: list[ResultPayload] = []
+        hook = _RecordingHook(seen)
+        event_manager.add_post_dispatch_hook(_ProbeRequest, hook)
+        event_manager.add_post_dispatch_hook(_ProbeRequest, hook)
+
+        event_manager.handle_request(_ProbeRequest())
+
+        assert len(seen) == 1
+
+    def test_remove_post_dispatch_hook_stops_invocation(self) -> None:
+        def handler(_request: _ProbeRequest) -> _ProbeResult:
+            return _ProbeResult(result_details="ok")
+
+        event_manager = self._manager_with_handler(handler)
+
+        seen: list[ResultPayload] = []
+        hook = _RecordingHook(seen)
+        event_manager.add_post_dispatch_hook(_ProbeRequest, hook)
+        event_manager.remove_post_dispatch_hook(_ProbeRequest, hook)
+
+        event_manager.handle_request(_ProbeRequest())
+
+        assert seen == []
+
+    def test_remove_unregistered_post_dispatch_hook_is_noop(self) -> None:
+        def handler(_request: _ProbeRequest) -> _ProbeResult:
+            return _ProbeResult(result_details="ok")
+
+        event_manager = self._manager_with_handler(handler)
+        seen: list[ResultPayload] = []
+        registered = _RecordingHook(seen)
+        other = _RecordingHook([])
+
+        # Neither an unknown request type nor an unknown callback may raise.
+        event_manager.remove_post_dispatch_hook(_ProbeRequest, other)
+        event_manager.add_post_dispatch_hook(_ProbeRequest, registered)
+        event_manager.remove_post_dispatch_hook(_ProbeRequest, other)
+        event_manager.remove_post_dispatch_hook(_SubProbeRequest, registered)
+
+        # And none of it may have disturbed the hook that *is* registered. Without this
+        # the test passes even when `other` removes `registered`: the two are separate
+        # objects but a `@dataclass` compares by field, and both were built empty.
+        assert other == registered
+        event_manager.handle_request(_ProbeRequest())
+        assert len(seen) == 1
+
+    def test_field_equal_hooks_from_two_libraries_are_kept_apart(self) -> None:
+        """Hooks are matched by identity, never by `__eq__`.
+
+        Two libraries can register callable objects that happen to compare equal -- a
+        `@dataclass` hook with the same field values is the obvious case. If the store
+        matched by equality the second registration would be silently dropped, and either
+        library's teardown would disarm the other's live hook.
+        """
+
+        def handler(_request: _ProbeRequest) -> _ProbeResult:
+            return _ProbeResult(result_details="ok")
+
+        event_manager = self._manager_with_handler(handler)
+
+        shared_log: list[ResultPayload] = []
+        hook_a = _RecordingHook(shared_log)
+        hook_b = _RecordingHook(shared_log)
+        assert hook_a == hook_b
+        assert hook_a is not hook_b
+
+        event_manager.add_post_dispatch_hook(_ProbeRequest, hook_a)
+        event_manager.add_post_dispatch_hook(_ProbeRequest, hook_b)
+        event_manager.handle_request(_ProbeRequest())
+
+        # Both registered, so both fired.
+        assert len(shared_log) == 2  # noqa: PLR2004
+
+        # Removing one leaves the other armed.
+        event_manager.remove_post_dispatch_hook(_ProbeRequest, hook_b)
+        shared_log.clear()
+        event_manager.handle_request(_ProbeRequest())
+
+        assert len(shared_log) == 1
+        assert event_manager._post_dispatch_hooks[_ProbeRequest] == [hook_a]
+        assert event_manager._post_dispatch_hooks[_ProbeRequest][0] is hook_a
+
+    def test_hook_reissuing_its_own_request_type_does_not_recurse(self) -> None:
+        def handler(_request: _ProbeRequest) -> _ProbeResult:
+            return _ProbeResult(result_details="ok")
+
+        event_manager = self._manager_with_handler(handler)
+
+        calls: list[RequestPayload] = []
+
+        def hook(request: RequestPayload, _result: ResultPayload) -> None:
+            calls.append(request)
+            # Hooks are told not to do this, but it must terminate if one does.
+            event_manager.handle_request(_ProbeRequest())
+
+        event_manager.add_post_dispatch_hook(_ProbeRequest, hook)
+
+        event_manager.handle_request(_ProbeRequest())
+
+        assert len(calls) == 1
+
+    def test_hook_cycle_across_two_request_types_terminates(self) -> None:
+        """The re-entrancy marker has to survive from one hook generation to the next.
+
+        Each hook runs in a *fresh* context, which resets every ContextVar -- so the
+        accumulated chain is threaded in explicitly rather than read from the context
+        inside the hook. Without that, this pair alternates forever: each new task starts
+        from an empty chain, matches nothing, and schedules the other hook again.
+        """
+
+        def handler(_request: RequestPayload) -> _ProbeResult:
+            return _ProbeResult(result_details="ok")
+
+        event_manager = EventManager()
+        event_manager.assign_manager_to_request_type(_ProbeRequest, handler)
+        event_manager.assign_manager_to_request_type(_CycleProbeRequest, handler)
+
+        calls: list[str] = []
+        # Bounded so a regression fails the assertion instead of hanging the suite.
+        cap = 20
+
+        def hook_on_probe(_request: RequestPayload, _result: ResultPayload) -> None:
+            calls.append("probe")
+            if len(calls) < cap:
+                event_manager.handle_request(_CycleProbeRequest())
+
+        def hook_on_cycle(_request: RequestPayload, _result: ResultPayload) -> None:
+            calls.append("cycle")
+            if len(calls) < cap:
+                event_manager.handle_request(_ProbeRequest())
+
+        event_manager.add_post_dispatch_hook(_ProbeRequest, hook_on_probe)
+        event_manager.add_post_dispatch_hook(_CycleProbeRequest, hook_on_cycle)
+
+        event_manager.handle_request(_ProbeRequest())
+
+        assert calls == ["probe", "cycle"]
+
+    def test_async_callable_object_hook_is_awaited(self) -> None:
+        """A hook whose `__call__` is async must be awaited, not handed to a thread.
+
+        `inspect.iscoroutinefunction` says False for an instance of such a class, so
+        without the `type(callback).__call__` check the coroutine it returns is dropped on
+        the floor and the hook silently does nothing. `RemoteHandler` has this shape.
+        """
+
+        def handler(_request: _ProbeRequest) -> _ProbeResult:
+            return _ProbeResult(result_details="ok")
+
+        event_manager = self._manager_with_handler(handler)
+
+        seen: list[ResultPayload] = []
+        hook = _AsyncRecordingHook(seen)
+        assert not inspect.iscoroutinefunction(hook)  # Guards the premise.
+
+        event_manager.add_post_dispatch_hook(_ProbeRequest, hook)
+        event_manager.handle_request(_ProbeRequest())
+
+        assert len(seen) == 1
+
+    def test_omitted_request_fields_are_scrubbed_on_the_ordinary_path(self) -> None:
+        """The guarantee is stated unconditionally, so pin it where most requests go.
+
+        On this path it rests entirely on the fire site sitting *after* the scrub in
+        `_handle_request_core`. Moving the fire earlier keeps every result-event test
+        green while handing hooks the secret on every success.
+        """
+
+        def handler(_request: _OmitFieldProbeRequest) -> _ProbeResult:
+            return _ProbeResult(result_details="ok")
+
+        event_manager = EventManager()
+        event_manager.assign_manager_to_request_type(_OmitFieldProbeRequest, handler)
+
+        # Sampled inside the hook, not by holding the request: the scrub mutates the
+        # object in place, so a saved reference reads post-scrub state whenever the
+        # assertion runs and would pass even if the hook had been handed the secret.
+        seen: list[str | None] = []
+
+        def hook(request: RequestPayload, _result: ResultPayload) -> None:
+            assert isinstance(request, _OmitFieldProbeRequest)
+            seen.append(request.secret)
+
+        event_manager.add_post_dispatch_hook(_OmitFieldProbeRequest, hook)
+
+        event = event_manager.handle_request(_OmitFieldProbeRequest(secret="super-secret"))  # noqa: S106
+
+        assert event.result.succeeded()
+        assert seen == [None]
+
+    def test_hook_runs_outside_the_dispatching_operation_depth(self) -> None:
+        """Fired after the operation-depth context closes, so a hook does not inflate it.
+
+        `OperationDepthManager._depth` is a plain counter -- neither thread-local nor
+        context-local -- so a hook fired from inside the block would still be at depth 1.
+        A request the hook then issued would reach depth 2, `is_top_level()` would be
+        False, and its retained-mode echo would be silently suppressed.
+
+        Uses its own `Engine` so the depth counter starts from a known zero.
+        """
+        engine = Engine()
+        event_manager = engine.event_manager
+
+        def handler(_request: _ProbeRequest) -> _ProbeResult:
+            return _ProbeResult(result_details="ok")
+
+        event_manager.assign_manager_to_request_type(_ProbeRequest, handler)
+
+        depths: list[int] = []
+
+        def hook(_request: RequestPayload, _result: ResultPayload) -> None:
+            depths.append(engine.operation_depth_manager.get_depth())
+
+        event_manager.add_post_dispatch_hook(_ProbeRequest, hook)
+
+        event_manager.handle_request(_ProbeRequest())
+
+        assert depths == [0]
+
+    def test_omitted_request_fields_are_scrubbed_when_the_handler_raises(self) -> None:
+        """The scrub lives on the result-building path, which a raising handler skips.
+
+        `omit_from_result` exists to keep sensitive and bulky values out of anything
+        downstream, so the exception path -- the one this feature advertises as its most
+        interesting case -- must not be the hole that leaks them to a library.
+        """
+
+        def handler(_request: _OmitFieldProbeRequest) -> _ProbeResult:
+            msg = "handler blew up"
+            raise RuntimeError(msg)
+
+        event_manager = EventManager()
+        event_manager.assign_manager_to_request_type(_OmitFieldProbeRequest, handler)
+
+        # Sampled inside the hook for the reason given in the test above.
+        seen: list[str | None] = []
+
+        def hook(request: RequestPayload, _result: ResultPayload) -> None:
+            assert isinstance(request, _OmitFieldProbeRequest)
+            seen.append(request.secret)
+
+        event_manager.add_post_dispatch_hook(_OmitFieldProbeRequest, hook)
+
+        with pytest.raises(RuntimeError):
+            event_manager.handle_request(_OmitFieldProbeRequest(secret="super-secret"))  # noqa: S106
+
+        assert seen == [None]
+
+    def test_hook_runs_inline_when_the_stored_loop_is_open_but_never_driven(self) -> None:
+        """`create_task` on an undriven loop returns a task that never executes.
+
+        `asyncio.run` closes the loop it created, and nothing clears `_event_loop`, so a
+        stale loop reference is a real possibility. Scheduling onto one must fall back to
+        inline rather than silently dropping the hook.
+        """
+
+        def handler(_request: _ProbeRequest) -> _ProbeResult:
+            return _ProbeResult(result_details="ok")
+
+        event_manager = self._manager_with_handler(handler)
+
+        seen: list[ResultPayload] = []
+        event_manager.add_post_dispatch_hook(_ProbeRequest, _RecordingHook(seen))
+
+        stale_loop = asyncio.new_event_loop()
+        try:
+            event_manager._event_loop = stale_loop
+            event_manager.handle_request(_ProbeRequest())
+        finally:
+            stale_loop.close()
+
+        assert len(seen) == 1
+
+    def test_hook_runs_inline_when_the_stored_loop_is_closed(self) -> None:
+        def handler(_request: _ProbeRequest) -> _ProbeResult:
+            return _ProbeResult(result_details="ok")
+
+        event_manager = self._manager_with_handler(handler)
+
+        seen: list[ResultPayload] = []
+        event_manager.add_post_dispatch_hook(_ProbeRequest, _RecordingHook(seen))
+
+        closed_loop = asyncio.new_event_loop()
+        closed_loop.close()
+        event_manager._event_loop = closed_loop
+
+        event_manager.handle_request(_ProbeRequest())
+
+        assert len(seen) == 1
+
+    def test_hook_completes_when_sync_dispatch_runs_inside_a_running_loop(self) -> None:
+        """Regression guard for scheduling onto `asyncio.get_running_loop()`.
+
+        Sync `handle_request` drives async work on a transient `ThreadRunner` side loop
+        that stops as soon as the handler returns. A hook detached onto that loop would
+        lose the race with teardown, so the inline path awaits it instead. An `AsyncMock`
+        resolves synchronously and would mask the bug; this hook yields many times.
+        """
+        event_manager = EventManager()
+
+        async def handler(_request: _ProbeRequest) -> _ProbeResult:
+            return _ProbeResult(result_details="ok")
+
+        event_manager.assign_manager_to_request_type(_ProbeRequest, handler)
+
+        seen: list[ResultPayload] = []
+
+        async def hook(_request: RequestPayload, result: ResultPayload) -> None:
+            for _ in range(50):
+                await asyncio.sleep(0)
+            seen.append(result)
+
+        event_manager.add_post_dispatch_hook(_ProbeRequest, hook)
+
+        async def driver() -> None:
+            # A running loop on this thread makes `handle_request` take the ThreadRunner
+            # branch -- the same branch a sync handler hits in production.
+            event_manager.handle_request(_ProbeRequest())
+
+        asyncio.run(driver())
+
+        assert len(seen) == 1
+
+    @pytest.mark.asyncio
+    async def test_hook_does_not_delay_the_result(self) -> None:
+        """The point of the feature: the result comes back before the hook runs."""
+        event_manager = EventManager()
+        event_manager.initialize_queue(asyncio.Queue())
+
+        async def handler(_request: _ProbeRequest) -> _ProbeResult:
+            return _ProbeResult(result_details="ok")
+
+        event_manager.assign_manager_to_request_type(_ProbeRequest, handler)
+
+        seen: list[ResultPayload] = []
+
+        async def hook(_request: RequestPayload, result: ResultPayload) -> None:
+            await asyncio.sleep(0)
+            seen.append(result)
+
+        event_manager.add_post_dispatch_hook(_ProbeRequest, hook)
+
+        event = await event_manager.ahandle_request(_ProbeRequest())
+
+        assert event.result.succeeded()
+        assert seen == []
+
+        await _drain_post_dispatch_hooks(event_manager)
+
+        assert len(seen) == 1
+
+    @pytest.mark.asyncio
+    async def test_detached_hook_task_is_retained_then_released(self) -> None:
+        """A detached task needs a strong reference, because asyncio keeps only a weak one.
+
+        Nothing else in the process references a detached hook task, so without the
+        in-flight set it can be garbage collected mid-await and the hook silently stops
+        part-way through. The set also must not grow without bound, hence the second half.
+        """
+        event_manager = EventManager()
+        event_manager.initialize_queue(asyncio.Queue())
+
+        async def handler(_request: _ProbeRequest) -> _ProbeResult:
+            return _ProbeResult(result_details="ok")
+
+        event_manager.assign_manager_to_request_type(_ProbeRequest, handler)
+
+        async def hook(_request: RequestPayload, _result: ResultPayload) -> None:
+            await asyncio.sleep(0)
+
+        event_manager.add_post_dispatch_hook(_ProbeRequest, hook)
+
+        await event_manager.ahandle_request(_ProbeRequest())
+
+        # The task is created by a call_soon_threadsafe callback, so it does not exist
+        # until the loop turns once.
+        await asyncio.sleep(0)
+        assert len(event_manager._inflight_post_dispatch_hook_tasks) == 1
+
+        await _drain_post_dispatch_hooks(event_manager)
+
+        assert event_manager._inflight_post_dispatch_hook_tasks == set()
+
+    @pytest.mark.asyncio
+    async def test_a_backlog_of_inflight_hooks_logs_a_warning(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Back-pressure is unbounded by design, so this log is the only signal of a backlog.
+
+        Nothing is dropped or coalesced, which means a hook slower than its request rate
+        accumulates silently unless this fires.
+        """
+        monkeypatch.setattr(
+            "griptape_nodes.retained_mode.managers.event_manager.POST_DISPATCH_HOOK_INFLIGHT_WARNING_THRESHOLD",
+            2,
+        )
+        event_manager = EventManager()
+        event_manager.initialize_queue(asyncio.Queue())
+
+        async def handler(_request: _ProbeRequest) -> _ProbeResult:
+            return _ProbeResult(result_details="ok")
+
+        event_manager.assign_manager_to_request_type(_ProbeRequest, handler)
+
+        release = asyncio.Event()
+
+        async def blocked_hook(_request: RequestPayload, _result: ResultPayload) -> None:
+            await release.wait()
+
+        event_manager.add_post_dispatch_hook(_ProbeRequest, blocked_hook)
+
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+            for _ in range(3):
+                await event_manager.ahandle_request(_ProbeRequest())
+            await asyncio.sleep(0)
+
+            # Guards the test itself: without three live tasks there is no backlog to warn
+            # about and the assertion below would pass or fail for the wrong reason.
+            assert len(event_manager._inflight_post_dispatch_hook_tasks) == 3  # noqa: PLR2004
+            warnings = [r for r in caplog.records if "post-dispatch hooks are still running" in r.getMessage()]
+
+        release.set()
+        await _drain_post_dispatch_hooks(event_manager)
+
+        assert warnings
+
+    @pytest.mark.asyncio
+    async def test_hook_sees_the_engine_that_dispatched_the_request(self) -> None:
+        """The fresh context drops the engine binding, so the hook re-establishes it.
+
+        Without it a hook reaching the engine through the `GriptapeNodes` facade -- which
+        is how a library gets at managers -- would silently operate on the process-root
+        engine instead of the one whose request it is observing.
+        """
+        engine = Engine()
+        event_manager = engine.event_manager
+        event_manager.initialize_queue(asyncio.Queue())
+
+        # Not the ambient engine, so resolving to the process root would be visible.
+        assert current_engine() is not engine
+
+        async def handler(_request: _ProbeRequest) -> _ProbeResult:
+            return _ProbeResult(result_details="ok")
+
+        event_manager.assign_manager_to_request_type(_ProbeRequest, handler)
+
+        seen_engines: list[Engine] = []
+
+        async def hook(_request: RequestPayload, _result: ResultPayload) -> None:
+            seen_engines.append(current_engine())
+
+        event_manager.add_post_dispatch_hook(_ProbeRequest, hook)
+
+        await event_manager.ahandle_request(_ProbeRequest())
+        await _drain_post_dispatch_hooks(event_manager)
+
+        assert seen_engines == [engine]
+
+    @pytest.mark.asyncio
+    async def test_every_dispatch_gets_its_own_hook_invocation(self) -> None:
+        """Nothing is dropped or coalesced, however slow the hook is relative to dispatch."""
+        event_manager = EventManager()
+        event_manager.initialize_queue(asyncio.Queue())
+
+        async def handler(_request: _ProbeRequest) -> _ProbeResult:
+            return _ProbeResult(result_details="ok")
+
+        event_manager.assign_manager_to_request_type(_ProbeRequest, handler)
+
+        seen: list[ResultPayload] = []
+
+        async def slow_hook(_request: RequestPayload, result: ResultPayload) -> None:
+            for _ in range(5):
+                await asyncio.sleep(0)
+            seen.append(result)
+
+        event_manager.add_post_dispatch_hook(_ProbeRequest, slow_hook)
+
+        dispatch_count = 12
+        for _ in range(dispatch_count):
+            await event_manager.ahandle_request(_ProbeRequest())
+
+        await _drain_post_dispatch_hooks(event_manager)
+
+        assert len(seen) == dispatch_count
+
+    @pytest.mark.asyncio
+    async def test_sync_hook_does_not_run_on_the_engine_loop(self) -> None:
+        """A blocking sync hook would stall the event queue, so it is handed to a thread."""
+        event_manager = EventManager()
+        event_manager.initialize_queue(asyncio.Queue())
+        engine_loop_thread = threading.get_ident()
+
+        async def handler(_request: _ProbeRequest) -> _ProbeResult:
+            return _ProbeResult(result_details="ok")
+
+        event_manager.assign_manager_to_request_type(_ProbeRequest, handler)
+
+        hook_threads: list[int] = []
+
+        def hook(_request: RequestPayload, _result: ResultPayload) -> None:
+            hook_threads.append(threading.get_ident())
+
+        event_manager.add_post_dispatch_hook(_ProbeRequest, hook)
+
+        await event_manager.ahandle_request(_ProbeRequest())
+        await _drain_post_dispatch_hooks(event_manager)
+
+        assert len(hook_threads) == 1
+        assert hook_threads[0] != engine_loop_thread
 
 
 class TestAuthorizationCheckpointHooks:

--- a/tests/unit/retained_mode/managers/test_event_manager_strict_mode.py
+++ b/tests/unit/retained_mode/managers/test_event_manager_strict_mode.py
@@ -22,6 +22,7 @@ class below, including a test that it and the detector cannot disagree.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 
 import pytest
@@ -41,9 +42,14 @@ from griptape_nodes.common.strict_mode import (
 from griptape_nodes.node_library.library_registry import _constructing_node
 from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
+    ResultPayload,
     ResultPayloadSuccess,
 )
-from griptape_nodes.retained_mode.managers.event_manager import EventManager, reentrant_bus_in_init_would_report
+from griptape_nodes.retained_mode.managers.event_manager import (
+    EventManager,
+    current_request_type,
+    reentrant_bus_in_init_would_report,
+)
 
 
 @dataclass(kw_only=True)
@@ -66,6 +72,23 @@ def _make_event_manager_with_probe_handler() -> EventManager:
 
     event_manager.assign_manager_to_request_type(_ProbeRequest, handler)
     return event_manager
+
+
+# Kept in step with the copy in test_event_manager.py; see the note there.
+_HOOK_DRAIN_TICKS = 50
+
+
+async def _drain_post_dispatch_hooks(event_manager: EventManager) -> None:
+    """Run the loop until every detached hook task has finished.
+
+    Hooks reach the loop via ``call_soon_threadsafe``, so the ``asyncio.Task`` does not
+    exist yet when the dispatch call returns.
+    """
+    for _ in range(_HOOK_DRAIN_TICKS):
+        await asyncio.sleep(0)
+        pending = list(event_manager._inflight_post_dispatch_hook_tasks)
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
 
 
 class TestReentrantBusInInit:
@@ -260,3 +283,109 @@ class TestReentrantBusInInitWouldReport:
             _constructing_node.reset(token)
 
         assert predicted is (len(scope.violations) == 1)
+
+
+class TestPostDispatchHookContextIsolation:
+    """A post-dispatch hook must not inherit the dispatching task's strict-mode scope.
+
+    Hook tasks are created with a *fresh* ``contextvars.Context()`` rather than a copy of
+    the caller's. The scope stack holds mutable ``StrictModeScope`` objects, so a hook
+    that inherited a node's ``RUNTIME_EXECUTE`` scope could append to ``scope.violations``
+    after the node's own scope had already been evaluated -- and on a worker an
+    ERROR-severity violation promotes ``ExecuteNodeResultSuccess`` to a failure. A
+    library's telemetry hook must not be able to fail a user's node.
+
+    The fresh context also clears the dispatching request type, so
+    ``current_request_type()`` does not lie inside the hook.
+    """
+
+    @pytest.mark.asyncio
+    async def test_detached_hook_cannot_report_into_the_dispatching_scope(self) -> None:
+        event_manager = _make_event_manager_with_probe_handler()
+        event_manager.initialize_queue(asyncio.Queue())
+
+        seen_request_types: list[type | None] = []
+
+        async def hook(_request: RequestPayload, _result: ResultPayload) -> None:
+            seen_request_types.append(current_request_type())
+            STRICT_MODE.report(rule_id="reentrant-bus-in-init", message="from the hook")
+
+        event_manager.add_post_dispatch_hook(_ProbeRequest, hook)
+
+        with STRICT_MODE.open_scope(
+            kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+            subject="MyNode",
+            library_name="libA",
+            is_worker=True,
+        ) as scope:
+            await event_manager.ahandle_request(_ProbeRequest(marker="hook-detached"))
+            await _drain_post_dispatch_hooks(event_manager)
+
+        assert seen_request_types == [None]
+        assert scope.violations == []
+
+    def test_inline_hook_cannot_report_into_the_dispatching_scope(self) -> None:
+        """Same guarantee on the fallback path, which blocks the caller until the hook returns.
+
+        The hook does not run *on* the caller's thread: a sync callback goes through
+        ``to_thread``, onto a worker of the transient loop ``asyncio.run`` creates here.
+        The isolation has to survive that hop, which is why the fresh context is entered
+        before the loop is started rather than inside the callback.
+        """
+        event_manager = _make_event_manager_with_probe_handler()
+
+        seen_request_types: list[type | None] = []
+
+        def hook(_request: RequestPayload, _result: ResultPayload) -> None:
+            seen_request_types.append(current_request_type())
+            STRICT_MODE.report(rule_id="reentrant-bus-in-init", message="from the hook")
+
+        event_manager.add_post_dispatch_hook(_ProbeRequest, hook)
+
+        with STRICT_MODE.open_scope(
+            kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+            subject="MyNode",
+            library_name="libA",
+            is_worker=True,
+        ) as scope:
+            event_manager.handle_request(_ProbeRequest(marker="hook-inline"))
+
+        assert seen_request_types == [None]
+        assert scope.violations == []
+
+    @pytest.mark.asyncio
+    async def test_inline_hook_on_the_side_loop_cannot_report_into_the_dispatching_scope(self) -> None:
+        """The inline fallback has two sub-branches; this covers the one taken inside a loop.
+
+        Running the hook on another thread is not isolation by itself. ``ThreadRunner.run``
+        hands the coroutine over with ``run_coroutine_threadsafe``, which has no
+        ``context=`` parameter, and the ``call_soon_threadsafe`` underneath it captures
+        ``copy_context()`` on the *submitting* thread -- so without an explicit fresh
+        context the hook inherits this scope and a library hook can fail a user's node.
+        The sync-callback hop to a worker thread does not save it either, because
+        ``to_thread`` propagates the context it was called in.
+
+        A bare ``EventManager`` has no ``_event_loop``, so a sync dispatch from inside this
+        test's running loop takes the fallback and then its ThreadRunner sub-branch.
+        """
+        event_manager = _make_event_manager_with_probe_handler()
+        assert event_manager._event_loop is None
+
+        seen_request_types: list[type | None] = []
+
+        def hook(_request: RequestPayload, _result: ResultPayload) -> None:
+            seen_request_types.append(current_request_type())
+            STRICT_MODE.report(rule_id="reentrant-bus-in-init", message="from the hook")
+
+        event_manager.add_post_dispatch_hook(_ProbeRequest, hook)
+
+        with STRICT_MODE.open_scope(
+            kind=StrictModeScopeKind.RUNTIME_EXECUTE,
+            subject="MyNode",
+            library_name="libA",
+            is_worker=True,
+        ) as scope:
+            event_manager.handle_request(_ProbeRequest(marker="hook-side-loop"))
+
+        assert seen_request_types == [None]
+        assert scope.violations == []

--- a/tests/unit/retained_mode/managers/test_library_manager_post_dispatch_hooks.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_post_dispatch_hooks.py
@@ -1,0 +1,263 @@
+"""Tests for get_post_dispatch_hooks() registration in _attempt_load_nodes_from_library."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Never
+from unittest.mock import MagicMock, patch
+
+from griptape_nodes.node_library.advanced_node_library import AdvancedNodeLibrary
+from griptape_nodes.node_library.library_registry import Library, LibrarySchema
+from griptape_nodes.retained_mode.events.base_events import RequestPayload, ResultPayload
+from griptape_nodes.retained_mode.managers.fitness_problems.libraries import (
+    PostDispatchHookRegistrationProblem,
+    PostDispatchHooksWorkerIncompatibleProblem,
+)
+from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+
+@dataclass
+class _TestRequest(RequestPayload):
+    pass
+
+
+def _hook(_request: RequestPayload, _result: ResultPayload) -> None:
+    return None
+
+
+def _make_library_info() -> LibraryManager.LibraryInfo:
+    return LibraryManager.LibraryInfo(
+        lifecycle_state=LibraryManager.LibraryLifecycleState.EVALUATED,
+        fitness=LibraryManager.LibraryFitness.NOT_EVALUATED,
+        library_path="/fake/path",
+        is_sandbox=False,
+        library_name="TestLib",
+        library_version="1.0.0",
+    )
+
+
+def _make_library(advanced_library: AdvancedNodeLibrary | None = None) -> Library:
+    schema = MagicMock(spec=LibrarySchema)
+    schema.is_default_library = False
+    schema.name = "TestLib"
+    schema.nodes = []
+    schema.workflow_nodes = []
+    schema.widgets = []
+    schema.config_categories = []
+    return Library(library_data=schema, advanced_library=advanced_library)
+
+
+def _load(lm: LibraryManager, library: Library, library_info: LibraryManager.LibraryInfo) -> None:
+    lm._attempt_load_nodes_from_library(
+        library_data=library._library_data,
+        library=library,
+        base_dir=Path("/fake"),
+        library_info=library_info,
+    )
+
+
+class TestPostDispatchHookRegistration:
+    def test_hooks_registered_via_event_manager(self, griptape_nodes: GriptapeNodes) -> None:
+        """get_post_dispatch_hooks() pairs should be registered with EventManager."""
+
+        class MyLib(AdvancedNodeLibrary):
+            def get_post_dispatch_hooks(self) -> list:
+                return [(_TestRequest, _hook)]
+
+        library = _make_library(advanced_library=MyLib())
+        library_info = _make_library_info()
+
+        lm = griptape_nodes.LibraryManager()
+        event_manager = MagicMock()
+        with patch.object(griptape_nodes, "_event_manager", event_manager):
+            _load(lm, library, library_info)
+
+        event_manager.add_post_dispatch_hook.assert_called_once_with(_TestRequest, _hook)
+
+    def test_hook_pairs_recorded_on_library(self, griptape_nodes: GriptapeNodes) -> None:
+        """The request type is tracked alongside the callback, because removal needs both."""
+
+        class MyLib(AdvancedNodeLibrary):
+            def get_post_dispatch_hooks(self) -> list:
+                return [(_TestRequest, _hook)]
+
+        library = _make_library(advanced_library=MyLib())
+        library_info = _make_library_info()
+
+        lm = griptape_nodes.LibraryManager()
+        event_manager = MagicMock()
+        with patch.object(griptape_nodes, "_event_manager", event_manager):
+            _load(lm, library, library_info)
+
+        assert library.get_registered_post_dispatch_hooks() == [(_TestRequest, _hook)]
+
+    def test_exception_in_get_post_dispatch_hooks_appends_problem(self, griptape_nodes: GriptapeNodes) -> None:
+        """An exception from get_post_dispatch_hooks() should append PostDispatchHookRegistrationProblem."""
+
+        class BoomLib(AdvancedNodeLibrary):
+            def get_post_dispatch_hooks(self) -> Never:
+                msg = "hook registration exploded"
+                raise RuntimeError(msg)
+
+        library = _make_library(advanced_library=BoomLib())
+        library_info = _make_library_info()
+
+        lm = griptape_nodes.LibraryManager()
+        event_manager = MagicMock()
+        with patch.object(griptape_nodes, "_event_manager", event_manager):
+            _load(lm, library, library_info)
+
+        problem_types = [type(p) for p in library_info.problems]
+        assert PostDispatchHookRegistrationProblem in problem_types
+
+    def test_non_callable_hook_appends_problem(self, griptape_nodes: GriptapeNodes) -> None:
+        """Library code is untyped at this boundary, so a bad pair must fail loudly here."""
+
+        class BadLib(AdvancedNodeLibrary):
+            def get_post_dispatch_hooks(self) -> list:
+                return [(_TestRequest, "not a callable")]
+
+        library = _make_library(advanced_library=BadLib())
+        library_info = _make_library_info()
+
+        lm = griptape_nodes.LibraryManager()
+        event_manager = MagicMock()
+        with patch.object(griptape_nodes, "_event_manager", event_manager):
+            _load(lm, library, library_info)
+
+        problem_types = [type(p) for p in library_info.problems]
+        assert PostDispatchHookRegistrationProblem in problem_types
+        event_manager.add_post_dispatch_hook.assert_not_called()
+        assert library.get_registered_post_dispatch_hooks() == []
+
+    def test_a_bad_pair_stops_registration_but_leaves_earlier_pairs_tracked(
+        self, griptape_nodes: GriptapeNodes
+    ) -> None:
+        """A bad pair abandons the rest of the list, so what did register must still be tracked.
+
+        Registration aborts on the first bad entry, matching the request-handler block
+        above it, which also fails the whole block rather than skipping one entry. That
+        leaves a library partially registered, which is only safe because every pair that
+        did register is in the tracking list and so gets removed on unload. An untracked
+        live hook would keep calling into a module the unload was supposed to retire.
+        """
+
+        def first_hook(_request: RequestPayload, _result: ResultPayload) -> None:
+            return
+
+        def never_reached(_request: RequestPayload, _result: ResultPayload) -> None:
+            return
+
+        class PartlyBadLib(AdvancedNodeLibrary):
+            def get_post_dispatch_hooks(self) -> list:
+                return [(_TestRequest, first_hook), (_TestRequest, "not a callable"), (_TestRequest, never_reached)]
+
+        library = _make_library(advanced_library=PartlyBadLib())
+        library_info = _make_library_info()
+
+        lm = griptape_nodes.LibraryManager()
+        event_manager = MagicMock()
+        with patch.object(griptape_nodes, "_event_manager", event_manager):
+            _load(lm, library, library_info)
+
+        problem_types = [type(p) for p in library_info.problems]
+        assert PostDispatchHookRegistrationProblem in problem_types
+
+        registered = [c.args[1] for c in event_manager.add_post_dispatch_hook.call_args_list]
+        assert registered == [first_hook]
+        assert library.get_registered_post_dispatch_hooks() == [(_TestRequest, first_hook)]
+
+    def test_non_type_request_key_appends_problem(self, griptape_nodes: GriptapeNodes) -> None:
+        """A key that is not a class would register and then never fire, silently.
+
+        `_fire_post_dispatch_hooks` looks the callbacks up by `type(request)`, so a key
+        like an instance or a string matches nothing. Without this check the library
+        author gets a hook that does nothing and no diagnostic anywhere.
+        """
+
+        class BadKeyLib(AdvancedNodeLibrary):
+            def get_post_dispatch_hooks(self) -> list:
+                return [(_TestRequest(), _hook)]  # an instance, not the class
+
+        library = _make_library(advanced_library=BadKeyLib())
+        library_info = _make_library_info()
+
+        lm = griptape_nodes.LibraryManager()
+        event_manager = MagicMock()
+        with patch.object(griptape_nodes, "_event_manager", event_manager):
+            _load(lm, library, library_info)
+
+        problem_types = [type(p) for p in library_info.problems]
+        assert PostDispatchHookRegistrationProblem in problem_types
+        event_manager.add_post_dispatch_hook.assert_not_called()
+        assert library.get_registered_post_dispatch_hooks() == []
+
+    def test_no_advanced_library_does_nothing(self, griptape_nodes: GriptapeNodes) -> None:
+        """A library with no advanced library should not touch EventManager at all."""
+        library = _make_library(advanced_library=None)
+        library_info = _make_library_info()
+
+        lm = griptape_nodes.LibraryManager()
+        event_manager = MagicMock()
+        with patch.object(griptape_nodes, "_event_manager", event_manager):
+            _load(lm, library, library_info)
+
+        event_manager.add_post_dispatch_hook.assert_not_called()
+
+    def test_empty_get_post_dispatch_hooks_does_nothing(self, griptape_nodes: GriptapeNodes) -> None:
+        """A library returning [] should not register any hooks."""
+
+        class EmptyLib(AdvancedNodeLibrary):
+            pass  # base default returns []
+
+        library = _make_library(advanced_library=EmptyLib())
+        library_info = _make_library_info()
+
+        lm = griptape_nodes.LibraryManager()
+        event_manager = MagicMock()
+        with patch.object(griptape_nodes, "_event_manager", event_manager):
+            _load(lm, library, library_info)
+
+        event_manager.add_post_dispatch_hook.assert_not_called()
+
+    def test_worker_mode_library_with_hooks_appends_incompatible_problem(self, griptape_nodes: GriptapeNodes) -> None:
+        """Hooks registered in a worker process never see requests the orchestrator handles."""
+
+        class WorkerLib(AdvancedNodeLibrary):
+            def get_post_dispatch_hooks(self) -> list:
+                return [(_TestRequest, _hook)]
+
+        library = _make_library(advanced_library=WorkerLib())
+        library_info = _make_library_info()
+        library_info.requires_worker = True
+
+        lm = griptape_nodes.LibraryManager()
+        event_manager = MagicMock()
+        with patch.object(griptape_nodes, "_event_manager", event_manager):
+            _load(lm, library, library_info)
+
+        problem_types = [type(p) for p in library_info.problems]
+        assert PostDispatchHooksWorkerIncompatibleProblem in problem_types
+
+    def test_non_worker_library_with_hooks_no_incompatible_problem(self, griptape_nodes: GriptapeNodes) -> None:
+        """A non-worker library with hooks is the supported case and must load clean."""
+
+        class OrchestratorLib(AdvancedNodeLibrary):
+            def get_post_dispatch_hooks(self) -> list:
+                return [(_TestRequest, _hook)]
+
+        library = _make_library(advanced_library=OrchestratorLib())
+        library_info = _make_library_info()
+        library_info.requires_worker = False
+
+        lm = griptape_nodes.LibraryManager()
+        event_manager = MagicMock()
+        with patch.object(griptape_nodes, "_event_manager", event_manager):
+            _load(lm, library, library_info)
+
+        problem_types = [type(p) for p in library_info.problems]
+        assert PostDispatchHooksWorkerIncompatibleProblem not in problem_types


### PR DESCRIPTION
Closes #5306

Adds `AdvancedNodeLibrary.get_post_dispatch_hooks()`, so a node library can be notified
after the engine's own handler produced a result for a given request type — the missing
sibling next to pre-dispatch hooks (#4745) in the Library Event Handler Registration
family (#4741).

The motivating ask: a customer wants to run their own step after a workflow is saved.
`SaveWorkflowRequest` belongs to `WorkflowManager`, and every existing extension point is
on the wrong side of the problem (see #5306 for the full comparison). The only thing that
worked before this was stealing the handler and re-registering a wrapper, which
double-wraps on reload and leaves a wrapper calling into dead module code on unload.

## What a library writes

```python
class MyLibrary(AdvancedNodeLibrary):
    def get_post_dispatch_hooks(self):
        return [(SaveWorkflowRequest, self.on_workflow_saved)]

    async def on_workflow_saved(self, request, result) -> None:
        ...
```

Hooks are notification-only: the return value is ignored, and a hook can neither alter the
result nor fail the operation. They fire for success and failure alike, match on the exact
request type, and are normally scheduled as detached tasks so they never delay the caller.

## Design decisions worth reviewing

Several of these are non-obvious, and each closed a defect found during review.

**Fire site.** `_handle_request_core`, which every result-producing path runs through
(sync, async, and the pre-dispatch short-circuit), plus a second site for exceptions
escaping the handler. Firing in `EventManager` rather than `Engine` is deliberate: it
covers engine-internal dispatches, and the websocket app may call
`EventManager.ahandle_request` directly.

**Scheduling always targets `EventManager._event_loop` via `call_soon_threadsafe`**, never
`asyncio.get_running_loop()`. Sync `handle_request` drives async handlers on a transient
`ThreadRunner` side loop that stops before an orphaned task could run.

**The schedulability predicate tests `is_running()` as well as `is_closed()`.** `asyncio.run`
closes the loop it created and nothing clears `_event_loop`; `create_task` on an
open-but-undriven loop returns a pending task that never executes. Failing the predicate
falls back to running the hook inline, which *does* block the caller — that's the tradeoff
for CLI commands, bootstrap workflow runs, and worker threads, where dropping the hook
would mean "hooks fire, except sometimes."

**Hook tasks get a fresh `contextvars.Context()`, not `copy_context()`,** with the engine
binding re-established inside. This was the P0. `StrictModeReporter._scope_stack` holds
*mutable* `StrictModeScope` objects, so an inherited `RUNTIME_EXECUTE` scope would let a
library's telemetry hook append ERROR violations and promote `ExecuteNodeResultSuccess` to
a failure. A library hook must not be able to fail a user's node.

**Storage is lists, and dedupe/re-entrancy compare by identity.** A callable `@dataclass`
(as `worker_routing.RemoteHandler` is) has `__hash__ = None` and field-based `__eq__`, so a
set would raise on insert and equality would collapse two different libraries' field-equal
hooks into one.

**Sync callbacks run off the loop thread** via `async_utils.to_thread`. `call_function`
would run them inline and stall the event-queue processor and every in-flight request.

**Back-pressure is unbounded by design** — nothing dropped or coalesced, so a
per-save notification never misses a save. A backlog past a threshold logs a WARNING.
Detached-task exceptions are surfaced via `add_done_callback`; hooks fail open.

**`omit_from_result` scrubbing happens before the hook sees the request,** on both the
ordinary path and the handler-raised path. That scrub exists to keep sensitive and bulky
values out of anything downstream, and a hook must not be the hole that leaks them.

## Registration and teardown

Registration is a new block in `_attempt_load_nodes_from_library`, same shape as its 02C/02D
siblings: fail-all on a bad entry, appending `PostDispatchHookRegistrationProblem`. A
non-class request key is rejected too — hooks look up by `type(request)`, so a non-class key
would register cleanly and then never fire with nothing in the log to explain why.

`Library._registered_post_dispatch_hooks` stores `(request_type, callback)` **pairs**, because
removal needs the type. Every pair registered before a malformed one stays tracked, so a
partially-registered library still tears down completely — an untracked live hook would keep
calling into a module the unload was supposed to retire.

A worker-mode library declaring hooks surfaces `PostDispatchHooksWorkerIncompatibleProblem`,
since hooks registered in a worker never observe requests the orchestrator handled. Cross-worker
hooks are tracked separately by #4748.

## Testing

New `TestPostDispatchHooks` in `test_event_manager.py`, context-isolation tests in
`test_event_manager_strict_mode.py`, a new `test_library_manager_post_dispatch_hooks.py`, and
teardown/tracking additions under `tests/unit/node_library/`.

Every test added during the review loop was mutation-verified: the defect was injected, exactly
the intended test was confirmed to red, then the source was restored and diff-checked. Notably
this caught two tests that passed for the wrong reason — they asserted on the request object
*after* the fact, and because the `omit_from_result` scrub mutates in place, they read post-scrub
state regardless of when the hook actually ran. Both now sample inside the hook.

## Verification

- `make check` equivalents scoped to `src tests`: ruff format, ruff check, pyright (0 errors),
  typos, mdformat — all clean. Repo-wide `make check` fails at `check/format` on 7 files in an
  untracked vendored `libraries/` checkout, which is pre-existing and unrelated.
- Full suite: **4345 passed, 12 skipped**.
- `uv run mkdocs build --strict` passes.
- Reviewed with 5 rounds of independent reviewer subagents (13 agents; correctness, consistency,
  tests/docs, security, completeness lenses), stopping clean.

## Known limitations

- **No shutdown drain.** The engine has no shutdown path, so a hook in flight at process exit is
  abandoned. These hooks are explicitly **not durable**, and the docs say so.
- Sync hooks share the event loop's default `ThreadPoolExecutor` with every other `to_thread`
  caller. A dedicated executor was rejected — nothing would close it.
- No registration refcounting: two libraries registering the same callback for the same type
  means the first unload removes it for both. Pre-existing across this whole family (app-event
  listeners have the identical shape); wants one fix, not a divergence here.
- `add_pre_dispatch_hook` and `add_authorization_hook` dedupe by **equality**, so a
  callable-object hook can be silently dropped there. Same hazard, different family member —
  worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--5307.org.readthedocs.build/en/5307/

<!-- readthedocs-preview griptape-nodes end -->