### PR TITLE
Cancel-while-queued and session-heartbeat lifetime for managed execution

### DIFF
--- a/docs/reference/configuration_reference.md
+++ b/docs/reference/configuration_reference.md
@@ -36,6 +36,7 @@ Workflow execution and processing settings
 | `workflow_execution_mode` | one of `sequential`, `parallel`                        | `"sequential"`  | `GTN_CONFIG_WORKFLOW_EXECUTION_MODE` | Workflow execution mode for node processing. SEQUENTIAL mode uses ParallelResolutionMachine with max_nodes_in_parallel=1 to execute nodes one at a time. PARALLEL mode uses the configured max_nodes_in_parallel value. |
 | `max_nodes_in_parallel`   | integer                                                | `5`             | `GTN_CONFIG_MAX_NODES_IN_PARALLEL`   | Maximum number of nodes executing at a time for parallel execution.                                                                                                                                                     |
 | `worker`                  | object                                                 | (nested object) | n/a (nested; edit config file)       | Nested settings; edit the sub-keys directly in a config file.                                                                                                                                                           |
+| `execution_lease`         | object                                                 | (nested object) | n/a (nested; edit config file)       | Nested settings; edit the sub-keys directly in a config file.                                                                                                                                                           |
 
 ## Storage
 

--- a/src/griptape_nodes/retained_mode/managers/execution_lease_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/execution_lease_manager.py
@@ -44,6 +44,9 @@ from griptape_nodes.retained_mode.managers.settings import (
     EXECUTION_LEASE_BALANCER_TIMEOUT_KEY,
     EXECUTION_LEASE_ENABLED_KEY,
     EXECUTION_LEASE_RENEW_INTERVAL_KEY,
+    EXECUTION_LEASE_SESSION_GRACE_KEY,
+    EXECUTION_LEASE_SESSION_LIFETIME_KEY,
+    EXECUTION_LEASE_SESSION_TIMEOUT_KEY,
     EXECUTION_LEASE_TEARDOWN_TIMEOUT_KEY,
 )
 
@@ -98,6 +101,15 @@ class ExecutionLeaseManager(EngineScoped):
     # sending its first beacon, mirroring the worker heartbeat startup grace.
     DEFAULT_BALANCER_GRACE_S: float = 600.0
 
+    # Session heartbeats cross a LAN from an artist's laptop that may be
+    # briefly busy or suspended, so the timeout tolerates several missed beats
+    # (the worker-local 15s default would be far too aggressive here).
+    DEFAULT_SESSION_TIMEOUT_S: float = 60.0
+
+    # Covers engine boot plus the artist's client connecting and sending its
+    # first heartbeat.
+    DEFAULT_SESSION_GRACE_S: float = 600.0
+
     # After asking the process to shut down gracefully, how long to wait before
     # forcing the exit -- a wedged shutdown must not leave a zombie engine
     # claiming GPU memory on a box the balancer has already given up on.
@@ -112,6 +124,10 @@ class ExecutionLeaseManager(EngineScoped):
         self._lease_id: str | None = None
         self._lease_scope: str = "workflow"
         self._acquire_pending: bool = False
+        # The lease id of the acquire currently waiting for admission, and
+        # whether a cancel has been requested for it (cancel-while-queued).
+        self._pending_lease_id: str | None = None
+        self._pending_cancelled: bool = False
         self._lease_lost: bool = False
         self._state_lock = asyncio.Lock()
 
@@ -139,6 +155,19 @@ class ExecutionLeaseManager(EngineScoped):
             engine.event_manager.add_listener_to_app_event(
                 execution_lease_events.ExecutionBalancerHeartbeatEvent, self._on_balancer_heartbeat
             )
