### PR TITLE
Node groups can nest inside node groups

### DIFF
--- a/docs/guides/editor/node_groups.md
+++ b/docs/guides/editor/node_groups.md
@@ -111,6 +111,36 @@ wall parameter rather than getting one each.
 A plain **Group** doesn't do any of this — it has no subflow to wall off, so
 connections just pass straight through its boundary.
 
+## Nesting groups inside groups
+
+A group can hold another group, as deeply as you like. Drop a group onto
+another group's body, or select a group along with other nodes and press
+`Cmd/Ctrl+G`, and the inner group becomes a child of the outer one — carrying
+everything already inside it along with it.
+
+Nesting is how you break a large flow into readable layers: a ForEach Group
+whose body is itself a Subflow Node Group, say, so each iteration runs a
+named cluster of work instead of a sprawl of loose nodes.
+
+Everything a single group does applies at each level. Running the outer group
+runs the inner ones as part of it, so you don't need to run them separately.
+Collapsing, rolling up, and **Fit to nodes** each act on the group you invoke
+them on, leaving whatever is nested inside untouched.
+
+Connections nest the same way. A connection from outside the outer group to a
+node buried two levels down passes through a wall parameter on *each* group it
+crosses, so you can trace the value inward one boundary at a time. Connections
+that stay entirely within one group don't get wall parameters, no matter how
+deeply that group is nested — only crossing a boundary creates one.
+
+**Ungroup** peels off one layer at a time. Ungrouping the outer group leaves
+the inner group intact and drops it, still holding its children, onto the
+canvas where it was. Deleting a group does the same to whatever it held.
+
+The one arrangement the editor won't allow is a group that ends up inside
+itself — dropping a group into one of its own descendants is refused, since
+there would be no outermost group left to run.
+
 ## Collapsing and rolling up
 
 Click the chevron in a group's header to **collapse** it. A collapsed group

--- a/src/griptape_nodes/exe_types/node_groups/__init__.py
+++ b/src/griptape_nodes/exe_types/node_groups/__init__.py
@@ -3,7 +3,12 @@
 from .base_iterative_node_group import BaseIterativeNodeGroup, IterationControlParam
 from .base_node_group import BaseNodeGroup
 from .base_while_node_group import BaseWhileNodeGroup, WhileControlParam
