### PR TITLE
Gate managed execution behind an AcquireExecutionLease checkpoint

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/authorization_checkpoint.py
+++ b/src/griptape_nodes/retained_mode/managers/authorization_checkpoint.py
@@ -39,6 +39,7 @@ class CheckpointAction(StrEnum):
     ACTIVATE_PROJECT = "ActivateProject"
     READ_VIDEO_CODEC = "ReadVideoCodec"
     WRITE_VIDEO_CODEC = "WriteVideoCodec"
+    ACQUIRE_EXECUTION_LEASE = "AcquireExecutionLease"
 
 
 class CheckpointSubjectType(StrEnum):
@@ -49,6 +50,9 @@ class CheckpointSubjectType(StrEnum):
     MODEL = "Model"
     PROJECT = "Project"
     VIDEO_CODEC = "VideoCodec"
+    # An execution about to start on a managed engine (subject_id is the
+    # engine id requesting admission; see CheckpointAction.ACQUIRE_EXECUTION_LEASE).
+    EXECUTION = "Execution"
 
 
 class CheckpointAttribute(StrEnum):
@@ -76,6 +80,9 @@ class CheckpointAttribute(StrEnum):
     MODEL_FAMILIES = "model_families"
     NODE_TYPE = "node_type"
     CONTAINER_FORMAT = "container_format"
+    # The requested execution scope on an ACQUIRE_EXECUTION_LEASE checkpoint
+    # ("workflow" or "single_node").
+    SCOPE = "scope"
 
 
 @dataclass(frozen=True)

--- a/src/griptape_nodes/retained_mode/managers/execution_lease_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/execution_lease_manager.py
@@ -39,6 +39,12 @@ from typing import TYPE_CHECKING, Any
 from griptape_nodes.retained_mode.engine import EngineScoped
 from griptape_nodes.retained_mode.events import execution_lease_events
 from griptape_nodes.retained_mode.events.event_converter import converter