+        self.session_lifetime_enabled: bool = config.get_config_value(
+            EXECUTION_LEASE_SESSION_LIFETIME_KEY, default=False, cast_type=bool
+        )
+        self.session_timeout_s: float = config.get_config_value(
+            EXECUTION_LEASE_SESSION_TIMEOUT_KEY,
+            default=ExecutionLeaseManager.DEFAULT_SESSION_TIMEOUT_S,
+            cast_type=float,
+        )
+        self.session_grace_s: float = config.get_config_value(
+            EXECUTION_LEASE_SESSION_GRACE_KEY,
+            default=ExecutionLeaseManager.DEFAULT_SESSION_GRACE_S,
+            cast_type=float,
+        )
         self.renew_interval_s: float = config.get_config_value(
             EXECUTION_LEASE_RENEW_INTERVAL_KEY,
             default=ExecutionLeaseManager.DEFAULT_RENEW_INTERVAL_S,
@@ -193,24 +222,7 @@ class ExecutionLeaseManager(EngineScoped):
         if not self.enabled:
             return
 
-        if self._transport is None:
-            msg = (
-                "Attempted to start execution on a managed engine. Failed because the "
-                "execution manager (load balancer) link is not connected; this engine "
-                "refuses to run unmanaged. Contact your administrator."
-            )
-            raise RuntimeError(msg)
-
-        # The balancer dials in, so "is it connected" is only observable via
-        # its beacons. Without this check an acquire would wait forever on a
-        # topic nobody is subscribed to -- fail closed with a message instead.
-        if self._balancer_last_seen == 0.0:
-            msg = (
-                "Attempted to start execution on a managed engine. Failed because no "
-                "load balancer has connected to this engine yet; this engine refuses "
-                "to run unmanaged. Contact your administrator."
-            )
-            raise RuntimeError(msg)
+        transport = self._require_admission_authority()
 
         async with self._state_lock:
             if self._acquire_pending:
@@ -223,7 +235,9 @@ class ExecutionLeaseManager(EngineScoped):
                 self._restart_watchdog()
                 return
             self._acquire_pending = True
+            self._pending_cancelled = False
             lease_id = uuid.uuid4().hex
+            self._pending_lease_id = lease_id
 
         request = execution_lease_events.AcquireExecutionLeaseRequest(
             engine_id=self._engine_id(),
@@ -232,7 +246,7 @@ class ExecutionLeaseManager(EngineScoped):
             scope=scope,
         )
         try:
-            result = await self._transport.send_request(type(request).__name__, self._payload_of(request))
+            result = await transport.send_request(type(request).__name__, self._payload_of(request))
         except asyncio.CancelledError:
             # The waiting caller gave up its place in line; tell the balancer.
             await self._send_cancel(lease_id)
@@ -246,6 +260,12 @@ class ExecutionLeaseManager(EngineScoped):
         finally:
             async with self._state_lock:
                 self._acquire_pending = False
+                self._pending_lease_id = None
+
+        async with self._state_lock:
+            acquire_was_cancelled = self._pending_cancelled
+        if acquire_was_cancelled:
+            await self._refuse_cancelled_acquire(result, lease_id)
 
         if result.get("result_type") != execution_lease_events.AcquireExecutionLeaseResultSuccess.__name__:
             msg = f"Attempted to start execution. The execution manager refused: {self._details_of(result)}"
@@ -278,6 +298,75 @@ class ExecutionLeaseManager(EngineScoped):
         async with self._state_lock:
             if self._lease_id is not None:
                 await self._release_locked("returned: execution failed to start")
+
+    async def cancel_pending_acquire(self) -> bool:
+        """Abandon this engine's waiting acquire, if one exists.
+
+        The cancel path for a run still waiting for admission: nothing is
+        running yet, so giving up its place in line IS the cancel. The blocked
+        gate call unblocks when the balancer answers the abandoned acquire;
+        the cancelled mark is the engine-side guard that refuses a grant that
+        raced the cancel (the engine does not trust the balancer to have won
+        that race).
+
+        Returns:
+            Whether a waiting acquire existed to cancel.
+        """
+        if not self.enabled:
+            return False
+        async with self._state_lock:
+            lease_id = self._pending_lease_id
+            if lease_id is None:
+                return False
+            self._pending_cancelled = True
+        await self._send_cancel(lease_id)
+        return True
+
+    def _require_admission_authority(self) -> _LeaseTransport:
+        """Fail closed unless an admission authority is reachable.
+
+        The balancer dials in, so "is it connected" is only observable via its
+        beacons. Without the beacon check an acquire would wait forever on a
+        topic nobody is subscribed to.
+
+        Returns:
+            The attached transport.
+
+        Raises:
+            RuntimeError: When no transport is attached or no balancer has
+                ever beaconed.
+        """
+        if self._transport is None:
+            msg = (
+                "Attempted to start execution on a managed engine. Failed because the "
+                "execution manager (load balancer) link is not connected; this engine "
+                "refuses to run unmanaged. Contact your administrator."
+            )
+            raise RuntimeError(msg)
+        if self._balancer_last_seen == 0.0:
+            msg = (
+                "Attempted to start execution on a managed engine. Failed because no "
+                "load balancer has connected to this engine yet; this engine refuses "
+                "to run unmanaged. Contact your administrator."
+            )
+            raise RuntimeError(msg)
+        return self._transport
+
+    async def _refuse_cancelled_acquire(self, result: dict[str, Any], lease_id: str) -> None:
+        """Refuse a start whose wait was cancelled; hand back a racing grant.
+
+        Raises:
+            RuntimeError: Always -- a cancelled wait never starts.
+        """
+        if result.get("result_type") == execution_lease_events.AcquireExecutionLeaseResultSuccess.__name__:
+            # The grant raced the cancel; hand it back rather than start a
+            # run the artist already cancelled.
+            async with self._state_lock:
+                self._lease_id = lease_id
+                self._lease_lost = False
+                await self._release_locked("returned: cancelled while waiting for admission")
+        msg = "This run was cancelled while it was waiting for its turn to run."
+        raise RuntimeError(msg)
 
     async def _run_pre_release_teardown(self) -> None:
         """Release execution-scoped memory before the lease is returned.
@@ -438,6 +527,38 @@ class ExecutionLeaseManager(EngineScoped):
                     "Load balancer heartbeat lost (%s); this engine is shutting down "
                     "(managed engines do not outlive their admission authority).",
                     f"{elapsed:.0f}s since last beacon" if last_seen else "never connected",
+                )
+                await self._terminate_process()
+                return
+
+    async def run_session_liveness_monitor(self) -> None:
+        """Self-terminate when the artist's session heartbeats stop.
+
+        The other half of a managed engine's lifetime (design section 4.5):
+        the balancer monitor watches the admission authority, this one watches
+        the artist. An engine whose artist went away has no one to serve --
+        heartbeat-driven, not idle-driven, so an open editor doing nothing
+        keeps its engine alive indefinitely, and no heartbeats means no
+        engine even mid-run (the lease releases with teardown on the way out).
+
+        Gated separately from `enabled` because it requires a client actually
+        sending SessionHeartbeatRequest on a cadence; enabling it against a
+        client that never heartbeats would kill every engine at the grace
+        deadline.
+        """
+        if not self.enabled or not self.session_lifetime_enabled:
+            return
+        await asyncio.sleep(self.session_grace_s)
+        poll_s = max(0.05, min(self.session_timeout_s / 3.0, 10.0))
+        while True:
+            await asyncio.sleep(poll_s)
+            last_seen = self.engine.session_manager.last_heartbeat_monotonic
+            elapsed = time.monotonic() - last_seen if last_seen else float("inf")
+            if elapsed > self.session_timeout_s:
+                logger.critical(
+                    "Session heartbeat lost (%s); this engine is shutting down "
+                    "(a managed engine lives only as long as its artist's session).",
+                    f"{elapsed:.0f}s since last heartbeat" if last_seen else "never received one",
                 )
                 await self._terminate_process()
                 return

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -3052,6 +3052,13 @@ class FlowManager(EngineScoped):
             details = f"Could not cancel flow execution. Error: {err}"
 
             return CancelFlowResultFailure(result_details=details)
+        # Managed execution: a run still waiting for admission has nothing
+        # live to cancel -- abandoning its place in line is the cancel.
+        if await self.engine.execution_lease_manager.cancel_pending_acquire():
+            details = (
+                f"Successfully cancelled flow execution with name {flow_name} while it was waiting for its turn to run."
+            )
+            return CancelFlowResultSuccess(result_details=details)
         try:
             await self.cancel_flow_run()
         except Exception as e:

--- a/src/griptape_nodes/retained_mode/managers/session_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/session_manager.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
@@ -74,6 +75,10 @@ class SessionManager:
         self._engine_identity_manager = engine_identity_manager
         self._sessions_data = self._load_sessions_data()
         self._active_session_id = self._get_or_initialize_active_session()
+        # Monotonic timestamp of the last SessionHeartbeatRequest; 0.0 = never.
+        # Read by ExecutionLeaseManager's session liveness monitor, which ends
+        # a managed engine whose artist stopped heartbeating.
+        self.last_heartbeat_monotonic: float = 0.0
         BaseEvent._session_id = self._active_session_id
         if event_manager is not None:
             event_manager.assign_manager_to_request_type(AppStartSessionRequest, self.handle_session_start_request)
@@ -312,7 +317,8 @@ class SessionManager:
     def handle_session_heartbeat_request(self, request: SessionHeartbeatRequest) -> ResultPayload:  # noqa: ARG002
         """Handle session heartbeat requests.
 
-        Simply verifies that the session is active and responds with success.
+        Verifies that the session is active, stamps the liveness timestamp the
+        session liveness monitor watches, and responds with success.
         """
         try:
             active_session_id = self.active_session_id
@@ -321,6 +327,7 @@ class SessionManager:
                 logger.warning(details)
                 return SessionHeartbeatResultFailure(result_details=details)
 
+            self.last_heartbeat_monotonic = time.monotonic()
             details = f"Session heartbeat successful for session: {active_session_id}"
             return SessionHeartbeatResultSuccess(result_details=details)
         except Exception as err:

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -37,6 +37,16 @@ EXECUTION_LEASE_TEARDOWN_TIMEOUT_KEY = "execution_lease.teardown_timeout_s"
 # startup grace covers engine boot + balancer linking before enforcement.
 EXECUTION_LEASE_BALANCER_TIMEOUT_KEY = "execution_lease.balancer_heartbeat_timeout_s"
 EXECUTION_LEASE_BALANCER_GRACE_KEY = "execution_lease.balancer_startup_grace_s"
+# Session-heartbeat lifetime: a managed engine lives exactly as long as its
+# artist's session heartbeats keep arriving -- no heartbeats past the timeout,
+# no engine (its run dies with it; the lease releases with teardown on the way
+# out). Off by default until clients send SessionHeartbeatRequest on a cadence;
+# the timeout is deliberately conservative because the heartbeats cross a LAN
+# from a laptop that may be briefly busy or suspended -- a single missed beat
+# must never kill an engine.
+EXECUTION_LEASE_SESSION_LIFETIME_KEY = "execution_lease.session_lifetime_enabled"
+EXECUTION_LEASE_SESSION_TIMEOUT_KEY = "execution_lease.session_heartbeat_timeout_s"
+EXECUTION_LEASE_SESSION_GRACE_KEY = "execution_lease.session_startup_grace_s"
 DISCOVERY_MAX_DEPTH_KEY = "discovery_max_depth"
 # The `Settings.libraries_directory` field below, named here so every reader of it -- the live
 # libraries root, the provisioning preview, the offline libraries-root resolver, and the packager --

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -310,6 +310,79 @@ class WorkerSettings(BaseModel):
     )
 
 
+class ExecutionLeaseSettings(BaseModel):
+    """Managed execution on a shared machine (execution leases).
+
+    When enabled, this engine asks an external admission authority (the load
+    balancer) for an execution lease before starting any node or workflow run,
+    so several artists' engines on one GPU machine take turns instead of
+    fighting for memory. Defaults here must match ExecutionLeaseManager's.
+    """
+
+    enabled: bool = Field(
+        default=False,
+        description=(
+            "Acquire an execution lease from the load balancer before starting any node or "
+            "workflow run, and refuse to run if the balancer is unreachable (fail closed). "
+            "Leave off for a standalone engine; brokered engines on a shared GPU machine "
+            "run with this on."
+        ),
+    )
+    renew_interval_s: float = Field(
+        default=30.0,
+        description="Interval in seconds between lease renewals while a run is in flight.",
+    )
+    teardown_timeout_s: float = Field(
+        default=120.0,
+        description=(
+            "Ceiling in seconds on the memory teardown that runs before a lease is released. "
+            "Generous by default -- clearing a multi-gigabyte pipeline takes real time -- but "
+            "bounded, so a wedged teardown cannot hold the admission queue forever."
+        ),
+    )
+    balancer_heartbeat_timeout_s: float = Field(
+        default=30.0,
+        description=(
+            "Seconds without a load-balancer beacon before this engine shuts itself down. "
+            "A managed engine does not outlive its admission authority: it cannot run "
+            "without one and would only hold memory."
+        ),
+    )
+    balancer_startup_grace_s: float = Field(
+        default=600.0,
+        description=(
+            "Grace period in seconds after engine start before balancer beacons are "
+            "required. Covers library loading and the balancer connecting and sending "
+            "its first beacon."
+        ),
+    )
+    session_lifetime_enabled: bool = Field(
+        default=False,
+        description=(
+            "End this engine when its artist's session heartbeats stop. Requires a client "
+            "that sends SessionHeartbeatRequest on a cadence; enabling it without one kills "
+            "the engine when the startup grace expires."
+        ),
+    )
+    session_heartbeat_timeout_s: float = Field(
+        default=60.0,
+        description=(
+            "Seconds without a session heartbeat before this engine shuts itself down. "
+            "Deliberately conservative: heartbeats cross the network from an artist's "
+            "machine that may be briefly busy or suspended, and a single missed beat "
+            "must never end a session."
+        ),
+    )
+    session_startup_grace_s: float = Field(
+        default=600.0,
+        description=(
+            "Grace period in seconds after engine start before session heartbeats are "
+            "required. Covers library loading plus the artist's client connecting and "
+            "sending its first heartbeat."
+        ),
+    )
+
+
 class AgentSettings(BaseModel):
     system_prompt: str = Field(
         default="",
@@ -451,6 +524,10 @@ class Settings(BaseModel):
     worker: WorkerSettings = Field(
         category=EXECUTION,
         default_factory=WorkerSettings,
+    )
+    execution_lease: ExecutionLeaseSettings = Field(
+        category=EXECUTION,
+        default_factory=ExecutionLeaseSettings,
     )
     storage_backend: Literal["local", "gtc"] = Field(
         category=STORAGE,

--- a/tests/unit/retained_mode/managers/test_execution_lease_manager.py
+++ b/tests/unit/retained_mode/managers/test_execution_lease_manager.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
+from griptape_nodes.retained_mode.events.app_events import SessionHeartbeatRequest
 from griptape_nodes.retained_mode.events.execution_lease_events import ExecutionLeaseReleasing
 from griptape_nodes.retained_mode.managers.execution_lease_manager import ExecutionLeaseManager
 from griptape_nodes.retained_mode.managers.settings import (
@@ -220,6 +221,84 @@ class TestAcquire:
         await wait_for(lambda: len(balancer.sent("CancelExecutionLeaseRequest")) == 1)
         assert balancer.sent("CancelExecutionLeaseRequest")[0]["lease_id"] == minted_lease_id
         assert manager.lease_id is None
+
+
+class TestCancelWhileQueued:
+    @pytest.mark.asyncio
+    async def test_cancel_with_no_pending_acquire_returns_false(
+        self, engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager, balancer, _ = make_manager(engine, monkeypatch)
+
+        assert await manager.cancel_pending_acquire() is False
+        assert len(balancer.sent("CancelExecutionLeaseRequest")) == 0
+
+    @pytest.mark.asyncio
+    async def test_cancel_is_a_noop_when_unmanaged(self, engine: Engine) -> None:
+        engine.config_manager.set_config_value(EXECUTION_LEASE_ENABLED_KEY, value=False)
+        manager = ExecutionLeaseManager(engine=engine)
+
+        assert await manager.cancel_pending_acquire() is False
+
+    @pytest.mark.asyncio
+    async def test_cancel_unblocks_the_waiting_gate(self, engine: Engine, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Cancel-while-queued: the blocked gate resolves as a refused start."""
+        manager, balancer, _ = make_manager(engine, monkeypatch)
+        balancer.grant_gate.clear()  # acquire waits in line
+
+        gate_task = asyncio.create_task(manager.gate_execution_start())
+        await wait_for(lambda: len(balancer.sent("AcquireExecutionLeaseRequest")) == 1)
+        minted_lease_id = balancer.sent("AcquireExecutionLeaseRequest")[0]["lease_id"]
+
+        assert await manager.cancel_pending_acquire() is True
+        assert balancer.sent("CancelExecutionLeaseRequest")[0]["lease_id"] == minted_lease_id
+        # The real balancer answers the abandoned acquire with a failure.
+        balancer.acquire_result_type = "AcquireExecutionLeaseResultFailure"
+        balancer.grant_gate.set()
+
+        with pytest.raises(RuntimeError, match="cancelled while it was waiting"):
+            await gate_task
+        assert manager.lease_id is None
+
+    @pytest.mark.asyncio
+    async def test_grant_racing_the_cancel_is_handed_back(
+        self, engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A grant that lands after the cancel must be returned, never run."""
+        manager, balancer, _ = make_manager(engine, monkeypatch)
+        balancer.grant_gate.clear()
+
+        gate_task = asyncio.create_task(manager.gate_execution_start())
+        await wait_for(lambda: len(balancer.sent("AcquireExecutionLeaseRequest")) == 1)
+
+        assert await manager.cancel_pending_acquire() is True
+        balancer.grant_gate.set()  # balancer grants anyway: the race the engine must not trust
+
+        with pytest.raises(RuntimeError, match="cancelled while it was waiting"):
+            await gate_task
+        assert manager.lease_id is None
+        assert len(balancer.sent("ReleaseExecutionLeaseRequest")) == 1
+
+    @pytest.mark.asyncio
+    async def test_gate_works_again_after_a_cancelled_wait(
+        self, engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager, balancer, _ = make_manager(engine, monkeypatch)
+        balancer.grant_gate.clear()
+
+        gate_task = asyncio.create_task(manager.gate_execution_start())
+        await wait_for(lambda: len(balancer.sent("AcquireExecutionLeaseRequest")) == 1)
+        assert await manager.cancel_pending_acquire() is True
+        balancer.acquire_result_type = "AcquireExecutionLeaseResultFailure"
+        balancer.grant_gate.set()
+        with pytest.raises(RuntimeError, match="cancelled while it was waiting"):
+            await gate_task
+
+        balancer.acquire_result_type = "AcquireExecutionLeaseResultSuccess"
+        await manager.gate_execution_start()
+
+        assert manager.lease_id is not None
+        manager._cancel_watchdog()
 
 
 class TestWatchdogRelease:
@@ -480,3 +559,70 @@ class TestBalancerLiveness:
         manager = ExecutionLeaseManager(engine=engine)
 
         await manager.run_balancer_liveness_monitor()  # returns immediately
+
+
+class TestSessionLiveness:
+    @pytest.mark.asyncio
+    async def test_heartbeat_handler_stamps_liveness(self, engine: Engine) -> None:
+        engine.session_manager.active_session_id = "test-session"
+        assert engine.session_manager.last_heartbeat_monotonic == 0.0
+
+        result = engine.session_manager.handle_session_heartbeat_request(SessionHeartbeatRequest())
+
+        assert result.succeeded()
+        assert engine.session_manager.last_heartbeat_monotonic > 0.0
+
+    @pytest.mark.asyncio
+    async def test_monitor_is_a_noop_unless_session_lifetime_enabled(
+        self, engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Lease-managed alone is not enough: the client must be known to heartbeat."""
+        manager, _, _ = make_manager(engine, monkeypatch)
+        assert manager.session_lifetime_enabled is False
+
+        await manager.run_session_liveness_monitor()  # returns immediately
+
+    @pytest.mark.asyncio
+    async def test_monitor_terminates_when_heartbeats_stop(
+        self, engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager, _, _ = make_manager(engine, monkeypatch)
+        manager.session_lifetime_enabled = True
+        manager.session_grace_s = 0.05
+        manager.session_timeout_s = 0.1
+        terminated = asyncio.Event()
+
+        async def fake_terminate() -> None:
+            terminated.set()
+
+        monkeypatch.setattr(manager, "_terminate_process", fake_terminate)
+        monitor = asyncio.create_task(manager.run_session_liveness_monitor())
+        try:
+            await asyncio.wait_for(terminated.wait(), timeout=2.0)
+        finally:
+            monitor.cancel()
+
+    @pytest.mark.asyncio
+    async def test_fresh_heartbeats_keep_the_engine_alive(
+        self, engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager, _, _ = make_manager(engine, monkeypatch)
+        manager.session_lifetime_enabled = True
+        manager.session_grace_s = 0.05
+        manager.session_timeout_s = 0.3
+        engine.session_manager.active_session_id = "test-session"
+        terminated = asyncio.Event()
+
+        async def fake_terminate() -> None:
+            terminated.set()
+
+        monkeypatch.setattr(manager, "_terminate_process", fake_terminate)
+        monitor = asyncio.create_task(manager.run_session_liveness_monitor())
+
+        try:
+            for _ in range(10):
+                engine.session_manager.handle_session_heartbeat_request(SessionHeartbeatRequest())
+                await asyncio.sleep(0.08)
+            assert not terminated.is_set()
+        finally:
+            monitor.cancel()


### PR DESCRIPTION
Stacked on #5310 (lease teardown + balancer liveness). Part of the cross-engine execution admission work; adds two lease-lifecycle behaviors (design §5.4 cancel relay, §4.5 engine lifetime).

## Cancel-while-queued (E4)

An artist whose run is waiting for admission had no way out: \`CancelFlowRequest\` failed with "flow has not begun" because nothing is running yet — the request is blocked inside the gate.

- \`ExecutionLeaseManager.cancel_pending_acquire()\`: abandons the waiting acquire by sending \`CancelExecutionLeaseRequest\` (fire-and-forget, SkipTheLine) and marking the pending acquire cancelled.
- \`on_cancel_flow_request\` tries it before \`cancel_flow_run()\`: a queued run's cancel returns success ("…while it was waiting for its turn to run"), covering both workflow and single-node cold starts.
- The blocked gate unblocks when the balancer answers the abandoned acquire with a failure (balancer-side change, in the balancer repo). Engine-side guard for the race: a grant that lands after the cancel is handed straight back (\`_refuse_cancelled_acquire\`) — the engine does not trust the balancer to have processed the cancel first.

## Session-heartbeat lifetime (E5)

Design §4.5: a managed engine lives exactly as long as its artist's session heartbeats keep arriving — heartbeat-driven, not idle-driven, and a mid-run loss kills the run (lease releases with teardown via the normal SIGTERM path).

- \`SessionManager\` stamps \`last_heartbeat_monotonic\` on every \`SessionHeartbeatRequest\` (previously the handler recorded nothing — the "dead wiring" the design calls out).
- \`ExecutionLeaseManager.run_session_liveness_monitor()\` sits beside the balancer monitor ("both monitors coexist": one watches the artist, one watches the admission authority) and self-terminates via the process's own signal handlers, escalating to a hard exit if shutdown wedges.
- New settings: \`execution_lease.session_lifetime_enabled\` (default **off** — enabling it against a client that never heartbeats would kill every engine at the grace deadline; flips when the GUI sender lands), \`session_heartbeat_timeout_s\` (60s — LAN-conservative, several missed beats survivable), \`session_startup_grace_s\` (600s).

## Verification

- \`make check\` clean; full suite 4367 passed (9 new tests: 5 cancel, 4 session).
- E2E, real dev stack: **cancel-while-queued 7/7** — run queued behind a held lease, \`CancelFlowRequest\` → success with the waiting message, blocked resolve unblocked as a refused start (no hang), fresh run executed after release. **Session lifetime 4/4** — heartbeats every 3s kept the engine alive past the 25s grace; going silent killed it 11s after the last beat (10s timeout), graceful exit 0, log: "Session heartbeat lost (11s since last heartbeat); this engine is shutting down".

## Notes

- The GUI sending \`SessionHeartbeatRequest\` on a cadence is the remaining (frontend) half of E5; until then the feature is dark behind its own setting.
- Companion balancer commit: cancel of a waiting acquire now answers the deferred acquire responder with a failure instead of dropping it silently.