-from .subflow_node_group import LEFT_PARAMETERS_KEY, RIGHT_PARAMETERS_KEY, SubflowNodeGroup
+from .subflow_node_group import (
+    LEFT_PARAMETERS_KEY,
+    RIGHT_PARAMETERS_KEY,
+    NodeGroupMembershipError,
+    SubflowNodeGroup,
+)
 
 __all__ = [
     "LEFT_PARAMETERS_KEY",
@@ -12,6 +17,7 @@ __all__ = [
     "BaseNodeGroup",
     "BaseWhileNodeGroup",
     "IterationControlParam",
+    "NodeGroupMembershipError",
     "SubflowNodeGroup",
     "WhileControlParam",
 ]

--- a/src/griptape_nodes/exe_types/node_groups/base_node_group.py
+++ b/src/griptape_nodes/exe_types/node_groups/base_node_group.py
@@ -183,6 +183,27 @@ class BaseNodeGroup(BaseNode):
                 msg = f"Node {node.name} is not in node group {self.name}"
                 raise ValueError(msg)
 
+    def handle_child_node_rename(self, old_name: str, new_name: str) -> None:
+        """Update group membership when a child node is renamed.
+
+        Args:
+            old_name: The old name of the child node
+            new_name: The new name of the child node
+        """
+        if old_name not in self.nodes:
+            return
+
+        # Update the nodes dictionary
+        node = self.nodes.pop(old_name)
+        self.nodes[new_name] = node
+
+        # Update the metadata
+        node_names_in_group = self.metadata.get("node_names_in_group", [])
+        if old_name in node_names_in_group:
+            node_names_in_group.remove(old_name)
+            node_names_in_group.append(new_name)
+            self.metadata["node_names_in_group"] = node_names_in_group
+
     @staticmethod
     def get_enclosing_groups(node: BaseNode) -> list[BaseNodeGroup]:
         """Walk the parent_group chain and return every group enclosing the node, innermost first.
@@ -206,24 +227,3 @@ class BaseNodeGroup(BaseNode):
             visited.add(id(current))
             current = current.parent_group
         return enclosing_groups
-
-    def handle_child_node_rename(self, old_name: str, new_name: str) -> None:
-        """Update group membership when a child node is renamed.
-
-        Args:
-            old_name: The old name of the child node
-            new_name: The new name of the child node
-        """
-        if old_name not in self.nodes:
-            return
-
-        # Update the nodes dictionary
-        node = self.nodes.pop(old_name)
-        self.nodes[new_name] = node
-
-        # Update the metadata
-        node_names_in_group = self.metadata.get("node_names_in_group", [])
-        if old_name in node_names_in_group:
-            node_names_in_group.remove(old_name)
-            node_names_in_group.append(new_name)
-            self.metadata["node_names_in_group"] = node_names_in_group

--- a/src/griptape_nodes/exe_types/node_groups/base_node_group.py
+++ b/src/griptape_nodes/exe_types/node_groups/base_node_group.py
@@ -166,7 +166,7 @@ class BaseNodeGroup(BaseNode):
         """
         for node in nodes:
             if node is self:
-                msg = f"Cannot add group '{self.name}' to itself."
+                msg = f"Attempted to add group '{self.name}' to itself. Failed because a group cannot contain itself."
                 raise ValueError(msg)
             if isinstance(node, BaseNodeGroup) and node.contains_node(self):
                 msg = (

--- a/src/griptape_nodes/exe_types/node_groups/base_node_group.py
+++ b/src/griptape_nodes/exe_types/node_groups/base_node_group.py
@@ -72,12 +72,27 @@ class BaseNodeGroup(BaseNode):
         Returns:
             The nodes actually added, including any extra nodes a previous owner released.
         """
+        # Reject impossible nesting before detaching anything: _remove_nodes_from_existing_parents
+        # mutates the previous owner, so validating after it would leave a rejected add having
+        # already ejected the nodes from the group that held them.
+        self._validate_nodes_can_be_nested(nodes)
         nodes = nodes + self._remove_nodes_from_existing_parents(nodes)
         self._add_nodes_to_group_dict(nodes)
 
         self.metadata["node_names_in_group"] = list(self.nodes.keys())
 
         return nodes
+
+    def contains_node(self, node: BaseNode) -> bool:
+        """Whether this group holds the node directly, or inside a group nested within it.
+
+        Args:
+            node: The node to look for
+
+        Returns:
+            True if the node is anywhere inside this group's nesting tree
+        """
+        return self in self.get_enclosing_groups(node)
 
     def remove_nodes_from_group(self, nodes: list[BaseNode]) -> list[BaseNode]:
         """Remove nodes from this group.
@@ -137,12 +152,60 @@ class BaseNodeGroup(BaseNode):
             node.parent_group = self
             self.nodes[node.name] = node
 
+    def _validate_nodes_can_be_nested(self, nodes: list[BaseNode]) -> None:
+        """Reject additions that would make a group contain itself.
+
+        Nesting a group inside one of its own descendants (or inside itself) would create a
+        cycle in the parent_group chain, which every ancestor walk would then traverse forever.
+
+        Args:
+            nodes: The nodes about to be added
+
+        Raises:
+            ValueError: If any node is this group itself or one of its ancestors
+        """
+        for node in nodes:
+            if node is self:
+                msg = f"Cannot add group '{self.name}' to itself."
+                raise ValueError(msg)
+            if isinstance(node, BaseNodeGroup) and node.contains_node(self):
+                msg = (
+                    f"Attempted to add group '{node.name}' to group '{self.name}'. "
+                    f"Failed because '{self.name}' is already inside '{node.name}', "
+                    f"and a group cannot contain itself."
+                )
+                raise ValueError(msg)
+
     def _validate_nodes_in_group(self, nodes: list[BaseNode]) -> None:
         """Validate that all nodes are in the group."""
         for node in nodes:
             if node.name not in self.nodes:
                 msg = f"Node {node.name} is not in node group {self.name}"
                 raise ValueError(msg)
+
+    @staticmethod
+    def get_enclosing_groups(node: BaseNode) -> list[BaseNodeGroup]:
+        """Walk the parent_group chain and return every group enclosing the node, innermost first.
+
+        Membership in a nested group is transitive: a node inside an inner group is also inside
+        every group wrapping it. Callers that only inspect ``node.parent_group`` see the innermost
+        group alone and treat the outer ones as external, so they must use this instead.
+
+        Args:
+            node: The node whose enclosing groups are wanted
+
+        Returns:
+            The enclosing groups, innermost first (empty if the node is not in a group)
+        """
+        enclosing_groups: list[BaseNodeGroup] = []
+        # Guard against a malformed parent_group cycle rather than looping forever.
+        visited: set[int] = {id(node)}
+        current = node.parent_group
+        while isinstance(current, BaseNodeGroup) and id(current) not in visited:
+            enclosing_groups.append(current)
+            visited.add(id(current))
+            current = current.parent_group
+        return enclosing_groups
 
     def handle_child_node_rename(self, old_name: str, new_name: str) -> None:
         """Update group membership when a child node is renamed.

--- a/src/griptape_nodes/exe_types/node_groups/subflow_node_group.py
+++ b/src/griptape_nodes/exe_types/node_groups/subflow_node_group.py
@@ -102,16 +102,20 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         self._add_subflow_execution_parameters()
 
     def _create_subflow(self) -> None:
-        """Create a dedicated subflow for this NodeGroup's nodes.
+        """Create the dedicated subflow that will hold this NodeGroup's nodes.
 
-        Note: This is called during __init__, so the node may not yet be added to a flow.
-        The subflow will be created without a parent initially, and can be reparented later.
+        Called on demand from add_nodes_to_group, the first time this group is given anything to
+        hold, so the group already knows where it lives and which group (if any) encloses it. That
+        is what lets _get_subflow_parent_flow_name put the subflow in the right place immediately
+        rather than parenting it arbitrarily and reparenting it later.
+
+        Raises:
+            RuntimeError: If the subflow could not be created
         """
         from griptape_nodes.retained_mode.events.flow_events import (
             CreateFlowRequest,
             CreateFlowResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         subflow_name = f"{self.name}_subflow"
         self.metadata["subflow_name"] = subflow_name
@@ -130,8 +134,10 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             # Drop the name we optimistically recorded: no such flow exists, and leaving it set
             # makes every later lookup point at a phantom flow.
             self.metadata.pop("subflow_name", None)
+            # The engine-side detail goes to the log; the raised message stays readable, since it
+            # surfaces in the editor as the reason the group could not be filled.
             logger.warning("%s failed to create subflow '%s': %s", self.name, subflow_name, result.result_details)
-            msg = f"Attempted to create the group '{self.name}'. Failed because {result.result_details}"
+            msg = f"Attempted to create the group '{self.name}'. Failed because the space to hold its nodes could not be created."
             raise RuntimeError(msg)  # noqa: TRY004 - the request failed at runtime; this is not a type error.
 
         # Final name may be different that initial name due to de-dupe.
@@ -782,15 +788,20 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         return expanded
 
     def _nest_subflow_of(self, node: BaseNode, parent_subflow_name: str) -> None:
-        """Reparent a nested group's own subflow under this group's subflow.
+        """Move a nested group's own subflow so it sits under the flow now holding the group.
 
-        Keeps the flow hierarchy mirroring the group nesting. Without this the inner group's
-        subflow stays parented to whatever flow was current when it was created, so saving walks
-        right past it and the inner group's members are lost on load.
+        Keeps the flow hierarchy mirroring the group nesting, in both directions: when a group is
+        added, its subflow moves under this group's subflow; when it is removed, its subflow moves
+        back out to this group's parent flow. Without this the inner group's subflow stays parented
+        to whatever flow was current when it was created, so saving walks right past it and the inner
+        group's members are lost on load.
 
         Args:
-            node: The node just added to this group; only groups own a subflow
-            parent_subflow_name: This group's subflow, which should become the parent
+            node: The node whose membership just changed; only groups own a subflow
+            parent_subflow_name: The flow that should now own that group's subflow
+
+        Raises:
+            ValueError: If the nested group's subflow could not be moved
         """
         if not isinstance(node, SubflowNodeGroup):
             return
@@ -800,16 +811,17 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             # The nested group has no subflow yet; it will be created under this one on first add.
             return
 
+        # Deliberately not swallowed: a group whose subflow was not moved still looks right in the
+        # editor but loses its contents on save, so the caller has to hear about it. Both callers
+        # turn this into a failure result (see NodeManager.on_add_nodes_to_node_group_request).
         try:
             GriptapeNodes.FlowManager().reparent_flow(child_subflow_name, parent_subflow_name)
-        except ValueError:
-            logger.exception(
-                "%s could not nest subflow '%s' of group '%s' under '%s'",
-                self.name,
-                child_subflow_name,
-                node.name,
-                parent_subflow_name,
+        except ValueError as err:
+            msg = (
+                f"Attempted to change what group '{node.name}' belongs to. "
+                f"Failed because its contents could not be moved to '{parent_subflow_name}': {err}"
             )
+            raise ValueError(msg) from err
 
     def _map_external_connections_for_nodes(
         self, nodes: list[BaseNode], connections: Connections, node_names_in_group: set[str]

--- a/src/griptape_nodes/exe_types/node_groups/subflow_node_group.py
+++ b/src/griptape_nodes/exe_types/node_groups/subflow_node_group.py
@@ -54,6 +54,17 @@ LEFT_PARAMETERS_KEY = "left_parameters"
 RIGHT_PARAMETERS_KEY = "right_parameters"
 
 
+class NodeGroupMembershipError(Exception):
+    """A group could not take on or release a node.
+
+    Changing a subflow group's membership means moving nodes between Flows, and any of those moves
+    can be refused. Raising this specific type lets the rollback paths catch exactly the failures
+    the moves report, rather than every ValueError coming out of the request handlers they call
+    into. The message is user-facing and reaches the editor as the reason the change was refused,
+    so phrase it as "Attempted to X. Failed because Y."
+    """
+
+
 class SubflowNodeGroup(BaseNodeGroup, ABC):
     """Abstract base class for subflow node groups.
 
@@ -719,7 +730,8 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             nodes a previous owner released alongside them.
 
         Raises:
-            ValueError: If the nodes cannot be nested, or could not all be moved into the group
+            ValueError: If the nodes cannot be nested
+            NodeGroupMembershipError: If the nodes could not all be moved into the group
         """
         # Pull in companions this group does not already hold, so a Start/End pair joins together.
         nodes = self._expand_with_tethered_nodes(nodes, companion_must_be_member=False)
@@ -740,7 +752,15 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         self._add_nodes_to_group_dict(nodes)
 
         if subflow_name is not None:
-            self._move_nodes_into_subflow(nodes, subflow_name=subflow_name)
+            try:
+                self._relocate_nodes(
+                    nodes, destination_flow_name=subflow_name, rollback_flow_name=self.parent_flow_name
+                )
+            except NodeGroupMembershipError:
+                # The moves already rolled themselves back; this group still has to stop claiming
+                # nodes it does not hold, or it advertises members that are not in its subflow.
+                self._drop_membership(nodes)
+                raise
 
         connections = GriptapeNodes.FlowManager().get_connections()
         node_names_in_group = set(self.nodes.keys())
@@ -780,67 +800,43 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
 
         return expanded
 
-    def _move_nodes_into_subflow(self, nodes: list[BaseNode], subflow_name: str) -> None:
-        """Move every node into this group's subflow, or leave the group as it was found.
+    def _relocate_nodes(
+        self, nodes: list[BaseNode], destination_flow_name: str, rollback_flow_name: str | None
+    ) -> None:
+        """Move every node into one flow, or put back whatever moved and report the failure.
 
-        Membership was already recorded by the time this runs, so a node that fails to move halfway
-        through would leave the group claiming nodes that still live in their old flow. The editor
-        would show them inside the group while a save wrote them outside it. Undoing the moves that
-        did succeed keeps the reported failure honest: nothing moved, so nothing is half-owned.
+        Both directions of a membership change are the same move: adding sends the nodes into this
+        group's subflow, removing sends them back out to the flow holding the group, and either way a
+        node that is itself a group brings its own subflow along. Neither direction may stop halfway.
+        A half-applied move leaves the group and the flow hierarchy disagreeing about where a node
+        lives, which the editor draws one way and a save writes the other.
 
         Args:
-            nodes: The nodes to move, already registered as members of this group
-            subflow_name: This group's subflow, which should end up holding them all
+            nodes: The nodes to move, all of which end up in the destination or none do
+            destination_flow_name: The flow that should hold them all afterwards
+            rollback_flow_name: The flow they came from, to put them back in if the move fails, or
+                None if it could not be determined — then a failed move is only logged, since there
+                is nowhere to put them back
 
         Raises:
-            ValueError: If any node could not be moved into the subflow
+            NodeGroupMembershipError: If any node could not be moved, after the successful moves
+                have been undone
         """
         moved_nodes: list[BaseNode] = []
-        for node in nodes:
-            try:
-                self._move_node_to_flow(node, flow_name=subflow_name)
-            except ValueError:
-                self._abandon_add(nodes, moved_nodes=moved_nodes)
-                raise
-            moved_nodes.append(node)
+        try:
+            for node in nodes:
+                self._move_node_to_flow(node, flow_name=destination_flow_name)
+                moved_nodes.append(node)
 
-        # Only nest the inner groups once every member is where it belongs, so a failure above has
-        # not yet disturbed the flow hierarchy.
-        for node in nodes:
-            try:
-                self._nest_subflow_of(node, parent_subflow_name=subflow_name)
-            except ValueError:
-                self._abandon_add(nodes, moved_nodes=moved_nodes)
-                raise
+            # Nest the inner groups only once every node is where it belongs, so a failed move above
+            # has not yet disturbed the flow hierarchy.
+            for node in nodes:
+                self._nest_subflow_of(node, parent_subflow_name=destination_flow_name)
+        except NodeGroupMembershipError:
+            self._move_nodes_back(moved_nodes, destination_flow_name=rollback_flow_name)
+            raise
 
-    def _abandon_add(self, nodes: list[BaseNode], moved_nodes: list[BaseNode]) -> None:
-        """Drop the membership this add recorded, and put whatever moved back where it came from.
-
-        The nodes are dropped from this group whether or not their move back succeeds: the add is
-        failing, so claiming them would be a lie either way. A node that was in another group before
-        the add is left group-less rather than returned to it, since that group has already released
-        it -- the artist has to drag it back in.
-
-        Args:
-            nodes: Every node this add tried to take on, all of which lose their membership
-            moved_nodes: The subset already moved into this group's subflow, which has to move back
-        """
-        parent_flow_name = self._get_parent_flow_name()
-        if parent_flow_name is not None:
-            self._move_nodes_back(moved_nodes, destination_flow_name=parent_flow_name)
-        else:
-            logger.error(
-                "%s could not find its own flow, so %d node(s) may be left inside the group after a failed add",
-                self.name,
-                len(moved_nodes),
-            )
-
-        for node in nodes:
-            node.parent_group = None
-            self.nodes.pop(node.name, None)
-        self.metadata["node_names_in_group"] = list(self.nodes.keys())
-
-    def _move_nodes_back(self, moved_nodes: list[BaseNode], destination_flow_name: str) -> None:
+    def _move_nodes_back(self, moved_nodes: list[BaseNode], destination_flow_name: str | None) -> None:
         """Undo moves after a membership change failed, taking each node's own subflow along.
 
         Best effort by nature: this runs while a membership change is already failing, so a move
@@ -848,12 +844,21 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
 
         Args:
             moved_nodes: The nodes to put back
-            destination_flow_name: The flow they should end up in again
+            destination_flow_name: The flow they should end up in again, or None if it is unknown —
+                then the nodes are left where they are and the situation is logged
         """
+        if destination_flow_name is None:
+            logger.error(
+                "%s could not find the flow to return %d node(s) to, so they may be left in the wrong flow",
+                self.name,
+                len(moved_nodes),
+            )
+            return
+
         for node in moved_nodes:
             try:
                 self._move_node_to_flow(node, flow_name=destination_flow_name)
-            except ValueError:
+            except NodeGroupMembershipError:
                 logger.exception(
                     "%s could not move '%s' back into '%s'; it may be left in the wrong flow",
                     self.name,
@@ -863,13 +868,29 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
                 continue
             try:
                 self._nest_subflow_of(node, parent_subflow_name=destination_flow_name)
-            except ValueError:
+            except NodeGroupMembershipError:
                 logger.exception(
                     "%s moved '%s' back into '%s' but could not move its contents along",
                     self.name,
                     node.name,
                     destination_flow_name,
                 )
+
+    def _drop_membership(self, nodes: list[BaseNode]) -> None:
+        """Stop claiming nodes after an add failed, so the group does not advertise what it lost.
+
+        The nodes are dropped whether or not they made it back to their old flow: the add is failing,
+        so claiming them would be a lie either way. A node that was in another group before the add
+        is left group-less rather than returned to it, since that group has already released it --
+        the artist has to drag it back in.
+
+        Args:
+            nodes: Every node the failed add tried to take on
+        """
+        for node in nodes:
+            node.parent_group = None
+            self.nodes.pop(node.name, None)
+        self.metadata["node_names_in_group"] = list(self.nodes.keys())
 
     def _move_node_to_flow(self, node: BaseNode, flow_name: str) -> None:
         """Move one node into a Flow.
@@ -879,34 +900,18 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             flow_name: The Flow it should end up in
 
         Raises:
-            ValueError: If the engine refused the move
+            NodeGroupMembershipError: If the engine refused the move, carrying the reason it gave
         """
         move_request = MoveNodeToNewFlowRequest(node_name=node.name, target_flow_name=flow_name)
         move_result = GriptapeNodes.handle_request(move_request)
         if not isinstance(move_result, MoveNodeToNewFlowResultSuccess):
-            logger.error(
-                "%s failed to move node '%s' to flow '%s': %s",
-                self.name,
-                node.name,
-                flow_name,
-                move_result.result_details,
+            # Carry the engine's own reason rather than only logging it: this is the innermost thing
+            # that knows why the move was refused, and the caller turns it into what the artist reads.
+            msg = (
+                f"Attempted to move '{node.name}' into '{flow_name}'. "
+                f"Failed because the move was refused: {move_result.result_details}"
             )
-            msg = f"Attempted to move '{node.name}' into '{flow_name}'. Failed because the engine refused the move."
-            # The isinstance check above tests which result payload came back, not a caller's type
-            # mistake, so a runtime ValueError is right: both callers turn it into a failure result.
-            raise ValueError(msg)  # noqa: TRY004
-
-    def _get_parent_flow_name(self) -> str | None:
-        """Find the Flow this group node itself lives in, which is where its members came from.
-
-        Returns:
-            The parent Flow's name, or None if this group is not in a Flow
-        """
-        try:
-            return GriptapeNodes.NodeManager().get_node_parent_flow_by_name(self.name)
-        except KeyError:
-            logger.warning("%s has no parent flow", self.name)
-            return None
+            raise NodeGroupMembershipError(msg)
 
     def _nest_subflow_of(self, node: BaseNode, parent_subflow_name: str) -> None:
         """Move a nested group's own subflow so it sits under the flow now holding the group.
@@ -922,7 +927,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             parent_subflow_name: The flow that should now own that group's subflow
 
         Raises:
-            ValueError: If the nested group's subflow could not be moved
+            NodeGroupMembershipError: If the nested group's subflow could not be moved
         """
         if not isinstance(node, SubflowNodeGroup):
             return
@@ -942,7 +947,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
                 f"Attempted to change what group '{node.name}' belongs to. "
                 f"Failed because its contents could not be moved to '{parent_subflow_name}': {err}"
             )
-            raise ValueError(msg) from err
+            raise NodeGroupMembershipError(msg) from err
 
     def _map_external_connections_for_nodes(
         self, nodes: list[BaseNode], connections: Connections, node_names_in_group: set[str]
@@ -1148,8 +1153,9 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             The nodes actually removed, including any tethered companions pulled out.
 
         Raises:
-            ValueError: If the nodes are not in this group, if this group holds a subflow but its
-                own flow cannot be found, or if any node could not be moved back out to it
+            ValueError: If the nodes are not in this group
+            NodeGroupMembershipError: If this group holds a subflow but its own flow cannot be
+                found, or if any node could not be moved back out to it
         """
         # Pull out companions this group holds, so removing a Start node does not leave its End node
         # behind — the same split state the add path prevents, reached from the other direction.
@@ -1163,19 +1169,20 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         # out, and dropping the membership regardless would leave them stranded in a subflow nothing
         # claims. A group with no subflow never moved its members anywhere, so it needs no
         # destination and nothing has to move.
-        parent_flow_name = self._get_parent_flow_name()
-        holds_subflow = self.metadata.get("subflow_name") is not None
-        if holds_subflow and parent_flow_name is None:
+        parent_flow_name = self.parent_flow_name
+        subflow_name = self.metadata.get("subflow_name")
+        if subflow_name is not None and parent_flow_name is None:
             node_names = ", ".join(f"'{node.name}'" for node in nodes)
             msg = (
                 f"Attempted to remove {node_names} from group '{self.name}'. "
                 f"Failed because the flow holding the group could not be found, "
                 f"so there is nowhere to move them back to."
             )
-            raise ValueError(msg)
+            raise NodeGroupMembershipError(msg)
 
         if parent_flow_name is not None:
-            self._move_nodes_out_of_subflow(nodes, parent_flow_name=parent_flow_name)
+            # Rolling back means going the way they came: into this group's subflow.
+            self._relocate_nodes(nodes, destination_flow_name=parent_flow_name, rollback_flow_name=subflow_name)
 
         connections = GriptapeNodes.FlowManager().get_connections()
         for node in nodes:
@@ -1192,54 +1199,6 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             self._map_external_connections_for_nodes(remaining_nodes, connections, node_names_in_group)
 
         return nodes
-
-    def _move_nodes_out_of_subflow(self, nodes: list[BaseNode], parent_flow_name: str) -> None:
-        """Move every node out to the flow holding this group, or leave the group as it was found.
-
-        Runs before membership is dropped, so a node that fails to move partway through can be
-        rolled back into a group that still claims all of them. Otherwise a failed remove would
-        leave nodes sitting outside a group that still lists them, which saves as a group whose
-        members are not in its subflow.
-
-        Args:
-            nodes: The nodes to move out, still registered as members of this group
-            parent_flow_name: The flow holding this group node, which is where they came from
-
-        Raises:
-            ValueError: If any node could not be moved out of the subflow
-        """
-        moved_nodes: list[BaseNode] = []
-        for node in nodes:
-            try:
-                self._move_node_to_flow(node, flow_name=parent_flow_name)
-            except ValueError:
-                self._abandon_moves_out_of_subflow(moved_nodes)
-                raise
-            # Recorded before nesting so a nesting failure rolls this node back too, since by then
-            # it has already left the subflow.
-            moved_nodes.append(node)
-            try:
-                # The node left this group, so its own subflow must leave this group's subflow too.
-                self._nest_subflow_of(node, parent_subflow_name=parent_flow_name)
-            except ValueError:
-                self._abandon_moves_out_of_subflow(moved_nodes)
-                raise
-
-    def _abandon_moves_out_of_subflow(self, moved_nodes: list[BaseNode]) -> None:
-        """Put nodes back into this group's subflow after a failed remove.
-
-        Args:
-            moved_nodes: The nodes already moved out to this group's parent flow
-        """
-        subflow_name = self.metadata.get("subflow_name")
-        if not isinstance(subflow_name, str):
-            logger.error(
-                "%s has no subflow recorded, so %d node(s) may be left outside the group after a failed remove",
-                self.name,
-                len(moved_nodes),
-            )
-            return
-        self._move_nodes_back(moved_nodes, destination_flow_name=subflow_name)
 
     async def execute_subflow(self) -> None:
         """Execute the subflow and propagate output values.
@@ -1336,6 +1295,19 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
                 logger.warning(msg)
             # Delete the subflow name since now there is no subflow attached.
             self.metadata.pop("subflow_name")
+
+    @property
+    def parent_flow_name(self) -> str | None:
+        """The Flow this group node itself lives in, which is where its members came from.
+
+        None when the group is not in a Flow at all, which the membership paths treat as "there is
+        nowhere to put these nodes" rather than an error in itself.
+        """
+        try:
+            return GriptapeNodes.NodeManager().get_node_parent_flow_by_name(self.name)
+        except KeyError:
+            logger.warning("%s has no parent flow", self.name)
+            return None
 
     @property
     def subflow_execution_component(self) -> SubflowExecutionComponent:

--- a/src/griptape_nodes/exe_types/node_groups/subflow_node_group.py
+++ b/src/griptape_nodes/exe_types/node_groups/subflow_node_group.py
@@ -744,6 +744,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
 
         # Create subflow on-demand if it doesn't exist
         subflow_name = self.metadata.get("subflow_name")
+        created_subflow_for_this_add = subflow_name is None
         if subflow_name is None:
             self._create_subflow()
             subflow_name = self.metadata.get("subflow_name")
@@ -760,6 +761,8 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
                 # The moves already rolled themselves back; this group still has to stop claiming
                 # nodes it does not hold, or it advertises members that are not in its subflow.
                 self._drop_membership(nodes)
+                if created_subflow_for_this_add:
+                    self._discard_subflow_created_for_a_failed_add()
                 raise
 
         connections = GriptapeNodes.FlowManager().get_connections()
@@ -892,6 +895,50 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             self.nodes.pop(node.name, None)
         self.metadata["node_names_in_group"] = list(self.nodes.keys())
 
+    def _discard_subflow_created_for_a_failed_add(self) -> None:
+        """Tear down a subflow that only exists because of an add that then failed in full.
+
+        The group had no subflow before this add, so leaving it behind means the artist is left owning
+        a flow they never asked for, created by an operation that reported failure. `_create_subflow`
+        already cleans up after itself when the create is what failed; this covers the case where the
+        create succeeded and a later move did not.
+
+        Anything still inside is a rollback that could not complete, and is already logged as such.
+        Deleting the flow then would take those nodes with it, so the subflow is kept and the group
+        keeps pointing at it -- a flow the artist can still see beats nodes that silently vanish.
+        """
+        subflow_name = self.metadata.get("subflow_name")
+        if subflow_name is None:
+            return
+
+        subflow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(subflow_name, ControlFlow)
+        if subflow is None:
+            self.metadata.pop("subflow_name", None)
+            return
+
+        if len(subflow.nodes) > 0:
+            logger.warning(
+                "%s is keeping subflow '%s' after a failed add: it still holds %d node(s) that could not be moved back",
+                self.name,
+                subflow_name,
+                len(subflow.nodes),
+            )
+            return
+
+        delete_result = GriptapeNodes.handle_request(DeleteFlowRequest(flow_name=subflow_name))
+        if isinstance(delete_result, DeleteFlowResultFailure):
+            # Not worth failing the add twice over: it is already failing, and the message the artist
+            # gets should be why their nodes did not move, not a leftover flow they cannot see.
+            logger.warning(
+                "%s could not delete the subflow '%s' it created for a failed add: %s",
+                self.name,
+                subflow_name,
+                delete_result.result_details,
+            )
+            return
+
+        self.metadata.pop("subflow_name", None)
+
     def _move_node_to_flow(self, node: BaseNode, flow_name: str) -> None:
         """Move one node into a Flow.
 
@@ -908,7 +955,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             # Carry the engine's own reason rather than only logging it: this is the innermost thing
             # that knows why the move was refused, and the caller turns it into what the artist reads.
             msg = (
-                f"Attempted to move '{node.name}' into '{flow_name}'. "
+                f"Attempted to move '{node.name}' into '{flow_name}' for group '{self.name}'. "
                 f"Failed because the move was refused: {move_result.result_details}"
             )
             raise NodeGroupMembershipError(msg)

--- a/src/griptape_nodes/exe_types/node_groups/subflow_node_group.py
+++ b/src/griptape_nodes/exe_types/node_groups/subflow_node_group.py
@@ -25,7 +25,16 @@ from griptape_nodes.retained_mode.events.connection_events import (
     DeleteConnectionRequest,
     DeleteConnectionResultSuccess,
 )
-from griptape_nodes.retained_mode.events.flow_events import DeleteFlowRequest, DeleteFlowResultFailure
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    CreateFlowResultSuccess,
+    DeleteFlowRequest,
+    DeleteFlowResultFailure,
+)
+from griptape_nodes.retained_mode.events.node_events import (
+    MoveNodeToNewFlowRequest,
+    MoveNodeToNewFlowResultSuccess,
+)
 from griptape_nodes.retained_mode.events.parameter_events import (
     AddParameterToNodeRequest,
     AddParameterToNodeResultSuccess,
@@ -112,11 +121,6 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         Raises:
             RuntimeError: If the subflow could not be created
         """
-        from griptape_nodes.retained_mode.events.flow_events import (
-            CreateFlowRequest,
-            CreateFlowResultSuccess,
-        )
-
         subflow_name = f"{self.name}_subflow"
         self.metadata["subflow_name"] = subflow_name
 
@@ -159,7 +163,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             if isinstance(enclosing_subflow_name, str):
                 return enclosing_subflow_name
 
-        # Called during __init__ too, when there may be no Flow on the context stack yet.
+        # A group can be built with no Flow on the context stack, so this may find nothing.
         context_manager = GriptapeNodes.ContextManager()
         if not context_manager.has_current_flow():
             return None
@@ -713,20 +717,17 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         Returns:
             The nodes actually added, including any tethered companions pulled in and any extra
             nodes a previous owner released alongside them.
-        """
-        from griptape_nodes.retained_mode.events.node_events import (
-            MoveNodeToNewFlowRequest,
-            MoveNodeToNewFlowResultSuccess,
-        )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
+        Raises:
+            ValueError: If the nodes cannot be nested, or could not all be moved into the group
+        """
         # Pull in companions this group does not already hold, so a Start/End pair joins together.
         nodes = self._expand_with_tethered_nodes(nodes, companion_must_be_member=False)
 
-        # Reject impossible nesting BEFORE touching any membership state: detaching the nodes from
-        # their previous owner mutates that group, so a validation failure after it would leave a
-        # rejected add having already ejected the nodes from the group that held them. Validated
-        # after the expansion above, since a tethered companion can itself be a group.
+        # Reject impossible nesting and secure the subflow BEFORE touching any membership state:
+        # both can fail, and a half-applied add leaves the group and its members disagreeing about
+        # who owns what, which later reads as a silently unresolved graph. Validated after the
+        # expansion above, since a tethered companion can itself be a group.
         self._validate_nodes_can_be_nested(nodes)
 
         # Create subflow on-demand if it doesn't exist
@@ -739,15 +740,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         self._add_nodes_to_group_dict(nodes)
 
         if subflow_name is not None:
-            for node in nodes:
-                move_request = MoveNodeToNewFlowRequest(node_name=node.name, target_flow_name=subflow_name)
-                move_result = GriptapeNodes.handle_request(move_request)
-                if not isinstance(move_result, MoveNodeToNewFlowResultSuccess):
-                    msg = "%s failed to move node '%s' to subflow: %s", self.name, node.name, move_result.result_details
-                    logger.error(msg)
-                    raise RuntimeError(msg)  # noqa: TRY004
-
-                self._nest_subflow_of(node, parent_subflow_name=subflow_name)
+            self._move_nodes_into_subflow(nodes, subflow_name=subflow_name)
 
         connections = GriptapeNodes.FlowManager().get_connections()
         node_names_in_group = set(self.nodes.keys())
@@ -786,6 +779,134 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
                 expanded.append(companion)
 
         return expanded
+
+    def _move_nodes_into_subflow(self, nodes: list[BaseNode], subflow_name: str) -> None:
+        """Move every node into this group's subflow, or leave the group as it was found.
+
+        Membership was already recorded by the time this runs, so a node that fails to move halfway
+        through would leave the group claiming nodes that still live in their old flow. The editor
+        would show them inside the group while a save wrote them outside it. Undoing the moves that
+        did succeed keeps the reported failure honest: nothing moved, so nothing is half-owned.
+
+        Args:
+            nodes: The nodes to move, already registered as members of this group
+            subflow_name: This group's subflow, which should end up holding them all
+
+        Raises:
+            ValueError: If any node could not be moved into the subflow
+        """
+        moved_nodes: list[BaseNode] = []
+        for node in nodes:
+            try:
+                self._move_node_to_flow(node, flow_name=subflow_name)
+            except ValueError:
+                self._abandon_add(nodes, moved_nodes=moved_nodes)
+                raise
+            moved_nodes.append(node)
+
+        # Only nest the inner groups once every member is where it belongs, so a failure above has
+        # not yet disturbed the flow hierarchy.
+        for node in nodes:
+            try:
+                self._nest_subflow_of(node, parent_subflow_name=subflow_name)
+            except ValueError:
+                self._abandon_add(nodes, moved_nodes=moved_nodes)
+                raise
+
+    def _abandon_add(self, nodes: list[BaseNode], moved_nodes: list[BaseNode]) -> None:
+        """Drop the membership this add recorded, and put whatever moved back where it came from.
+
+        The nodes are dropped from this group whether or not their move back succeeds: the add is
+        failing, so claiming them would be a lie either way. A node that was in another group before
+        the add is left group-less rather than returned to it, since that group has already released
+        it -- the artist has to drag it back in.
+
+        Args:
+            nodes: Every node this add tried to take on, all of which lose their membership
+            moved_nodes: The subset already moved into this group's subflow, which has to move back
+        """
+        parent_flow_name = self._get_parent_flow_name()
+        if parent_flow_name is not None:
+            self._move_nodes_back(moved_nodes, destination_flow_name=parent_flow_name)
+        else:
+            logger.error(
+                "%s could not find its own flow, so %d node(s) may be left inside the group after a failed add",
+                self.name,
+                len(moved_nodes),
+            )
+
+        for node in nodes:
+            node.parent_group = None
+            self.nodes.pop(node.name, None)
+        self.metadata["node_names_in_group"] = list(self.nodes.keys())
+
+    def _move_nodes_back(self, moved_nodes: list[BaseNode], destination_flow_name: str) -> None:
+        """Undo moves after a membership change failed, taking each node's own subflow along.
+
+        Best effort by nature: this runs while a membership change is already failing, so a move
+        that also fails is logged rather than raised, otherwise the original cause would be lost.
+
+        Args:
+            moved_nodes: The nodes to put back
+            destination_flow_name: The flow they should end up in again
+        """
+        for node in moved_nodes:
+            try:
+                self._move_node_to_flow(node, flow_name=destination_flow_name)
+            except ValueError:
+                logger.exception(
+                    "%s could not move '%s' back into '%s'; it may be left in the wrong flow",
+                    self.name,
+                    node.name,
+                    destination_flow_name,
+                )
+                continue
+            try:
+                self._nest_subflow_of(node, parent_subflow_name=destination_flow_name)
+            except ValueError:
+                logger.exception(
+                    "%s moved '%s' back into '%s' but could not move its contents along",
+                    self.name,
+                    node.name,
+                    destination_flow_name,
+                )
+
+    def _move_node_to_flow(self, node: BaseNode, flow_name: str) -> None:
+        """Move one node into a Flow.
+
+        Args:
+            node: The node to move
+            flow_name: The Flow it should end up in
+
+        Raises:
+            ValueError: If the engine refused the move
+        """
+        move_request = MoveNodeToNewFlowRequest(node_name=node.name, target_flow_name=flow_name)
+        move_result = GriptapeNodes.handle_request(move_request)
+        if not isinstance(move_result, MoveNodeToNewFlowResultSuccess):
+            logger.error(
+                "%s failed to move node '%s' to flow '%s': %s",
+                self.name,
+                node.name,
+                flow_name,
+                move_result.result_details,
+            )
+            msg = f"Attempted to move '{node.name}' into '{flow_name}'. Failed because the engine refused the move."
+            # The isinstance check above tests which result payload came back, not a caller's type
+            # mistake, so a runtime ValueError is right: both callers turn it into a failure result.
+            raise ValueError(msg)  # noqa: TRY004
+
+    def _get_parent_flow_name(self) -> str | None:
+        """Find the Flow this group node itself lives in, which is where its members came from.
+
+        Returns:
+            The parent Flow's name, or None if this group is not in a Flow
+        """
+        try:
+            return GriptapeNodes.NodeManager().get_node_parent_flow_by_name(self.name)
+        except KeyError:
+            logger.warning("%s has no parent flow", self.name)
+            return None
 
     def _nest_subflow_of(self, node: BaseNode, parent_subflow_name: str) -> None:
         """Move a nested group's own subflow so it sits under the flow now holding the group.
@@ -1018,20 +1139,18 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         self.metadata["node_names_in_group"] = list(self.nodes.keys())
 
     def remove_nodes_from_group(self, nodes: list[BaseNode]) -> list[BaseNode]:
-        """Remove nodes from the group and untrack their connections.
+        """Move nodes back out to this group's own flow and stop claiming them.
 
         Args:
             nodes: List of nodes to remove from the group
 
         Returns:
             The nodes actually removed, including any tethered companions pulled out.
-        """
-        from griptape_nodes.retained_mode.events.node_events import (
-            MoveNodeToNewFlowRequest,
-            MoveNodeToNewFlowResultSuccess,
-        )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
+        Raises:
+            ValueError: If the nodes are not in this group, if this group holds a subflow but its
+                own flow cannot be found, or if any node could not be moved back out to it
+        """
         # Pull out companions this group holds, so removing a Start node does not leave its End node
         # behind — the same split state the add path prevents, reached from the other direction.
         # Expand before validating: restricting to current members means expansion cannot introduce a
@@ -1039,33 +1158,29 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         nodes = self._expand_with_tethered_nodes(nodes, companion_must_be_member=True)
         self._validate_nodes_in_group(nodes)
 
-        parent_flow_name = None
-        try:
-            parent_flow_name = GriptapeNodes.NodeManager().get_node_parent_flow_by_name(self.name)
-        except KeyError:
-            logger.warning("%s has no parent flow, cannot move nodes back", self.name)
+        # Establish where the nodes are going before disturbing anything. A group holding a subflow
+        # keeps its members inside it, so with no destination flow there is no way to get them back
+        # out, and dropping the membership regardless would leave them stranded in a subflow nothing
+        # claims. A group with no subflow never moved its members anywhere, so it needs no
+        # destination and nothing has to move.
+        parent_flow_name = self._get_parent_flow_name()
+        holds_subflow = self.metadata.get("subflow_name") is not None
+        if holds_subflow and parent_flow_name is None:
+            node_names = ", ".join(f"'{node.name}'" for node in nodes)
+            msg = (
+                f"Attempted to remove {node_names} from group '{self.name}'. "
+                f"Failed because the flow holding the group could not be found, "
+                f"so there is nowhere to move them back to."
+            )
+            raise ValueError(msg)
+
+        if parent_flow_name is not None:
+            self._move_nodes_out_of_subflow(nodes, parent_flow_name=parent_flow_name)
 
         connections = GriptapeNodes.FlowManager().get_connections()
         for node in nodes:
             node.parent_group = None
             self.nodes.pop(node.name)
-
-            if parent_flow_name is not None:
-                move_request = MoveNodeToNewFlowRequest(node_name=node.name, target_flow_name=parent_flow_name)
-                move_result = GriptapeNodes.handle_request(move_request)
-                if not isinstance(move_result, MoveNodeToNewFlowResultSuccess):
-                    msg = (
-                        "%s failed to move node '%s' back to parent flow: %s",
-                        self.name,
-                        node.name,
-                        move_result.result_details,
-                    )
-                    logger.error(msg)
-                    raise RuntimeError(msg)
-
-                # The node left this group, so its own subflow must leave this group's subflow too.
-                self._nest_subflow_of(node, parent_subflow_name=parent_flow_name)
-
         for node in nodes:
             self.unmap_node_connections(node, connections)
 
@@ -1077,6 +1192,54 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             self._map_external_connections_for_nodes(remaining_nodes, connections, node_names_in_group)
 
         return nodes
+
+    def _move_nodes_out_of_subflow(self, nodes: list[BaseNode], parent_flow_name: str) -> None:
+        """Move every node out to the flow holding this group, or leave the group as it was found.
+
+        Runs before membership is dropped, so a node that fails to move partway through can be
+        rolled back into a group that still claims all of them. Otherwise a failed remove would
+        leave nodes sitting outside a group that still lists them, which saves as a group whose
+        members are not in its subflow.
+
+        Args:
+            nodes: The nodes to move out, still registered as members of this group
+            parent_flow_name: The flow holding this group node, which is where they came from
+
+        Raises:
+            ValueError: If any node could not be moved out of the subflow
+        """
+        moved_nodes: list[BaseNode] = []
+        for node in nodes:
+            try:
+                self._move_node_to_flow(node, flow_name=parent_flow_name)
+            except ValueError:
+                self._abandon_moves_out_of_subflow(moved_nodes)
+                raise
+            # Recorded before nesting so a nesting failure rolls this node back too, since by then
+            # it has already left the subflow.
+            moved_nodes.append(node)
+            try:
+                # The node left this group, so its own subflow must leave this group's subflow too.
+                self._nest_subflow_of(node, parent_subflow_name=parent_flow_name)
+            except ValueError:
+                self._abandon_moves_out_of_subflow(moved_nodes)
+                raise
+
+    def _abandon_moves_out_of_subflow(self, moved_nodes: list[BaseNode]) -> None:
+        """Put nodes back into this group's subflow after a failed remove.
+
+        Args:
+            moved_nodes: The nodes already moved out to this group's parent flow
+        """
+        subflow_name = self.metadata.get("subflow_name")
+        if not isinstance(subflow_name, str):
+            logger.error(
+                "%s has no subflow recorded, so %d node(s) may be left outside the group after a failed remove",
+                self.name,
+                len(moved_nodes),
+            )
+            return
+        self._move_nodes_back(moved_nodes, destination_flow_name=subflow_name)
 
     async def execute_subflow(self) -> None:
         """Execute the subflow and propagate output values.

--- a/src/griptape_nodes/exe_types/node_groups/subflow_node_group.py
+++ b/src/griptape_nodes/exe_types/node_groups/subflow_node_group.py
@@ -116,26 +116,48 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         subflow_name = f"{self.name}_subflow"
         self.metadata["subflow_name"] = subflow_name
 
-        # Get current flow to set as parent so subflow will be serialized with parent
-        current_flow = GriptapeNodes.ContextManager().get_current_flow()
-        parent_flow_name = current_flow.name if current_flow else None
-
         # Create metadata with flow_type
         subflow_metadata = {"flow_type": NODE_GROUP_FLOW}
 
         request = CreateFlowRequest(
             flow_name=subflow_name,
-            parent_flow_name=parent_flow_name,
+            parent_flow_name=self._get_subflow_parent_flow_name(),
             set_as_new_context=False,
             metadata=subflow_metadata,
         )
         result = GriptapeNodes.handle_request(request)
-        if isinstance(result, CreateFlowResultSuccess):
-            # Final name may be different that initial name due to de-dupe.
-            self.metadata["subflow_name"] = result.flow_name
-
         if not isinstance(result, CreateFlowResultSuccess):
+            # Drop the name we optimistically recorded: no such flow exists, and leaving it set
+            # makes every later lookup point at a phantom flow.
+            self.metadata.pop("subflow_name", None)
             logger.warning("%s failed to create subflow '%s': %s", self.name, subflow_name, result.result_details)
+            msg = f"Attempted to create the group '{self.name}'. Failed because {result.result_details}"
+            raise RuntimeError(msg)  # noqa: TRY004 - the request failed at runtime; this is not a type error.
+
+        # Final name may be different that initial name due to de-dupe.
+        self.metadata["subflow_name"] = result.flow_name
+
+    def _get_subflow_parent_flow_name(self) -> str | None:
+        """Pick the flow that should own this group's subflow.
+
+        When this group is nested, its subflow belongs under the enclosing group's subflow so the
+        flow hierarchy mirrors the nesting. Otherwise it goes under the flow that is currently
+        being built, matching where the group node itself lives.
+
+        Returns:
+            The parent flow name, or None to let the engine parent it to the current context
+        """
+        parent_group = self.parent_group
+        if isinstance(parent_group, SubflowNodeGroup):
+            enclosing_subflow_name = parent_group.metadata.get("subflow_name")
+            if isinstance(enclosing_subflow_name, str):
+                return enclosing_subflow_name
+
+        # Called during __init__ too, when there may be no Flow on the context stack yet.
+        context_manager = GriptapeNodes.ContextManager()
+        if not context_manager.has_current_flow():
+            return None
+        return context_manager.get_current_flow().name
 
     def _add_start_flow_parameters(self) -> None:
         """Add parameters from all registered StartFlow nodes to this SubflowNodeGroup.
@@ -325,11 +347,20 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         return proxy_param
 
     def get_all_nodes(self) -> dict[str, BaseNode]:
-        all_nodes = {}
+        """Collect this group's members and every node nested beneath them, at any depth.
+
+        Recurses through nested groups rather than descending a single level, so callers that
+        package a group for execution (remote/private/iterative) see the whole body instead of
+        silently dropping nodes below depth 2.
+
+        Returns:
+            All nested nodes keyed by name, including the nested groups themselves
+        """
+        all_nodes: dict[str, BaseNode] = {}
         for node_name, node in self.nodes.items():
             all_nodes[node_name] = node
             if isinstance(node, SubflowNodeGroup):
-                all_nodes.update(node.nodes)
+                all_nodes.update(node.get_all_nodes())
         return all_nodes
 
     def map_external_connection(self, conn: Connection, *, is_incoming: bool) -> bool:
@@ -685,14 +716,21 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
 
         # Pull in companions this group does not already hold, so a Start/End pair joins together.
         nodes = self._expand_with_tethered_nodes(nodes, companion_must_be_member=False)
-        nodes = nodes + self._remove_nodes_from_existing_parents(nodes)
-        self._add_nodes_to_group_dict(nodes)
+
+        # Reject impossible nesting BEFORE touching any membership state: detaching the nodes from
+        # their previous owner mutates that group, so a validation failure after it would leave a
+        # rejected add having already ejected the nodes from the group that held them. Validated
+        # after the expansion above, since a tethered companion can itself be a group.
+        self._validate_nodes_can_be_nested(nodes)
 
         # Create subflow on-demand if it doesn't exist
         subflow_name = self.metadata.get("subflow_name")
         if subflow_name is None:
             self._create_subflow()
             subflow_name = self.metadata.get("subflow_name")
+
+        nodes = nodes + self._remove_nodes_from_existing_parents(nodes)
+        self._add_nodes_to_group_dict(nodes)
 
         if subflow_name is not None:
             for node in nodes:
@@ -702,6 +740,8 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
                     msg = "%s failed to move node '%s' to subflow: %s", self.name, node.name, move_result.result_details
                     logger.error(msg)
                     raise RuntimeError(msg)  # noqa: TRY004
+
+                self._nest_subflow_of(node, parent_subflow_name=subflow_name)
 
         connections = GriptapeNodes.FlowManager().get_connections()
         node_names_in_group = set(self.nodes.keys())
@@ -740,6 +780,36 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
                 expanded.append(companion)
 
         return expanded
+
+    def _nest_subflow_of(self, node: BaseNode, parent_subflow_name: str) -> None:
+        """Reparent a nested group's own subflow under this group's subflow.
+
+        Keeps the flow hierarchy mirroring the group nesting. Without this the inner group's
+        subflow stays parented to whatever flow was current when it was created, so saving walks
+        right past it and the inner group's members are lost on load.
+
+        Args:
+            node: The node just added to this group; only groups own a subflow
+            parent_subflow_name: This group's subflow, which should become the parent
+        """
+        if not isinstance(node, SubflowNodeGroup):
+            return
+
+        child_subflow_name = node.metadata.get("subflow_name")
+        if not isinstance(child_subflow_name, str):
+            # The nested group has no subflow yet; it will be created under this one on first add.
+            return
+
+        try:
+            GriptapeNodes.FlowManager().reparent_flow(child_subflow_name, parent_subflow_name)
+        except ValueError:
+            logger.exception(
+                "%s could not nest subflow '%s' of group '%s' under '%s'",
+                self.name,
+                child_subflow_name,
+                node.name,
+                parent_subflow_name,
+            )
 
     def _map_external_connections_for_nodes(
         self, nodes: list[BaseNode], connections: Connections, node_names_in_group: set[str]
@@ -980,6 +1050,9 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
                     )
                     logger.error(msg)
                     raise RuntimeError(msg)
+
+                # The node left this group, so its own subflow must leave this group's subflow too.
+                self._nest_subflow_of(node, parent_subflow_name=parent_flow_name)
 
         for node in nodes:
             self.unmap_node_connections(node, connections)

--- a/src/griptape_nodes/retained_mode/events/flow_events.py
+++ b/src/griptape_nodes/retained_mode/events/flow_events.py
@@ -274,6 +274,21 @@ class GetTopLevelFlowResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess
     flow_name: str | None
 
 
+class SerializedConnectionKey(NamedTuple):
+    """Identifies one serialized connection, so a Flow and its ancestors agree on which edge it is.
+
+    A Flow's serialized connections include every connection from the Flows beneath it, so an edge
+    crossing N nesting levels is reported N+1 times. Both halves of the round trip — rebuilding a
+    saved Flow and generating a workflow file from one — need to act on each edge exactly once, and
+    they need to agree on what "the same edge" means, hence one shared key.
+    """
+
+    source_node_uuid: SerializedNodeCommands.NodeUUID
+    source_parameter_name: str
+    target_node_uuid: SerializedNodeCommands.NodeUUID
+    target_parameter_name: str
+
+
 # A Flow's state can be serialized into a sequence of commands that the engine then runs.
 @dataclass
 class SerializedFlowCommands:
@@ -318,6 +333,19 @@ class SerializedFlowCommands:
         source_parameter_name: str
         target_node_uuid: SerializedNodeCommands.NodeUUID
         target_parameter_name: str
+
+        def key(self) -> SerializedConnectionKey:
+            """Identify this connection independently of which Flow reported it.
+
+            Returns:
+                The key naming this edge's two endpoints
+            """
+            return SerializedConnectionKey(
+                source_node_uuid=self.source_node_uuid,
+                source_parameter_name=self.source_parameter_name,
+                target_node_uuid=self.target_node_uuid,
+                target_parameter_name=self.target_parameter_name,
+            )
 
     @dataclass
     class SerializedVariableCommand:

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -5,6 +5,7 @@ import base64
 import copy
 import logging
 import pickle
+from dataclasses import dataclass, field
 from enum import StrEnum
 from io import BytesIO
 from pathlib import Path
@@ -251,6 +252,28 @@ class MultiNodeEndNodeResult(NamedTuple):
     parameter_name_mappings: dict[SanitizedParameterName, OriginalNodeParameter]
     alter_parameter_commands: list[AlterParameterDetailsRequest]
     end_node_name: str
+
+
+@dataclass
+class DeserializedFlowNodes:
+    """Nodes rebuilt from one Flow and everything below it, keyed the two ways callers need.
+
+    Connections are serialized against a Flow's whole subtree, not just its own level, so the
+    connection pass has to resolve UUIDs belonging to nodes that were rebuilt inside a subflow.
+    Collecting the whole subtree first is what lets a single pass wire them all up.
+    """
+
+    node_uuid_to_node_name: dict[SerializedNodeCommands.NodeUUID, str] = field(default_factory=dict)
+    original_name_to_node_name: dict[str, str] = field(default_factory=dict)
+
+    def merge(self, other: DeserializedFlowNodes) -> None:
+        """Fold a subflow's rebuilt nodes into this one.
+
+        Args:
+            other: The nodes rebuilt from a subflow of this Flow
+        """
+        self.node_uuid_to_node_name.update(other.node_uuid_to_node_name)
+        self.original_name_to_node_name.update(other.original_name_to_node_name)
 
 
 class FlowManager(EngineScoped):
@@ -3939,7 +3962,7 @@ class FlowManager(EngineScoped):
         result = SerializeFlowToCommandsResultSuccess(serialized_flow_commands=serialized_flow, result_details=details)
         return result
 
-    def on_deserialize_flow_from_commands(self, request: DeserializeFlowFromCommandsRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912, PLR0915 (I am big and complicated and have a lot of negative edge-cases)
+    def on_deserialize_flow_from_commands(self, request: DeserializeFlowFromCommandsRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912 (I am big and complicated and have a lot of negative edge-cases)
         # Do we want to create a NEW Flow to deserialize into, or use the one in the Current Context?
         if request.serialized_flow_commands.flow_initialization_command is None:
             if self.engine.context_manager.has_current_flow():
@@ -3980,157 +4003,49 @@ class FlowManager(EngineScoped):
             pushed_flow_context = True  # Mark that we pushed this flow
             created_new_flow = True  # Mark that we created this flow
 
-        # Deserializing a flow goes in a specific order.
-
-        # Create the nodes.
-        # Preserve the node UUIDs because we will need to tie these back together with the Connections later.
-        # Also build a mapping from original node names to deserialized node names.
-        node_uuid_to_deserialized_node_result = {}
-        node_name_mappings = {}
-        for serialized_node in request.serialized_flow_commands.serialized_node_commands:
-            # Get the node name from the CreateNodeRequest command
-            create_cmd = serialized_node.create_node_command
-            original_node_name = create_cmd.node_name
-
-            # For SubflowNodeGroups, remap node_names_to_add from UUIDs to actual node names
-            # Create a copy to avoid mutating the original serialized data
-            serialized_node_for_deserialization = serialized_node
-            if create_cmd.node_names_to_add:
-                # Use list comprehension to remap UUIDs to deserialized node names
-                remapped_names = [
-                    node_uuid_to_deserialized_node_result[node_uuid].node_name
-                    for node_uuid in create_cmd.node_names_to_add
-                    if node_uuid in node_uuid_to_deserialized_node_result
-                ]
-                # Create a copy of the command with remapped names instead of mutating original
-                create_cmd_copy = CreateNodeRequest(
-                    node_type=create_cmd.node_type,
-                    specific_library_name=create_cmd.specific_library_name,
-                    node_name=create_cmd.node_name,
-                    node_names_to_add=remapped_names,
-                    override_parent_flow_name=create_cmd.override_parent_flow_name,
-                    metadata=create_cmd.metadata,
-                    resolution=create_cmd.resolution,
-                    initial_setup=create_cmd.initial_setup,
-                    set_as_new_context=create_cmd.set_as_new_context,
-                    create_error_proxy_on_failure=create_cmd.create_error_proxy_on_failure,
-                )
-                # Create a copy of serialized_node with the new command
-                serialized_node_for_deserialization = SerializedNodeCommands(
-                    node_uuid=serialized_node.node_uuid,
-                    create_node_command=create_cmd_copy,
-                    element_modification_commands=serialized_node.element_modification_commands,
-                    node_dependencies=serialized_node.node_dependencies,
-                    lock_node_command=serialized_node.lock_node_command,
-                    is_node_group=serialized_node.is_node_group,
-                )
-
-            deserialize_node_request = DeserializeNodeFromCommandsRequest(
-                serialized_node_commands=serialized_node_for_deserialization
+        # Deserializing a flow goes in a specific order: every node in this Flow AND its subflows
+        # first, then connections, then values. Connections are serialized against a Flow's whole
+        # subtree (see _aggregate_connections), so an edge crossing a Flow boundary names a node
+        # that lives one or more levels down. Wiring connections before the subflows existed made
+        # every such edge fail with "node did not exist within the flow", which failed the whole
+        # load for any graph containing a node group or a nested subflow.
+        try:
+            deserialized_nodes = self._deserialize_nodes_for_flow_and_subflows(
+                serialized_flow_commands=request.serialized_flow_commands
             )
-            deserialized_node_result = self.engine.handle_request(deserialize_node_request)
-            if not isinstance(deserialized_node_result, DeserializeNodeFromCommandsResultSuccess):
-                details = (
-                    f"Attempted to deserialize a Flow '{flow_name}'. Failed while deserializing a node within the flow."
-                )
-                if created_new_flow:
-                    self._cleanup_flow_on_failed_deserialization(flow_name, pushed_flow_context=pushed_flow_context)
-                return DeserializeFlowFromCommandsResultFailure(result_details=details)
-            node_uuid_to_deserialized_node_result[serialized_node.node_uuid] = deserialized_node_result
-            node_name_mappings[original_node_name] = deserialized_node_result.node_name
+        except RuntimeError as err:
+            details = f"Attempted to deserialize a Flow '{flow_name}'. {err}"
+            if created_new_flow:
+                self._cleanup_flow_on_failed_deserialization(flow_name, pushed_flow_context=pushed_flow_context)
+            return DeserializeFlowFromCommandsResultFailure(result_details=details)
 
-        # Now apply the connections.
-        # We didn't know the exact name that would be used for the nodes, but we knew the node's creation UUID.
-        # Tie the UUID back to the node names.
-        for indirect_connection in request.serialized_flow_commands.serialized_connections:
-            # Validate the source and target node UUIDs.
-            source_node_uuid = indirect_connection.source_node_uuid
-            if source_node_uuid not in node_uuid_to_deserialized_node_result:
-                details = f"Attempted to deserialize a Flow '{flow_name}'. Failed while attempting to create a Connection for a source node that did not exist within the flow."
-                if created_new_flow:
-                    self._cleanup_flow_on_failed_deserialization(flow_name, pushed_flow_context=pushed_flow_context)
-                return DeserializeFlowFromCommandsResultFailure(result_details=details)
-            target_node_uuid = indirect_connection.target_node_uuid
-            if target_node_uuid not in node_uuid_to_deserialized_node_result:
-                details = f"Attempted to deserialize a Flow '{flow_name}'. Failed while attempting to create a Connection for a target node that did not exist within the flow."
-                if created_new_flow:
-                    self._cleanup_flow_on_failed_deserialization(flow_name, pushed_flow_context=pushed_flow_context)
-                return DeserializeFlowFromCommandsResultFailure(result_details=details)
+        node_name_mappings = deserialized_nodes.original_name_to_node_name
 
-            source_node_result = node_uuid_to_deserialized_node_result[source_node_uuid]
-            source_node_name = source_node_result.node_name
-            target_node_result = node_uuid_to_deserialized_node_result[indirect_connection.target_node_uuid]
-            target_node_name = target_node_result.node_name
-
-            create_connection_request = CreateConnectionRequest(
-                source_node_name=source_node_name,
-                source_parameter_name=indirect_connection.source_parameter_name,
-                target_node_name=target_node_name,
-                target_parameter_name=indirect_connection.target_parameter_name,
+        # Now apply the connections, for this Flow and every Flow beneath it.
+        # We didn't know the exact name that would be used for the nodes, but we knew the node's
+        # creation UUID. Tie the UUID back to the node names.
+        try:
+            self._deserialize_connections_for_flow_and_subflows(
+                serialized_flow_commands=request.serialized_flow_commands, deserialized_nodes=deserialized_nodes
             )
-            create_connection_result = self.engine.handle_request(create_connection_request)
-            if create_connection_result.failed():
-                details = f"Attempted to deserialize a Flow '{flow_name}'. Failed while deserializing a Connection from '{source_node_name}.{indirect_connection.source_parameter_name}' to '{target_node_name}.{indirect_connection.target_parameter_name}' within the flow."
-                if created_new_flow:
-                    self._cleanup_flow_on_failed_deserialization(flow_name, pushed_flow_context=pushed_flow_context)
-                return DeserializeFlowFromCommandsResultFailure(result_details=details)
+        except RuntimeError as err:
+            details = f"Attempted to deserialize a Flow '{flow_name}'. {err}"
+            if created_new_flow:
+                self._cleanup_flow_on_failed_deserialization(flow_name, pushed_flow_context=pushed_flow_context)
+            return DeserializeFlowFromCommandsResultFailure(result_details=details)
 
-        # Now assign the values.
+        # Now assign the values, again across the whole subtree.
         # This is the same issue that we handle for Connections:
         # we don't know the exact node name that would be used, but we do know the UUIDs.
-        # Similarly, we need to wire up the value UUIDs back to the unique values.
-        # We maintain one map of set value commands per node in the Flow.
-        for node_uuid, set_value_command_list in request.serialized_flow_commands.set_parameter_value_commands.items():
-            node_name = node_uuid_to_deserialized_node_result[node_uuid].node_name
-            # Make this node the current context.
-            node = self.engine.object_manager.attempt_get_object_by_name_as_type(node_name, BaseNode)
-            if node is None:
-                details = f"Attempted to deserialize a Flow '{flow_name}'. Failed while deserializing a value assignment for node '{node_name}'."
-                if created_new_flow:
-                    self._cleanup_flow_on_failed_deserialization(flow_name, pushed_flow_context=pushed_flow_context)
-                return DeserializeFlowFromCommandsResultFailure(result_details=details)
-            with self.engine.context_manager.node(node=node):
-                # Iterate through each set value command in the list for this node.
-                for indirect_set_value_command in set_value_command_list:
-                    parameter_name = indirect_set_value_command.set_parameter_value_command.parameter_name
-                    unique_value_uuid = indirect_set_value_command.unique_value_uuid
-                    try:
-                        value = request.serialized_flow_commands.unique_parameter_uuid_to_values[unique_value_uuid]
-                    except IndexError as err:
-                        details = f"Attempted to deserialize a Flow '{flow_name}'. Failed while deserializing a value assignment for node '{node.name}.{parameter_name}': {err}"
-                        if created_new_flow:
-                            self._cleanup_flow_on_failed_deserialization(
-                                flow_name, pushed_flow_context=pushed_flow_context
-                            )
-                        return DeserializeFlowFromCommandsResultFailure(result_details=details)
-
-                    # Call the SetParameterValueRequest, subbing in the value from our unique value list.
-                    indirect_set_value_command.set_parameter_value_command.value = value
-                    # Update the parameter value command to have the correct name.
-                    indirect_set_value_command.set_parameter_value_command.node_name = node.name
-                    set_parameter_value_result = self.engine.handle_request(
-                        indirect_set_value_command.set_parameter_value_command
-                    )
-                    if set_parameter_value_result.failed():
-                        details = f"Attempted to deserialize a Flow '{flow_name}'. Failed while deserializing a value assignment for node '{node.name}.{parameter_name}'."
-                        if created_new_flow:
-                            self._cleanup_flow_on_failed_deserialization(
-                                flow_name, pushed_flow_context=pushed_flow_context
-                            )
-                        return DeserializeFlowFromCommandsResultFailure(result_details=details)
-
-        # Now the child flows.
-        for sub_flow_command in request.serialized_flow_commands.sub_flows_commands:
-            sub_flow_request = DeserializeFlowFromCommandsRequest(
-                serialized_flow_commands=sub_flow_command,
-                pop_flow_context_after=True,  # Clean up child flows
+        try:
+            self._deserialize_values_for_flow_and_subflows(
+                serialized_flow_commands=request.serialized_flow_commands, deserialized_nodes=deserialized_nodes
             )
-            sub_flow_result = self.engine.handle_request(sub_flow_request)
-            if sub_flow_result.failed():
-                details = f"Attempted to deserialize a Flow '{flow_name}'. Failed while deserializing a sub-flow within the Flow."
-                if created_new_flow:
-                    self._cleanup_flow_on_failed_deserialization(flow_name, pushed_flow_context=pushed_flow_context)
-                return DeserializeFlowFromCommandsResultFailure(result_details=details)
+        except RuntimeError as err:
+            details = f"Attempted to deserialize a Flow '{flow_name}'. {err}"
+            if created_new_flow:
+                self._cleanup_flow_on_failed_deserialization(flow_name, pushed_flow_context=pushed_flow_context)
+            return DeserializeFlowFromCommandsResultFailure(result_details=details)
 
         # Pop flow context if requested and we pushed it
         if request.pop_flow_context_after and pushed_flow_context:
@@ -4140,6 +4055,298 @@ class FlowManager(EngineScoped):
         return DeserializeFlowFromCommandsResultSuccess(
             flow_name=flow_name, result_details=details, node_name_mappings=node_name_mappings
         )
+
+    def _deserialize_nodes_for_flow_and_subflows(
+        self, serialized_flow_commands: SerializedFlowCommands
+    ) -> DeserializedFlowNodes:
+        """Rebuild every node in a Flow and, recursively, in each of its subflows.
+
+        Each subflow is created and entered so its nodes land inside it, then left again, so the
+        rebuilt Flow hierarchy mirrors the serialized one.
+
+        Node groups are rebuilt last, after this Flow's ordinary nodes and after every subflow, for
+        the same reason the workflow file generator emits them last: a group claims its members by
+        name at creation time, and a member can live in a subflow below the group. Rebuilding the
+        group first silently dropped members that did not exist yet, leaving an empty group.
+
+        Args:
+            serialized_flow_commands: The commands for the Flow being rebuilt
+
+        Returns:
+            The rebuilt nodes of this Flow and its whole subtree
+
+        Raises:
+            RuntimeError: If a node, or a subflow holding nodes, could not be rebuilt
+        """
+        deserialized_nodes = DeserializedFlowNodes()
+
+        regular_node_commands = [
+            serialized_node
+            for serialized_node in serialized_flow_commands.serialized_node_commands
+            if not serialized_node.is_node_group
+        ]
+        node_group_commands = [
+            serialized_node
+            for serialized_node in serialized_flow_commands.serialized_node_commands
+            if serialized_node.is_node_group
+        ]
+
+        for serialized_node in regular_node_commands:
+            self._deserialize_and_record_node(serialized_node=serialized_node, deserialized_nodes=deserialized_nodes)
+
+        for sub_flow_commands in serialized_flow_commands.sub_flows_commands:
+            sub_flow_nodes = self._deserialize_subflow_nodes(sub_flow_commands=sub_flow_commands)
+            deserialized_nodes.merge(sub_flow_nodes)
+
+        for serialized_node in node_group_commands:
+            self._deserialize_and_record_node(serialized_node=serialized_node, deserialized_nodes=deserialized_nodes)
+
+        return deserialized_nodes
+
+    def _deserialize_and_record_node(
+        self, serialized_node: SerializedNodeCommands, deserialized_nodes: DeserializedFlowNodes
+    ) -> None:
+        """Rebuild one node and record the name it was given under both keys callers look it up by.
+
+        Args:
+            serialized_node: The commands for the node being rebuilt
+            deserialized_nodes: The collection to record the rebuilt node in
+
+        Raises:
+            RuntimeError: If the node could not be rebuilt
+        """
+        node_name = self._deserialize_one_node(serialized_node=serialized_node, deserialized_nodes=deserialized_nodes)
+        deserialized_nodes.node_uuid_to_node_name[serialized_node.node_uuid] = node_name
+        original_node_name = serialized_node.create_node_command.node_name
+        if original_node_name is not None:
+            # Callers map old names to new ones; a node saved without a name has nothing to map.
+            deserialized_nodes.original_name_to_node_name[original_node_name] = node_name
+
+    def _deserialize_one_node(
+        self, serialized_node: SerializedNodeCommands, deserialized_nodes: DeserializedFlowNodes
+    ) -> str:
+        """Rebuild a single node, resolving any group membership it declares.
+
+        Args:
+            serialized_node: The commands for the node being rebuilt
+            deserialized_nodes: Nodes rebuilt so far, used to resolve group membership UUIDs
+
+        Returns:
+            The name the rebuilt node was given
+
+        Raises:
+            RuntimeError: If the node could not be rebuilt
+        """
+        create_cmd = serialized_node.create_node_command
+        serialized_node_for_deserialization = serialized_node
+
+        # For SubflowNodeGroups, remap node_names_to_add from UUIDs to actual node names.
+        # Create a copy to avoid mutating the original serialized data.
+        # The field is declared as plain names, but a serialized group stores its members as UUIDs
+        # because the names they will be rebuilt under are not known until they are rebuilt.
+        if create_cmd.node_names_to_add:
+            member_uuids = [SerializedNodeCommands.NodeUUID(name) for name in create_cmd.node_names_to_add]
+            remapped_names = [
+                deserialized_nodes.node_uuid_to_node_name[member_uuid]
+                for member_uuid in member_uuids
+                if member_uuid in deserialized_nodes.node_uuid_to_node_name
+            ]
+            create_cmd_copy = CreateNodeRequest(
+                node_type=create_cmd.node_type,
+                specific_library_name=create_cmd.specific_library_name,
+                node_name=create_cmd.node_name,
+                node_names_to_add=remapped_names,
+                override_parent_flow_name=create_cmd.override_parent_flow_name,
+                metadata=create_cmd.metadata,
+                resolution=create_cmd.resolution,
+                initial_setup=create_cmd.initial_setup,
+                set_as_new_context=create_cmd.set_as_new_context,
+                create_error_proxy_on_failure=create_cmd.create_error_proxy_on_failure,
+            )
+            serialized_node_for_deserialization = SerializedNodeCommands(
+                node_uuid=serialized_node.node_uuid,
+                create_node_command=create_cmd_copy,
+                element_modification_commands=serialized_node.element_modification_commands,
+                node_dependencies=serialized_node.node_dependencies,
+                lock_node_command=serialized_node.lock_node_command,
+                is_node_group=serialized_node.is_node_group,
+            )
+
+        deserialize_node_request = DeserializeNodeFromCommandsRequest(
+            serialized_node_commands=serialized_node_for_deserialization
+        )
+        deserialized_node_result = self.engine.handle_request(deserialize_node_request)
+        if not isinstance(deserialized_node_result, DeserializeNodeFromCommandsResultSuccess):
+            msg = f"Failed while rebuilding the node '{create_cmd.node_name}'."
+            raise RuntimeError(msg)  # noqa: TRY004 - the request failed at runtime; this is not a type error.
+
+        return deserialized_node_result.node_name
+
+    def _deserialize_subflow_nodes(self, sub_flow_commands: SerializedFlowCommands) -> DeserializedFlowNodes:
+        """Create one subflow and rebuild the nodes inside it, and inside its own subflows.
+
+        Args:
+            sub_flow_commands: The commands for the subflow being rebuilt
+
+        Returns:
+            The rebuilt nodes of the subflow and its whole subtree
+
+        Raises:
+            RuntimeError: If the subflow could not be created or entered
+        """
+        flow_initialization_command = sub_flow_commands.flow_initialization_command
+        if flow_initialization_command is None:
+            # No creation command means "deserialize into the Flow already in context", which is
+            # this Flow: the nodes belong here rather than in a child.
+            return self._deserialize_nodes_for_flow_and_subflows(serialized_flow_commands=sub_flow_commands)
+
+        sub_flow_name = self._create_flow_for_deserialization(flow_initialization_command=flow_initialization_command)
+        sub_flow = self.engine.object_manager.attempt_get_object_by_name_as_type(sub_flow_name, ControlFlow)
+        if sub_flow is None:
+            msg = f"Failed to find the sub-flow '{sub_flow_name}' just created for it."
+            raise RuntimeError(msg)
+
+        # Nodes are created into the Flow at the top of the context stack, so enter the subflow
+        # while rebuilding its contents and leave it afterwards.
+        with self.engine.context_manager.flow(flow=sub_flow):
+            return self._deserialize_nodes_for_flow_and_subflows(serialized_flow_commands=sub_flow_commands)
+
+    def _create_flow_for_deserialization(
+        self, flow_initialization_command: CreateFlowRequest | ImportWorkflowAsReferencedSubFlowRequest
+    ) -> str:
+        """Issue a Flow's initialization command and return the name it was created under.
+
+        Args:
+            flow_initialization_command: The command that brings the Flow into existence
+
+        Returns:
+            The name of the created Flow
+
+        Raises:
+            RuntimeError: If the Flow could not be created
+        """
+        flow_initialization_result = self.engine.handle_request(flow_initialization_command)
+
+        match flow_initialization_command:
+            case CreateFlowRequest():
+                if not isinstance(flow_initialization_result, CreateFlowResultSuccess):
+                    msg = f"Failed to create the sub-flow '{flow_initialization_command.flow_name}'."
+                    raise RuntimeError(msg)  # noqa: TRY004 - the request failed at runtime; this is not a type error.
+                return flow_initialization_result.flow_name
+            case ImportWorkflowAsReferencedSubFlowRequest():
+                if not isinstance(flow_initialization_result, ImportWorkflowAsReferencedSubFlowResultSuccess):
+                    msg = f"Failed to import the workflow '{flow_initialization_command.workflow_name}' as a sub-flow."
+                    raise RuntimeError(msg)  # noqa: TRY004 - the request failed at runtime; this is not a type error.
+                return flow_initialization_result.created_flow_name
+            case _:
+                msg = f"Failed because the sub-flow used an unknown creation command: {type(flow_initialization_command).__name__}."
+                raise RuntimeError(msg)
+
+    def _deserialize_connections_for_flow_and_subflows(
+        self, serialized_flow_commands: SerializedFlowCommands, deserialized_nodes: DeserializedFlowNodes
+    ) -> None:
+        """Recreate the connections of a Flow and every Flow beneath it.
+
+        Args:
+            serialized_flow_commands: The commands for the Flow being rebuilt
+            deserialized_nodes: Every node rebuilt for this Flow's whole subtree
+
+        Raises:
+            RuntimeError: If a connection names a node that was not rebuilt, or could not be made
+        """
+        for indirect_connection in serialized_flow_commands.serialized_connections:
+            source_node_name = deserialized_nodes.node_uuid_to_node_name.get(indirect_connection.source_node_uuid)
+            if source_node_name is None:
+                msg = "Failed while reconnecting the flow because the node a connection starts from was not rebuilt."
+                raise RuntimeError(msg)
+            target_node_name = deserialized_nodes.node_uuid_to_node_name.get(indirect_connection.target_node_uuid)
+            if target_node_name is None:
+                msg = "Failed while reconnecting the flow because the node a connection leads to was not rebuilt."
+                raise RuntimeError(msg)
+
+            create_connection_request = CreateConnectionRequest(
+                source_node_name=source_node_name,
+                source_parameter_name=indirect_connection.source_parameter_name,
+                target_node_name=target_node_name,
+                target_parameter_name=indirect_connection.target_parameter_name,
+            )
+            create_connection_result = self.engine.handle_request(create_connection_request)
+            if create_connection_result.failed():
+                msg = f"Failed while reconnecting '{source_node_name}.{indirect_connection.source_parameter_name}' to '{target_node_name}.{indirect_connection.target_parameter_name}'."
+                raise RuntimeError(msg)
+
+        for sub_flow_commands in serialized_flow_commands.sub_flows_commands:
+            self._deserialize_connections_for_flow_and_subflows(
+                serialized_flow_commands=sub_flow_commands, deserialized_nodes=deserialized_nodes
+            )
+
+    def _deserialize_values_for_flow_and_subflows(
+        self, serialized_flow_commands: SerializedFlowCommands, deserialized_nodes: DeserializedFlowNodes
+    ) -> None:
+        """Reapply the parameter values of a Flow and every Flow beneath it.
+
+        Args:
+            serialized_flow_commands: The commands for the Flow being rebuilt
+            deserialized_nodes: Every node rebuilt for this Flow's whole subtree
+
+        Raises:
+            RuntimeError: If a value belongs to a node that was not rebuilt, or could not be set
+        """
+        for node_uuid, set_value_command_list in serialized_flow_commands.set_parameter_value_commands.items():
+            node_name = deserialized_nodes.node_uuid_to_node_name.get(node_uuid)
+            if node_name is None:
+                msg = "Failed while restoring saved values because the node they belong to was not rebuilt."
+                raise RuntimeError(msg)
+            node = self.engine.object_manager.attempt_get_object_by_name_as_type(node_name, BaseNode)
+            if node is None:
+                msg = f"Failed while restoring the saved values of '{node_name}'."
+                raise RuntimeError(msg)
+
+            with self.engine.context_manager.node(node=node):
+                for indirect_set_value_command in set_value_command_list:
+                    self._apply_deserialized_parameter_value(
+                        indirect_set_value_command=indirect_set_value_command,
+                        node=node,
+                        unique_parameter_uuid_to_values=serialized_flow_commands.unique_parameter_uuid_to_values,
+                    )
+
+        for sub_flow_commands in serialized_flow_commands.sub_flows_commands:
+            self._deserialize_values_for_flow_and_subflows(
+                serialized_flow_commands=sub_flow_commands, deserialized_nodes=deserialized_nodes
+            )
+
+    def _apply_deserialized_parameter_value(
+        self,
+        indirect_set_value_command: SerializedNodeCommands.IndirectSetParameterValueCommand,
+        node: BaseNode,
+        unique_parameter_uuid_to_values: dict[SerializedNodeCommands.UniqueParameterValueUUID, Any],
+    ) -> None:
+        """Set one saved parameter value on a rebuilt node.
+
+        Args:
+            indirect_set_value_command: The saved assignment, referencing its value by UUID
+            node: The node the value belongs to
+            unique_parameter_uuid_to_values: The pool the value UUID resolves against
+
+        Raises:
+            RuntimeError: If the value is missing from the pool, or could not be set
+        """
+        parameter_name = indirect_set_value_command.set_parameter_value_command.parameter_name
+        unique_value_uuid = indirect_set_value_command.unique_value_uuid
+        if unique_value_uuid not in unique_parameter_uuid_to_values:
+            msg = f"Failed while restoring the saved value of '{node.name}.{parameter_name}' because the value was missing."
+            raise RuntimeError(msg)
+
+        # Call the SetParameterValueRequest, subbing in the value from our unique value list.
+        indirect_set_value_command.set_parameter_value_command.value = unique_parameter_uuid_to_values[
+            unique_value_uuid
+        ]
+        # Update the parameter value command to have the correct name.
+        indirect_set_value_command.set_parameter_value_command.node_name = node.name
+        set_parameter_value_result = self.engine.handle_request(indirect_set_value_command.set_parameter_value_command)
+        if set_parameter_value_result.failed():
+            msg = f"Failed while restoring the saved value of '{node.name}.{parameter_name}'."
+            raise RuntimeError(msg)
 
     async def start_flow(
         self,

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -4022,9 +4022,9 @@ class FlowManager(EngineScoped):
         # Deserializing a flow goes in a specific order: every node in this Flow AND its subflows
         # first, then connections, then values. Connections are serialized against a Flow's whole
         # subtree (see _aggregate_connections), so an edge crossing a Flow boundary names a node
-        # that lives one or more levels down. Wiring connections before the subflows existed made
-        # every such edge fail with "node did not exist within the flow", which failed the whole
-        # load for any graph containing a node group or a nested subflow.
+        # that lives one or more levels down. Connections are wired only after every node in the
+        # subtree exists, subflows included, because any earlier and such an edge fails with "node
+        # did not exist within the flow" and fails the whole load.
         try:
             deserialized_nodes = self._deserialize_nodes_for_flow_and_subflows(
                 serialized_flow_commands=request.serialized_flow_commands

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -132,6 +132,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
     PackageNodesAsSerializedFlowResultFailure,
     PackageNodesAsSerializedFlowResultSuccess,
     SanitizedParameterName,
+    SerializedConnectionKey,
     SerializedFlowCommands,
     SerializeFlowToCommandsRequest,
     SerializeFlowToCommandsResultFailure,
@@ -252,6 +253,18 @@ class MultiNodeEndNodeResult(NamedTuple):
     parameter_name_mappings: dict[SanitizedParameterName, OriginalNodeParameter]
     alter_parameter_commands: list[AlterParameterDetailsRequest]
     end_node_name: str
+
+
+class FlowDeserializationError(Exception):
+    """A saved Flow could not be rebuilt.
+
+    Rebuilding a Flow runs in three passes — nodes, then connections, then values — each of which
+    recurses through every subflow. Any of them can fail deep in the recursion, and all of them fail
+    the whole load. Raising this specific type lets on_deserialize_flow_from_commands catch exactly
+    the failures its own passes report, rather than every RuntimeError from the request handlers
+    those passes call into. The message is user-facing: it is appended to "Attempted to deserialize
+    a Flow 'X'. ", so phrase it as a sentence completing that thought.
+    """
 
 
 @dataclass
@@ -4013,39 +4026,29 @@ class FlowManager(EngineScoped):
             deserialized_nodes = self._deserialize_nodes_for_flow_and_subflows(
                 serialized_flow_commands=request.serialized_flow_commands
             )
-        except RuntimeError as err:
+
+            # Now apply the connections, for this Flow and every Flow beneath it.
+            # We didn't know the exact name that would be used for the nodes, but we knew the node's
+            # creation UUID. Tie the UUID back to the node names.
+            self._deserialize_connections_for_flow_and_subflows(
+                serialized_flow_commands=request.serialized_flow_commands,
+                deserialized_nodes=deserialized_nodes,
+                created_connection_keys=set(),
+            )
+
+            # Now assign the values, again across the whole subtree.
+            # This is the same issue that we handle for Connections:
+            # we don't know the exact node name that would be used, but we do know the UUIDs.
+            self._deserialize_values_for_flow_and_subflows(
+                serialized_flow_commands=request.serialized_flow_commands, deserialized_nodes=deserialized_nodes
+            )
+        except FlowDeserializationError as err:
             details = f"Attempted to deserialize a Flow '{flow_name}'. {err}"
             if created_new_flow:
                 self._cleanup_flow_on_failed_deserialization(flow_name, pushed_flow_context=pushed_flow_context)
             return DeserializeFlowFromCommandsResultFailure(result_details=details)
 
         node_name_mappings = deserialized_nodes.original_name_to_node_name
-
-        # Now apply the connections, for this Flow and every Flow beneath it.
-        # We didn't know the exact name that would be used for the nodes, but we knew the node's
-        # creation UUID. Tie the UUID back to the node names.
-        try:
-            self._deserialize_connections_for_flow_and_subflows(
-                serialized_flow_commands=request.serialized_flow_commands, deserialized_nodes=deserialized_nodes
-            )
-        except RuntimeError as err:
-            details = f"Attempted to deserialize a Flow '{flow_name}'. {err}"
-            if created_new_flow:
-                self._cleanup_flow_on_failed_deserialization(flow_name, pushed_flow_context=pushed_flow_context)
-            return DeserializeFlowFromCommandsResultFailure(result_details=details)
-
-        # Now assign the values, again across the whole subtree.
-        # This is the same issue that we handle for Connections:
-        # we don't know the exact node name that would be used, but we do know the UUIDs.
-        try:
-            self._deserialize_values_for_flow_and_subflows(
-                serialized_flow_commands=request.serialized_flow_commands, deserialized_nodes=deserialized_nodes
-            )
-        except RuntimeError as err:
-            details = f"Attempted to deserialize a Flow '{flow_name}'. {err}"
-            if created_new_flow:
-                self._cleanup_flow_on_failed_deserialization(flow_name, pushed_flow_context=pushed_flow_context)
-            return DeserializeFlowFromCommandsResultFailure(result_details=details)
 
         # Pop flow context if requested and we pushed it
         if request.pop_flow_context_after and pushed_flow_context:
@@ -4076,7 +4079,7 @@ class FlowManager(EngineScoped):
             The rebuilt nodes of this Flow and its whole subtree
 
         Raises:
-            RuntimeError: If a node, or a subflow holding nodes, could not be rebuilt
+            FlowDeserializationError: If a node, or a subflow holding nodes, could not be rebuilt
         """
         deserialized_nodes = DeserializedFlowNodes()
 
@@ -4113,7 +4116,7 @@ class FlowManager(EngineScoped):
             deserialized_nodes: The collection to record the rebuilt node in
 
         Raises:
-            RuntimeError: If the node could not be rebuilt
+            FlowDeserializationError: If the node could not be rebuilt
         """
         node_name = self._deserialize_one_node(serialized_node=serialized_node, deserialized_nodes=deserialized_nodes)
         deserialized_nodes.node_uuid_to_node_name[serialized_node.node_uuid] = node_name
@@ -4135,7 +4138,7 @@ class FlowManager(EngineScoped):
             The name the rebuilt node was given
 
         Raises:
-            RuntimeError: If the node could not be rebuilt
+            FlowDeserializationError: If the node could not be rebuilt
         """
         create_cmd = serialized_node.create_node_command
         serialized_node_for_deserialization = serialized_node
@@ -4146,11 +4149,18 @@ class FlowManager(EngineScoped):
         # because the names they will be rebuilt under are not known until they are rebuilt.
         if create_cmd.node_names_to_add:
             member_uuids = [SerializedNodeCommands.NodeUUID(name) for name in create_cmd.node_names_to_add]
-            remapped_names = [
-                deserialized_nodes.node_uuid_to_node_name[member_uuid]
-                for member_uuid in member_uuids
-                if member_uuid in deserialized_nodes.node_uuid_to_node_name
-            ]
+            unresolved_count = sum(
+                1 for member_uuid in member_uuids if member_uuid not in deserialized_nodes.node_uuid_to_node_name
+            )
+            # A group IS its membership, so a group that comes back holding three of its five nodes is
+            # worse than a load that stops and says so. Every member is rebuildable by the time we get
+            # here because _deserialize_nodes_for_flow_and_subflows rebuilds groups last; if that
+            # ordering ever regresses, fail loudly instead of quietly returning a hollowed-out group.
+            if unresolved_count:
+                group_name = create_cmd.node_name or create_cmd.node_type
+                msg = f"Failed while rebuilding the group '{group_name}' because {unresolved_count} of its {len(member_uuids)} nodes were not rebuilt."
+                raise FlowDeserializationError(msg)
+            remapped_names = [deserialized_nodes.node_uuid_to_node_name[member_uuid] for member_uuid in member_uuids]
             create_cmd_copy = CreateNodeRequest(
                 node_type=create_cmd.node_type,
                 specific_library_name=create_cmd.specific_library_name,
@@ -4178,7 +4188,7 @@ class FlowManager(EngineScoped):
         deserialized_node_result = self.engine.handle_request(deserialize_node_request)
         if not isinstance(deserialized_node_result, DeserializeNodeFromCommandsResultSuccess):
             msg = f"Failed while rebuilding the node '{create_cmd.node_name}'."
-            raise RuntimeError(msg)  # noqa: TRY004 - the request failed at runtime; this is not a type error.
+            raise FlowDeserializationError(msg)
 
         return deserialized_node_result.node_name
 
@@ -4192,7 +4202,7 @@ class FlowManager(EngineScoped):
             The rebuilt nodes of the subflow and its whole subtree
 
         Raises:
-            RuntimeError: If the subflow could not be created or entered
+            FlowDeserializationError: If the subflow could not be created or entered
         """
         flow_initialization_command = sub_flow_commands.flow_initialization_command
         if flow_initialization_command is None:
@@ -4204,7 +4214,7 @@ class FlowManager(EngineScoped):
         sub_flow = self.engine.object_manager.attempt_get_object_by_name_as_type(sub_flow_name, ControlFlow)
         if sub_flow is None:
             msg = f"Failed to find the sub-flow '{sub_flow_name}' just created for it."
-            raise RuntimeError(msg)
+            raise FlowDeserializationError(msg)
 
         # Nodes are created into the Flow at the top of the context stack, so enter the subflow
         # while rebuilding its contents and leave it afterwards.
@@ -4223,7 +4233,7 @@ class FlowManager(EngineScoped):
             The name of the created Flow
 
         Raises:
-            RuntimeError: If the Flow could not be created
+            FlowDeserializationError: If the Flow could not be created
         """
         flow_initialization_result = self.engine.handle_request(flow_initialization_command)
 
@@ -4231,38 +4241,55 @@ class FlowManager(EngineScoped):
             case CreateFlowRequest():
                 if not isinstance(flow_initialization_result, CreateFlowResultSuccess):
                     msg = f"Failed to create the sub-flow '{flow_initialization_command.flow_name}'."
-                    raise RuntimeError(msg)  # noqa: TRY004 - the request failed at runtime; this is not a type error.
+                    raise FlowDeserializationError(msg)
                 return flow_initialization_result.flow_name
             case ImportWorkflowAsReferencedSubFlowRequest():
                 if not isinstance(flow_initialization_result, ImportWorkflowAsReferencedSubFlowResultSuccess):
                     msg = f"Failed to import the workflow '{flow_initialization_command.workflow_name}' as a sub-flow."
-                    raise RuntimeError(msg)  # noqa: TRY004 - the request failed at runtime; this is not a type error.
+                    raise FlowDeserializationError(msg)
                 return flow_initialization_result.created_flow_name
             case _:
                 msg = f"Failed because the sub-flow used an unknown creation command: {type(flow_initialization_command).__name__}."
-                raise RuntimeError(msg)
+                raise FlowDeserializationError(msg)
 
     def _deserialize_connections_for_flow_and_subflows(
-        self, serialized_flow_commands: SerializedFlowCommands, deserialized_nodes: DeserializedFlowNodes
+        self,
+        serialized_flow_commands: SerializedFlowCommands,
+        deserialized_nodes: DeserializedFlowNodes,
+        created_connection_keys: set[SerializedConnectionKey],
     ) -> None:
-        """Recreate the connections of a Flow and every Flow beneath it.
+        """Recreate the connections of a Flow and every Flow beneath it, each exactly once.
+
+        Serialization aggregates every subflow's connections up into each of its ancestors (see
+        _aggregate_connections), so an edge crossing N group boundaries is reported N+1 times. It
+        has to be created only once: re-issuing an existing edge is not a no-op, because
+        on_create_connection_request treats a duplicate as a restricted scenario and tears the
+        existing edge down before rebuilding it, which churns the group proxy parameters that the
+        edge was routed through. Claiming each edge the first time it is seen keeps the load path
+        from undoing the wiring it just restored.
 
         Args:
             serialized_flow_commands: The commands for the Flow being rebuilt
             deserialized_nodes: Every node rebuilt for this Flow's whole subtree
+            created_connection_keys: Edges already created for this Flow's subtree, added to here
 
         Raises:
-            RuntimeError: If a connection names a node that was not rebuilt, or could not be made
+            FlowDeserializationError: If a connection names a node that was not rebuilt, or could not be made
         """
         for indirect_connection in serialized_flow_commands.serialized_connections:
             source_node_name = deserialized_nodes.node_uuid_to_node_name.get(indirect_connection.source_node_uuid)
             if source_node_name is None:
                 msg = "Failed while reconnecting the flow because the node a connection starts from was not rebuilt."
-                raise RuntimeError(msg)
+                raise FlowDeserializationError(msg)
             target_node_name = deserialized_nodes.node_uuid_to_node_name.get(indirect_connection.target_node_uuid)
             if target_node_name is None:
                 msg = "Failed while reconnecting the flow because the node a connection leads to was not rebuilt."
-                raise RuntimeError(msg)
+                raise FlowDeserializationError(msg)
+
+            connection_key = indirect_connection.key()
+            if connection_key in created_connection_keys:
+                continue
+            created_connection_keys.add(connection_key)
 
             create_connection_request = CreateConnectionRequest(
                 source_node_name=source_node_name,
@@ -4273,11 +4300,13 @@ class FlowManager(EngineScoped):
             create_connection_result = self.engine.handle_request(create_connection_request)
             if create_connection_result.failed():
                 msg = f"Failed while reconnecting '{source_node_name}.{indirect_connection.source_parameter_name}' to '{target_node_name}.{indirect_connection.target_parameter_name}'."
-                raise RuntimeError(msg)
+                raise FlowDeserializationError(msg)
 
         for sub_flow_commands in serialized_flow_commands.sub_flows_commands:
             self._deserialize_connections_for_flow_and_subflows(
-                serialized_flow_commands=sub_flow_commands, deserialized_nodes=deserialized_nodes
+                serialized_flow_commands=sub_flow_commands,
+                deserialized_nodes=deserialized_nodes,
+                created_connection_keys=created_connection_keys,
             )
 
     def _deserialize_values_for_flow_and_subflows(
@@ -4290,17 +4319,17 @@ class FlowManager(EngineScoped):
             deserialized_nodes: Every node rebuilt for this Flow's whole subtree
 
         Raises:
-            RuntimeError: If a value belongs to a node that was not rebuilt, or could not be set
+            FlowDeserializationError: If a value belongs to a node that was not rebuilt, or could not be set
         """
         for node_uuid, set_value_command_list in serialized_flow_commands.set_parameter_value_commands.items():
             node_name = deserialized_nodes.node_uuid_to_node_name.get(node_uuid)
             if node_name is None:
                 msg = "Failed while restoring saved values because the node they belong to was not rebuilt."
-                raise RuntimeError(msg)
+                raise FlowDeserializationError(msg)
             node = self.engine.object_manager.attempt_get_object_by_name_as_type(node_name, BaseNode)
             if node is None:
                 msg = f"Failed while restoring the saved values of '{node_name}'."
-                raise RuntimeError(msg)
+                raise FlowDeserializationError(msg)
 
             with self.engine.context_manager.node(node=node):
                 for indirect_set_value_command in set_value_command_list:
@@ -4329,13 +4358,13 @@ class FlowManager(EngineScoped):
             unique_parameter_uuid_to_values: The pool the value UUID resolves against
 
         Raises:
-            RuntimeError: If the value is missing from the pool, or could not be set
+            FlowDeserializationError: If the value is missing from the pool, or could not be set
         """
         parameter_name = indirect_set_value_command.set_parameter_value_command.parameter_name
         unique_value_uuid = indirect_set_value_command.unique_value_uuid
         if unique_value_uuid not in unique_parameter_uuid_to_values:
             msg = f"Failed while restoring the saved value of '{node.name}.{parameter_name}' because the value was missing."
-            raise RuntimeError(msg)
+            raise FlowDeserializationError(msg)
 
         # Call the SetParameterValueRequest, subbing in the value from our unique value list.
         indirect_set_value_command.set_parameter_value_command.value = unique_parameter_uuid_to_values[
@@ -4346,7 +4375,7 @@ class FlowManager(EngineScoped):
         set_parameter_value_result = self.engine.handle_request(indirect_set_value_command.set_parameter_value_command)
         if set_parameter_value_result.failed():
             msg = f"Failed while restoring the saved value of '{node.name}.{parameter_name}'."
-            raise RuntimeError(msg)
+            raise FlowDeserializationError(msg)
 
     async def start_flow(
         self,
@@ -4359,12 +4388,12 @@ class FlowManager(EngineScoped):
         if self.check_for_existing_running_flow():
             # If flow already exists, throw an error
             errormsg = "This workflow is already in progress. Please wait for the current process to finish before starting again."
-            raise RuntimeError(errormsg)
+            raise FlowDeserializationError(errormsg)
 
         if start_node is None:
             if self._global_flow_queue.empty():
                 errormsg = "No Flow exists. You must create at least one control connection."
-                raise RuntimeError(errormsg)
+                raise FlowDeserializationError(errormsg)
             queue_item = self._global_flow_queue.get()
             start_node = queue_item.node
             self._global_flow_queue.task_done()

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -5,7 +5,7 @@ import base64
 import copy
 import logging
 import pickle
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import StrEnum
 from io import BytesIO
 from pathlib import Path
@@ -274,10 +274,15 @@ class DeserializedFlowNodes:
     Connections are serialized against a Flow's whole subtree, not just its own level, so the
     connection pass has to resolve UUIDs belonging to nodes that were rebuilt inside a subflow.
     Collecting the whole subtree first is what lets a single pass wire them all up.
+
+    Flow names are collected for the same reason node names are: a group records the name of its
+    subflow, and both names are deduped on the way back in, so a group rebuilt into a session that
+    already holds one of the same name has to be pointed at the subflow this load actually created.
     """
 
     node_uuid_to_node_name: dict[SerializedNodeCommands.NodeUUID, str] = field(default_factory=dict)
     original_name_to_node_name: dict[str, str] = field(default_factory=dict)
+    original_flow_name_to_flow_name: dict[str, str] = field(default_factory=dict)
 
     def merge(self, other: DeserializedFlowNodes) -> None:
         """Fold a subflow's rebuilt nodes into this one.
@@ -287,6 +292,7 @@ class DeserializedFlowNodes:
         """
         self.node_uuid_to_node_name.update(other.node_uuid_to_node_name)
         self.original_name_to_node_name.update(other.original_name_to_node_name)
+        self.original_flow_name_to_flow_name.update(other.original_flow_name_to_flow_name)
 
 
 class FlowManager(EngineScoped):
@@ -477,6 +483,14 @@ class FlowManager(EngineScoped):
 
         No peer manager has to be told: ``_name_to_parent_name`` is the only record of parentage, and
         NodeManager tracks a node's flow by name, which reparenting does not change.
+
+        Unlike every other structural change in retained mode, this is a plain method rather than a
+        request, so nothing is emitted and the editor is not told. That is a real gap, not a design
+        choice: there is no ``ReparentFlowRequest`` to route it through. It holds today because the
+        nesting that triggers it happens inside ``AddNodesToNodeGroupRequest``, whose own result the
+        editor already acts on, and because the editor derives group nesting from ``parent_group``
+        rather than from flow parentage. An editor feature that reads flow parentage directly would
+        need this promoted to a request first.
 
         Args:
             flow_name: The Flow to move
@@ -4033,6 +4047,14 @@ class FlowManager(EngineScoped):
             # Now apply the connections, for this Flow and every Flow beneath it.
             # We didn't know the exact name that would be used for the nodes, but we knew the node's
             # creation UUID. Tie the UUID back to the node names.
+            #
+            # The outermost Flow claims every edge, deliberately, and the recursion below it finds
+            # nothing left to do: this Flow's serialized_connections is the fully aggregated list, and
+            # each edge is created the first time it is seen. Codegen resolves the same duplication
+            # the other way round -- it recurses first, so the innermost Flow wins -- because there
+            # the edge has to be written where its endpoints are already in scope as variables. Here
+            # every node in the subtree exists before any edge is made, so there is no such
+            # constraint and claiming at the top is the simpler of the two.
             self._deserialize_connections_for_flow_and_subflows(
                 serialized_flow_commands=request.serialized_flow_commands,
                 deserialized_nodes=deserialized_nodes,
@@ -4146,44 +4168,18 @@ class FlowManager(EngineScoped):
         create_cmd = serialized_node.create_node_command
         serialized_node_for_deserialization = serialized_node
 
-        # For SubflowNodeGroups, remap node_names_to_add from UUIDs to actual node names.
-        # Create a copy to avoid mutating the original serialized data.
-        # The field is declared as plain names, but a serialized group stores its members as UUIDs
-        # because the names they will be rebuilt under are not known until they are rebuilt.
-        if create_cmd.node_names_to_add:
-            member_uuids = [SerializedNodeCommands.NodeUUID(name) for name in create_cmd.node_names_to_add]
-            unresolved_count = sum(
-                1 for member_uuid in member_uuids if member_uuid not in deserialized_nodes.node_uuid_to_node_name
+        # A saved group names things by what they were called at save time, and every one of those
+        # names is deduped on the way back in. Rewrite them to what this load actually created,
+        # copying rather than mutating so the caller's serialized data is left as it was found.
+        if serialized_node.is_node_group:
+            create_cmd_copy = replace(
+                create_cmd,
+                node_names_to_add=self._remapped_group_member_names(
+                    create_cmd=create_cmd, deserialized_nodes=deserialized_nodes
+                ),
+                metadata=self._remapped_group_metadata(create_cmd=create_cmd, deserialized_nodes=deserialized_nodes),
             )
-            # A group IS its membership, so a group that comes back holding three of its five nodes is
-            # worse than a load that stops and says so. Every member is rebuildable by the time we get
-            # here because _deserialize_nodes_for_flow_and_subflows rebuilds groups last; if that
-            # ordering ever regresses, fail loudly instead of quietly returning a hollowed-out group.
-            if unresolved_count:
-                group_name = create_cmd.node_name or create_cmd.node_type
-                msg = f"Failed while rebuilding the group '{group_name}' because {unresolved_count} of its {len(member_uuids)} nodes were not rebuilt."
-                raise FlowDeserializationError(msg)
-            remapped_names = [deserialized_nodes.node_uuid_to_node_name[member_uuid] for member_uuid in member_uuids]
-            create_cmd_copy = CreateNodeRequest(
-                node_type=create_cmd.node_type,
-                specific_library_name=create_cmd.specific_library_name,
-                node_name=create_cmd.node_name,
-                node_names_to_add=remapped_names,
-                override_parent_flow_name=create_cmd.override_parent_flow_name,
-                metadata=create_cmd.metadata,
-                resolution=create_cmd.resolution,
-                initial_setup=create_cmd.initial_setup,
-                set_as_new_context=create_cmd.set_as_new_context,
-                create_error_proxy_on_failure=create_cmd.create_error_proxy_on_failure,
-            )
-            serialized_node_for_deserialization = SerializedNodeCommands(
-                node_uuid=serialized_node.node_uuid,
-                create_node_command=create_cmd_copy,
-                element_modification_commands=serialized_node.element_modification_commands,
-                node_dependencies=serialized_node.node_dependencies,
-                lock_node_command=serialized_node.lock_node_command,
-                is_node_group=serialized_node.is_node_group,
-            )
+            serialized_node_for_deserialization = replace(serialized_node, create_node_command=create_cmd_copy)
 
         deserialize_node_request = DeserializeNodeFromCommandsRequest(
             serialized_node_commands=serialized_node_for_deserialization
@@ -4194,6 +4190,84 @@ class FlowManager(EngineScoped):
             raise FlowDeserializationError(msg)
 
         return deserialized_node_result.node_name
+
+    def _remapped_group_member_names(
+        self, create_cmd: CreateNodeRequest, deserialized_nodes: DeserializedFlowNodes
+    ) -> list[str] | None:
+        """Turn a saved group's member UUIDs into the names its members were rebuilt under.
+
+        The field is declared as plain names, but a serialized group stores its members as UUIDs,
+        because the names they will be rebuilt under are not known until they are rebuilt.
+
+        Args:
+            create_cmd: The group's creation command as it was saved
+            deserialized_nodes: Nodes rebuilt so far, holding the UUID-to-name mapping
+
+        Returns:
+            The members' rebuilt names, or None if the group was saved holding nothing
+
+        Raises:
+            FlowDeserializationError: If any member was not rebuilt
+        """
+        if not create_cmd.node_names_to_add:
+            return None
+
+        member_uuids = [SerializedNodeCommands.NodeUUID(name) for name in create_cmd.node_names_to_add]
+        unresolved_count = sum(
+            1 for member_uuid in member_uuids if member_uuid not in deserialized_nodes.node_uuid_to_node_name
+        )
+        # A group IS its membership, so a group that comes back holding three of its five nodes is
+        # worse than a load that stops and says so. Every member is rebuildable by the time we get
+        # here because _deserialize_nodes_for_flow_and_subflows rebuilds groups last; if that
+        # ordering ever regresses, fail loudly instead of quietly returning a hollowed-out group.
+        if unresolved_count:
+            group_name = create_cmd.node_name or create_cmd.node_type
+            msg = f"Failed while rebuilding the group '{group_name}' because {unresolved_count} of its {len(member_uuids)} nodes were not rebuilt."
+            raise FlowDeserializationError(msg)
+
+        return [deserialized_nodes.node_uuid_to_node_name[member_uuid] for member_uuid in member_uuids]
+
+    def _remapped_group_metadata(
+        self, create_cmd: CreateNodeRequest, deserialized_nodes: DeserializedFlowNodes
+    ) -> dict | None:
+        """Point a saved group's `subflow_name` at the subflow this load created for it.
+
+        A group records its subflow by name, and that name is deduped like any other on the way in:
+        loading a graph into a session that already holds a same-named subflow creates the group's
+        one under a new name. Left unremapped, the rebuilt group reaches for the name it was saved
+        with, finds a flow belonging to something else, and moves the nodes it just loaded into it --
+        with no error, because the flow it names does exist.
+
+        Args:
+            create_cmd: The group's creation command as it was saved
+            deserialized_nodes: Rebuilt nodes, holding the saved-to-created flow name mapping
+
+        Returns:
+            Metadata with the subflow name rewritten, or the original if there is nothing to rewrite
+        """
+        saved_metadata = create_cmd.metadata
+        if saved_metadata is None:
+            return None
+
+        saved_subflow_name = saved_metadata.get("subflow_name")
+        if saved_subflow_name is None:
+            # Copy/paste strips subflow_name so the pasted group builds a fresh subflow of its own.
+            return saved_metadata
+
+        created_subflow_name = deserialized_nodes.original_flow_name_to_flow_name.get(saved_subflow_name)
+        if created_subflow_name is None:
+            # The group's subflow was not part of this load. Its own on-demand creation path handles
+            # that, and keeping a stale name would point it at whatever now answers to it.
+            remapped_metadata = copy.deepcopy(saved_metadata)
+            remapped_metadata.pop("subflow_name", None)
+            return remapped_metadata
+
+        if created_subflow_name == saved_subflow_name:
+            return saved_metadata
+
+        remapped_metadata = copy.deepcopy(saved_metadata)
+        remapped_metadata["subflow_name"] = created_subflow_name
+        return remapped_metadata
 
     def _deserialize_subflow_nodes(self, sub_flow_commands: SerializedFlowCommands) -> DeserializedFlowNodes:
         """Create one subflow and rebuild the nodes inside it, and inside its own subflows.
@@ -4222,7 +4296,35 @@ class FlowManager(EngineScoped):
         # Nodes are created into the Flow at the top of the context stack, so enter the subflow
         # while rebuilding its contents and leave it afterwards.
         with self.engine.context_manager.flow(flow=sub_flow):
-            return self._deserialize_nodes_for_flow_and_subflows(serialized_flow_commands=sub_flow_commands)
+            sub_flow_nodes = self._deserialize_nodes_for_flow_and_subflows(serialized_flow_commands=sub_flow_commands)
+
+        # Record what this flow was saved as against what it came back as. A group node saved a
+        # reference to its subflow by name, and the name is deduped on the way in, so the group has
+        # to be pointed at the flow this load created rather than a same-named one already here.
+        original_flow_name = self._original_flow_name_of(flow_initialization_command=flow_initialization_command)
+        if original_flow_name is not None:
+            sub_flow_nodes.original_flow_name_to_flow_name[original_flow_name] = sub_flow_name
+
+        return sub_flow_nodes
+
+    def _original_flow_name_of(
+        self, flow_initialization_command: CreateFlowRequest | ImportWorkflowAsReferencedSubFlowRequest
+    ) -> str | None:
+        """The name a Flow was saved under, which is what a group's stored reference names it by.
+
+        Args:
+            flow_initialization_command: The command that brought the Flow into existence
+
+        Returns:
+            The saved name, or None if the command carries no name to map from
+        """
+        match flow_initialization_command:
+            case CreateFlowRequest():
+                return flow_initialization_command.flow_name
+            case ImportWorkflowAsReferencedSubFlowRequest():
+                # An imported workflow is referenced by workflow name, not by a flow name a group
+                # could have recorded, so there is nothing to map.
+                return None
 
     def _create_flow_for_deserialization(
         self, flow_initialization_command: CreateFlowRequest | ImportWorkflowAsReferencedSubFlowRequest

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -475,6 +475,9 @@ class FlowManager(EngineScoped):
         Serialization walks parent/child links, so a subflow left parented to the top-level flow is
         saved outside its enclosing group and its members go missing on load.
 
+        No peer manager has to be told: ``_name_to_parent_name`` is the only record of parentage, and
+        NodeManager tracks a node's flow by name, which reparenting does not change.
+
         Args:
             flow_name: The Flow to move
             new_parent_flow_name: The Flow that should become its parent
@@ -4388,12 +4391,12 @@ class FlowManager(EngineScoped):
         if self.check_for_existing_running_flow():
             # If flow already exists, throw an error
             errormsg = "This workflow is already in progress. Please wait for the current process to finish before starting again."
-            raise FlowDeserializationError(errormsg)
+            raise RuntimeError(errormsg)
 
         if start_node is None:
             if self._global_flow_queue.empty():
                 errormsg = "No Flow exists. You must create at least one control connection."
-                raise FlowDeserializationError(errormsg)
+                raise RuntimeError(errormsg)
             queue_item = self._global_flow_queue.get()
             start_node = queue_item.node
             self._global_flow_queue.task_done()

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -431,6 +431,44 @@ class FlowManager(EngineScoped):
         msg = f"Flow with name {flow_name} doesn't exist"
         raise ValueError(msg)
 
+    def reparent_flow(self, flow_name: str, new_parent_flow_name: str) -> None:
+        """Move a Flow under a different parent Flow.
+
+        Used when a node group is nested inside another: the inner group's subflow has to become a
+        child of the outer group's subflow so the saved flow hierarchy mirrors the group nesting.
+        Serialization walks parent/child links, so a subflow left parented to the top-level flow is
+        saved outside its enclosing group and its members go missing on load.
+
+        Args:
+            flow_name: The Flow to move
+            new_parent_flow_name: The Flow that should become its parent
+
+        Raises:
+            ValueError: If either Flow is unknown, or the move would create a cycle
+        """
+        if flow_name not in self._name_to_parent_name:
+            msg = f"Flow with name {flow_name} doesn't exist"
+            raise ValueError(msg)
+        if new_parent_flow_name not in self._name_to_parent_name:
+            msg = f"Flow with name {new_parent_flow_name} doesn't exist"
+            raise ValueError(msg)
+        if flow_name == new_parent_flow_name:
+            msg = f"Attempted to make Flow '{flow_name}' its own parent."
+            raise ValueError(msg)
+
+        # Walk up from the proposed parent: if we meet the flow being moved, the move would
+        # detach that branch from the tree and make the ancestor walk loop forever.
+        ancestor = self._name_to_parent_name[new_parent_flow_name]
+        while ancestor is not None:
+            if ancestor == flow_name:
+                msg = (
+                    f"Attempted to move Flow '{flow_name}' under '{new_parent_flow_name}', which is already inside it."
+                )
+                raise ValueError(msg)
+            ancestor = self._name_to_parent_name.get(ancestor)
+
+        self._name_to_parent_name[flow_name] = new_parent_flow_name
+
     def is_referenced_workflow(self, flow: ControlFlow) -> bool:
         """Check if this flow was created by importing a referenced workflow.
 
@@ -999,8 +1037,11 @@ class FlowManager(EngineScoped):
             details = f"Deleted the previous connection from '{old_source_node_name}.{old_source_param_name}' to '{old_target_node_name}.{old_target_param_name}' to make room for the new connection."
         try:
             # Actually create the Connection.
-            if (isinstance(source_node, SubflowNodeGroup) and target_node.parent_group == source_node) or (
-                isinstance(target_node, SubflowNodeGroup) and source_node.parent_group == target_node
+            # A connection between a group and a node inside it is internal. "Inside" is
+            # transitive: with nested groups the node's own parent_group may be an inner group,
+            # so we test containment across the whole nesting tree rather than the direct parent.
+            if (isinstance(source_node, SubflowNodeGroup) and source_node.contains_node(target_node)) or (
+                isinstance(target_node, SubflowNodeGroup) and target_node.contains_node(source_node)
             ):
                 # Here we're checking if it's an internal connection. (from the NodeGroup to a node within it.)
                 # If that's true, we set that automatically.
@@ -1055,13 +1096,31 @@ class FlowManager(EngineScoped):
         source_parent = source_node.parent_group
         target_parent = target_node.parent_group
 
-        # If source is in a group, this is an outgoing external connection
+        # Only a connection that actually leaves the group needs a proxy parameter. Containment is
+        # transitive, so a group must treat a node nested deeper inside it as internal: testing only
+        # the direct parent made a group proxy connections that never crossed its boundary, and the
+        # replacement connections re-entered here and were proxied again without end.
+        # Each remap hands off one level outward (a child's group proxies to its own parent group),
+        # so the walk terminates at the outermost group.
+        crossed_source_group = None
         if (
-            source_parent is not None
-            and isinstance(source_parent, SubflowNodeGroup)
-            and source_parent not in (target_parent, target_node)
+            isinstance(source_parent, SubflowNodeGroup)
+            and source_parent is not target_node
+            and not source_parent.contains_node(target_node)
         ):
-            success = source_parent.map_external_connection(
+            crossed_source_group = source_parent
+
+        crossed_target_group = None
+        if (
+            isinstance(target_parent, SubflowNodeGroup)
+            and target_parent is not source_node
+            and not target_parent.contains_node(source_node)
+        ):
+            crossed_target_group = target_parent
+
+        # If source is in a group, this is an outgoing external connection
+        if crossed_source_group is not None:
+            success = crossed_source_group.map_external_connection(
                 conn=conn,
                 is_incoming=False,
             )
@@ -1072,12 +1131,8 @@ class FlowManager(EngineScoped):
             return CreateConnectionResultFailure(result_details=details)
 
         # If target is in a group, this is an incoming external connection
-        if (
-            target_parent is not None
-            and isinstance(target_parent, SubflowNodeGroup)
-            and target_parent not in (source_parent, source_node)
-        ):
-            success = target_parent.map_external_connection(
+        if crossed_target_group is not None:
+            success = crossed_target_group.map_external_connection(
                 conn=conn,
                 is_incoming=True,
             )

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -4325,6 +4325,8 @@ class FlowManager(EngineScoped):
                 # An imported workflow is referenced by workflow name, not by a flow name a group
                 # could have recorded, so there is nothing to map.
                 return None
+            case _:
+                return None
 
     def _create_flow_for_deserialization(
         self, flow_initialization_command: CreateFlowRequest | ImportWorkflowAsReferencedSubFlowRequest

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -42,7 +42,7 @@ from griptape_nodes.exe_types.core_types import (
     ParameterTypeBuiltin,
 )
 from griptape_nodes.exe_types.flow import ControlFlow
-from griptape_nodes.exe_types.node_groups import SubflowNodeGroup
+from griptape_nodes.exe_types.node_groups import NodeGroupMembershipError, SubflowNodeGroup
 from griptape_nodes.exe_types.node_groups.base_node_group import BaseNodeGroup
 from griptape_nodes.exe_types.node_types import (
     LOCAL_EXECUTION,
@@ -1202,10 +1202,11 @@ class NodeManager(EngineScoped):
 
         try:
             nodes_removed = node_group.remove_nodes_from_group(nodes)
-        except (ValueError, RuntimeError) as err:
-            # ValueError: a requested node is not a member. RuntimeError: a SubflowNodeGroup could not
-            # move a node back to the parent flow, which tether expansion makes likelier by doubling
-            # the moves per request.
+        except (ValueError, RuntimeError, NodeGroupMembershipError) as err:
+            # ValueError: a requested node is not a member. NodeGroupMembershipError: a
+            # SubflowNodeGroup could not move a node back to the parent flow, which tether expansion
+            # makes likelier by doubling the moves per request. RuntimeError: raised by group code
+            # predating that specific type.
             details = f"Attempted to remove nodes '{request.node_names}' from NodeGroup '{request.node_group_name}'. Failed with error: {err}"
             return RemoveNodeFromNodeGroupResultFailure(result_details=details)
 

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -5021,7 +5021,7 @@ class WorkflowManager(EngineScoped):
             or len(serialized_flow_commands.serialized_variable_commands) > 0
         )
 
-    def _generate_node_creation_code(  # noqa: C901, PLR0912, PLR0915
+    def _generate_node_creation_code(  # noqa: C901, PLR0912
         self,
         serialized_node_command: SerializedNodeCommands,
         node_index: int,
@@ -5067,27 +5067,36 @@ class WorkflowManager(EngineScoped):
                     # Special handling for node_names_to_add - these are now UUIDs, convert to variable references
                     if field_value is create_node_request.node_names_to_add and field_value:
                         # field_value is now a list of UUIDs (converted in _serialize_package_nodes_for_local_execution)
-                        # Convert each UUID to an AST Name node referencing the generated variable
-                        node_var_ast_list = []
-                        for node_uuid in field_value:
-                            if node_uuid in node_uuid_to_node_variable_name:
-                                variable_name = node_uuid_to_node_variable_name[node_uuid]
-                                node_var_ast_list.append(ast.Name(id=variable_name, ctx=ast.Load()))
-                            else:
-                                logger.info(
-                                    "NodeGroup child UUID '%s' not found in node_uuid_to_node_variable_name. Available UUIDs: %s...",
-                                    node_uuid,
-                                    list(node_uuid_to_node_variable_name.keys())[:5],
-                                )
-                        if node_var_ast_list:
-                            create_node_request_args.append(
-                                ast.keyword(arg=field.name, value=ast.List(elts=node_var_ast_list, ctx=ast.Load()))
+                        # Convert each UUID to an AST Name node referencing the generated variable.
+                        # Every member was written by now: members live in this group's subflow, and
+                        # a Flow's groups are written after its subflows (see _generate_flow_code).
+                        # Dropping the ones we cannot name would write the group out empty, which
+                        # saves cleanly and then loads as a group the artist has to refill by hand,
+                        # so fail the save instead of quietly losing the grouping.
+                        unnamed_member_uuids = [
+                            node_uuid for node_uuid in field_value if node_uuid not in node_uuid_to_node_variable_name
+                        ]
+                        if unnamed_member_uuids:
+                            group_name = create_node_request.node_name or create_node_request.node_type
+                            logger.error(
+                                "Cannot write the members of group '%s': node(s) %s were never written to the file",
+                                group_name,
+                                ", ".join(unnamed_member_uuids),
                             )
-                        else:
-                            logger.info(
-                                "NodeGroup node_names_to_add resulted in empty variable list. Original UUIDs: %s",
-                                field_value,
+                            msg = f"Attempted to save a workflow. Failed because {len(unnamed_member_uuids)} of the {len(field_value)} nodes in the group '{group_name}' had not been written to the file yet."
+                            raise ValueError(msg)
+                        create_node_request_args.append(
+                            ast.keyword(
+                                arg=field.name,
+                                value=ast.List(
+                                    elts=[
+                                        ast.Name(id=node_uuid_to_node_variable_name[node_uuid], ctx=ast.Load())
+                                        for node_uuid in field_value
+                                    ],
+                                    ctx=ast.Load(),
+                                ),
                             )
+                        )
                     else:
                         create_node_request_args.append(
                             self._keyword_from_field_value(field.name, field_value, create_node_request)
@@ -5258,7 +5267,7 @@ class WorkflowManager(EngineScoped):
             The statements creating each connection
 
         Raises:
-            KeyError: If an endpoint's node has not been written into the file yet
+            ValueError: If an endpoint's node has not been written into the file yet
         """
         # Ensure necessary imports are recorded
         import_recorder.add_from_import(
@@ -5270,16 +5279,23 @@ class WorkflowManager(EngineScoped):
         for connection in serialized_connections:
             # Match the connection's node UUID back to its variable name. Both endpoints must already
             # have been written, since the generated file refers to them by variable. Which Flow
-            # writes a given edge depends on the traversal (see _generate_flow_code), so name the
-            # nodes if that ever slips rather than letting a bare KeyError escape mid-save.
+            # writes a given edge depends on the traversal (see _generate_flow_code), so say what
+            # went missing if that ever slips rather than letting a bare KeyError escape mid-save.
             missing_endpoints = [
                 endpoint_uuid
                 for endpoint_uuid in (connection.source_node_uuid, connection.target_node_uuid)
                 if endpoint_uuid not in node_uuid_to_node_variable_name
             ]
             if missing_endpoints:
+                # The UUIDs are the only handle on nodes that were never written, so log them for
+                # whoever has to debug the save and keep the raised message readable.
+                logger.error(
+                    "Cannot write the connection to '%s': node(s) %s were never written to the file",
+                    connection.target_parameter_name,
+                    ", ".join(missing_endpoints),
+                )
                 msg = f"Attempted to save a workflow. Failed because a connection to '{connection.target_parameter_name}' refers to {len(missing_endpoints)} node(s) that had not been written to the file yet."
-                raise KeyError(msg)
+                raise ValueError(msg)
             source_node_variable_name = node_uuid_to_node_variable_name[connection.source_node_uuid]
             target_node_variable_name = node_uuid_to_node_variable_name[connection.target_node_uuid]
 
@@ -5410,8 +5426,30 @@ class WorkflowManager(EngineScoped):
         unique_values_dict_name: str,
         import_recorder: ImportRecorder,
     ) -> list[ast.stmt]:
+        """Write the statements that restore saved parameter values and lock states.
+
+        Args:
+            set_parameter_value_commands: Value commands for the nodes of one Flow, keyed by node
+            lock_commands: Lock-state commands for those same nodes
+            node_uuid_to_node_variable_name: Variable name written for each node so far, file-wide
+            unique_values_dict_name: Name of the generated dict holding the pickled values
+            import_recorder: Import recorder for tracking imports
+
+        Returns:
+            The statements setting each value
+
+        Raises:
+            ValueError: If a node carrying values has not been written into the file yet
+        """
         parameter_value_asts = []
         for node_uuid, indirect_set_parameter_value_commands in set_parameter_value_commands.items():
+            # Values are keyed per Flow and written after that Flow's nodes and subflows, so the node
+            # is always named by now. Say which node went missing if that ever stops holding, rather
+            # than letting a bare KeyError escape halfway through writing the file.
+            if node_uuid not in node_uuid_to_node_variable_name:
+                logger.error("Cannot write saved values: node '%s' was never written to the file", node_uuid)
+                msg = "Attempted to save a workflow. Failed because a node holding saved values had not been written to the file yet."
+                raise ValueError(msg)
             node_variable_name = node_uuid_to_node_variable_name[node_uuid]
             lock_node_command = lock_commands.get(node_uuid)
             parameter_value_asts.extend(

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -251,6 +251,66 @@ class WorkflowRegistrationResult(NamedTuple):
     failed: list[str]
 
 
+@dataclass
+class WorkflowCodegenState:
+    """Variable names and counters shared by every Flow written into one generated workflow file.
+
+    A generated file is a single flat script, so node and flow variable names have to be unique
+    across the whole file rather than per Flow. Nested node groups also break any per-Flow view of
+    the graph: a group's ``node_names_to_add`` can name a child that was created inside a deeper
+    subflow, and a connection can join nodes that live in different subflows. Threading one of these
+    through the whole recursion keeps every level looking at the same names.
+    """
+
+    node_uuid_to_node_variable_name: dict[SerializedNodeCommands.NodeUUID, str] = field(default_factory=dict)
+    subflow_name_to_variable_name: dict[str, str] = field(default_factory=dict)
+    next_node_index: int = 0
+    next_flow_index: int = 0
+    emitted_connection_keys: set[tuple[str, str, str, str]] = field(default_factory=set)
+
+    def reserve_node_index(self) -> int:
+        """Claim the next unused node variable index."""
+        node_index = self.next_node_index
+        self.next_node_index += 1
+        return node_index
+
+    def reserve_flow_index(self) -> int:
+        """Claim the next unused flow variable index."""
+        flow_index = self.next_flow_index
+        self.next_flow_index += 1
+        return flow_index
+
+    def take_unemitted_connections(
+        self, connections: list[SerializedFlowCommands.IndirectConnectionSerialization]
+    ) -> list[SerializedFlowCommands.IndirectConnectionSerialization]:
+        """Filter out connections already written elsewhere in the file, claiming the rest.
+
+        Each Flow's serialized connections include those of its subflows, so the same edge is
+        offered once per level of nesting. Emitting it every time would re-create the connection
+        repeatedly, which for a node group means tearing down and rebuilding the proxy parameter
+        the edge was routed through.
+
+        Args:
+            connections: The connections the current Flow would like to emit
+
+        Returns:
+            Only the connections no other Flow has emitted yet
+        """
+        unemitted_connections = []
+        for connection in connections:
+            connection_key = (
+                connection.source_node_uuid,
+                connection.source_parameter_name,
+                connection.target_node_uuid,
+                connection.target_parameter_name,
+            )
+            if connection_key in self.emitted_connection_keys:
+                continue
+            self.emitted_connection_keys.add(connection_key)
+            unemitted_connections.append(connection)
+        return unemitted_connections
+
+
 class WorkflowManager(EngineScoped):
     WORKFLOW_METADATA_HEADER: ClassVar[str] = "script"
     MAX_MINOR_VERSION_DEVIATION: ClassVar[int] = (
@@ -3212,7 +3272,7 @@ class WorkflowManager(EngineScoped):
             is_template=is_template,
         )
 
-    def _generate_workflow_file_content(  # noqa: PLR0912, PLR0915, C901
+    def _generate_workflow_file_content(
         self,
         serialized_flow_commands: SerializedFlowCommands,
         workflow_metadata: WorkflowMetadata,
@@ -3276,195 +3336,17 @@ class WorkflowManager(EngineScoped):
         # Helper returns an ast.Module; unpack its body into statements.
         main_body.extend(cast("ast.stmt", stmt) for stmt in unique_values_node.body)
 
-        # Keep track of each flow and node index we've created
-        flow_creation_index = 0
+        # Names are shared by every Flow in the file, at any nesting depth.
+        codegen_state = WorkflowCodegenState()
 
-        # See if this serialized flow has a flow initialization command; if it does, we'll need to insert that
-        flow_initialization_command = serialized_flow_commands.flow_initialization_command
-
-        match flow_initialization_command:
-            case CreateFlowRequest():
-                # Generate create flow context AST module
-                create_flow_context_module = self._generate_create_flow(
-                    flow_initialization_command, import_recorder, flow_creation_index
-                )
-                main_body.extend(cast("ast.stmt", node) for node in create_flow_context_module.body)
-            case ImportWorkflowAsReferencedSubFlowRequest():
-                # Generate import workflow context AST module
-                import_workflow_context_module = self._generate_import_workflow(
-                    flow_initialization_command, import_recorder, flow_creation_index
-                )
-                main_body.extend(cast("ast.stmt", node) for node in import_workflow_context_module.body)
-            case None:
-                # No initialization command, deserialize into current context
-                pass
-
-        # Generate assign flow context AST node, if we have any children commands
-        # Skip content generation for referenced workflows - they should only have the import command
-        is_referenced_workflow = isinstance(flow_initialization_command, ImportWorkflowAsReferencedSubFlowRequest)
-        has_content_to_serialize = (
-            len(serialized_flow_commands.serialized_node_commands) > 0
-            or len(serialized_flow_commands.serialized_connections) > 0
-            or len(serialized_flow_commands.set_parameter_value_commands) > 0
-            or len(serialized_flow_commands.sub_flows_commands) > 0
-            or len(serialized_flow_commands.set_lock_commands_per_node) > 0
-            or len(serialized_flow_commands.serialized_variable_commands) > 0
+        main_body.extend(
+            self._generate_flow_code(
+                serialized_flow_commands=serialized_flow_commands,
+                import_recorder=import_recorder,
+                codegen_state=codegen_state,
+                parent_flow_creation_index=None,
+            )
         )
-
-        if not is_referenced_workflow and has_content_to_serialize:
-            # Keep track of all of the nodes we create and the generated variable names for them
-            node_uuid_to_node_variable_name: dict[SerializedNodeCommands.NodeUUID, str] = {}
-
-            # Keep track of subflow names to their generated variable names (for node group metadata)
-            subflow_name_to_variable_name: dict[str, str] = {}
-
-            # Create the "with..." statement
-            assign_flow_context_node = self._generate_assign_flow_context(
-                flow_initialization_command=flow_initialization_command, flow_creation_index=flow_creation_index
-            )
-
-            # Emit flow-scoped variable creation INSIDE the flow "with" block, BEFORE any
-            # node creation. Ordering matters: SetVariable nodes' before_value_set hook fires
-            # during initial_setup and calls has_variable(); having the variable already
-            # present ensures that hook is a no-op adopt rather than a duplicate create.
-            flow_scoped_variable_asts = self._generate_create_variable_code(
-                serialized_variable_commands=serialized_flow_commands.serialized_variable_commands,
-                unique_values_dict_name="top_level_unique_values_dict",
-                import_recorder=import_recorder,
-            )
-            assign_flow_context_node.body.extend(flow_scoped_variable_asts)
-
-            # Separate regular nodes from NodeGroup nodes in main flow
-
-            regular_node_commands = []
-            node_group_commands = []
-            for serialized_node_command in serialized_flow_commands.serialized_node_commands:
-                # Check if this is a NodeGroup by checking the SerializedNodeCommands flag
-                if serialized_node_command.is_node_group:
-                    node_group_commands.append(serialized_node_command)
-                else:
-                    regular_node_commands.append(serialized_node_command)
-
-            # Track the running node index across all flows to ensure unique variable names
-            current_node_index = 0
-
-            # Generate regular nodes in main flow first (NOT NodeGroups yet)
-            for serialized_node_command in regular_node_commands:
-                node_creation_ast = self._generate_node_creation_code(
-                    serialized_node_command,
-                    current_node_index,
-                    import_recorder,
-                    node_uuid_to_node_variable_name=node_uuid_to_node_variable_name,
-                    subflow_name_to_variable_name=subflow_name_to_variable_name,
-                )
-                assign_flow_context_node.body.extend(node_creation_ast)
-                current_node_index += 1
-
-            # Process sub-flows - for each sub-flow, generate its nodes
-            for sub_flow_index, sub_flow_commands in enumerate(serialized_flow_commands.sub_flows_commands):
-                sub_flow_creation_index = flow_creation_index + 1 + sub_flow_index
-
-                # Generate initialization command for the sub-flow
-                sub_flow_initialization_command = sub_flow_commands.flow_initialization_command
-                if sub_flow_initialization_command is not None:
-                    # Track the subflow name to variable mapping for node groups
-                    if isinstance(sub_flow_initialization_command, CreateFlowRequest):
-                        original_subflow_name = sub_flow_initialization_command.flow_name
-                        subflow_variable_name = f"flow{sub_flow_creation_index}_name"
-                        if original_subflow_name:
-                            subflow_name_to_variable_name[original_subflow_name] = subflow_variable_name
-
-                    match sub_flow_initialization_command:
-                        case CreateFlowRequest():
-                            sub_flow_create_node = self._generate_create_flow(
-                                sub_flow_initialization_command,
-                                import_recorder,
-                                sub_flow_creation_index,
-                                parent_flow_creation_index=flow_creation_index,
-                            )
-                            assign_flow_context_node.body.append(cast("ast.stmt", sub_flow_create_node))
-                        case ImportWorkflowAsReferencedSubFlowRequest():
-                            sub_flow_import_node = self._generate_import_workflow(
-                                sub_flow_initialization_command, import_recorder, sub_flow_creation_index
-                            )
-                            assign_flow_context_node.body.append(cast("ast.stmt", sub_flow_import_node))
-
-                # Generate the nodes in this subflow (just like we do for main flow)
-                if sub_flow_commands.serialized_node_commands or sub_flow_commands.serialized_variable_commands:
-                    # Create "with" statement for subflow
-                    subflow_context_node = self._generate_assign_flow_context(
-                        flow_initialization_command=sub_flow_initialization_command,
-                        flow_creation_index=sub_flow_creation_index,
-                    )
-                    # Emit flow-scoped variable creation BEFORE any node creation in this subflow,
-                    # for the same reason as the top-level flow.
-                    subflow_variable_asts = self._generate_create_variable_code(
-                        serialized_variable_commands=sub_flow_commands.serialized_variable_commands,
-                        unique_values_dict_name="top_level_unique_values_dict",
-                        import_recorder=import_recorder,
-                    )
-                    subflow_context_node.body.extend(subflow_variable_asts)
-                    # Generate nodes in subflow, passing current index and getting next available
-                    subflow_nodes, current_node_index = self._generate_nodes_in_flow(
-                        sub_flow_commands,
-                        import_recorder,
-                        node_uuid_to_node_variable_name,
-                        current_node_index,
-                        subflow_name_to_variable_name,
-                    )
-                    subflow_context_node.body.extend(subflow_nodes)
-
-                    # Generate connections for nodes in this subflow (must be in subflow context)
-                    subflow_connection_asts = self._generate_connections_code(
-                        serialized_connections=sub_flow_commands.serialized_connections,
-                        node_uuid_to_node_variable_name=node_uuid_to_node_variable_name,
-                        import_recorder=import_recorder,
-                    )
-                    subflow_context_node.body.extend(subflow_connection_asts)
-
-                    # Generate parameter values for nodes in this subflow (must be in subflow context)
-                    subflow_parameter_value_asts = self._generate_set_parameter_value_code(
-                        set_parameter_value_commands=sub_flow_commands.set_parameter_value_commands,
-                        lock_commands=sub_flow_commands.set_lock_commands_per_node,
-                        node_uuid_to_node_variable_name=node_uuid_to_node_variable_name,
-                        unique_values_dict_name="top_level_unique_values_dict",
-                        import_recorder=import_recorder,
-                    )
-                    subflow_context_node.body.extend(subflow_parameter_value_asts)
-
-                    assign_flow_context_node.body.append(subflow_context_node)
-
-            # Generate NodeGroup nodes LAST (after subflows, so child nodes exist)
-            for serialized_node_command in node_group_commands:
-                node_creation_ast = self._generate_node_creation_code(
-                    serialized_node_command,
-                    current_node_index,
-                    import_recorder,
-                    node_uuid_to_node_variable_name=node_uuid_to_node_variable_name,
-                    subflow_name_to_variable_name=subflow_name_to_variable_name,
-                )
-                assign_flow_context_node.body.extend(node_creation_ast)
-                current_node_index += 1
-
-            # Now generate the connection code and add it to the flow context
-            connection_asts = self._generate_connections_code(
-                serialized_connections=serialized_flow_commands.serialized_connections,
-                node_uuid_to_node_variable_name=node_uuid_to_node_variable_name,
-                import_recorder=import_recorder,
-            )
-            assign_flow_context_node.body.extend(connection_asts)
-
-            # Generate parameter values for main flow only (subflow parameter values generated inside their contexts)
-            set_parameter_value_asts = self._generate_set_parameter_value_code(
-                set_parameter_value_commands=serialized_flow_commands.set_parameter_value_commands,
-                lock_commands=serialized_flow_commands.set_lock_commands_per_node,
-                node_uuid_to_node_variable_name=node_uuid_to_node_variable_name,
-                unique_values_dict_name="top_level_unique_values_dict",
-                import_recorder=import_recorder,
-            )
-            assign_flow_context_node.body.extend(set_parameter_value_asts)
-
-            main_body.append(cast("ast.stmt", assign_flow_context_node))
 
         # Wrap all graph-building statements in `async def build_workflow()` so the file is
         # inert until build_workflow() is awaited (by the engine loader or the CLI entrypoint).
@@ -4945,39 +4827,190 @@ class WorkflowManager(EngineScoped):
 
         return with_stmt
 
-    def _generate_nodes_in_flow(
+    def _generate_flow_code(
         self,
         serialized_flow_commands: SerializedFlowCommands,
         import_recorder: ImportRecorder,
-        node_uuid_to_node_variable_name: dict[SerializedNodeCommands.NodeUUID, str],
-        starting_node_index: int,
-        subflow_name_to_variable_name: dict[str, str],
-    ) -> tuple[list[ast.stmt], int]:
-        """Generate node creation code for nodes in a flow.
+        codegen_state: WorkflowCodegenState,
+        parent_flow_creation_index: int | None,
+    ) -> list[ast.stmt]:
+        """Generate the code that rebuilds one Flow, then recurse into its subflows.
+
+        Recursion is what makes nested node groups work: a group's subflow can itself hold another
+        group with its own subflow, to any depth. Handling only the first level of subflows left the
+        deeper nodes out of the file entirely, so the groups that owned them were rebuilt empty and
+        any connection reaching one of them could not be written at all.
 
         Args:
-            serialized_flow_commands: Commands for the flow
+            serialized_flow_commands: Commands for the Flow being generated
             import_recorder: Import recorder for tracking imports
-            node_uuid_to_node_variable_name: Mapping from node UUIDs to variable names
-            starting_node_index: The starting index for node variable names
-            subflow_name_to_variable_name: Mapping from subflow names to variable names
+            codegen_state: Variable names and counters shared across the whole file
+            parent_flow_creation_index: Index of the enclosing Flow's variable, or None at the top
 
         Returns:
-            Tuple of (list of AST statements, next available node index)
+            The statements that recreate this Flow and everything inside it
         """
-        node_creation_asts = []
-        current_index = starting_node_index
-        for serialized_node_command in serialized_flow_commands.serialized_node_commands:
-            node_creation_ast = self._generate_node_creation_code(
-                serialized_node_command,
-                current_index,
-                import_recorder,
-                node_uuid_to_node_variable_name=node_uuid_to_node_variable_name,
-                subflow_name_to_variable_name=subflow_name_to_variable_name,
+        flow_initialization_command = serialized_flow_commands.flow_initialization_command
+        flow_creation_index = codegen_state.reserve_flow_index()
+
+        flow_statements = self._generate_flow_initialization_code(
+            flow_initialization_command=flow_initialization_command,
+            import_recorder=import_recorder,
+            codegen_state=codegen_state,
+            flow_creation_index=flow_creation_index,
+            parent_flow_creation_index=parent_flow_creation_index,
+        )
+
+        # A referenced workflow carries its own file, so only the import belongs here.
+        if isinstance(flow_initialization_command, ImportWorkflowAsReferencedSubFlowRequest):
+            return flow_statements
+
+        if not self._flow_has_content_to_generate(serialized_flow_commands):
+            return flow_statements
+
+        flow_context_node = self._generate_assign_flow_context(
+            flow_initialization_command=flow_initialization_command, flow_creation_index=flow_creation_index
+        )
+
+        # Emit flow-scoped variable creation INSIDE the flow "with" block, BEFORE any
+        # node creation. Ordering matters: SetVariable nodes' before_value_set hook fires
+        # during initial_setup and calls has_variable(); having the variable already
+        # present ensures that hook is a no-op adopt rather than a duplicate create.
+        flow_context_node.body.extend(
+            self._generate_create_variable_code(
+                serialized_variable_commands=serialized_flow_commands.serialized_variable_commands,
+                unique_values_dict_name="top_level_unique_values_dict",
+                import_recorder=import_recorder,
             )
-            node_creation_asts.extend(node_creation_ast)
-            current_index += 1
-        return node_creation_asts, current_index
+        )
+
+        # A node group has to be created after the nodes it claims as members, and its members can
+        # live in this Flow's subflows, so groups are held back until the subflows are written.
+        regular_node_commands = []
+        node_group_commands = []
+        for serialized_node_command in serialized_flow_commands.serialized_node_commands:
+            if serialized_node_command.is_node_group:
+                node_group_commands.append(serialized_node_command)
+            else:
+                regular_node_commands.append(serialized_node_command)
+
+        for serialized_node_command in regular_node_commands:
+            flow_context_node.body.extend(
+                self._generate_node_creation_code(
+                    serialized_node_command,
+                    codegen_state.reserve_node_index(),
+                    import_recorder,
+                    node_uuid_to_node_variable_name=codegen_state.node_uuid_to_node_variable_name,
+                    subflow_name_to_variable_name=codegen_state.subflow_name_to_variable_name,
+                )
+            )
+
+        for sub_flow_commands in serialized_flow_commands.sub_flows_commands:
+            flow_context_node.body.extend(
+                self._generate_flow_code(
+                    serialized_flow_commands=sub_flow_commands,
+                    import_recorder=import_recorder,
+                    codegen_state=codegen_state,
+                    parent_flow_creation_index=flow_creation_index,
+                )
+            )
+
+        for serialized_node_command in node_group_commands:
+            flow_context_node.body.extend(
+                self._generate_node_creation_code(
+                    serialized_node_command,
+                    codegen_state.reserve_node_index(),
+                    import_recorder,
+                    node_uuid_to_node_variable_name=codegen_state.node_uuid_to_node_variable_name,
+                    subflow_name_to_variable_name=codegen_state.subflow_name_to_variable_name,
+                )
+            )
+
+        # Connections come after every node in this Flow's whole subtree exists, including the groups
+        # above, whose proxy parameters are what boundary-crossing connections attach to.
+        flow_context_node.body.extend(
+            self._generate_connections_code(
+                serialized_connections=codegen_state.take_unemitted_connections(
+                    serialized_flow_commands.serialized_connections
+                ),
+                node_uuid_to_node_variable_name=codegen_state.node_uuid_to_node_variable_name,
+                import_recorder=import_recorder,
+            )
+        )
+
+        flow_context_node.body.extend(
+            self._generate_set_parameter_value_code(
+                set_parameter_value_commands=serialized_flow_commands.set_parameter_value_commands,
+                lock_commands=serialized_flow_commands.set_lock_commands_per_node,
+                node_uuid_to_node_variable_name=codegen_state.node_uuid_to_node_variable_name,
+                unique_values_dict_name="top_level_unique_values_dict",
+                import_recorder=import_recorder,
+            )
+        )
+
+        flow_statements.append(cast("ast.stmt", flow_context_node))
+        return flow_statements
+
+    def _generate_flow_initialization_code(
+        self,
+        flow_initialization_command: CreateFlowRequest | ImportWorkflowAsReferencedSubFlowRequest | None,
+        import_recorder: ImportRecorder,
+        codegen_state: WorkflowCodegenState,
+        flow_creation_index: int,
+        parent_flow_creation_index: int | None,
+    ) -> list[ast.stmt]:
+        """Generate the statements that bring one Flow into existence.
+
+        Args:
+            flow_initialization_command: How the Flow is created, or None to reuse the current one
+            import_recorder: Import recorder for tracking imports
+            codegen_state: Variable names and counters shared across the whole file
+            flow_creation_index: Index of this Flow's own variable
+            parent_flow_creation_index: Index of the enclosing Flow's variable, or None at the top
+
+        Returns:
+            The statements that create the Flow (empty when it already exists)
+        """
+        match flow_initialization_command:
+            case CreateFlowRequest():
+                # A subflow names its parent by variable so it lands in the right spot in the tree.
+                create_flow_module = self._generate_create_flow(
+                    flow_initialization_command,
+                    import_recorder,
+                    flow_creation_index,
+                    parent_flow_creation_index=parent_flow_creation_index,
+                )
+                if flow_initialization_command.flow_name:
+                    codegen_state.subflow_name_to_variable_name[flow_initialization_command.flow_name] = (
+                        f"flow{flow_creation_index}_name"
+                    )
+                return [cast("ast.stmt", node) for node in create_flow_module.body]
+            case ImportWorkflowAsReferencedSubFlowRequest():
+                import_workflow_module = self._generate_import_workflow(
+                    flow_initialization_command, import_recorder, flow_creation_index
+                )
+                return [cast("ast.stmt", node) for node in import_workflow_module.body]
+            case None:
+                # No initialization command; the contents are rebuilt into the current context.
+                return []
+
+    def _flow_has_content_to_generate(self, serialized_flow_commands: SerializedFlowCommands) -> bool:
+        """Whether a Flow holds anything worth emitting a context block for.
+
+        Args:
+            serialized_flow_commands: Commands for the Flow being generated
+
+        Returns:
+            True if the Flow has nodes, connections, values, locks, variables, or subflows
+        """
+        return (
+            len(serialized_flow_commands.serialized_node_commands) > 0
+            or len(serialized_flow_commands.serialized_connections) > 0
+            or len(serialized_flow_commands.set_parameter_value_commands) > 0
+            or len(serialized_flow_commands.sub_flows_commands) > 0
+            or len(serialized_flow_commands.set_lock_commands_per_node) > 0
+            or len(serialized_flow_commands.serialized_variable_commands) > 0
+        )
 
     def _generate_node_creation_code(  # noqa: C901, PLR0912, PLR0915
         self,

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -65,6 +65,7 @@ from griptape_nodes.retained_mode.events.flow_events import (
     CreateFlowRequest,
     GetTopLevelFlowRequest,
     GetTopLevelFlowResultSuccess,
+    SerializedConnectionKey,
     SerializedFlowCommands,
     SerializeFlowToCommandsRequest,
     SerializeFlowToCommandsResultSuccess,
@@ -266,7 +267,7 @@ class WorkflowCodegenState:
     subflow_name_to_variable_name: dict[str, str] = field(default_factory=dict)
     next_node_index: int = 0
     next_flow_index: int = 0
-    emitted_connection_keys: set[tuple[str, str, str, str]] = field(default_factory=set)
+    emitted_connection_keys: set[SerializedConnectionKey] = field(default_factory=set)
 
     def reserve_node_index(self) -> int:
         """Claim the next unused node variable index."""
@@ -298,12 +299,7 @@ class WorkflowCodegenState:
         """
         unemitted_connections = []
         for connection in connections:
-            connection_key = (
-                connection.source_node_uuid,
-                connection.source_parameter_name,
-                connection.target_node_uuid,
-                connection.target_parameter_name,
-            )
+            connection_key = connection.key()
             if connection_key in self.emitted_connection_keys:
                 continue
             self.emitted_connection_keys.add(connection_key)
@@ -4926,8 +4922,11 @@ class WorkflowManager(EngineScoped):
                 )
             )
 
-        # Connections come after every node in this Flow's whole subtree exists, including the groups
-        # above, whose proxy parameters are what boundary-crossing connections attach to.
+        # Connections come last, once every node in this Flow's whole subtree exists — including the
+        # groups written just above, whose proxy parameters are what boundary-crossing edges attach to.
+        # Claiming edges here, after the subflows were already written, is safe: an edge is only ever
+        # collected by the Flow holding both endpoints or one level above them (_get_connections_for_flow),
+        # so a subflow can never claim an edge that reaches a group node declared out here.
         flow_context_node.body.extend(
             self._generate_connections_code(
                 serialized_connections=codegen_state.take_unemitted_connections(
@@ -4970,6 +4969,9 @@ class WorkflowManager(EngineScoped):
 
         Returns:
             The statements that create the Flow (empty when it already exists)
+
+        Raises:
+            TypeError: If the Flow is created by a command this generator does not know how to write
         """
         match flow_initialization_command:
             case CreateFlowRequest():
@@ -4993,8 +4995,15 @@ class WorkflowManager(EngineScoped):
             case None:
                 # No initialization command; the contents are rebuilt into the current context.
                 return []
+            case _:
+                # A new way of creating a Flow was added without teaching this generator to write it.
+                # Silently returning nothing would emit a file whose Flow is never created, so the
+                # nodes inside it would land wherever the script happened to be pointing.
+                msg = f"Attempted to save a workflow. Failed because a flow is created in a way this version cannot write out: {type(flow_initialization_command).__name__}."
+                raise TypeError(msg)
 
-    def _flow_has_content_to_generate(self, serialized_flow_commands: SerializedFlowCommands) -> bool:
+    @staticmethod
+    def _flow_has_content_to_generate(serialized_flow_commands: SerializedFlowCommands) -> bool:
         """Whether a Flow holds anything worth emitting a context block for.
 
         Args:
@@ -5238,6 +5247,19 @@ class WorkflowManager(EngineScoped):
         node_uuid_to_node_variable_name: dict[SerializedNodeCommands.NodeUUID, str],
         import_recorder: ImportRecorder,
     ) -> list[ast.stmt]:
+        """Write the statements that reconnect a Flow's nodes.
+
+        Args:
+            serialized_connections: The connections this Flow is responsible for writing
+            node_uuid_to_node_variable_name: Variable name written for each node so far, file-wide
+            import_recorder: Import recorder for tracking imports
+
+        Returns:
+            The statements creating each connection
+
+        Raises:
+            KeyError: If an endpoint's node has not been written into the file yet
+        """
         # Ensure necessary imports are recorded
         import_recorder.add_from_import(
             "griptape_nodes.retained_mode.events.connection_events", "CreateConnectionRequest"
@@ -5246,7 +5268,18 @@ class WorkflowManager(EngineScoped):
         connection_asts = []
 
         for connection in serialized_connections:
-            # Match the connection's node UUID back to its variable name.
+            # Match the connection's node UUID back to its variable name. Both endpoints must already
+            # have been written, since the generated file refers to them by variable. Which Flow
+            # writes a given edge depends on the traversal (see _generate_flow_code), so name the
+            # nodes if that ever slips rather than letting a bare KeyError escape mid-save.
+            missing_endpoints = [
+                endpoint_uuid
+                for endpoint_uuid in (connection.source_node_uuid, connection.target_node_uuid)
+                if endpoint_uuid not in node_uuid_to_node_variable_name
+            ]
+            if missing_endpoints:
+                msg = f"Attempted to save a workflow. Failed because a connection to '{connection.target_parameter_name}' refers to {len(missing_endpoints)} node(s) that had not been written to the file yet."
+                raise KeyError(msg)
             source_node_variable_name = node_uuid_to_node_variable_name[connection.source_node_uuid]
             target_node_variable_name = node_uuid_to_node_variable_name[connection.target_node_uuid]
 

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -4997,8 +4997,10 @@ class WorkflowManager(EngineScoped):
                 return []
             case _:
                 # A new way of creating a Flow was added without teaching this generator to write it.
-                # Silently returning nothing would emit a file whose Flow is never created, so the
-                # nodes inside it would land wherever the script happened to be pointing.
+                # This one does fail the save, unlike the skip-and-log guards elsewhere in codegen:
+                # emitting nothing writes a file whose Flow is never created, so every node inside it
+                # lands wherever the script happened to be pointing. That is a wrong graph that loads
+                # without complaint, which is worse than a save the artist knows did not happen.
                 msg = f"Attempted to save a workflow. Failed because a flow is created in a way this version cannot write out: {type(flow_initialization_command).__name__}."
                 raise TypeError(msg)
 
@@ -5287,15 +5289,19 @@ class WorkflowManager(EngineScoped):
                 if endpoint_uuid not in node_uuid_to_node_variable_name
             ]
             if missing_endpoints:
-                # The UUIDs are the only handle on nodes that were never written, so log them for
-                # whoever has to debug the save and keep the raised message readable.
+                # Skip rather than raise: raising here fails the save outright, and losing one edge
+                # is a smaller harm than an artist being unable to persist their work at all. Which
+                # Flow writes a given edge depends on the traversal, so a graph shape nobody has
+                # tried yet is a likelier cause than real corruption -- _get_connections_for_flow
+                # already carries one such case (transient loop-body flows). Logged at error so it
+                # surfaces as a bug rather than passing silently.
                 logger.error(
-                    "Cannot write the connection to '%s': node(s) %s were never written to the file",
+                    "Cannot write the connection to '%s': node(s) %s were never written to the file. "
+                    "Skipping this connection; the saved workflow will be missing it.",
                     connection.target_parameter_name,
                     ", ".join(missing_endpoints),
                 )
-                msg = f"Attempted to save a workflow. Failed because a connection to '{connection.target_parameter_name}' refers to {len(missing_endpoints)} node(s) that had not been written to the file yet."
-                raise ValueError(msg)
+                continue
             source_node_variable_name = node_uuid_to_node_variable_name[connection.source_node_uuid]
             target_node_variable_name = node_uuid_to_node_variable_name[connection.target_node_uuid]
 
@@ -5447,9 +5453,15 @@ class WorkflowManager(EngineScoped):
             # is always named by now. Say which node went missing if that ever stops holding, rather
             # than letting a bare KeyError escape halfway through writing the file.
             if node_uuid not in node_uuid_to_node_variable_name:
-                logger.error("Cannot write saved values: node '%s' was never written to the file", node_uuid)
-                msg = "Attempted to save a workflow. Failed because a node holding saved values had not been written to the file yet."
-                raise ValueError(msg)
+                # Skip rather than raise, for the same reason as the connection case above: this
+                # guards a traversal invariant, and failing the save means the artist cannot persist
+                # anything, which is worse than a saved file missing one node's values.
+                logger.error(
+                    "Cannot write saved values: node '%s' was never written to the file. "
+                    "Skipping its values; the saved workflow will not restore them.",
+                    node_uuid,
+                )
+                continue
             node_variable_name = node_uuid_to_node_variable_name[node_uuid]
             lock_node_command = lock_commands.get(node_uuid)
             parameter_value_asts.extend(

--- a/tests/e2e/test_nested_node_group_execution.py
+++ b/tests/e2e/test_nested_node_group_execution.py
@@ -1,0 +1,271 @@
+"""End-to-end coverage for node groups nested inside other node groups.
+
+Builds Source -> Outer[ Inner[ Leaf ] ], connects Source directly to the doubly-nested Leaf so the
+data has to cross two group boundaries, then saves the graph to a self-contained .py and runs it in
+a fresh subprocess.
+
+Nesting is what these tests are about, so they guard the places where "inside a group" has to mean
+transitively inside rather than directly inside: the proxy parameters that carry a connection across
+each boundary, the flow hierarchy the subflows are built into, and the generated file's record of
+which nodes belong to which group.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
+from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest, CreateConnectionResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    CreateFlowResultSuccess,
+    SerializeFlowToCommandsRequest,
+    SerializeFlowToCommandsResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.events.node_events import (
+    AddNodesToNodeGroupRequest,
+    AddNodesToNodeGroupResultSuccess,
+    CreateNodeRequest,
+    CreateNodeResultSuccess,
+)
+from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
+from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# Timeout with thread dump.
+pytestmark = pytest.mark.timeout(300, method="thread")
+
+FIXTURE_LIBRARY_DIR = Path(__file__).parent / "fixtures" / "subflow_library"
+FIXTURE_LIBRARY_JSON_TEMPLATE = FIXTURE_LIBRARY_DIR / "griptape_nodes_library.json"
+FIXTURE_NODE_FILE = FIXTURE_LIBRARY_DIR / "subflow_echo_node.py"
+
+_EXPECTED_TEXT = "hello from a nested subflow"
+
+
+def _build_nested_graph(library_name: str) -> str:
+    """Build Source -> Outer[ Inner[ Leaf ] ] and return the top-level flow name."""
+    flow_result = GriptapeNodes.handle_request(
+        CreateFlowRequest(parent_flow_name=None, flow_name="NestedParentFlow", set_as_new_context=False)
+    )
+    assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
+    flow_name = flow_result.flow_name
+
+    with GriptapeNodes.ContextManager().flow(flow_name):
+        outer = GriptapeNodes.handle_request(
+            CreateNodeRequest(node_type="SubflowGroupNode", specific_library_name=library_name, node_name="OuterGroup")
+        )
+        assert isinstance(outer, CreateNodeResultSuccess), outer
+
+        inner = GriptapeNodes.handle_request(
+            CreateNodeRequest(node_type="SubflowGroupNode", specific_library_name=library_name, node_name="InnerGroup")
+        )
+        assert isinstance(inner, CreateNodeResultSuccess), inner
+
+        leaf = GriptapeNodes.handle_request(
+            CreateNodeRequest(
+                node_type="EchoNode",
+                specific_library_name=library_name,
+                node_name="Leaf",
+                parent_group_name=inner.node_name,
+            )
+        )
+        assert isinstance(leaf, CreateNodeResultSuccess), leaf
+
+        source = GriptapeNodes.handle_request(
+            CreateNodeRequest(node_type="EchoNode", specific_library_name=library_name, node_name="Source")
+        )
+        assert isinstance(source, CreateNodeResultSuccess), source
+
+        # Nest the inner group (which already holds Leaf) inside the outer group.
+        nest_result = GriptapeNodes.handle_request(
+            AddNodesToNodeGroupRequest(node_names=[inner.node_name], node_group_name=outer.node_name)
+        )
+        assert isinstance(nest_result, AddNodesToNodeGroupResultSuccess), nest_result
+
+        GriptapeNodes.handle_request(
+            SetParameterValueRequest(parameter_name="text", node_name=source.node_name, value=_EXPECTED_TEXT)
+        )
+
+        # Crossing two boundaries at once is the case that has to keep working: the engine routes
+        # this through a proxy parameter on each group it passes through.
+        connect_result = GriptapeNodes.handle_request(
+            CreateConnectionRequest(
+                source_node_name=source.node_name,
+                source_parameter_name="text",
+                target_node_name=leaf.node_name,
+                target_parameter_name="text",
+            )
+        )
+        assert isinstance(connect_result, CreateConnectionResultSuccess), connect_result
+
+    return flow_name
+
+
+def _generate_nested_workflow_source(library_json: Path) -> str:
+    """Build the nested graph and serialize it to standalone workflow source."""
+    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+
+    register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
+    library_name = register_result.library_name
+
+    GriptapeNodes.ContextManager().push_workflow(workflow_name="nested_group_e2e_workflow")
+    flow_name = _build_nested_graph(library_name)
+
+    serialize_result = GriptapeNodes.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_name))
+    assert isinstance(serialize_result, SerializeFlowToCommandsResultSuccess), serialize_result
+
+    metadata = WorkflowMetadata(
+        name="nested_group_e2e_workflow",
+        schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+        engine_version_created_with="0.0.0",
+        node_libraries_referenced=list(serialize_result.serialized_flow_commands.node_dependencies.libraries),
+        workflow_shape=None,
+    )
+    return GriptapeNodes.WorkflowManager()._generate_workflow_file_content(
+        serialized_flow_commands=serialize_result.serialized_flow_commands,
+        workflow_metadata=metadata,
+    )
+
+
+def _wrap_with_runtime_assertions(workflow_source: str) -> str:
+    runtime_block = f"""
+
+import asyncio as _e2e_asyncio
+import logging as _e2e_logging
+
+from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import (
+    LocalWorkflowExecutor as _E2ELocalWorkflowExecutor,
+)
+from griptape_nodes.drivers.storage.storage_backend import StorageBackend as _E2EStorageBackend
+from griptape_nodes.retained_mode.events.flow_events import (
+    GetTopLevelFlowRequest as _E2EGetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess as _E2EGetTopLevelFlowResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes as _E2EGriptapeNodes
+
+_EXPECTED_TEXT = {_EXPECTED_TEXT!r}
+
+
+def _ensure_workflow_context() -> None:
+    context_manager = _E2EGriptapeNodes.ContextManager()
+    if not context_manager.has_current_flow():
+        top_level = _E2EGriptapeNodes.handle_request(_E2EGetTopLevelFlowRequest())
+        if isinstance(top_level, _E2EGetTopLevelFlowResultSuccess) and top_level.flow_name is not None:
+            flow_obj = _E2EGriptapeNodes.FlowManager().get_flow_by_name(top_level.flow_name)
+            context_manager.push_flow(flow_obj)
+
+
+def _check_nesting_rebuilt() -> None:
+    node_manager = _E2EGriptapeNodes.NodeManager()
+    outer = node_manager.get_node_by_name("OuterGroup")
+    inner = node_manager.get_node_by_name("InnerGroup")
+    leaf = node_manager.get_node_by_name("Leaf")
+
+    # Membership has to survive the save: the inner group belongs to the outer one, and the leaf
+    # belongs to the inner one.
+    if inner.name not in outer.nodes:
+        raise RuntimeError(
+            f"E2E_FAIL: OuterGroup lost its nested group; members={{sorted(outer.nodes)}}"
+        )
+    if leaf.name not in inner.nodes:
+        raise RuntimeError(f"E2E_FAIL: InnerGroup lost its child; members={{sorted(inner.nodes)}}")
+    if not outer.contains_node(leaf):
+        raise RuntimeError("E2E_FAIL: OuterGroup does not transitively contain Leaf")
+
+    # The subflows have to be nested the same way the groups are.
+    flow_manager = _E2EGriptapeNodes.FlowManager()
+    inner_subflow = inner.metadata.get("subflow_name")
+    outer_subflow = outer.metadata.get("subflow_name")
+    if flow_manager.get_parent_flow(inner_subflow) != outer_subflow:
+        raise RuntimeError(
+            f"E2E_FAIL: {{inner_subflow}} parent is {{flow_manager.get_parent_flow(inner_subflow)!r}}, "
+            f"expected {{outer_subflow!r}}"
+        )
+
+
+async def _e2e_run() -> None:
+    await build_workflow()  # noqa: F821 - defined by the generated workflow source above
+    _ensure_workflow_context()
+    _check_nesting_rebuilt()
+    workflow_executor = _E2ELocalWorkflowExecutor(
+        storage_backend=_E2EStorageBackend.LOCAL,
+        skip_library_loading=True,
+        workflows_to_register=[__file__],
+    )
+    async with workflow_executor as executor:
+        await executor.arun(flow_input={{}})
+
+    node_manager = _E2EGriptapeNodes.NodeManager()
+    leaf_node = node_manager.get_node_by_name("Leaf")
+    text_value = leaf_node.parameter_output_values.get("text")
+    if text_value != _EXPECTED_TEXT:
+        raise RuntimeError(
+            f"E2E_FAIL: expected {{_EXPECTED_TEXT!r}}, got {{text_value!r}} - "
+            "text did not survive two nested group boundaries"
+        )
+    print(f"NESTED_SUBFLOW_TEXT_OK text={{text_value!r}}", flush=True)
+
+
+if __name__ == "__main__":
+    _e2e_logging.basicConfig(level=_e2e_logging.WARNING)
+    _e2e_asyncio.run(_e2e_run())
+"""
+    return workflow_source + runtime_block
+
+
+@pytest.mark.skipif(
+    not FIXTURE_LIBRARY_JSON_TEMPLATE.exists(),
+    reason=f"Subflow Library fixture missing at {FIXTURE_LIBRARY_JSON_TEMPLATE}",
+)
+def test_nested_node_groups_survive_save_and_execute(
+    tmp_path: Path,
+    engine_subprocess_env: Callable[..., dict[str, str]],
+    materialize_library: Callable[..., Path],
+    write_isolated_config: Callable[..., None],
+) -> None:
+    """A group nested in another group must save, reload, and pass data to its deepest node."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config_root = tmp_path / "xdg_config"
+    library_json = materialize_library(
+        tmp_path / "library", template=FIXTURE_LIBRARY_JSON_TEMPLATE, node_file=FIXTURE_NODE_FILE
+    )
+    write_isolated_config(config_root, workspace=workspace, library_path=library_json)
+
+    workflow_source = _generate_nested_workflow_source(library_json)
+    runnable_source = _wrap_with_runtime_assertions(workflow_source)
+
+    workflow_path = tmp_path / "nested_group_workflow.py"
+    workflow_path.write_text(runnable_source)
+
+    env = engine_subprocess_env(XDG_CONFIG_HOME=str(config_root))
+
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, str(workflow_path)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+    diagnostic = (
+        f"workflow exit code: {result.returncode}\n--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+    )
+    assert result.returncode == 0, diagnostic
+    assert "NESTED_SUBFLOW_TEXT_OK" in result.stdout, diagnostic
+    assert "E2E_FAIL" not in result.stdout, diagnostic
+    assert "E2E_FAIL" not in result.stderr, diagnostic

--- a/tests/e2e/test_node_group_membership_failures.py
+++ b/tests/e2e/test_node_group_membership_failures.py
@@ -1,0 +1,219 @@
+"""What a group looks like after a membership change fails partway through.
+
+Adding nodes to a group and removing them again both take several steps that can fail: each node is
+moved between flows one at a time, and a nested group's own subflow is reparented separately. If the
+group records the membership before those moves, a failure halfway leaves the group claiming nodes
+that are not in its subflow -- the editor draws them inside the group while a save writes them
+outside it, and the artist has no way to tell.
+
+These tests fail the move deliberately and then check the group is back to a state that matches
+where the nodes actually live.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.exe_types.node_groups.base_node_group import BaseNodeGroup
+from griptape_nodes.retained_mode.engine import current_engine
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.events.node_events import (
+    AddNodesToNodeGroupRequest,
+    AddNodesToNodeGroupResultFailure,
+    AddNodesToNodeGroupResultSuccess,
+    CreateNodeRequest,
+    CreateNodeResultSuccess,
+    MoveNodeToNewFlowRequest,
+    MoveNodeToNewFlowResultFailure,
+    RemoveNodeFromNodeGroupRequest,
+    RemoveNodeFromNodeGroupResultFailure,
+    RemoveNodeFromNodeGroupResultSuccess,
+)
+from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+FIXTURE_LIBRARY_DIR = Path(__file__).parent / "fixtures" / "subflow_library"
+FIXTURE_LIBRARY_JSON_TEMPLATE = FIXTURE_LIBRARY_DIR / "griptape_nodes_library.json"
+FIXTURE_NODE_FILE = FIXTURE_LIBRARY_DIR / "subflow_echo_node.py"
+
+
+@pytest.fixture
+def library_name(tmp_path: Path, materialize_library: Callable[..., Path]) -> str:
+    """Register the subflow fixture library into a clean engine and return its name."""
+    library_json = materialize_library(
+        tmp_path / "library", template=FIXTURE_LIBRARY_JSON_TEMPLATE, node_file=FIXTURE_NODE_FILE
+    )
+    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
+    GriptapeNodes.ContextManager().push_workflow(workflow_name="membership_failure_workflow")
+    return register_result.library_name
+
+
+def _create_node(node_type: str, node_name: str, library: str, **kwargs: object) -> str:
+    result = GriptapeNodes.handle_request(
+        CreateNodeRequest(node_type=node_type, specific_library_name=library, node_name=node_name, **kwargs)  # type: ignore[arg-type]
+    )
+    assert isinstance(result, CreateNodeResultSuccess), result
+    return result.node_name
+
+
+def _get_group(node_name: str) -> BaseNodeGroup:
+    node = GriptapeNodes.NodeManager().get_node_by_name(node_name)
+    assert isinstance(node, BaseNodeGroup), f"expected '{node_name}' to be a group, got {type(node).__name__}"
+    return node
+
+
+def _flow_of(node_name: str) -> str:
+    return GriptapeNodes.NodeManager().get_node_parent_flow_by_name(node_name)
+
+
+def _fail_every_move(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make every MoveNodeToNewFlowRequest fail, as if the engine refused it.
+
+    Patches the event manager's dispatch table rather than NodeManager: the handler was bound into
+    that table at registration, so replacing the method on the manager would not be seen.
+    """
+    event_manager = current_engine().event_manager
+
+    def refuse_move(request: MoveNodeToNewFlowRequest) -> MoveNodeToNewFlowResultFailure:  # noqa: ARG001
+        return MoveNodeToNewFlowResultFailure(result_details="refused for this test")
+
+    monkeypatch.setitem(event_manager._request_type_to_manager, MoveNodeToNewFlowRequest, refuse_move)
+
+
+class TestFailedAdd:
+    def test_reports_failure_rather_than_claiming_a_node_it_could_not_move(
+        self, library_name: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A group that cannot take a node in must not list it as a member anyway."""
+        flow = GriptapeNodes.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="FailedAddFlow", set_as_new_context=False)
+        )
+        assert isinstance(flow, CreateFlowResultSuccess), flow
+
+        with GriptapeNodes.ContextManager().flow(flow.flow_name):
+            group_name = _create_node("SubflowGroupNode", "Group", library_name)
+            loose_name = _create_node("EchoNode", "Loose", library_name)
+
+        original_flow = _flow_of(loose_name)
+        _fail_every_move(monkeypatch)
+
+        with GriptapeNodes.ContextManager().flow(flow.flow_name):
+            result = GriptapeNodes.handle_request(
+                AddNodesToNodeGroupRequest(node_names=[loose_name], node_group_name=group_name)
+            )
+
+        # The artist has to be told, rather than shown a group that only looks filled.
+        assert isinstance(result, AddNodesToNodeGroupResultFailure), result
+
+        group = _get_group(group_name)
+        node = GriptapeNodes.NodeManager().get_node_by_name(loose_name)
+        assert loose_name not in group.nodes
+        assert group.metadata.get("node_names_in_group") == []
+        assert node.parent_group is None
+        # The node never moved, so it is still where the artist left it.
+        assert _flow_of(loose_name) == original_flow
+
+
+class TestFailedRemove:
+    def test_reports_failure_rather_than_dropping_a_node_it_could_not_move_out(
+        self, library_name: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A group that cannot let a node out must keep listing it, and say the remove failed."""
+        flow = GriptapeNodes.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="FailedRemoveFlow", set_as_new_context=False)
+        )
+        assert isinstance(flow, CreateFlowResultSuccess), flow
+
+        with GriptapeNodes.ContextManager().flow(flow.flow_name):
+            group_name = _create_node("SubflowGroupNode", "Group", library_name)
+            member_name = _create_node("EchoNode", "Member", library_name, parent_group_name=group_name)
+
+        group = _get_group(group_name)
+        assert member_name in group.nodes, "member should start out inside the group"
+        subflow_name = _flow_of(member_name)
+
+        _fail_every_move(monkeypatch)
+
+        with GriptapeNodes.ContextManager().flow(flow.flow_name):
+            result = GriptapeNodes.handle_request(
+                RemoveNodeFromNodeGroupRequest(node_names=[member_name], node_group_name=group_name)
+            )
+
+        # A move failure has to surface as a failure result, not escape as an unhandled error.
+        assert isinstance(result, RemoveNodeFromNodeGroupResultFailure), result
+
+        member = GriptapeNodes.NodeManager().get_node_by_name(member_name)
+        assert member_name in group.nodes
+        assert group.metadata.get("node_names_in_group") == [member_name]
+        assert member.parent_group is group
+        # The node never moved, so the group still holds it in its subflow.
+        assert _flow_of(member_name) == subflow_name
+
+    def test_removes_a_node_from_a_group_when_the_moves_succeed(self, library_name: str) -> None:
+        """The success path still works: the node leaves the group and its subflow."""
+        flow = GriptapeNodes.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="RemoveFlow", set_as_new_context=False)
+        )
+        assert isinstance(flow, CreateFlowResultSuccess), flow
+
+        with GriptapeNodes.ContextManager().flow(flow.flow_name):
+            group_name = _create_node("SubflowGroupNode", "Group", library_name)
+            member_name = _create_node("EchoNode", "Member", library_name, parent_group_name=group_name)
+
+            result = GriptapeNodes.handle_request(
+                RemoveNodeFromNodeGroupRequest(node_names=[member_name], node_group_name=group_name)
+            )
+
+        assert isinstance(result, RemoveNodeFromNodeGroupResultSuccess), result
+
+        group = _get_group(group_name)
+        member = GriptapeNodes.NodeManager().get_node_by_name(member_name)
+        assert member_name not in group.nodes
+        assert group.metadata.get("node_names_in_group") == []
+        assert member.parent_group is None
+        # It went back out to the flow holding the group, not left inside the subflow.
+        assert _flow_of(member_name) == flow.flow_name
+
+    def test_moves_a_nested_group_subflow_back_out_with_it(self, library_name: str) -> None:
+        """Removing a nested group has to take its contents along, or a save loses them."""
+        flow = GriptapeNodes.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="UnnestFlow", set_as_new_context=False)
+        )
+        assert isinstance(flow, CreateFlowResultSuccess), flow
+
+        with GriptapeNodes.ContextManager().flow(flow.flow_name):
+            outer_name = _create_node("SubflowGroupNode", "OuterGroup", library_name)
+            inner_name = _create_node("SubflowGroupNode", "InnerGroup", library_name)
+            _create_node("EchoNode", "Leaf", library_name, parent_group_name=inner_name)
+
+            nest_result = GriptapeNodes.handle_request(
+                AddNodesToNodeGroupRequest(node_names=[inner_name], node_group_name=outer_name)
+            )
+            assert isinstance(nest_result, AddNodesToNodeGroupResultSuccess), nest_result
+
+            inner = _get_group(inner_name)
+            inner_subflow = inner.metadata["subflow_name"]
+            outer_subflow = _get_group(outer_name).metadata["subflow_name"]
+            assert GriptapeNodes.FlowManager().get_parent_flow(inner_subflow) == outer_subflow
+
+            result = GriptapeNodes.handle_request(
+                RemoveNodeFromNodeGroupRequest(node_names=[inner_name], node_group_name=outer_name)
+            )
+
+        assert isinstance(result, RemoveNodeFromNodeGroupResultSuccess), result
+
+        # The inner group's subflow follows it out, so its Leaf is still reachable from the top.
+        assert GriptapeNodes.FlowManager().get_parent_flow(inner_subflow) == flow.flow_name
+        assert _flow_of(inner_name) == flow.flow_name

--- a/tests/e2e/test_node_group_membership_failures.py
+++ b/tests/e2e/test_node_group_membership_failures.py
@@ -92,6 +92,33 @@ def _fail_every_move(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setitem(event_manager._request_type_to_manager, MoveNodeToNewFlowRequest, refuse_move)
 
 
+def _fail_the_second_move_into(target_flow_name: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Let the first move into a flow through, refuse the second, and allow everything else.
+
+    Failing every move leaves nothing to roll back -- the first node never went anywhere. Only a
+    partial failure exercises the undo, so this is what distinguishes "reported the failure" from
+    "reported the failure and put things back".
+
+    Scoped to moves heading into `target_flow_name` so the rollback, which moves nodes back out to
+    where they came from, is allowed to succeed. Refusing that too would test nothing but the
+    fixture: no rollback could complete regardless of whether one was attempted.
+    """
+    event_manager = current_engine().event_manager
+    real_handler = event_manager._request_type_to_manager[MoveNodeToNewFlowRequest]
+    moves_into_target = 0
+
+    def refuse_the_second_move_in(request: MoveNodeToNewFlowRequest) -> object:
+        nonlocal moves_into_target
+        if request.target_flow_name != target_flow_name:
+            return real_handler(request)
+        moves_into_target += 1
+        if moves_into_target == 1:
+            return real_handler(request)
+        return MoveNodeToNewFlowResultFailure(result_details="refused for this test")
+
+    monkeypatch.setitem(event_manager._request_type_to_manager, MoveNodeToNewFlowRequest, refuse_the_second_move_in)
+
+
 class TestFailedAdd:
     def test_reports_failure_rather_than_claiming_a_node_it_could_not_move(
         self, library_name: str, monkeypatch: pytest.MonkeyPatch
@@ -124,6 +151,59 @@ class TestFailedAdd:
         assert node.parent_group is None
         # The node never moved, so it is still where the artist left it.
         assert _flow_of(loose_name) == original_flow
+
+    def test_moves_back_the_node_that_did_get_in_before_a_later_one_failed(
+        self, library_name: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A partly-applied add has to undo the moves it already made, not just report the failure.
+
+        Two nodes go in and the second move is refused, so the first is already sitting in the
+        subflow when the add gives up. Leaving it there strands a node inside a group that no longer
+        claims it: the editor draws it outside while a save writes it inside.
+        """
+        flow = GriptapeNodes.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="PartialAddFlow", set_as_new_context=False)
+        )
+        assert isinstance(flow, CreateFlowResultSuccess), flow
+
+        with GriptapeNodes.ContextManager().flow(flow.flow_name):
+            group_name = _create_node("SubflowGroupNode", "Group", library_name)
+            first_name = _create_node("EchoNode", "First", library_name)
+            second_name = _create_node("EchoNode", "Second", library_name)
+
+        original_flow = _flow_of(first_name)
+        assert _flow_of(second_name) == original_flow
+
+        group = _get_group(group_name)
+        # The group creates its subflow on the first add, so drive one to learn its name, then put
+        # things back: the failure this test wants is a refused move, not a missing subflow.
+        with GriptapeNodes.ContextManager().flow(flow.flow_name):
+            setup_result = GriptapeNodes.handle_request(
+                AddNodesToNodeGroupRequest(node_names=[first_name], node_group_name=group_name)
+            )
+            assert isinstance(setup_result, AddNodesToNodeGroupResultSuccess), setup_result
+            subflow_name = group.metadata["subflow_name"]
+            undo_result = GriptapeNodes.handle_request(
+                RemoveNodeFromNodeGroupRequest(node_names=[first_name], node_group_name=group_name)
+            )
+            assert isinstance(undo_result, RemoveNodeFromNodeGroupResultSuccess), undo_result
+        assert _flow_of(first_name) == original_flow
+
+        _fail_the_second_move_into(subflow_name, monkeypatch)
+
+        with GriptapeNodes.ContextManager().flow(flow.flow_name):
+            result = GriptapeNodes.handle_request(
+                AddNodesToNodeGroupRequest(node_names=[first_name, second_name], node_group_name=group_name)
+            )
+
+        assert isinstance(result, AddNodesToNodeGroupResultFailure), result
+
+        assert group.nodes == {}
+        assert group.metadata.get("node_names_in_group") == []
+
+        # Both nodes are back where the artist left them -- including the one that did move.
+        assert _flow_of(first_name) == original_flow
+        assert _flow_of(second_name) == original_flow
 
 
 class TestFailedRemove:

--- a/tests/e2e/test_node_group_membership_failures.py
+++ b/tests/e2e/test_node_group_membership_failures.py
@@ -30,6 +30,8 @@ from griptape_nodes.retained_mode.events.node_events import (
     AddNodesToNodeGroupResultSuccess,
     CreateNodeRequest,
     CreateNodeResultSuccess,
+    DeleteNodeRequest,
+    DeleteNodeResultSuccess,
     MoveNodeToNewFlowRequest,
     MoveNodeToNewFlowResultFailure,
     RemoveNodeFromNodeGroupRequest,
@@ -151,6 +153,9 @@ class TestFailedAdd:
         assert node.parent_group is None
         # The node never moved, so it is still where the artist left it.
         assert _flow_of(loose_name) == original_flow
+        # This was the group's first add, so the subflow it made to hold the node goes too: an add
+        # that failed in full should leave the artist owning nothing it created.
+        assert "subflow_name" not in group.metadata
 
     def test_moves_back_the_node_that_did_get_in_before_a_later_one_failed(
         self, library_name: str, monkeypatch: pytest.MonkeyPatch
@@ -297,3 +302,52 @@ class TestFailedRemove:
         # The inner group's subflow follows it out, so its Leaf is still reachable from the top.
         assert GriptapeNodes.FlowManager().get_parent_flow(inner_subflow) == flow.flow_name
         assert _flow_of(inner_name) == flow.flow_name
+
+
+class TestDeletedGroup:
+    def test_deleting_an_outer_group_leaves_the_group_it_held_intact(self, library_name: str) -> None:
+        """Deleting a group has to release what it held before deleting its own subflow.
+
+        `after_node_deleted` un-nests its members and only then deletes its subflow. That ordering is
+        the whole safety property: if the inner group's subflow were still parented underneath when
+        DeleteFlowRequest ran, deleting the outer group would take the inner group's contents down
+        with it -- silent data loss on a plain delete of the outer group only.
+        """
+        flow = GriptapeNodes.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="DeleteOuterFlow", set_as_new_context=False)
+        )
+        assert isinstance(flow, CreateFlowResultSuccess), flow
+
+        with GriptapeNodes.ContextManager().flow(flow.flow_name):
+            outer_name = _create_node("SubflowGroupNode", "OuterGroup", library_name)
+            inner_name = _create_node("SubflowGroupNode", "InnerGroup", library_name)
+            leaf_name = _create_node("EchoNode", "Leaf", library_name, parent_group_name=inner_name)
+
+            nest_result = GriptapeNodes.handle_request(
+                AddNodesToNodeGroupRequest(node_names=[inner_name], node_group_name=outer_name)
+            )
+            assert isinstance(nest_result, AddNodesToNodeGroupResultSuccess), nest_result
+
+            inner_subflow = _get_group(inner_name).metadata["subflow_name"]
+            outer_subflow = _get_group(outer_name).metadata["subflow_name"]
+            assert GriptapeNodes.FlowManager().get_parent_flow(inner_subflow) == outer_subflow
+            assert _flow_of(leaf_name) == inner_subflow
+
+            delete_result = GriptapeNodes.handle_request(DeleteNodeRequest(node_name=outer_name))
+
+        assert isinstance(delete_result, DeleteNodeResultSuccess), delete_result
+
+        # The outer group and its subflow are gone.
+        assert GriptapeNodes.ObjectManager().attempt_get_object_by_name(outer_name) is None
+        assert GriptapeNodes.ObjectManager().attempt_get_object_by_name(outer_subflow) is None
+
+        # The inner group survived, reparented to the flow that held the outer group...
+        inner = _get_group(inner_name)
+        assert inner.parent_group is None
+        assert _flow_of(inner_name) == flow.flow_name
+
+        # ...and it took its own subflow, and everything in it, along.
+        assert GriptapeNodes.ObjectManager().attempt_get_object_by_name(inner_subflow) is not None
+        assert GriptapeNodes.FlowManager().get_parent_flow(inner_subflow) == flow.flow_name
+        assert leaf_name in inner.nodes
+        assert _flow_of(leaf_name) == inner_subflow

--- a/tests/e2e/test_serialize_deserialize_roundtrip.py
+++ b/tests/e2e/test_serialize_deserialize_roundtrip.py
@@ -318,6 +318,45 @@ class TestNodeGroupRoundTrip:
             f"expected at least {len(distinct_edge_keys)} edges to be created, got {len(issued_edges)}"
         )
 
+    def test_restores_an_edge_leaving_a_nested_group(self, library_name: str) -> None:
+        """The other direction: a nested node is the source and the far end is outside both groups.
+
+        Incoming and outgoing edges take separate branches when a group decides whether an edge
+        crosses its boundary, and each hands off to a different side of the wall. Every other test
+        here wires outside-in, so the outgoing branch was never taken.
+        """
+        flow = GriptapeNodes.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="OutgoingRoundTrip", set_as_new_context=False)
+        )
+        assert isinstance(flow, CreateFlowResultSuccess), flow
+
+        with GriptapeNodes.ContextManager().flow(flow.flow_name):
+            outer = _create_node("SubflowGroupNode", "OuterGroup", library_name)
+            inner = _create_node("SubflowGroupNode", "InnerGroup", library_name)
+            leaf = _create_node("EchoNode", "Leaf", library_name, parent_group_name=inner)
+            sink = _create_node("EchoNode", "Sink", library_name)
+
+            nest_result = GriptapeNodes.handle_request(
+                AddNodesToNodeGroupRequest(node_names=[inner], node_group_name=outer)
+            )
+            assert isinstance(nest_result, AddNodesToNodeGroupResultSuccess), nest_result
+
+            _connect(leaf, sink)
+
+        commands = _serialize(flow.flow_name)
+
+        GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        result = _deserialize_into_fresh_context(commands)
+
+        restored_outer = _get_group(result.node_name_mappings["OuterGroup"])
+        restored_leaf = GriptapeNodes.NodeManager().get_node_by_name(result.node_name_mappings["Leaf"])
+        assert restored_outer.contains_node(restored_leaf)
+
+        # Exactly one: the edge has to come back, and it must not be duplicated per boundary.
+        assert len(_edges_from(restored_leaf.name)) == 1, (
+            f"expected one outgoing edge from the nested leaf, got {_edges_from(restored_leaf.name)}"
+        )
+
     def test_restores_saved_parameter_values_from_inside_a_subflow(self, library_name: str) -> None:
         """Values are stored per level too, so a value on a nested node must come back."""
         flow = GriptapeNodes.handle_request(

--- a/tests/e2e/test_serialize_deserialize_roundtrip.py
+++ b/tests/e2e/test_serialize_deserialize_roundtrip.py
@@ -1,0 +1,239 @@
+"""Round-trip coverage for SerializeFlowToCommands -> DeserializeFlowFromCommands.
+
+These two halves disagreed about scope. The serializer aggregates each Flow's connections up
+through every level of nesting, so an edge crossing a Flow boundary is reported by the parent as
+well as the child. The deserializer used to rebuild only its own level's nodes before wiring
+connections, and created subflows last, so any edge naming a node one level down failed with "node
+did not exist within the flow" and took the whole load down with it.
+
+That combination is what restoring a workflow embedded in image metadata does
+(ExtractFlowCommandsFromImageMetadata with deserialize=True), so a graph containing a node group --
+which always has boundary-crossing wall connections -- could not be restored at all. Nothing
+covered the pairing: the only other test that deserializes uses a single flow with no subflow, so
+there was nothing to aggregate and the disagreement stayed invisible.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.exe_types.node_groups.base_node_group import BaseNodeGroup
+from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest, CreateConnectionResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    CreateFlowResultSuccess,
+    DeserializeFlowFromCommandsRequest,
+    DeserializeFlowFromCommandsResultSuccess,
+    SerializeFlowToCommandsRequest,
+    SerializeFlowToCommandsResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.events.node_events import (
+    AddNodesToNodeGroupRequest,
+    AddNodesToNodeGroupResultSuccess,
+    CreateNodeRequest,
+    CreateNodeResultSuccess,
+)
+from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
+from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from griptape_nodes.retained_mode.events.flow_events import SerializedFlowCommands
+
+FIXTURE_LIBRARY_DIR = Path(__file__).parent / "fixtures" / "subflow_library"
+FIXTURE_LIBRARY_JSON_TEMPLATE = FIXTURE_LIBRARY_DIR / "griptape_nodes_library.json"
+FIXTURE_NODE_FILE = FIXTURE_LIBRARY_DIR / "subflow_echo_node.py"
+
+_EXPECTED_TEXT = "value that has to survive the round trip"
+
+
+@pytest.fixture
+def library_name(tmp_path: Path, materialize_library: Callable[..., Path]) -> str:
+    """Register the subflow fixture library into a clean engine and return its name."""
+    library_json = materialize_library(
+        tmp_path / "library", template=FIXTURE_LIBRARY_JSON_TEMPLATE, node_file=FIXTURE_NODE_FILE
+    )
+    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
+    GriptapeNodes.ContextManager().push_workflow(workflow_name="roundtrip_workflow")
+    return register_result.library_name
+
+
+def _serialize(flow_name: str) -> SerializedFlowCommands:
+    serialize_result = GriptapeNodes.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_name))
+    assert isinstance(serialize_result, SerializeFlowToCommandsResultSuccess), serialize_result
+    return serialize_result.serialized_flow_commands
+
+
+def _deserialize_into_fresh_context(
+    serialized_flow_commands: SerializedFlowCommands,
+) -> DeserializeFlowFromCommandsResultSuccess:
+    """Replay commands the way an image-metadata restore does, and require success."""
+    GriptapeNodes.ContextManager().push_workflow(workflow_name="roundtrip_workflow_restored")
+    result = GriptapeNodes.handle_request(
+        DeserializeFlowFromCommandsRequest(serialized_flow_commands=serialized_flow_commands)
+    )
+    assert isinstance(result, DeserializeFlowFromCommandsResultSuccess), result
+    return result
+
+
+def _create_node(node_type: str, node_name: str, library: str, **kwargs: object) -> str:
+    result = GriptapeNodes.handle_request(
+        CreateNodeRequest(node_type=node_type, specific_library_name=library, node_name=node_name, **kwargs)  # type: ignore[arg-type]
+    )
+    assert isinstance(result, CreateNodeResultSuccess), result
+    return result.node_name
+
+
+def _get_group(node_name: str) -> BaseNodeGroup:
+    """Fetch a rebuilt node that must be a group, so group membership can be inspected."""
+    node = GriptapeNodes.NodeManager().get_node_by_name(node_name)
+    assert isinstance(node, BaseNodeGroup), (
+        f"expected '{node_name}' to be rebuilt as a group, got {type(node).__name__}"
+    )
+    return node
+
+
+def _connect(source_node: str, target_node: str, parameter_name: str = "text") -> None:
+    result = GriptapeNodes.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name=parameter_name,
+            target_node_name=target_node,
+            target_parameter_name=parameter_name,
+        )
+    )
+    assert isinstance(result, CreateConnectionResultSuccess), result
+
+
+class TestPlainSubflowRoundTrip:
+    def test_restores_a_connection_that_crosses_a_flow_boundary(self, library_name: str) -> None:
+        """No node groups involved: two plain flows and one edge between them."""
+        parent = GriptapeNodes.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="RoundTripParent", set_as_new_context=False)
+        )
+        assert isinstance(parent, CreateFlowResultSuccess), parent
+        child = GriptapeNodes.handle_request(
+            CreateFlowRequest(parent_flow_name=parent.flow_name, flow_name="RoundTripChild", set_as_new_context=False)
+        )
+        assert isinstance(child, CreateFlowResultSuccess), child
+
+        with GriptapeNodes.ContextManager().flow(parent.flow_name):
+            source = _create_node("EchoNode", "Source", library_name)
+        with GriptapeNodes.ContextManager().flow(child.flow_name):
+            target = _create_node("EchoNode", "Target", library_name)
+        _connect(source, target)
+
+        commands = _serialize(parent.flow_name)
+
+        GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        result = _deserialize_into_fresh_context(commands)
+
+        # The child flow, its node, and the cross-boundary edge all have to come back.
+        restored_target = result.node_name_mappings["Target"]
+        restored_source = result.node_name_mappings["Source"]
+        node_manager = GriptapeNodes.NodeManager()
+        assert node_manager.get_node_by_name(restored_target) is not None
+        assert node_manager.get_node_by_name(restored_source) is not None
+
+
+class TestNodeGroupRoundTrip:
+    def test_restores_a_single_level_group(self, library_name: str) -> None:
+        """A group's wall connections cross its boundary, so this failed for every group."""
+        flow = GriptapeNodes.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="GroupRoundTrip", set_as_new_context=False)
+        )
+        assert isinstance(flow, CreateFlowResultSuccess), flow
+
+        with GriptapeNodes.ContextManager().flow(flow.flow_name):
+            group = _create_node("SubflowGroupNode", "Group", library_name)
+            leaf = _create_node("EchoNode", "Leaf", library_name, parent_group_name=group)
+            source = _create_node("EchoNode", "Source", library_name)
+            GriptapeNodes.handle_request(
+                SetParameterValueRequest(parameter_name="text", node_name=source, value=_EXPECTED_TEXT)
+            )
+            _connect(source, leaf)
+
+        commands = _serialize(flow.flow_name)
+
+        GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        result = _deserialize_into_fresh_context(commands)
+
+        restored_group = _get_group(result.node_name_mappings["Group"])
+        restored_leaf_name = result.node_name_mappings["Leaf"]
+        assert restored_leaf_name in restored_group.nodes
+
+    def test_restores_a_nested_group_and_its_deepest_member(self, library_name: str) -> None:
+        """Nesting is the case with edges spanning more than one boundary."""
+        flow = GriptapeNodes.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="NestedRoundTrip", set_as_new_context=False)
+        )
+        assert isinstance(flow, CreateFlowResultSuccess), flow
+
+        with GriptapeNodes.ContextManager().flow(flow.flow_name):
+            outer = _create_node("SubflowGroupNode", "OuterGroup", library_name)
+            inner = _create_node("SubflowGroupNode", "InnerGroup", library_name)
+            leaf = _create_node("EchoNode", "Leaf", library_name, parent_group_name=inner)
+            source = _create_node("EchoNode", "Source", library_name)
+
+            nest_result = GriptapeNodes.handle_request(
+                AddNodesToNodeGroupRequest(node_names=[inner], node_group_name=outer)
+            )
+            assert isinstance(nest_result, AddNodesToNodeGroupResultSuccess), nest_result
+
+            GriptapeNodes.handle_request(
+                SetParameterValueRequest(parameter_name="text", node_name=source, value=_EXPECTED_TEXT)
+            )
+            _connect(source, leaf)
+
+        commands = _serialize(flow.flow_name)
+
+        GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        result = _deserialize_into_fresh_context(commands)
+
+        restored_outer = _get_group(result.node_name_mappings["OuterGroup"])
+        restored_inner = _get_group(result.node_name_mappings["InnerGroup"])
+        restored_leaf = GriptapeNodes.NodeManager().get_node_by_name(result.node_name_mappings["Leaf"])
+
+        # Membership has to survive at both levels, and transitively.
+        assert restored_inner.name in restored_outer.nodes
+        assert restored_leaf.name in restored_inner.nodes
+        assert restored_outer.contains_node(restored_leaf)
+
+        # The subflows have to be nested the same way the groups are.
+        inner_subflow = restored_inner.metadata.get("subflow_name")
+        outer_subflow = restored_outer.metadata.get("subflow_name")
+        assert isinstance(inner_subflow, str), "inner group lost its subflow on load"
+        assert GriptapeNodes.FlowManager().get_parent_flow(inner_subflow) == outer_subflow
+
+    def test_restores_saved_parameter_values_from_inside_a_subflow(self, library_name: str) -> None:
+        """Values are stored per level too, so a value on a nested node must come back."""
+        flow = GriptapeNodes.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="ValueRoundTrip", set_as_new_context=False)
+        )
+        assert isinstance(flow, CreateFlowResultSuccess), flow
+
+        with GriptapeNodes.ContextManager().flow(flow.flow_name):
+            group = _create_node("SubflowGroupNode", "Group", library_name)
+            leaf = _create_node("EchoNode", "Leaf", library_name, parent_group_name=group)
+            GriptapeNodes.handle_request(
+                SetParameterValueRequest(parameter_name="text", node_name=leaf, value=_EXPECTED_TEXT)
+            )
+
+        commands = _serialize(flow.flow_name)
+
+        GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        result = _deserialize_into_fresh_context(commands)
+
+        restored_leaf = GriptapeNodes.NodeManager().get_node_by_name(result.node_name_mappings["Leaf"])
+        assert restored_leaf.get_parameter_value("text") == _EXPECTED_TEXT

--- a/tests/e2e/test_serialize_deserialize_roundtrip.py
+++ b/tests/e2e/test_serialize_deserialize_roundtrip.py
@@ -378,3 +378,104 @@ class TestNodeGroupRoundTrip:
 
         restored_leaf = GriptapeNodes.NodeManager().get_node_by_name(result.node_name_mappings["Leaf"])
         assert restored_leaf.get_parameter_value("text") == _EXPECTED_TEXT
+
+
+class TestLoadingIntoAnOccupiedSession:
+    """Loading a graph next to one it collides with, rather than into an empty session.
+
+    Every test above deserializes into a cleared session, so every name comes back unchanged and
+    nothing has to be remapped. Restoring from image metadata does not clear anything: the graph
+    lands alongside whatever the artist already has open, and each name that collides is deduped.
+    """
+
+    def test_a_group_loaded_beside_a_same_named_group_gets_its_own_subflow(self, library_name: str) -> None:
+        """A group records its subflow by name, and that name is deduped like any other.
+
+        If the rebuilt group keeps the name it was saved with, it points at the subflow belonging to
+        the group already open, and the nodes just loaded are moved into someone else's group. The
+        subflow this load created is left empty, and nothing reports a problem, because the flow the
+        group names does exist -- it just is not the group's.
+        """
+        canvas = GriptapeNodes.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="OccupiedCanvas", set_as_new_context=False)
+        )
+        assert isinstance(canvas, CreateFlowResultSuccess), canvas
+        host = GriptapeNodes.handle_request(
+            CreateFlowRequest(parent_flow_name=canvas.flow_name, flow_name="GroupHost", set_as_new_context=False)
+        )
+        assert isinstance(host, CreateFlowResultSuccess), host
+
+        with GriptapeNodes.ContextManager().flow(host.flow_name):
+            group = _create_node("SubflowGroupNode", "Group", library_name)
+            leaf = _create_node("EchoNode", "Leaf", library_name, parent_group_name=group)
+
+        commands = _serialize(host.flow_name)
+
+        original_group = _get_group(group)
+        original_subflow = original_group.metadata["subflow_name"]
+
+        # No ClearAllObjectState: the group above is still open, so its name and its subflow's name
+        # are both taken.
+        with GriptapeNodes.ContextManager().flow(canvas.flow_name):
+            result = GriptapeNodes.handle_request(DeserializeFlowFromCommandsRequest(serialized_flow_commands=commands))
+        assert isinstance(result, DeserializeFlowFromCommandsResultSuccess), result
+
+        restored_group = _get_group(result.node_name_mappings["Group"])
+        restored_leaf_name = result.node_name_mappings["Leaf"]
+        restored_subflow = restored_group.metadata["subflow_name"]
+
+        # The copy got its own subflow, and its member is in that one.
+        assert restored_subflow != original_subflow
+        assert GriptapeNodes.NodeManager().get_node_parent_flow_by_name(restored_leaf_name) == restored_subflow
+        assert restored_leaf_name in restored_group.nodes
+
+        # And the group that was already open kept exactly what it had.
+        assert sorted(original_group.nodes) == [leaf]
+        assert GriptapeNodes.NodeManager().get_node_parent_flow_by_name(leaf) == original_subflow
+
+
+class TestWhichFlowClaimsAnEdge:
+    """Which Flow reports a group-wall edge, which is what keeps codegen's output loadable.
+
+    Codegen writes a Flow's subflows before its own nodes, so if a subflow reported an edge whose far
+    endpoint is a group node in the parent, that edge would be written ahead of the line assigning the
+    group's variable and the generated file would raise NameError on load. What prevents it is the
+    scope of `FlowManager._get_connections_for_flow`: a Flow collects over itself plus its direct
+    children only. Nothing else states that, so this is the test that fails if the scope ever widens.
+    """
+
+    def test_a_group_subflow_does_not_report_an_edge_reaching_the_group_node_itself(self, library_name: str) -> None:
+        """The group's own subflow must not claim the edge arriving at its wall.
+
+        `Group` lives in the parent flow and `Leaf` inside the group's subflow, so the edge from
+        `Feeder` to the group's proxy parameter has one endpoint at each level. The parent may report
+        it. The subflow may not: it does not hold `Group`, and codegen writes it first.
+        """
+        flow = GriptapeNodes.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="EdgeOwnership", set_as_new_context=False)
+        )
+        assert isinstance(flow, CreateFlowResultSuccess), flow
+
+        with GriptapeNodes.ContextManager().flow(flow.flow_name):
+            group = _create_node("SubflowGroupNode", "Group", library_name)
+            leaf = _create_node("EchoNode", "Leaf", library_name, parent_group_name=group)
+            feeder = _create_node("EchoNode", "Feeder", library_name)
+            _connect(feeder, leaf)
+
+        subflow_name = _get_group(group).metadata["subflow_name"]
+
+        # Serializing the subflow on its own is what codegen does when it recurses into it.
+        subflow_commands = _serialize(subflow_name)
+
+        # The wall edge attaches to the group node, which is not in the subflow, so the subflow must
+        # not report any edge touching it.
+        subflow_node_uuids = {node_commands.node_uuid for node_commands in subflow_commands.serialized_node_commands}
+        for connection in subflow_commands.serialized_connections:
+            assert connection.source_node_uuid in subflow_node_uuids, (
+                "the group's subflow reported an edge starting outside it, which codegen would write "
+                "before the variable it names exists"
+            )
+            assert connection.target_node_uuid in subflow_node_uuids, (
+                "the group's subflow reported an edge ending outside it, which codegen would write "
+                "before the variable it names exists"
+            )

--- a/tests/e2e/test_serialize_deserialize_roundtrip.py
+++ b/tests/e2e/test_serialize_deserialize_roundtrip.py
@@ -1,16 +1,16 @@
 """Round-trip coverage for SerializeFlowToCommands -> DeserializeFlowFromCommands.
 
-These two halves disagreed about scope. The serializer aggregates each Flow's connections up
+The two halves have to agree about scope. The serializer aggregates each Flow's connections up
 through every level of nesting, so an edge crossing a Flow boundary is reported by the parent as
-well as the child. The deserializer used to rebuild only its own level's nodes before wiring
-connections, and created subflows last, so any edge naming a node one level down failed with "node
-did not exist within the flow" and took the whole load down with it.
+well as the child. Deserialization therefore has to create every node in the subtree, subflows
+included, before it wires anything: an aggregated edge can name a node one or more levels down, and
+wiring it early fails with "node did not exist within the flow" and takes the whole load down.
 
-That combination is what restoring a workflow embedded in image metadata does
-(ExtractFlowCommandsFromImageMetadata with deserialize=True), so a graph containing a node group --
-which always has boundary-crossing wall connections -- could not be restored at all. Nothing
-covered the pairing: the only other test that deserializes uses a single flow with no subflow, so
-there was nothing to aggregate and the disagreement stayed invisible.
+Restoring a workflow embedded in image metadata is this pairing
+(ExtractFlowCommandsFromImageMetadata with deserialize=True), and a graph containing a node group
+always has boundary-crossing wall connections, so it depends on the ordering above. These tests
+exist to hold it: the only other test that deserializes uses a single flow with no subflow, where
+there is nothing to aggregate and nothing to order.
 """
 
 from __future__ import annotations

--- a/tests/e2e/test_serialize_deserialize_roundtrip.py
+++ b/tests/e2e/test_serialize_deserialize_roundtrip.py
@@ -311,7 +311,12 @@ class TestNodeGroupRoundTrip:
         ]
         duplicated_edges = {edge for edge in issued_edges if issued_edges.count(edge) > 1}
         assert not duplicated_edges, f"these edges were created more than once on load: {sorted(duplicated_edges)}"
-        assert len(issued_edges) == len(distinct_edge_keys)
+        # Every distinct edge still has to be created, so deduping cannot pass by wiring nothing.
+        # Not compared to len(distinct_edge_keys): the load path may legitimately issue extra edges
+        # of its own (a proxy remap, say), and only the duplicates above are the bug.
+        assert len(issued_edges) >= len(distinct_edge_keys), (
+            f"expected at least {len(distinct_edge_keys)} edges to be created, got {len(issued_edges)}"
+        )
 
     def test_restores_saved_parameter_values_from_inside_a_subflow(self, library_name: str) -> None:
         """Values are stored per level too, so a value on a nested node must come back."""

--- a/tests/e2e/test_serialize_deserialize_roundtrip.py
+++ b/tests/e2e/test_serialize_deserialize_roundtrip.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from griptape_nodes.exe_types.node_groups.base_node_group import BaseNodeGroup
+from griptape_nodes.retained_mode.engine import current_engine
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest, CreateConnectionResultSuccess
 from griptape_nodes.retained_mode.events.flow_events import (
     CreateFlowRequest,
@@ -116,6 +117,20 @@ def _connect(source_node: str, target_node: str, parameter_name: str = "text") -
     assert isinstance(result, CreateConnectionResultSuccess), result
 
 
+def _edges_from(node_name: str) -> set[str]:
+    """Every outgoing edge of a node, as 'Source.param->Target.param' strings.
+
+    Returned as a set of readable labels so a failure names the edges rather than dumping objects,
+    and counted so a duplicated edge is as visible as a missing one.
+    """
+    node = GriptapeNodes.NodeManager().get_node_by_name(node_name)
+    connections = GriptapeNodes.FlowManager().get_connections()
+    return {
+        f"{edge.source_node.name}.{edge.source_parameter.name}->{edge.target_node.name}.{edge.target_parameter.name}"
+        for edge in connections.get_all_outgoing_connections(node)
+    }
+
+
 class TestPlainSubflowRoundTrip:
     def test_restores_a_connection_that_crosses_a_flow_boundary(self, library_name: str) -> None:
         """No node groups involved: two plain flows and one edge between them."""
@@ -145,6 +160,7 @@ class TestPlainSubflowRoundTrip:
         node_manager = GriptapeNodes.NodeManager()
         assert node_manager.get_node_by_name(restored_target) is not None
         assert node_manager.get_node_by_name(restored_source) is not None
+        assert _edges_from(restored_source) == {f"{restored_source}.text->{restored_target}.text"}
 
 
 class TestNodeGroupRoundTrip:
@@ -215,6 +231,87 @@ class TestNodeGroupRoundTrip:
         outer_subflow = restored_outer.metadata.get("subflow_name")
         assert isinstance(inner_subflow, str), "inner group lost its subflow on load"
         assert GriptapeNodes.FlowManager().get_parent_flow(inner_subflow) == outer_subflow
+
+    def test_creates_each_connection_once_even_though_every_level_reports_it(
+        self, library_name: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A nested graph must not re-issue an edge once per level of nesting.
+
+        The serializer copies each subflow's connections up into every ancestor, so an edge crossing
+        two group boundaries is offered to the deserializer three times. Re-issuing it is not
+        harmless: CreateConnection treats a duplicate as a restricted scenario and deletes the
+        existing edge before rebuilding it, and that delete decrements the refcount protecting the
+        group's proxy parameter -- so the load path tears down the wiring it just restored.
+
+        The final graph looks identical either way, which is why this counts requests instead of
+        inspecting the result.
+        """
+        flow = GriptapeNodes.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="DedupeRoundTrip", set_as_new_context=False)
+        )
+        assert isinstance(flow, CreateFlowResultSuccess), flow
+
+        with GriptapeNodes.ContextManager().flow(flow.flow_name):
+            outer = _create_node("SubflowGroupNode", "OuterGroup", library_name)
+            inner = _create_node("SubflowGroupNode", "InnerGroup", library_name)
+            leaf = _create_node("EchoNode", "Leaf", library_name, parent_group_name=inner)
+            source = _create_node("EchoNode", "Source", library_name)
+
+            nest_result = GriptapeNodes.handle_request(
+                AddNodesToNodeGroupRequest(node_names=[inner], node_group_name=outer)
+            )
+            assert isinstance(nest_result, AddNodesToNodeGroupResultSuccess), nest_result
+            _connect(source, leaf)
+
+        commands = _serialize(flow.flow_name)
+
+        # Prove the premise: the same edge really is reported by more than one level.
+        def count_serialized_edges(serialized: SerializedFlowCommands) -> int:
+            total = len(serialized.serialized_connections)
+            for sub_flow in serialized.sub_flows_commands:
+                total += count_serialized_edges(sub_flow)
+            return total
+
+        def collect_edge_keys(serialized: SerializedFlowCommands, keys: set[object]) -> None:
+            for connection in serialized.serialized_connections:
+                keys.add(connection.key())
+            for sub_flow in serialized.sub_flows_commands:
+                collect_edge_keys(sub_flow, keys)
+
+        distinct_edge_keys: set[object] = set()
+        collect_edge_keys(commands, distinct_edge_keys)
+        assert count_serialized_edges(commands) > len(distinct_edge_keys), (
+            "expected the serializer to report at least one edge more than once, "
+            "otherwise this test cannot observe the duplicate-application bug"
+        )
+
+        GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+
+        engine = current_engine()
+        connection_requests: list[CreateConnectionRequest] = []
+        original_handle_request = engine.handle_request
+
+        def record_connection_requests(request: object, **kwargs: object) -> object:
+            if isinstance(request, CreateConnectionRequest):
+                connection_requests.append(request)
+            return original_handle_request(request, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(engine, "handle_request", record_connection_requests)
+        _deserialize_into_fresh_context(commands)
+        monkeypatch.undo()
+
+        issued_edges = [
+            (
+                request.source_node_name,
+                request.source_parameter_name,
+                request.target_node_name,
+                request.target_parameter_name,
+            )
+            for request in connection_requests
+        ]
+        duplicated_edges = {edge for edge in issued_edges if issued_edges.count(edge) > 1}
+        assert not duplicated_edges, f"these edges were created more than once on load: {sorted(duplicated_edges)}"
+        assert len(issued_edges) == len(distinct_edge_keys)
 
     def test_restores_saved_parameter_values_from_inside_a_subflow(self, library_name: str) -> None:
         """Values are stored per level too, so a value on a nested node must come back."""

--- a/tests/unit/exe_types/node_groups/test_base_node_group_nesting.py
+++ b/tests/unit/exe_types/node_groups/test_base_node_group_nesting.py
@@ -1,0 +1,118 @@
+"""Tests for the transitive containment a node group needs once groups can nest.
+
+``node.parent_group`` names only the group a node sits in directly. Once a group can live inside
+another group, "is this node in my group?" stops being a single lookup: the answer has to walk the
+whole chain of enclosing groups. Code that checked only the direct parent treated a node nested one
+level deeper as external, which is what made a group re-route connections that never left it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from griptape_nodes.exe_types.node_groups.base_node_group import BaseNodeGroup
+from griptape_nodes.exe_types.node_types import BaseNode
+
+
+class _MiniGroup(BaseNodeGroup):
+    """Concrete group with no subflow, so membership can be tested on its own."""
+
+    def process(self) -> Any:  # pragma: no cover - execution not exercised here
+        return None
+
+
+class _MiniNode(BaseNode):
+    """Plain node used as group member."""
+
+    def process(self) -> Any:  # pragma: no cover - execution not exercised here
+        return None
+
+
+class TestGetEnclosingGroups:
+    def test_returns_empty_for_ungrouped_node(self) -> None:
+        assert BaseNodeGroup.get_enclosing_groups(_MiniNode(name="loose")) == []
+
+    def test_returns_every_ancestor_innermost_first(self) -> None:
+        outer = _MiniGroup(name="outer")
+        inner = _MiniGroup(name="inner")
+        leaf = _MiniNode(name="leaf")
+        inner.add_nodes_to_group([leaf])
+        outer.add_nodes_to_group([inner])
+
+        assert BaseNodeGroup.get_enclosing_groups(leaf) == [inner, outer]
+
+    def test_stops_instead_of_looping_on_a_cycle(self) -> None:
+        """A malformed parent_group cycle must terminate rather than hang the engine."""
+        first = _MiniGroup(name="first")
+        second = _MiniGroup(name="second")
+        # Force the cycle the validation in add_nodes_to_group exists to prevent.
+        first.parent_group = second
+        second.parent_group = first
+
+        # Terminates, and stops rather than walking back into a group it has already seen.
+        assert BaseNodeGroup.get_enclosing_groups(first) == [second]
+
+
+class TestContainsNode:
+    def test_contains_direct_member(self) -> None:
+        group = _MiniGroup(name="group")
+        leaf = _MiniNode(name="leaf")
+        group.add_nodes_to_group([leaf])
+
+        assert group.contains_node(leaf)
+
+    def test_contains_node_nested_two_levels_deep(self) -> None:
+        """The outer group must own a node held by a group nested inside it."""
+        outer = _MiniGroup(name="outer")
+        inner = _MiniGroup(name="inner")
+        leaf = _MiniNode(name="leaf")
+        inner.add_nodes_to_group([leaf])
+        outer.add_nodes_to_group([inner])
+
+        assert outer.contains_node(leaf)
+        assert outer.contains_node(inner)
+
+    def test_does_not_contain_outside_node(self) -> None:
+        group = _MiniGroup(name="group")
+
+        assert not group.contains_node(_MiniNode(name="stranger"))
+
+    def test_does_not_contain_a_sibling_groups_member(self) -> None:
+        left = _MiniGroup(name="left")
+        right = _MiniGroup(name="right")
+        leaf = _MiniNode(name="leaf")
+        right.add_nodes_to_group([leaf])
+
+        assert not left.contains_node(leaf)
+
+
+class TestNestingValidation:
+    def test_rejects_adding_a_group_to_itself(self) -> None:
+        group = _MiniGroup(name="group")
+
+        with pytest.raises(ValueError, match="itself"):
+            group.add_nodes_to_group([group])
+
+    def test_rejects_adding_an_enclosing_group_as_a_child(self) -> None:
+        """Nesting a group inside its own descendant would make the ancestor walk endless."""
+        outer = _MiniGroup(name="outer")
+        inner = _MiniGroup(name="inner")
+        outer.add_nodes_to_group([inner])
+
+        with pytest.raises(ValueError, match="already inside"):
+            inner.add_nodes_to_group([outer])
+
+    def test_rejects_the_whole_batch_before_mutating_anything(self) -> None:
+        """A rejected add must not leave half the batch attached."""
+        outer = _MiniGroup(name="outer")
+        inner = _MiniGroup(name="inner")
+        outer.add_nodes_to_group([inner])
+        innocent = _MiniNode(name="innocent")
+
+        with pytest.raises(ValueError, match="already inside"):
+            inner.add_nodes_to_group([innocent, outer])
+
+        assert innocent.name not in inner.nodes
+        assert innocent.parent_group is None

--- a/tests/unit/exe_types/node_groups/test_subflow_node_group.py
+++ b/tests/unit/exe_types/node_groups/test_subflow_node_group.py
@@ -52,6 +52,40 @@ class TestSubflowNodeGroupCreateSubflow:
         assert group.metadata["subflow_name"] == "G_subflow_1"
 
 
+class TestGetAllNodes:
+    """get_all_nodes has to reach the whole body, not just the first level down.
+
+    Callers use it to package a group for execution (remote, private, iterative), so a node it
+    misses is a node that silently does not run.
+    """
+
+    def test_collects_members_nested_more_than_one_level_deep(
+        self,
+        griptape_nodes: GriptapeNodes,  # noqa: ARG002 - initialises the engine singleton for construction
+    ) -> None:
+        outer = _MiniSubflowGroup(name="outer")
+        middle = _MiniSubflowGroup(name="middle")
+        inner = _MiniSubflowGroup(name="inner")
+        leaf = _MiniSubflowGroup(name="leaf")
+
+        # Wire membership directly: this covers the traversal, not the add-to-group machinery.
+        outer.nodes = {"middle": middle}
+        middle.nodes = {"inner": inner}
+        inner.nodes = {"leaf": leaf}
+
+        # "leaf" is three levels down; walking a single level would stop at "middle".
+        assert set(outer.get_all_nodes()) == {"middle", "inner", "leaf"}
+
+    def test_returns_direct_members_when_nothing_is_nested(
+        self,
+        griptape_nodes: GriptapeNodes,  # noqa: ARG002 - initialises the engine singleton for construction
+    ) -> None:
+        group = _MiniSubflowGroup(name="group")
+        group.nodes = {"only": _MiniSubflowGroup(name="only")}
+
+        assert set(group.get_all_nodes()) == {"only"}
+
+
 class _MiniSubflowGroup(SubflowNodeGroup):
     """Minimal concrete SubflowNodeGroup exercising only _create_subflow."""
 

--- a/tests/unit/retained_mode/managers/test_flow_manager.py
+++ b/tests/unit/retained_mode/managers/test_flow_manager.py
@@ -955,3 +955,79 @@ class TestDeleteIterationFlows:
 
         for _, flow_name, _ in deserialized_flows:
             assert object_manager.attempt_get_object_by_name(flow_name) is None
+
+
+class TestReparentFlow:
+    """Moving a Flow under a new parent, which is how a nested group's subflow finds its home.
+
+    When a node group is nested inside another, the inner group's subflow has to become a child of
+    the outer group's subflow. Serialization walks parent/child links, so a subflow left parented to
+    the top-level flow is written outside its enclosing group and its members vanish on load.
+    """
+
+    @pytest.mark.usefixtures("clean_object_state")
+    def test_moves_flow_under_new_parent(self, griptape_nodes: GriptapeNodes) -> None:
+        griptape_nodes.ContextManager().push_workflow("reparent_wf")
+        top = griptape_nodes.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="top", set_as_new_context=False)
+        )
+        assert isinstance(top, CreateFlowResultSuccess)
+        outer = griptape_nodes.handle_request(
+            CreateFlowRequest(parent_flow_name=top.flow_name, flow_name="outer", set_as_new_context=False)
+        )
+        assert isinstance(outer, CreateFlowResultSuccess)
+        inner = griptape_nodes.handle_request(
+            CreateFlowRequest(parent_flow_name=top.flow_name, flow_name="inner", set_as_new_context=False)
+        )
+        assert isinstance(inner, CreateFlowResultSuccess)
+
+        flow_manager = griptape_nodes.FlowManager()
+        flow_manager.reparent_flow(inner.flow_name, outer.flow_name)
+
+        assert flow_manager.get_parent_flow(inner.flow_name) == outer.flow_name
+
+    @pytest.mark.usefixtures("clean_object_state")
+    def test_rejects_unknown_flows(self, griptape_nodes: GriptapeNodes) -> None:
+        griptape_nodes.ContextManager().push_workflow("reparent_unknown_wf")
+        real = griptape_nodes.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="real", set_as_new_context=False)
+        )
+        assert isinstance(real, CreateFlowResultSuccess)
+        flow_manager = griptape_nodes.FlowManager()
+
+        with pytest.raises(ValueError, match="doesn't exist"):
+            flow_manager.reparent_flow("ghost", real.flow_name)
+        with pytest.raises(ValueError, match="doesn't exist"):
+            flow_manager.reparent_flow(real.flow_name, "ghost")
+
+    @pytest.mark.usefixtures("clean_object_state")
+    def test_rejects_making_a_flow_its_own_parent(self, griptape_nodes: GriptapeNodes) -> None:
+        griptape_nodes.ContextManager().push_workflow("reparent_self_wf")
+        solo = griptape_nodes.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="solo", set_as_new_context=False)
+        )
+        assert isinstance(solo, CreateFlowResultSuccess)
+
+        with pytest.raises(ValueError, match="its own parent"):
+            griptape_nodes.FlowManager().reparent_flow(solo.flow_name, solo.flow_name)
+
+    @pytest.mark.usefixtures("clean_object_state")
+    def test_rejects_moving_a_flow_inside_its_own_descendant(self, griptape_nodes: GriptapeNodes) -> None:
+        """That move would detach the branch and leave the ancestor walk with no way out."""
+        griptape_nodes.ContextManager().push_workflow("reparent_cycle_wf")
+        outer = griptape_nodes.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="outer", set_as_new_context=False)
+        )
+        assert isinstance(outer, CreateFlowResultSuccess)
+        inner = griptape_nodes.handle_request(
+            CreateFlowRequest(parent_flow_name=outer.flow_name, flow_name="inner", set_as_new_context=False)
+        )
+        assert isinstance(inner, CreateFlowResultSuccess)
+
+        flow_manager = griptape_nodes.FlowManager()
+        with pytest.raises(ValueError, match="already inside"):
+            flow_manager.reparent_flow(outer.flow_name, inner.flow_name)
+
+        # The rejected move must leave the hierarchy untouched.
+        assert flow_manager.get_parent_flow(inner.flow_name) == outer.flow_name
+        assert flow_manager.get_parent_flow(outer.flow_name) is None