+from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
+    AuthorizationCheckpoint,
+    CheckpointAction,
+    CheckpointAttribute,
+    CheckpointSubjectType,
+)
 from griptape_nodes.retained_mode.managers.settings import (
     EXECUTION_LEASE_BALANCER_GRACE_KEY,
     EXECUTION_LEASE_BALANCER_TIMEOUT_KEY,
@@ -222,6 +228,7 @@ class ExecutionLeaseManager(EngineScoped):
         if not self.enabled:
             return
 
+        self._require_admission_entitlement(scope)
         transport = self._require_admission_authority()
 
         async with self._state_lock:
@@ -321,6 +328,32 @@ class ExecutionLeaseManager(EngineScoped):
             self._pending_cancelled = True
         await self._send_cancel(lease_id)
         return True
+
+    def _require_admission_entitlement(self, scope: str) -> None:
+        """Ask the authorization checkpoint whether managed execution is permitted.
+
+        Managed execution (GPU queueing) is a gated feature: the engine asks
+        any registered authorization hook -- the app maps this onto the
+        license's entitlements -- before requesting admission. An engine with
+        no hooks registered is unrestricted, so a policy-free deployment is
+        unaffected. Evaluated per acquire (not once at startup) so a license
+        change takes effect without an engine restart.
+
+        Raises:
+            RuntimeError: When the checkpoint is denied, carrying every
+                failure detail the hook returned.
+        """
+        engine_id = self._engine_id()
+        checkpoint = AuthorizationCheckpoint(
+            action=CheckpointAction.ACQUIRE_EXECUTION_LEASE,
+            subject_type=CheckpointSubjectType.EXECUTION,
+            subject_id=engine_id,
+            attributes={CheckpointAttribute.ID: engine_id, CheckpointAttribute.SCOPE: scope},
+        )
+        denial = self.engine.event_manager.evaluate_authorization_checkpoint(checkpoint)
+        if denial is not None:
+            msg = f"Attempted to start execution on a managed engine. Failed because: {denial.reason()}"
+            raise RuntimeError(msg)
 
     def _require_admission_authority(self) -> _LeaseTransport:
         """Fail closed unless an admission authority is reachable.

--- a/tests/unit/retained_mode/managers/test_execution_lease_manager.py
+++ b/tests/unit/retained_mode/managers/test_execution_lease_manager.py
@@ -17,6 +17,14 @@ import pytest
 
 from griptape_nodes.retained_mode.events.app_events import SessionHeartbeatRequest
 from griptape_nodes.retained_mode.events.execution_lease_events import ExecutionLeaseReleasing
+from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
+    AuthorizationCheckpoint,
+    CheckpointAction,
+    CheckpointAttribute,
+    CheckpointDenial,
+    CheckpointFailure,
+    CheckpointSubjectType,
+)
 from griptape_nodes.retained_mode.managers.execution_lease_manager import ExecutionLeaseManager
 from griptape_nodes.retained_mode.managers.settings import (
     EXECUTION_LEASE_ENABLED_KEY,
@@ -221,6 +229,74 @@ class TestAcquire:
         await wait_for(lambda: len(balancer.sent("CancelExecutionLeaseRequest")) == 1)
         assert balancer.sent("CancelExecutionLeaseRequest")[0]["lease_id"] == minted_lease_id
         assert manager.lease_id is None
+
+
+class TestAdmissionEntitlement:
+    """The paid-tier gate: an authorization hook can deny managed execution."""
+
+    @pytest.mark.asyncio
+    async def test_denied_checkpoint_refuses_the_start_before_any_acquire(
+        self, engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager, balancer, _ = make_manager(engine, monkeypatch)
+        seen: list[AuthorizationCheckpoint] = []
+
+        def denying_hook(checkpoint: AuthorizationCheckpoint) -> CheckpointDenial | None:
+            seen.append(checkpoint)
+            return CheckpointDenial(
+                failures=(CheckpointFailure(detail="Your license does not include GPU queueing."),)
+            )
+
+        engine.event_manager.add_authorization_hook(denying_hook)
+        try:
+            with pytest.raises(RuntimeError, match="does not include GPU queueing"):
+                await manager.gate_execution_start(scope="single_node")
+        finally:
+            engine.event_manager.remove_authorization_hook(denying_hook)
+
+        assert len(balancer.sent("AcquireExecutionLeaseRequest")) == 0
+        assert manager.lease_id is None
+        checkpoint = seen[0]
+        assert checkpoint.action == CheckpointAction.ACQUIRE_EXECUTION_LEASE
+        assert checkpoint.subject_type == CheckpointSubjectType.EXECUTION
+        assert checkpoint.attributes[CheckpointAttribute.SCOPE] == "single_node"
+
+    @pytest.mark.asyncio
+    async def test_allowing_hook_lets_the_acquire_proceed(
+        self, engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manager, balancer, _ = make_manager(engine, monkeypatch)
+
+        def allowing_hook(_checkpoint: AuthorizationCheckpoint) -> CheckpointDenial | None:
+            return None
+
+        engine.event_manager.add_authorization_hook(allowing_hook)
+        try:
+            await manager.gate_execution_start()
+        finally:
+            engine.event_manager.remove_authorization_hook(allowing_hook)
+
+        assert manager.lease_id is not None
+        assert len(balancer.sent("AcquireExecutionLeaseRequest")) == 1
+        manager._cancel_watchdog()
+
+    @pytest.mark.asyncio
+    async def test_unmanaged_engine_never_asks_the_checkpoint(self, engine: Engine) -> None:
+        engine.config_manager.set_config_value(EXECUTION_LEASE_ENABLED_KEY, value=False)
+        manager = ExecutionLeaseManager(engine=engine)
+        seen: list[AuthorizationCheckpoint] = []
+
+        def recording_hook(checkpoint: AuthorizationCheckpoint) -> CheckpointDenial | None:
+            seen.append(checkpoint)
+            return None
+
+        engine.event_manager.add_authorization_hook(recording_hook)
+        try:
+            await manager.gate_execution_start()
+        finally:
+            engine.event_manager.remove_authorization_hook(recording_hook)
+
+        assert seen == []
 
 
 class TestCancelWhileQueued:


### PR DESCRIPTION
Stacked on #5312 (cancel-while-queued + session lifetime). Engine half of E7, the paid-tier gate (design §3.4).

Before requesting admission from the load balancer, \`gate_execution_start\` asks the authorization checkpoint (\`CheckpointAction.ACQUIRE_EXECUTION_LEASE\`, subject \`Execution\`/engine-id, \`scope\` attribute) whether managed execution is permitted. The app's hook maps this onto the license's entitlements and answers with a denial naming the missing \`@capability\` and \`@advice\` — which the gate surfaces verbatim to the artist.

Design points:

- **Why the checkpoint and not the request screen:** the acquire is *outbound* traffic (the engine sends it to the balancer), so the inbound \`PolicyGate\` never sees it (§5.7). The checkpoint is the only shipped layer that can enforce this, and it's the same extension point LoadLibrary/InstantiateNode/InvokeModel already use.
- **Policy-free deployments are unaffected:** no registered hooks (or no license documents) means allow — the dev stack and OSS standalone engines run unchanged.
- **Per-acquire evaluation**, not once at startup, so a license change takes effect without restarting the engine.
- New enum members: \`CheckpointAction.ACQUIRE_EXECUTION_LEASE\`, \`CheckpointSubjectType.EXECUTION\`, \`CheckpointAttribute.SCOPE\`. The app repo declares the matching \`GateAction\`, resource-type mapping, and Cedar schema entity/action (its cross-repo lockstep test enforces the agreement once this engine ships).

Verification: \`make check\` clean; full suite 4370 passed (3 new tests: denial refuses the start before any acquire is sent and carries the hook's detail; an allowing hook leaves the acquire path untouched; an unmanaged engine never consults the checkpoint). App-side Cedar evaluation of the new action is tested in the app repo against the updated schema (denial carries \`@capability("managed-execution")\`).