### PR TITLE
Fire memory-teardown broadcast before lease release

### DIFF
--- a/src/griptape_nodes/retained_mode/events/execution_lease_events.py
+++ b/src/griptape_nodes/retained_mode/events/execution_lease_events.py
@@ -218,6 +218,41 @@ class CancelExecutionLeaseResultFailure(WorkflowNotAlteredMixin, ResultPayloadFa
 
 
 @dataclass
+@PayloadRegistry.register
+class ExecutionLeaseReleasing(AppPayload):
+    """Broadcast inside the engine just before its execution lease is returned.
+
+    ENGINE-INTERNAL, not part of the balancer wire contract above: this never
+    crosses to the admission authority. The release watchdog broadcasts it and
+    **awaits every listener to completion** before sending
+    ReleaseExecutionLeaseRequest, so anything a listener frees is genuinely
+    free before the next engine is admitted. That ordering is the event's
+    entire reason to exist -- on a shared GPU machine, serialized admission
+    buys nothing if the previous run's pipelines still occupy memory.
+
+    Libraries holding execution-scoped memory (model/pipeline caches) opt in
+    from ``after_library_nodes_loaded``::
+
+        GriptapeNodes.EventManager().add_listener_to_app_event(
+            ExecutionLeaseReleasing, self._clear_pipeline_cache
+        )
+
+    Async listeners are supported and awaited. A listener that raises does not
+    block the release (the failure is logged and release proceeds), and a
+    listener that hangs is abandoned after the configured teardown timeout --
+    a wedged teardown must not hold the admission queue forever. Libraries
+    must deregister their listener in ``before_library_unregistered``.
+
+    Args:
+        lease_id: The lease about to be returned.
+        scope: The scope string from the lease's acquire request.
+    """
+
+    lease_id: str
+    scope: str = "workflow"
+
+
+@dataclass
 class ExecutionAdmissionStatusEntry:
     """One engine's standing in the admission state, for status display.
 

--- a/src/griptape_nodes/retained_mode/events/execution_lease_events.py
+++ b/src/griptape_nodes/retained_mode/events/execution_lease_events.py
@@ -38,6 +38,15 @@ from griptape_nodes.retained_mode.events.base_events import (
 )
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 
+# Transport binding for the lease protocol over websocket_direct. The engine
+# publishes its lease requests on the request topic (the balancer subscribes to
+# it on connect); the balancer publishes responses and admission-status events
+# on the response topic (the engine's correlation filter watches it). Defined
+# beside the events because the two sides must agree on them exactly as they
+# must agree on the event shapes.
+LEASE_REQUEST_TOPIC = "execution_lease/request"
+LEASE_RESPONSE_TOPIC = "execution_lease/response"
+
 
 @dataclass
 @PayloadRegistry.register

--- a/src/griptape_nodes/retained_mode/events/execution_lease_events.py
+++ b/src/griptape_nodes/retained_mode/events/execution_lease_events.py
@@ -228,6 +228,23 @@ class CancelExecutionLeaseResultFailure(WorkflowNotAlteredMixin, ResultPayloadFa
 
 @dataclass
 @PayloadRegistry.register
+class ExecutionBalancerHeartbeatEvent(AppPayload):
+    """Periodic liveness beacon from the admission authority to each engine.
+
+    Part of the wire contract: the balancer publishes this on the lease
+    response topic every few seconds per linked engine. Its absence is the
+    engine's ONLY way to observe balancer loss -- the balancer dials in, so
+    the engine holds no connection state of its own -- and a brokered engine
+    whose beacons stop past the configured timeout self-terminates (engines
+    die with their admission authority: fail closed, no orphans holding GPU
+    memory). It also lets the gate fail fast with a clear message when no
+    balancer has ever connected, instead of waiting forever on an acquire
+    nobody will answer.
+    """
+
+
+@dataclass
+@PayloadRegistry.register
 class ExecutionLeaseReleasing(AppPayload):
     """Broadcast inside the engine just before its execution lease is returned.
 

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -34,6 +34,9 @@ if TYPE_CHECKING:
     from griptape_nodes.retained_mode.managers.context_manager import ContextManager
     from griptape_nodes.retained_mode.managers.engine_identity_manager import EngineIdentityManager
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
+    from griptape_nodes.retained_mode.managers.execution_lease_manager import (
+        ExecutionLeaseManager,
+    )
     from griptape_nodes.retained_mode.managers.flow_manager import FlowManager
     from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
     from griptape_nodes.retained_mode.managers.manifest_manager import ManifestManager
@@ -226,3 +229,7 @@ class GriptapeNodes(metaclass=_EngineRootMeta):
     @classmethod
     def WorkerManager(cls) -> WorkerManager:
         return current_engine().worker_manager
+
+    @classmethod
+    def ExecutionLeaseManager(cls) -> ExecutionLeaseManager:
+        return current_engine().execution_lease_manager

--- a/src/griptape_nodes/retained_mode/managers/execution_lease_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/execution_lease_manager.py
@@ -29,6 +29,8 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import os
+import signal
 import time
 import uuid
 from dataclasses import dataclass
@@ -38,6 +40,8 @@ from griptape_nodes.retained_mode.engine import EngineScoped
 from griptape_nodes.retained_mode.events import execution_lease_events
 from griptape_nodes.retained_mode.events.event_converter import converter
 from griptape_nodes.retained_mode.managers.settings import (
+    EXECUTION_LEASE_BALANCER_GRACE_KEY,
+    EXECUTION_LEASE_BALANCER_TIMEOUT_KEY,
     EXECUTION_LEASE_ENABLED_KEY,
     EXECUTION_LEASE_RENEW_INTERVAL_KEY,
     EXECUTION_LEASE_TEARDOWN_TIMEOUT_KEY,
@@ -88,6 +92,17 @@ class ExecutionLeaseManager(EngineScoped):
 
     DEFAULT_TEARDOWN_TIMEOUT_S: float = 120.0
 
+    DEFAULT_BALANCER_TIMEOUT_S: float = 30.0
+
+    # Generous: covers engine boot (library load) plus the balancer linking and
+    # sending its first beacon, mirroring the worker heartbeat startup grace.
+    DEFAULT_BALANCER_GRACE_S: float = 600.0
+
+    # After asking the process to shut down gracefully, how long to wait before
+    # forcing the exit -- a wedged shutdown must not leave a zombie engine
+    # claiming GPU memory on a box the balancer has already given up on.
+    _TERMINATE_ESCALATION_S: float = 15.0
+
     def __init__(self, *, engine: Engine) -> None:
         super().__init__(engine)
         self._transport: _LeaseTransport | None = None
@@ -104,8 +119,26 @@ class ExecutionLeaseManager(EngineScoped):
         # is reused for a follow-on run (queued starts draining back-to-back).
         self._watchdog_task: asyncio.Task | None = None
 
+        # Monotonic timestamp of the last balancer beacon; 0.0 = never seen.
+        # Written only by _on_balancer_heartbeat.
+        self._balancer_last_seen: float = 0.0
+
         config = engine.config_manager
         self.enabled: bool = config.get_config_value(EXECUTION_LEASE_ENABLED_KEY, default=False, cast_type=bool)
+        self.balancer_timeout_s: float = config.get_config_value(
+            EXECUTION_LEASE_BALANCER_TIMEOUT_KEY,
+            default=ExecutionLeaseManager.DEFAULT_BALANCER_TIMEOUT_S,
+            cast_type=float,
+        )
+        self.balancer_grace_s: float = config.get_config_value(
+            EXECUTION_LEASE_BALANCER_GRACE_KEY,
+            default=ExecutionLeaseManager.DEFAULT_BALANCER_GRACE_S,
+            cast_type=float,
+        )
+        if self.enabled:
+            engine.event_manager.add_listener_to_app_event(
+                execution_lease_events.ExecutionBalancerHeartbeatEvent, self._on_balancer_heartbeat
+            )
         self.renew_interval_s: float = config.get_config_value(
             EXECUTION_LEASE_RENEW_INTERVAL_KEY,
             default=ExecutionLeaseManager.DEFAULT_RENEW_INTERVAL_S,
@@ -165,6 +198,17 @@ class ExecutionLeaseManager(EngineScoped):
                 "Attempted to start execution on a managed engine. Failed because the "
                 "execution manager (load balancer) link is not connected; this engine "
                 "refuses to run unmanaged. Contact your administrator."
+            )
+            raise RuntimeError(msg)
+
+        # The balancer dials in, so "is it connected" is only observable via
+        # its beacons. Without this check an acquire would wait forever on a
+        # topic nobody is subscribed to -- fail closed with a message instead.
+        if self._balancer_last_seen == 0.0:
+            msg = (
+                "Attempted to start execution on a managed engine. Failed because no "
+                "load balancer has connected to this engine yet; this engine refuses "
+                "to run unmanaged. Contact your administrator."
             )
             raise RuntimeError(msg)
 
@@ -367,6 +411,46 @@ class ExecutionLeaseManager(EngineScoped):
     def _engine_id(self) -> str:
         engine_id = self.engine.engine_identity_manager.active_engine_id
         return engine_id if engine_id is not None else "unknown-engine"
+
+    async def run_balancer_liveness_monitor(self) -> None:
+        """Self-terminate when balancer beacons stop: engines die with their balancer.
+
+        The balancer dials in and connection state is invisible to Python, so
+        beacon receipt is the only liveness signal. After the startup grace
+        (covering boot + first link), a beacon gap past the timeout means the
+        admission authority is gone -- and a brokered engine without one must
+        not linger: it cannot run (fail closed) and would only hold memory.
+        Termination goes through the process's own signal handlers so shutdown
+        is graceful, with a hard exit escalation if that wedges.
+
+        Mirrors worker_heartbeat_monitor's shape; a no-op on unmanaged engines.
+        """
+        if not self.enabled:
+            return
+        await asyncio.sleep(self.balancer_grace_s)
+        poll_s = max(0.05, min(self.balancer_timeout_s / 3.0, 10.0))
+        while True:
+            await asyncio.sleep(poll_s)
+            last_seen = self._balancer_last_seen
+            elapsed = time.monotonic() - last_seen if last_seen else float("inf")
+            if elapsed > self.balancer_timeout_s:
+                logger.critical(
+                    "Load balancer heartbeat lost (%s); this engine is shutting down "
+                    "(managed engines do not outlive their admission authority).",
+                    f"{elapsed:.0f}s since last beacon" if last_seen else "never connected",
+                )
+                await self._terminate_process()
+                return
+
+    def _on_balancer_heartbeat(self, _event: Any) -> None:
+        self._balancer_last_seen = time.monotonic()
+
+    async def _terminate_process(self) -> None:
+        """Ask this process to shut down; force the exit if that wedges."""
+        os.kill(os.getpid(), signal.SIGTERM)
+        await asyncio.sleep(ExecutionLeaseManager._TERMINATE_ESCALATION_S)
+        logger.critical("Graceful shutdown did not complete; forcing exit.")
+        os._exit(1)
 
     @staticmethod
     def _payload_of(request: Any) -> dict[str, Any]:

--- a/src/griptape_nodes/retained_mode/managers/execution_lease_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/execution_lease_manager.py
@@ -204,8 +204,7 @@ class ExecutionLeaseManager(EngineScoped):
                 self._acquire_pending = False
 
         if result.get("result_type") != execution_lease_events.AcquireExecutionLeaseResultSuccess.__name__:
-            details = result.get("result_details", "no reason given")
-            msg = f"Attempted to start execution. The execution manager refused: {details}"
+            msg = f"Attempted to start execution. The execution manager refused: {self._details_of(result)}"
             raise RuntimeError(msg)
 
         async with self._state_lock:
@@ -332,7 +331,7 @@ class ExecutionLeaseManager(EngineScoped):
             self._lease_lost = True
             logger.error(
                 "Execution lease was not renewed (%s); this engine no longer holds admission.",
-                result.get("result_details", "no reason given"),
+                self._details_of(result),
             )
 
     async def _release_locked(self, reason: str) -> None:
@@ -353,7 +352,7 @@ class ExecutionLeaseManager(EngineScoped):
             return
         if result.get("result_type") != execution_lease_events.ReleaseExecutionLeaseResultSuccess.__name__:
             # Already reclaimed (crash eviction won a race) -- treat as released.
-            logger.info("Execution lease release answered: %s", result.get("result_details", ""))
+            logger.info("Execution lease release answered: %s", self._details_of(result))
         else:
             logger.debug("Execution lease released (%s)", reason)
 
@@ -372,3 +371,21 @@ class ExecutionLeaseManager(EngineScoped):
     @staticmethod
     def _payload_of(request: Any) -> dict[str, Any]:
         return converter.unstructure(request)
+
+    @staticmethod
+    def _details_of(result: dict[str, Any]) -> str:
+        """Flatten a result envelope's human-readable details.
+
+        On the wire, a result payload's ``result_details`` is the unstructured
+        ``ResultDetails`` object -- ``{"result_details": [{"level", "message"}]}``
+        nested under the envelope's ``result`` key -- not a plain string.
+        """
+        details = result.get("result", {}).get("result_details", "")
+        if isinstance(details, str):
+            return details or "no reason given"
+        if isinstance(details, dict):
+            details = details.get("result_details", [])
+        if isinstance(details, list):
+            messages = [entry.get("message", "") for entry in details if isinstance(entry, dict)]
+            return " ".join(m for m in messages if m) or "no reason given"
+        return "no reason given"

--- a/src/griptape_nodes/retained_mode/managers/execution_lease_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/execution_lease_manager.py
@@ -40,6 +40,7 @@ from griptape_nodes.retained_mode.events.event_converter import converter
 from griptape_nodes.retained_mode.managers.settings import (
     EXECUTION_LEASE_ENABLED_KEY,
     EXECUTION_LEASE_RENEW_INTERVAL_KEY,
+    EXECUTION_LEASE_TEARDOWN_TIMEOUT_KEY,
 )
 
 if TYPE_CHECKING:
@@ -85,6 +86,8 @@ class ExecutionLeaseManager(EngineScoped):
 
     DEFAULT_RENEW_INTERVAL_S: float = 30.0
 
+    DEFAULT_TEARDOWN_TIMEOUT_S: float = 120.0
+
     def __init__(self, *, engine: Engine) -> None:
         super().__init__(engine)
         self._transport: _LeaseTransport | None = None
@@ -92,6 +95,7 @@ class ExecutionLeaseManager(EngineScoped):
         # The held lease id, or None. Guarded by _state_lock together with
         # _acquire_pending so concurrent gate calls serialize their decisions.
         self._lease_id: str | None = None
+        self._lease_scope: str = "workflow"
         self._acquire_pending: bool = False
         self._lease_lost: bool = False
         self._state_lock = asyncio.Lock()
@@ -105,6 +109,11 @@ class ExecutionLeaseManager(EngineScoped):
         self.renew_interval_s: float = config.get_config_value(
             EXECUTION_LEASE_RENEW_INTERVAL_KEY,
             default=ExecutionLeaseManager.DEFAULT_RENEW_INTERVAL_S,
+            cast_type=float,
+        )
+        self.teardown_timeout_s: float = config.get_config_value(
+            EXECUTION_LEASE_TEARDOWN_TIMEOUT_KEY,
+            default=ExecutionLeaseManager.DEFAULT_TEARDOWN_TIMEOUT_S,
             cast_type=float,
         )
 
@@ -201,6 +210,7 @@ class ExecutionLeaseManager(EngineScoped):
 
         async with self._state_lock:
             self._lease_id = lease_id
+            self._lease_scope = scope
             self._lease_lost = False
             # A run that started while this acquire waited wins; return the
             # lease rather than piling a second run onto the engine.
@@ -230,10 +240,34 @@ class ExecutionLeaseManager(EngineScoped):
         """Release execution-scoped memory before the lease is returned.
 
         Ordering is the point: teardown happens BEFORE the release is sent, so
-        the next admitted engine starts against a reclaimed machine. The
-        teardown broadcast itself ships separately; until then this is the
-        seam it plugs into.
+        the next admitted engine starts against a reclaimed machine. Broadcasts
+        ExecutionLeaseReleasing and awaits every listener (libraries clearing
+        their pipeline caches). A failing listener is logged and release
+        proceeds; a hung one is abandoned at the teardown timeout -- either
+        way, a broken teardown must not hold the admission queue forever.
         """
+        if self._lease_id is None:
+            return
+        event = execution_lease_events.ExecutionLeaseReleasing(
+            lease_id=self._lease_id,
+            scope=self._lease_scope,
+        )
+        try:
+            await asyncio.wait_for(
+                self.engine.event_manager.abroadcast_app_event(event),
+                timeout=self.teardown_timeout_s,
+            )
+        except TimeoutError:
+            logger.error(
+                "Execution memory teardown did not finish within %.0fs; releasing the lease anyway. "
+                "The machine may still hold this run's memory.",
+                self.teardown_timeout_s,
+            )
+        except ExceptionGroup:
+            logger.exception(
+                "Execution memory teardown listener(s) failed; releasing the lease anyway. "
+                "The machine may still hold this run's memory."
+            )
 
     def _restart_watchdog(self) -> None:
         """(Re)start the release watchdog for a new run under the current lease."""

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -4098,16 +4098,18 @@ class FlowManager(EngineScoped):
             errormsg = "This workflow is already in progress. Please wait for the current process to finish before starting again."
             raise RuntimeError(errormsg)
 
+        if start_node is None and self._global_flow_queue.empty():
+            errormsg = "No Flow exists. You must create at least one control connection."
+            raise RuntimeError(errormsg)
+
         # Managed execution: acquire the execution lease exactly where the
         # running-flow signal is about to transition False -> True. No-op on
-        # unmanaged engines. Placed before the queue pop so a refused start
-        # leaves the execution queue intact.
+        # unmanaged engines. Placed after the cheap validations (so an empty
+        # queue never acquires) but before the queue pop (so a refused start
+        # leaves the execution queue intact).
         await self.engine.execution_lease_manager.gate_execution_start()
 
         if start_node is None:
-            if self._global_flow_queue.empty():
-                errormsg = "No Flow exists. You must create at least one control connection."
-                raise RuntimeError(errormsg)
             queue_item = self._global_flow_queue.get()
             start_node = queue_item.node
             self._global_flow_queue.task_done()

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -27,6 +27,11 @@ WORKER_HEARTBEAT_STARTUP_GRACE_KEY = "worker.heartbeat_startup_grace_s"
 # brokered and runs exactly as before.
 EXECUTION_LEASE_ENABLED_KEY = "execution_lease.enabled"
 EXECUTION_LEASE_RENEW_INTERVAL_KEY = "execution_lease.renew_interval_s"
+# Ceiling on the pre-release memory teardown (the ExecutionLeaseReleasing
+# broadcast). Generous by default -- clearing a multi-gigabyte video pipeline
+# transits components through system RAM and takes real time -- but bounded,
+# so a wedged library teardown cannot hold the admission queue forever.
+EXECUTION_LEASE_TEARDOWN_TIMEOUT_KEY = "execution_lease.teardown_timeout_s"
 DISCOVERY_MAX_DEPTH_KEY = "discovery_max_depth"
 # The `Settings.libraries_directory` field below, named here so every reader of it -- the live
 # libraries root, the provisioning preview, the offline libraries-root resolver, and the packager --

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -32,6 +32,11 @@ EXECUTION_LEASE_RENEW_INTERVAL_KEY = "execution_lease.renew_interval_s"
 # transits components through system RAM and takes real time -- but bounded,
 # so a wedged library teardown cannot hold the admission queue forever.
 EXECUTION_LEASE_TEARDOWN_TIMEOUT_KEY = "execution_lease.teardown_timeout_s"
+# Balancer liveness: the balancer beacons every few seconds; an engine whose
+# beacons stop past the timeout self-terminates (fail closed, no orphans). The
+# startup grace covers engine boot + balancer linking before enforcement.
+EXECUTION_LEASE_BALANCER_TIMEOUT_KEY = "execution_lease.balancer_heartbeat_timeout_s"
+EXECUTION_LEASE_BALANCER_GRACE_KEY = "execution_lease.balancer_startup_grace_s"
 DISCOVERY_MAX_DEPTH_KEY = "discovery_max_depth"
 # The `Settings.libraries_directory` field below, named here so every reader of it -- the live
 # libraries root, the provisioning preview, the offline libraries-root resolver, and the packager --

--- a/tests/unit/retained_mode/managers/test_execution_lease_manager.py
+++ b/tests/unit/retained_mode/managers/test_execution_lease_manager.py
@@ -430,7 +430,7 @@ class TestBalancerLiveness:
         manager, _, _ = make_manager(engine, monkeypatch)
         manager._balancer_last_seen = 0.0
 
-        with pytest.raises(RuntimeError, match="no .*load balancer has connected"):
+        with pytest.raises(RuntimeError, match=r"no .*load balancer has connected"):
             await manager.gate_execution_start()
 
     @pytest.mark.asyncio

--- a/tests/unit/retained_mode/managers/test_execution_lease_manager.py
+++ b/tests/unit/retained_mode/managers/test_execution_lease_manager.py
@@ -15,10 +15,12 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
+from griptape_nodes.retained_mode.events.execution_lease_events import ExecutionLeaseReleasing
 from griptape_nodes.retained_mode.managers.execution_lease_manager import ExecutionLeaseManager
 from griptape_nodes.retained_mode.managers.settings import (
     EXECUTION_LEASE_ENABLED_KEY,
     EXECUTION_LEASE_RENEW_INTERVAL_KEY,
+    EXECUTION_LEASE_TEARDOWN_TIMEOUT_KEY,
 )
 
 if TYPE_CHECKING:
@@ -69,13 +71,14 @@ def make_manager(
     engine: Engine,
     monkeypatch: pytest.MonkeyPatch,
     *,
-    enabled: bool = True,
     renew_interval_s: float = 30.0,
     startup_grace_s: float = 0.5,
+    teardown_timeout_s: float = 2.0,
 ) -> tuple[ExecutionLeaseManager, StubBalancer, RunningFlowSignal]:
-    """Build a manager against the stub balancer with test-scaled timings."""
-    engine.config_manager.set_config_value(EXECUTION_LEASE_ENABLED_KEY, value=enabled)
+    """Build a manager against the stub balancer with test-scaled timings; always enabled."""
+    engine.config_manager.set_config_value(EXECUTION_LEASE_ENABLED_KEY, value=True)
     engine.config_manager.set_config_value(EXECUTION_LEASE_RENEW_INTERVAL_KEY, value=renew_interval_s)
+    engine.config_manager.set_config_value(EXECUTION_LEASE_TEARDOWN_TIMEOUT_KEY, value=teardown_timeout_s)
     monkeypatch.setattr(ExecutionLeaseManager, "_STARTUP_GRACE_S", startup_grace_s)
     monkeypatch.setattr(ExecutionLeaseManager, "_POLL_INTERVAL_S", 0.01)
 
@@ -312,3 +315,98 @@ class TestRenewal:
 
         await wait_for(lambda: manager.lease_id is None)
         assert len(balancer.sent("ReleaseExecutionLeaseRequest")) == 0
+
+
+class TestTeardownBroadcast:
+    """The real _run_pre_release_teardown: ExecutionLeaseReleasing listeners."""
+
+    @pytest.mark.asyncio
+    async def test_listener_completes_before_release(self, engine: Engine, monkeypatch: pytest.MonkeyPatch) -> None:
+        manager, balancer, signal = make_manager(engine, monkeypatch)
+        order: list[str] = []
+
+        async def slow_teardown(event: ExecutionLeaseReleasing) -> None:
+            await asyncio.sleep(0.05)  # long enough that fire-and-forget would lose the race
+            order.append(f"teardown:{event.scope}")
+
+        engine.event_manager.add_listener_to_app_event(ExecutionLeaseReleasing, slow_teardown)
+        original_send = balancer.send_request
+
+        async def recording_send(request_type: str, payload: dict[str, Any]) -> dict[str, Any]:
+            if request_type == "ReleaseExecutionLeaseRequest":
+                order.append("release")
+            return await original_send(request_type, payload)
+
+        manager.attach_transport(send_request=recording_send, send_no_response=balancer.send_no_response)
+        try:
+            await manager.gate_execution_start(scope="single_node")
+            signal.running = True
+            await asyncio.sleep(0.05)
+            signal.running = False
+
+            await wait_for(lambda: "release" in order)
+            assert order == ["teardown:single_node", "release"]
+        finally:
+            engine.event_manager.remove_listener_for_app_event(ExecutionLeaseReleasing, slow_teardown)
+
+    @pytest.mark.asyncio
+    async def test_raising_listener_does_not_block_release(
+        self, engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager, balancer, signal = make_manager(engine, monkeypatch)
+
+        async def broken_teardown(_event: ExecutionLeaseReleasing) -> None:
+            msg = "cache clear failed"
+            raise RuntimeError(msg)
+
+        engine.event_manager.add_listener_to_app_event(ExecutionLeaseReleasing, broken_teardown)
+        try:
+            await manager.gate_execution_start()
+            signal.running = True
+            await asyncio.sleep(0.05)
+            signal.running = False
+
+            await wait_for(lambda: len(balancer.sent("ReleaseExecutionLeaseRequest")) == 1)
+            assert manager.lease_id is None
+        finally:
+            engine.event_manager.remove_listener_for_app_event(ExecutionLeaseReleasing, broken_teardown)
+
+    @pytest.mark.asyncio
+    async def test_hung_listener_is_abandoned_at_timeout(self, engine: Engine, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A wedged teardown must not hold the admission queue forever."""
+        manager, balancer, signal = make_manager(engine, monkeypatch, teardown_timeout_s=0.1)
+
+        async def hung_teardown(_event: ExecutionLeaseReleasing) -> None:
+            await asyncio.sleep(30)
+
+        engine.event_manager.add_listener_to_app_event(ExecutionLeaseReleasing, hung_teardown)
+        try:
+            await manager.gate_execution_start()
+            signal.running = True
+            await asyncio.sleep(0.05)
+            signal.running = False
+
+            await wait_for(lambda: len(balancer.sent("ReleaseExecutionLeaseRequest")) == 1)
+        finally:
+            engine.event_manager.remove_listener_for_app_event(ExecutionLeaseReleasing, hung_teardown)
+
+    @pytest.mark.asyncio
+    async def test_event_carries_the_held_lease_id(self, engine: Engine, monkeypatch: pytest.MonkeyPatch) -> None:
+        manager, _balancer, signal = make_manager(engine, monkeypatch)
+        seen: list[ExecutionLeaseReleasing] = []
+
+        async def observing_teardown(event: ExecutionLeaseReleasing) -> None:
+            seen.append(event)
+
+        engine.event_manager.add_listener_to_app_event(ExecutionLeaseReleasing, observing_teardown)
+        try:
+            await manager.gate_execution_start()
+            granted_lease_id = manager.lease_id
+            signal.running = True
+            await asyncio.sleep(0.05)
+            signal.running = False
+
+            await wait_for(lambda: len(seen) == 1)
+            assert seen[0].lease_id == granted_lease_id
+        finally:
+            engine.event_manager.remove_listener_for_app_event(ExecutionLeaseReleasing, observing_teardown)

--- a/tests/unit/retained_mode/managers/test_execution_lease_manager.py
+++ b/tests/unit/retained_mode/managers/test_execution_lease_manager.py
@@ -41,14 +41,20 @@ class StubBalancer:
         self.requests.append((request_type, payload))
         if request_type == "AcquireExecutionLeaseRequest":
             await self.grant_gate.wait()
+            details = "granted" if "Success" in self.acquire_result_type else "refused by test"
             return {
                 "result_type": self.acquire_result_type,
-                "result_details": "granted" if "Success" in self.acquire_result_type else "refused by test",
+                # The real wire shape: result_details is an unstructured
+                # ResultDetails object nested under the envelope's result key.
+                "result": {"result_details": {"result_details": [{"level": 10, "message": details}]}},
                 "lease_id": payload["lease_id"],
             }
         if request_type == "RenewExecutionLeaseRequest":
-            return {"result_type": self.renew_result_type, "result_details": "renewed"}
-        return {"result_type": f"{request_type.removesuffix('Request')}ResultSuccess", "result_details": "ok"}
+            return {"result_type": self.renew_result_type, "result": {"result_details": "renewed"}}
+        return {
+            "result_type": f"{request_type.removesuffix('Request')}ResultSuccess",
+            "result": {"result_details": "ok"},
+        }
 
     async def send_no_response(self, request_type: str, payload: dict[str, Any]) -> None:
         self.requests.append((request_type, payload))

--- a/tests/unit/retained_mode/managers/test_execution_lease_manager.py
+++ b/tests/unit/retained_mode/managers/test_execution_lease_manager.py
@@ -94,6 +94,9 @@ def make_manager(
     manager = ExecutionLeaseManager(engine=engine)
     balancer = StubBalancer()
     manager.attach_transport(send_request=balancer.send_request, send_no_response=balancer.send_no_response)
+    # The gate requires evidence a balancer is connected (its beacons are the
+    # only connection signal, since it dials in); stamp one for these tests.
+    manager._on_balancer_heartbeat(None)
     return manager, balancer, signal
 
 
@@ -416,3 +419,64 @@ class TestTeardownBroadcast:
             assert seen[0].lease_id == granted_lease_id
         finally:
             engine.event_manager.remove_listener_for_app_event(ExecutionLeaseReleasing, observing_teardown)
+
+
+class TestBalancerLiveness:
+    @pytest.mark.asyncio
+    async def test_gate_fails_fast_when_no_balancer_ever_beaconed(
+        self, engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No beacon = no balancer: refuse with a message, never wait forever."""
+        manager, _, _ = make_manager(engine, monkeypatch)
+        manager._balancer_last_seen = 0.0
+
+        with pytest.raises(RuntimeError, match="no .*load balancer has connected"):
+            await manager.gate_execution_start()
+
+    @pytest.mark.asyncio
+    async def test_monitor_terminates_when_beacons_stop(self, engine: Engine, monkeypatch: pytest.MonkeyPatch) -> None:
+        manager, _, _ = make_manager(engine, monkeypatch)
+        manager.balancer_grace_s = 0.05
+        manager.balancer_timeout_s = 0.1
+        terminated = asyncio.Event()
+
+        async def fake_terminate() -> None:
+            terminated.set()
+
+        monkeypatch.setattr(manager, "_terminate_process", fake_terminate)
+        monitor = asyncio.create_task(manager.run_balancer_liveness_monitor())
+        try:
+            await asyncio.wait_for(terminated.wait(), timeout=2.0)
+        finally:
+            monitor.cancel()
+
+    @pytest.mark.asyncio
+    async def test_fresh_beacons_keep_the_engine_alive(self, engine: Engine, monkeypatch: pytest.MonkeyPatch) -> None:
+        manager, _, _ = make_manager(engine, monkeypatch)
+        manager.balancer_grace_s = 0.05
+        manager.balancer_timeout_s = 0.3
+        terminated = asyncio.Event()
+
+        async def fake_terminate() -> None:
+            terminated.set()
+
+        monkeypatch.setattr(manager, "_terminate_process", fake_terminate)
+        monitor = asyncio.create_task(manager.run_balancer_liveness_monitor())
+
+        async def keep_beaconing() -> None:
+            for _ in range(10):
+                manager._on_balancer_heartbeat(None)
+                await asyncio.sleep(0.08)
+
+        try:
+            await keep_beaconing()
+            assert not terminated.is_set()
+        finally:
+            monitor.cancel()
+
+    @pytest.mark.asyncio
+    async def test_monitor_is_a_noop_when_unmanaged(self, engine: Engine) -> None:
+        engine.config_manager.set_config_value(EXECUTION_LEASE_ENABLED_KEY, value=False)
+        manager = ExecutionLeaseManager(engine=engine)
+
+        await manager.run_balancer_liveness_monitor()  # returns immediately


### PR DESCRIPTION
## Stack

Top of a 3-PR stack implementing managed execution (execution leases) on the engine side. Merge bottom-up.

1. #5308 — the lease protocol events (the wire contract)
2. #5309 — engine-side `ExecutionLeaseManager` + the execution gate
3. **#5310 ← this PR** — memory-teardown broadcast before lease release

## What this is

Serialized admission buys nothing if the previous run's pipelines still occupy VRAM when the next engine is admitted. This PR makes lease release also release memory: the watchdog broadcasts a new engine-internal `ExecutionLeaseReleasing` event and **awaits every listener to completion before** sending `ReleaseExecutionLeaseRequest` — so teardown happens strictly before the next admission.

## How libraries opt in

`abroadcast_app_event` already awaits async listeners via `asyncio.TaskGroup`, so no new registry or per-library request types were needed. A library holding execution-scoped memory (e.g. a diffusion pipeline cache) registers one listener in `after_library_nodes_loaded`:

```python
GriptapeNodes.EventManager().add_listener_to_app_event(
    ExecutionLeaseReleasing, self._clear_pipeline_cache
)
```

…and deregisters it in `before_library_unregistered`. The diffusers / advanced-media registrations land in their own repos, separately.

## Failure isolation

A broken teardown must not hold the admission queue forever:

- **A raising listener** is logged and release proceeds (`TaskGroup`'s `ExceptionGroup` is caught — without this, one failing library teardown would skip release entirely and wedge the queue).
- **A hung listener** is abandoned at `execution_lease.teardown_timeout_s` (default 120s — generous because clearing a multi-GB video pipeline transits components through system RAM and takes real time) and release proceeds, with a loud log that the machine may still hold memory.

`ExecutionLeaseReleasing` carries the held `lease_id` and the acquire's `scope`, and is documented as **engine-internal** — it never crosses to the balancer and is not part of the wire contract.

## Testing

4 new unit tests: listener-completes-before-release ordering (slow async listener), raising listener does not block release, hung listener abandoned at timeout, event carries the held lease id. `make check` clean; full unit suite green (4354 passed).