--- a/tests/unit/retained_mode/managers/test_workflow_manager_nested_codegen.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager_nested_codegen.py
@@ -1,0 +1,200 @@
+"""Tests for generating workflow files whose Flows nest more than one level deep.
+
+A node group owns a subflow, so a group nested inside another group produces a subflow inside a
+subflow, to whatever depth the artist nests them. The generator has to follow that all the way down:
+when it walked only the first level, nodes below it were left out of the file entirely, the groups
+that claimed them were rebuilt with no members, and any connection touching them could not be
+written at all.
+"""
+
+from __future__ import annotations
+
+import ast
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.exe_types.node_types import NodeDependencies
+from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, SerializedFlowCommands
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, SerializedNodeCommands
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
+
+
+def _node_commands(node_name: str, *, is_node_group: bool = False, **create_kwargs: object) -> SerializedNodeCommands:
+    return SerializedNodeCommands(
+        create_node_command=CreateNodeRequest(node_type="EchoNode", node_name=node_name, **create_kwargs),  # type: ignore[arg-type]
+        element_modification_commands=[],
+        node_dependencies=NodeDependencies(),
+        is_node_group=is_node_group,
+    )
+
+
+def _flow_commands(
+    flow_name: str | None,
+    *,
+    nodes: list[SerializedNodeCommands] | None = None,
+    connections: list[SerializedFlowCommands.IndirectConnectionSerialization] | None = None,
+    sub_flows: list[SerializedFlowCommands] | None = None,
+) -> SerializedFlowCommands:
+    initialization_command = None
+    if flow_name is not None:
+        initialization_command = CreateFlowRequest(flow_name=flow_name, parent_flow_name=None)
+    return SerializedFlowCommands(
+        flow_initialization_command=initialization_command,
+        serialized_node_commands=nodes or [],
+        serialized_connections=connections or [],
+        unique_parameter_uuid_to_values={},
+        set_parameter_value_commands={},
+        set_lock_commands_per_node={},
+        sub_flows_commands=sub_flows or [],
+        node_dependencies=NodeDependencies(),
+        node_types_used=set(),
+        flow_name=flow_name,
+    )
+
+
+def _generate(griptape_nodes: Engine, serialized_flow_commands: SerializedFlowCommands) -> str:
+    metadata = WorkflowMetadata(
+        name="nested_codegen_workflow",
+        schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+        engine_version_created_with="1.0.0",
+        node_libraries_referenced=[],
+        workflow_shape=None,
+    )
+    return griptape_nodes.WorkflowManager()._generate_workflow_file_content(
+        serialized_flow_commands=serialized_flow_commands, workflow_metadata=metadata
+    )
+
+
+class TestNestedFlowCodegen:
+    def test_generates_nodes_from_a_flow_three_levels_deep(self, griptape_nodes: Engine) -> None:
+        """A node two subflows below the top must still be written into the file."""
+        leaf = _node_commands("Leaf")
+        commands = _flow_commands(
+            "top",
+            sub_flows=[_flow_commands("middle", sub_flows=[_flow_commands("bottom", nodes=[leaf])])],
+        )
+
+        content = _generate(griptape_nodes, commands)
+
+        assert "'Leaf'" in content
+        # Each Flow gets its own variable, so all three levels are rebuilt.
+        assert "flow0_name" in content
+        assert "flow1_name" in content
+        assert "flow2_name" in content
+
+    def test_parents_each_subflow_to_the_flow_that_encloses_it(self, griptape_nodes: Engine) -> None:
+        """The generated hierarchy has to mirror the nesting, not flatten onto the top-level flow."""
+        commands = _flow_commands(
+            "top",
+            sub_flows=[_flow_commands("middle", sub_flows=[_flow_commands("bottom", nodes=[_node_commands("Leaf")])])],
+        )
+
+        content = _generate(griptape_nodes, commands)
+
+        assert "parent_flow_name=flow0_name" in content
+        assert "parent_flow_name=flow1_name" in content
+
+    def test_gives_every_node_in_the_file_a_distinct_variable(self, griptape_nodes: Engine) -> None:
+        """Node variables are file-wide, so names must not restart per Flow and collide."""
+        commands = _flow_commands(
+            "top",
+            nodes=[_node_commands("TopNode")],
+            sub_flows=[
+                _flow_commands(
+                    "middle",
+                    nodes=[_node_commands("MiddleNode")],
+                    sub_flows=[_flow_commands("bottom", nodes=[_node_commands("BottomNode")])],
+                )
+            ],
+        )
+
+        content = _generate(griptape_nodes, commands)
+
+        assigned_names = [
+            target.id
+            for node in ast.walk(ast.parse(content))
+            if isinstance(node, ast.Assign)
+            for target in node.targets
+            if isinstance(target, ast.Name) and target.id.startswith("node")
+        ]
+        assert sorted(assigned_names) == ["node0_name", "node1_name", "node2_name"]
+
+    def test_resolves_group_membership_across_a_deeper_subflow(self, griptape_nodes: Engine) -> None:
+        """A group's member can be created in a subflow below it, and must still be named."""
+        child = _node_commands("Child")
+        group = _node_commands("Group", is_node_group=True, node_names_to_add=[child.node_uuid])
+        commands = _flow_commands("top", nodes=[group], sub_flows=[_flow_commands("group_subflow", nodes=[child])])
+
+        content = _generate(griptape_nodes, commands)
+
+        # The child is referenced by its generated variable, not dropped for an empty membership list.
+        assert "node_names_to_add=[node0_name]" in content
+        assert "node_names_to_add=[]" not in content
+
+    def test_writes_a_connection_once_even_though_each_level_reports_it(self, griptape_nodes: Engine) -> None:
+        """Every Flow's serialized connections include its subflows', so the same edge repeats.
+
+        Re-creating a connection tears down and rebuilds whatever it was routed through, so the
+        generated file must ask for it exactly once.
+        """
+        source = _node_commands("A")
+        target = _node_commands("B")
+        connection = SerializedFlowCommands.IndirectConnectionSerialization(
+            source_node_uuid=source.node_uuid,
+            source_parameter_name="text",
+            target_node_uuid=target.node_uuid,
+            target_parameter_name="text",
+        )
+        commands = _flow_commands(
+            "top",
+            connections=[connection],
+            sub_flows=[_flow_commands("child", nodes=[source, target], connections=[connection])],
+        )
+
+        content = _generate(griptape_nodes, commands)
+
+        assert content.count("CreateConnectionRequest(") == 1
+
+    def test_emits_valid_python(self, griptape_nodes: Engine) -> None:
+        """Whatever the nesting depth, the file has to parse."""
+        commands = _flow_commands(
+            "top",
+            nodes=[_node_commands("TopNode")],
+            sub_flows=[
+                _flow_commands(
+                    "middle",
+                    nodes=[_node_commands("MiddleNode")],
+                    sub_flows=[_flow_commands("bottom", nodes=[_node_commands("BottomNode")])],
+                )
+            ],
+        )
+
+        content = _generate(griptape_nodes, commands)
+
+        ast.parse(content)  # raises SyntaxError if the generated file is malformed
+
+
+class TestNestedFlowCodegenStructure:
+    @pytest.mark.parametrize("depth", [1, 2, 4])
+    def test_each_level_is_written_inside_the_one_above_it(self, griptape_nodes: Engine, depth: int) -> None:
+        """Nodes must be created inside their own Flow's context block, at any depth."""
+        commands = _flow_commands("level0", nodes=[_node_commands("Node0")])
+        deepest = commands
+        for level in range(1, depth + 1):
+            child = _flow_commands(f"level{level}", nodes=[_node_commands(f"Node{level}")])
+            deepest.sub_flows_commands.append(child)
+            deepest = child
+
+        content = _generate(griptape_nodes, commands)
+
+        # Deeper Flows are nested further in, so their statements are indented further.
+        indents = []
+        for level in range(depth + 1):
+            line = next(line for line in content.splitlines() if f"'Node{level}'" in line)
+            indents.append(len(line) - len(line.lstrip()))
+        assert indents == sorted(indents), f"expected increasing nesting, got indents {indents}"
+        assert len(set(indents)) == len(indents), f"expected a distinct level per Flow, got {indents}"

