### PR TITLE
fix(workers): hand orchestrator stdio to worker subprocesses explicitly

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/worker_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/worker_manager.py
@@ -336,7 +336,21 @@ class WorkerManager(EngineScoped):
         orchestrator_engine_id = self.engine.engine_identity_manager.active_engine_id
         if orchestrator_engine_id is not None:
             worker_environ["GTN_ORCHESTRATOR_ENGINE_ID"] = orchestrator_engine_id
-        proc = await asyncio.create_subprocess_exec(*args, env=worker_environ)
+        # Worker stdout is a pipe when the orchestrator is hosted by a GUI app (e.g. the
+        # desktop app); unbuffered output keeps worker log lines from stalling in Python's
+        # block buffer and from being lost on a crash.
+        worker_environ["PYTHONUNBUFFERED"] = "1"
+        # Hand the orchestrator's own stdout/stderr to the worker explicitly so worker log
+        # lines land in the same stream as orchestrator logs. Implicit inheritance is
+        # POSIX-only: on Windows, redirected std handles (e.g. the desktop app's pipes) are
+        # not passed to a child unless subprocess sends them via STARTF_USESTDHANDLES, so
+        # the worker would log to an invisible console instead.
+        proc = await asyncio.create_subprocess_exec(
+            *args,
+            env=worker_environ,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+        )
         # Record the loop that owns this subprocess so termination can hop back to it.
         # All spawns run on the engine event-queue loop, so this is idempotent.
         self._spawn_loop = asyncio.get_running_loop()

--- a/tests/unit/app/test_app_worker.py
+++ b/tests/unit/app/test_app_worker.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import sys
 import threading
 import time
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
@@ -459,8 +460,23 @@ class TestSpawnWorker:
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
             await worker_manager.spawn_worker(args, "My Library")
 
-        mock_exec.assert_called_once_with(*args, env=ANY)
+        mock_exec.assert_called_once_with(*args, env=ANY, stdout=sys.stdout, stderr=sys.stderr)
         assert worker_manager._managed_worker_processes["My Library"] is mock_proc
+
+    @pytest.mark.asyncio
+    async def test_spawn_hands_worker_the_orchestrator_stdio(self, worker_manager: WorkerManager) -> None:
+        # Worker logs must land in the same stream as orchestrator logs. Implicit stdio
+        # inheritance is POSIX-only: on Windows a redirected stdout (e.g. the desktop app's
+        # pipe) never reaches the child unless passed explicitly, so the worker would log
+        # to an invisible console instead.
+        with patch("asyncio.create_subprocess_exec", return_value=MagicMock()) as mock_exec:
+            await worker_manager.spawn_worker(["/usr/bin/gtn", "engine"], "my-key")
+
+        assert mock_exec.call_args.kwargs["stdout"] is sys.stdout
+        assert mock_exec.call_args.kwargs["stderr"] is sys.stderr
+        # Worker stdout is a pipe under a GUI-hosted orchestrator; unbuffered output keeps
+        # log lines from stalling in Python's block buffer.
+        assert mock_exec.call_args.kwargs["env"]["PYTHONUNBUFFERED"] == "1"
 
     @pytest.mark.asyncio
     async def test_spawn_env_stamps_orchestrator_engine_id(self, worker_manager: WorkerManager) -> None:


### PR DESCRIPTION
Part of https://github.com/griptape-ai/griptape-nodes-engine/issues/5314

## Symptom

Worker-mode ("Isolated") library engines produce no log output alongside the orchestrator's logs when the engine runs under the desktop app on Windows. On macOS/Linux, and in a plain Windows terminal, worker logs interleave correctly with the `Worker-XXXXXXXX` column.

## Root cause

`WorkerManager.spawn_worker` spawned the worker with no `stdout`/`stderr` arguments, relying on implicit stdio inheritance. That only works on POSIX, where fd inheritance is unconditional.

On Windows the chain breaks:

1. The desktop app spawns the orchestrator with piped stdio and `windowsHide` (`CREATE_NO_WINDOW`), so the orchestrator runs attached to an invisible console with its std handles explicitly set to the desktop's pipes.
2. Python's subprocess layer only passes std handles to a child when they are explicitly redirected (`STARTF_USESTDHANDLES` + inheritable handle list). With `stdout=None` and the default `close_fds=True` (`bInheritHandles=FALSE`), the pipe handles cannot reach the worker.
3. The worker, a console process, attaches to the parent's invisible console instead. Its stdout is a valid handle pointing at a console that is never displayed — every log line is written there and lost. Nothing reaches the desktop's Engine Logs window, `engine.log`, or session log exports.

## Fix

- Pass `sys.stdout`/`sys.stderr` explicitly to `asyncio.create_subprocess_exec`. Explicitly passed file objects are handed to the child via `STARTF_USESTDHANDLES`, which works regardless of `close_fds` and console state. On POSIX this dup2's the same fds the child was already inheriting, so behavior there is unchanged — one cross-platform code path, and the worker's existing `Worker-XXXXXXXX` Rich column keeps rendering into the shared stream.
- Set `PYTHONUNBUFFERED=1` in the worker env so log lines don't stall in Python's block buffer (worker stdout is a pipe under a GUI-hosted orchestrator) and aren't lost on a crash.

## Testing

- Updated the spawn call-shape assertion and added a unit test covering the explicit stdio handles and `PYTHONUNBUFFERED`.
- `make check` clean; full unit suite passes (4326 passed, 13 skipped).