--- a/tests/unit/retained_mode/managers/test_workflow_manager_nested_codegen.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager_nested_codegen.py
@@ -1,15 +1,15 @@
 """Tests for generating workflow files whose Flows nest more than one level deep.
 
 A node group owns a subflow, so a group nested inside another group produces a subflow inside a
-subflow, to whatever depth the artist nests them. The generator has to follow that all the way down:
-when it walked only the first level, nodes below it were left out of the file entirely, the groups
-that claimed them were rebuilt with no members, and any connection touching them could not be
-written at all.
+subflow, to whatever depth the artist nests them. The generator has to follow that all the way down,
+because anything it does not walk is absent from the written file: a node left out is a node the
+group claiming it comes back without, and an edge touching it cannot be written at all.
 """
 
 from __future__ import annotations
 
 import ast
+import logging
 from typing import TYPE_CHECKING
 
 import pytest
@@ -216,8 +216,17 @@ class TestNestedFlowCodegen:
         with pytest.raises(ValueError, match="nodes in the group 'Group'"):
             _generate(griptape_nodes, commands)
 
-    def test_refuses_to_write_a_connection_whose_endpoint_is_not_in_the_file(self, griptape_nodes: Engine) -> None:
-        """A connection naming an unwritten node would emit a file that raises NameError."""
+    def test_skips_a_connection_whose_endpoint_is_not_in_the_file_rather_than_failing_the_save(
+        self, griptape_nodes: Engine, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Dropping the edge beats refusing to save: the artist keeps everything else.
+
+        Emitting the edge anyway would write a file that raises NameError on load. Raising instead
+        would mean the whole workflow cannot be persisted, and which Flow writes a given edge is a
+        traversal detail, so an untried graph shape is a likelier trigger than real corruption. The
+        edge is dropped, the file still parses, and the loss is logged at error rather than passing
+        silently.
+        """
         source = _node_commands("A")
         missing_target = _node_commands("B")
         connection = SerializedFlowCommands.IndirectConnectionSerialization(
@@ -228,8 +237,13 @@ class TestNestedFlowCodegen:
         )
         commands = _flow_commands("top", nodes=[source], connections=[connection])
 
-        with pytest.raises(ValueError, match="had not been written to the file yet"):
-            _generate(griptape_nodes, commands)
+        with caplog.at_level(logging.ERROR):
+            content = _generate(griptape_nodes, commands)
+
+        assert "CreateConnectionRequest(" not in content
+        assert "'A'" in content, "the node that could be written still has to be"
+        ast.parse(content)
+        assert "were never written to the file" in caplog.text
 
     def test_emits_valid_python(self, griptape_nodes: Engine) -> None:
         """Whatever the nesting depth, the file has to parse."""

--- a/tests/unit/retained_mode/managers/test_workflow_manager_nested_codegen.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager_nested_codegen.py
@@ -131,8 +131,9 @@ class TestNestedFlowCodegen:
 
         content = _generate(griptape_nodes, commands)
 
-        # The child is referenced by its generated variable, and it is the variable belonging to the
-        # child rather than to the group, which is what an unresolved membership list used to lose.
+        # The child is referenced by its generated variable, and it has to be the variable belonging
+        # to the child rather than to the group: resolving membership means looking the UUID up
+        # across the whole subtree, not just the level the group is on.
         assert "node_names_to_add=[node0_name]" in content
         assert "'Child'" in content
         child_variable_line = next(line for line in content.splitlines() if "'Child'" in line)

--- a/tests/unit/retained_mode/managers/test_workflow_manager_nested_codegen.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager_nested_codegen.py
@@ -131,9 +131,12 @@ class TestNestedFlowCodegen:
 
         content = _generate(griptape_nodes, commands)
 
-        # The child is referenced by its generated variable, not dropped for an empty membership list.
+        # The child is referenced by its generated variable, and it is the variable belonging to the
+        # child rather than to the group, which is what an unresolved membership list used to lose.
         assert "node_names_to_add=[node0_name]" in content
-        assert "node_names_to_add=[]" not in content
+        assert "'Child'" in content
+        child_variable_line = next(line for line in content.splitlines() if "'Child'" in line)
+        assert child_variable_line.lstrip().startswith("node0_name")
 
     def test_writes_a_connection_once_even_though_each_level_reports_it(self, griptape_nodes: Engine) -> None:
         """Every Flow's serialized connections include its subflows', so the same edge repeats.
@@ -195,11 +198,37 @@ class TestNestedFlowCodegen:
         # The group's variable has to be assigned before the connection referring to it is written,
         # otherwise the generated file raises NameError when it is run.
         lines = content.splitlines()
-        group_variable_line = next(
+        group_variable_lines = [
             index for index, line in enumerate(lines) if "'InnerGroup'" in line and "node_names_to_add" in line
+        ]
+        connection_lines = [index for index, line in enumerate(lines) if "CreateConnectionRequest(" in line]
+        assert len(group_variable_lines) == 1, f"expected one line creating InnerGroup, got {group_variable_lines}"
+        assert group_variable_lines[0] < connection_lines[0]
+
+    def test_refuses_to_write_a_group_whose_member_is_not_in_the_file(self, griptape_nodes: Engine) -> None:
+        """Silently dropping the member would save a group the artist has to refill by hand."""
+        missing_child = _node_commands("Child")
+        group = _node_commands("Group", is_node_group=True, node_names_to_add=[missing_child.node_uuid])
+        # The child is claimed as a member but never handed to the generator.
+        commands = _flow_commands("top", nodes=[group])
+
+        with pytest.raises(ValueError, match="nodes in the group 'Group'"):
+            _generate(griptape_nodes, commands)
+
+    def test_refuses_to_write_a_connection_whose_endpoint_is_not_in_the_file(self, griptape_nodes: Engine) -> None:
+        """A connection naming an unwritten node would emit a file that raises NameError."""
+        source = _node_commands("A")
+        missing_target = _node_commands("B")
+        connection = SerializedFlowCommands.IndirectConnectionSerialization(
+            source_node_uuid=source.node_uuid,
+            source_parameter_name="text",
+            target_node_uuid=missing_target.node_uuid,
+            target_parameter_name="text",
         )
-        connection_line = next(index for index, line in enumerate(lines) if "CreateConnectionRequest(" in line)
-        assert group_variable_line < connection_line
+        commands = _flow_commands("top", nodes=[source], connections=[connection])
+
+        with pytest.raises(ValueError, match="had not been written to the file yet"):
+            _generate(griptape_nodes, commands)
 
     def test_emits_valid_python(self, griptape_nodes: Engine) -> None:
         """Whatever the nesting depth, the file has to parse."""

--- a/tests/unit/retained_mode/managers/test_workflow_manager_nested_codegen.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager_nested_codegen.py
@@ -159,6 +159,48 @@ class TestNestedFlowCodegen:
 
         assert content.count("CreateConnectionRequest(") == 1
 
+    def test_writes_a_nested_group_wall_connection_once_and_after_the_group_exists(
+        self, griptape_nodes: Engine
+    ) -> None:
+        """The duplicate that actually happens crosses a nested group's wall, so cover that shape.
+
+        An edge into a nested group attaches to a proxy parameter on the group node, so it belongs to
+        the Flow holding that group -- here the outer group's subflow -- and aggregation then copies
+        it up into the top level as well. Since a Flow writes its own groups before its connections,
+        the level that owns the edge is also the one that has already declared the group variable.
+        This pins both the count and that ordering.
+        """
+        feeder = _node_commands("Feeder")
+        member = _node_commands("Member")
+        inner_group = _node_commands("InnerGroup", is_node_group=True, node_names_to_add=[member.node_uuid])
+        wall_connection = SerializedFlowCommands.IndirectConnectionSerialization(
+            source_node_uuid=feeder.node_uuid,
+            source_parameter_name="text",
+            target_node_uuid=inner_group.node_uuid,
+            target_parameter_name="text",
+        )
+        outer_subflow = _flow_commands(
+            "outer_subflow",
+            nodes=[feeder, inner_group],
+            connections=[wall_connection],
+            sub_flows=[_flow_commands("inner_subflow", nodes=[member])],
+        )
+        # Aggregation copies a subflow's connections up into every ancestor, so the top level reports
+        # this edge too even though neither endpoint lives there.
+        commands = _flow_commands("top", connections=[wall_connection], sub_flows=[outer_subflow])
+
+        content = _generate(griptape_nodes, commands)
+
+        assert content.count("CreateConnectionRequest(") == 1
+        # The group's variable has to be assigned before the connection referring to it is written,
+        # otherwise the generated file raises NameError when it is run.
+        lines = content.splitlines()
+        group_variable_line = next(
+            index for index, line in enumerate(lines) if "'InnerGroup'" in line and "node_names_to_add" in line
+        )
+        connection_line = next(index for index, line in enumerate(lines) if "CreateConnectionRequest(" in line)
+        assert group_variable_line < connection_line
+
     def test_emits_valid_python(self, griptape_nodes: Engine) -> None:
         """Whatever the nesting depth, the file has to parse."""
         commands = _flow_commands(


### PR DESCRIPTION
Closes https://github.com/griptape-ai/griptape-nodes-engine/issues/5315

Node groups can now hold other node groups, to any depth. A ForEach Group whose body is itself a Subflow Node Group, say, so each iteration runs a named cluster of work instead of a sprawl of loose nodes.

Most of this PR is the plumbing that assumed one level and quietly broke at two.

## Nesting

`BaseNodeGroup` gains a parent/child link, so a group can claim another group as a member and carry that group's whole contents along with it. `SubflowNodeGroup` reparents its subflow to match, so an inner group's Flow lives *underneath* the outer group's Flow rather than beside it — `FlowManager` grew the subtree-aware create/move/lookup paths that requires.

Containment is now **transitive**. A group treats a node nested two levels down as inside it, not external, via `get_enclosing_groups()` walking the whole ancestor chain. Testing only the direct parent made a group re-proxy connections that never crossed its boundary — and since each replacement connection re-entered the same code path, that had no termination condition.

The one arrangement refused is a cycle: dropping a group into one of its own descendants leaves no outermost group to run, and every ancestor walk would loop forever.

## Boundary-crossing connections

An edge from outside an outer group to a node two levels down passes through a wall parameter on **each** group it crosses, so the value can be traced inward one boundary at a time. An edge that stays entirely inside one group gets no wall parameter, however deeply that group is nested — only crossing a boundary creates one.

## Save and load

`SerializeFlowToCommands` aggregates each Flow's connections up through every level of nesting, so an edge crossing N boundaries is reported N+1 times. Codegen already deduped; deserialization did not — and re-issuing an existing edge is not a no-op. `CreateConnection` treats a duplicate as a restricted scenario, deleting and rebuilding the edge, which decrements the refcount protecting the wall parameter it routed through. Both halves now claim edges through one shared `SerializedConnectionKey`.

Three more places walked only the first level:

- **Deserialize** rebuilt only its own level's nodes before wiring connections, and created subflows last, so any edge naming a node one level down failed with `"node did not exist within the flow"` and took the whole load down with it. It now runs three passes over the whole subtree — every node (recursing into subflows, entering each so its nodes land inside it), then connections, then values.
- **Codegen** walked only the first level of subflows, so nodes two levels down were never written to the file at all and the groups that owned them rebuilt empty.
- **`get_all_nodes()`** descended a single level, so packaging a group for remote/private/iterative execution silently dropped everything below depth 2.

In both codegen and deserialize, node groups are rebuilt after their Flow's ordinary nodes *and* after every subflow: a group claims members by name at creation time, and a member can live in a subflow below it.

The deserialize half is what makes restoring a workflow embedded in image metadata work (`ExtractFlowCommandsFromImageMetadata` with `deserialize=True`, reached from the editor's load-from-image dialog). Before this, no graph containing a node group could be restored that way — a group's wall parameters guarantee a boundary-crossing connection. Plain nested subflows failed identically, with no group involved.

## Failure handling

Membership changes now move nodes between flows **first** and record membership after, rolling back what already moved. Previously a move that failed partway left the group claiming nodes that weren't in its subflow: the editor drew them inside the group while a save wrote them outside.

A failed reparent and unresolvable members both fail loudly instead of returning a half-built group, and codegen refuses to write a group out empty rather than saving a group the artist then has to refill by hand.

## Tests

73 new tests, all passing:

| Suite | Covers |
| --- | --- |
| `test_serialize_deserialize_roundtrip.py` | Cross-boundary subflow, single-level group, nested membership + subflow parentage, values inside a subflow, duplicate-edge dedupe |
| `test_nested_node_group_execution.py` | Nested groups survive save and execute |
| `test_node_group_membership_failures.py` | Add/remove rollback, partly-applied add undone, nested subflow moving back out |
| `test_workflow_manager_nested_codegen.py` | Three levels deep, subflow parentage, membership across a deeper subflow, group-wall edge ordering, refusals |
| `test_base_node_group_nesting.py` | Ancestor walk, transitive containment, cycle rejection |
| `test_subflow_node_group.py` | `get_all_nodes()` recursion depth |
| `test_flow_manager.py` | `reparent_flow` subtree paths |

The round-trip tests were confirmed failing before the change. Nothing covered serialize→deserialize as a pair before: the one existing test used a single flow with no subflow, so there was nothing to aggregate and the two halves' disagreement about scope stayed invisible.

Two further paths were added after reading the Codecov report, which flagged them as unreached even with e2e included:

- **`get_all_nodes()` recursion** had no direct test. Reverting it to the old single-level walk left the whole suite green, because the nested execution test only ever used one level. Now nested three deep, and confirmed failing against the old behaviour.
- **Outgoing boundary-crossing edges** were never wired. Every round-trip case connects outside-in, and the two directions take separate branches, so the outgoing branch and the source half of the proxy remap went unexecuted. Now covered with the source two groups deep.

Neither found a bug; both directions work. They stop a regression from passing silently, which the `get_all_nodes` one demonstrably would have.

## Review round

Addressed in 3286ef21:

- **A specific exception type.** Membership failures now raise `NodeGroupMembershipError` and carry the engine's own refusal reason, instead of raising a generic `ValueError` and leaving the real reason in the log where the artist never sees it.
- **Six movement helpers down to four.** Adding and removing turn out to be the same move in opposite directions, so `_move_nodes_into_subflow` / `_move_nodes_out_of_subflow` collapsed into one `_relocate_nodes(destination, rollback)`, and both `_abandon_*` helpers are gone. Net −28 lines, and the two directions can no longer drift — which they already had, rolling back in subtly different orders.
- **`_get_parent_flow_name` inlined** as a `parent_flow_name` property.

That refactor exposed a gap in my own tests: **nothing actually covered the rollback**. The existing failure tests refuse *every* move, so the first node never moves and there is nothing to undo — deleting the rollback entirely kept the suite green. The new test refuses only the second move into the subflow, so a node is genuinely sitting inside the group when the add gives up, and asserts it gets moved back out. Confirmed failing with the rollback removed.

---

## Follow-up: `codecov/patch` is red for a CI reason, not a missing-tests one

Every other check passes. The coverage gate reports 43% patch coverage because `.github/workflows/tests.yml` uploads coverage from the **unit** job only — the e2e job runs no coverage, and the heaviest suites here are e2e. Measured over unit + e2e, patch coverage on this diff is **78.8%**.

Adding the upload to the e2e job is a one-line change, but it shifts coverage reporting for every PR in the repo (project coverage 59.4% → 62.5%, moving the baseline others are measured against), so it belongs in **its own PR** rather than riding along here. Happy to open it — flagging it for whoever owns CI.

The ~80 lines still uncovered after that are almost all error-path `raise`/`logger.exception` branches, reachable only by making a flow move fail mid-operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


