### PR TITLE
feat(strict-mode): flag lifecycle-hook overrides that are inert under isolation

### DIFF
--- a/docs/development/custom_nodes/node_isolation_with_workers.md
+++ b/docs/development/custom_nodes/node_isolation_with_workers.md
@@ -232,17 +232,25 @@ list on the next execute. The
 [`parameter-mutation-during-aprocess`](strict_mode.md) rule fires
 on direct in-execute mutations and tells you which one to use.
 
-**Hydration-time mutations skip this rule but do not propagate
-either.** `before_value_set` / `after_value_set` run during input
-hydration on the same transient worker-side node, so a
-parameter-list mutation made there is discarded when the node is —
-and under isolation these hooks never run when a value changes in
-the editor, because the orchestrator's stub copy of your class does
-not carry the overrides. The standard dynamic-pipeline pattern
-(hooks adjust the parameter list as inputs change) therefore does
-not work for a worker-hosted library. Overriding a value hook fires
-the [`value-hooks-execute-only-on-worker`](strict_mode.md) warning
-at library load.
+**`before_value_set` / `after_value_set` do not fire on editor
+changes for isolated libraries.** These hooks run inside the worker
+subprocess, on the temporary copy of your node built for each
+execute. The orchestrator holds only a stub copy of your node class
+— parameters, no code — so it never calls your overrides when a
+user edits a value in the editor. Transforming an incoming value
+still works: the hooks run as inputs are applied, just before
+`process`. But a parameter-list change made inside them is
+discarded with the temporary node. It skips the
+[`parameter-mutation-during-aprocess`](strict_mode.md) rule, and it
+does not propagate either.
+
+The practical consequence: hooks that adjust the parameter list in
+response to user input (for example, showing or hiding fields when
+a dropdown changes) only work in Shared mode. For an isolated
+library, define the full parameter list statically in `__init__`.
+Overriding a value hook fires the
+[`value-hooks-execute-only-on-worker`](strict_mode.md) warning at
+library load.
 
 ### Connection hooks never fire under isolation
 
@@ -358,14 +366,16 @@ from, prefixed with `Worker-<engine-id>` so you can tell it apart
 from orchestrator output. Look for both **WARNING** and **ERROR**
 entries.
 
-The four rules and their actual severities:
+The six rules and their actual severities:
 
-| Rule                                                      | Orchestrator | Worker  | Notes                                                                                                                                                   |
-| --------------------------------------------------------- | ------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`reentrant-bus-in-init`](strict_mode.md)                 | ERROR        | ERROR   | Correctness rule. The class is dropped from the library schema.                                                                                         |
-| [`parameter-behaviors-dropped-in-schema`](strict_mode.md) | WARNING      | WARNING | Fires during library load when a `Parameter` carries `converters` / `validators` / `traits` that the worker schema cannot serialize. Does not escalate. |
-| [`parameter-mutation-during-aprocess`](strict_mode.md)    | WARNING      | ERROR   | Promotes the node's result to a failure on the worker.                                                                                                  |
-| [`worker-reach-into-orchestrator`](strict_mode.md)        | n/a          | WARNING | Fires anywhere during node execution including hydration. Does not escalate; intentional writes are explicitly fine to ignore.                          |
+| Rule                                                      | Orchestrator | Worker  | Notes                                                                                                                                                                                                         |
+| --------------------------------------------------------- | ------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`reentrant-bus-in-init`](strict_mode.md)                 | ERROR        | ERROR   | Correctness rule. The class is dropped from the library schema.                                                                                                                                               |
+| [`parameter-behaviors-dropped-in-schema`](strict_mode.md) | WARNING      | WARNING | Fires during library load when a `Parameter` carries `converters` / `validators` / `traits` that the worker schema cannot serialize. Does not escalate.                                                       |
+| [`connection-hooks-inert-on-worker`](strict_mode.md)      | WARNING      | WARNING | Fires during library load when a node class overrides a connection lifecycle hook. Those hooks run on the orchestrator against the stub, so the override never runs. Does not escalate.                       |
+| [`value-hooks-execute-only-on-worker`](strict_mode.md)    | WARNING      | WARNING | Fires during library load when a node class overrides `before_value_set` / `after_value_set`. Value transformation still works; editor-time reactivity and parameter-list mutation do not. Does not escalate. |
+| [`parameter-mutation-during-aprocess`](strict_mode.md)    | WARNING      | ERROR   | Promotes the node's result to a failure on the worker.                                                                                                                                                        |
+| [`worker-reach-into-orchestrator`](strict_mode.md)        | n/a          | WARNING | Fires anywhere during node execution including hydration. Does not escalate; intentional writes are explicitly fine to ignore.                                                                                |
 
 If a strict-mode line fires, the rule's remediation message names
 exactly which guideline above was violated and how to fix it. A

--- a/docs/development/custom_nodes/node_isolation_with_workers.md
+++ b/docs/development/custom_nodes/node_isolation_with_workers.md
@@ -232,12 +232,30 @@ list on the next execute. The
 [`parameter-mutation-during-aprocess`](strict_mode.md) rule fires
 on direct in-execute mutations and tells you which one to use.
 
-**Hydration-time mutations are explicitly sanctioned.** The standard
-dynamic-pipeline pattern — `before_value_set` / `after_value_set`
-adjusts the parameter list as inputs change — does **not** trip this
-rule. The rule only fires once the framework has entered
-`aprocess_scope()`, which it opens specifically around `process`
-execution, not around the input-hydration pass.
+**Hydration-time mutations skip this rule but do not propagate
+either.** `before_value_set` / `after_value_set` run during input
+hydration on the same transient worker-side node, so a
+parameter-list mutation made there is discarded when the node is —
+and under isolation these hooks never run when a value changes in
+the editor, because the orchestrator's stub copy of your class does
+not carry the overrides. The standard dynamic-pipeline pattern
+(hooks adjust the parameter list as inputs change) therefore does
+not work for a worker-hosted library. Overriding a value hook fires
+the [`value-hooks-execute-only-on-worker`](strict_mode.md) warning
+at library load.
+
+### Connection hooks never fire under isolation
+
+`after_incoming_connection`, `after_outgoing_connection`, the
+`allow_*` validators, and the `*_removed` variants are invoked on
+the orchestrator when connections change — connections are
+orchestrator-owned state, and the worker is not consulted. For a
+worker-hosted library those calls land on the stub class, so an
+override you write never runs, silently. Overriding a connection
+hook fires the
+[`connection-hooks-inert-on-worker`](strict_mode.md) warning at
+library load. If your node needs to react to wiring (the
+dynamic-parameter pattern), run the library in Shared mode.
 
 ### Parameter `converters`, `validators`, and `traits` do not cross to the orchestrator
 
@@ -320,6 +338,11 @@ logs a `WARNING` so the asymmetry is visible.
     `GriptapeNodes.handle_request(...)` instead
 - [ ] Cross-node / flow state passed in via parameters, not fetched
     from inside `process`
+- [ ] No connection hooks (`after_incoming_connection` and siblings)
+    overridden -- they never fire for a worker-hosted library
+- [ ] `before_value_set` / `after_value_set` used only for value
+    transformation, not editor-time reactivity or parameter-list
+    mutation
 - [ ] Custom `converters` / `validators` / `traits` either re-run
     inside `process` or accepted as orchestrator-only UI sugar
 - [ ] `pip_dependencies` pinned to specific versions

--- a/docs/development/custom_nodes/strict_mode.md
+++ b/docs/development/custom_nodes/strict_mode.md
@@ -96,3 +96,40 @@ node's execution -- including from `before_value_set` /
 parameter value), ignore the warning. If this is a read of flow /
 connection state, consider whether the data could be passed in via
 parameters instead of fetched per-call.
+
+#### `connection-hooks-inert-on-worker`
+
+A node class in a worker-hosted library overrides one or more
+connection lifecycle hooks (`allow_incoming_connection`,
+`before_incoming_connection`, `after_incoming_connection`, their
+outgoing counterparts, or the `_removed` variants). Connections are
+orchestrator-owned state, so these hooks are invoked on the
+orchestrator -- where a worker-hosted library is represented by a
+synthesized stub class that does not carry the override. The
+author's code never runs, silently.
+
+Fires once per node class at library load, during the worker's
+schema probe. Hooks implemented by engine-owned bases and components
+are not flagged; the rule targets code the library author can
+change.
+
+**Remediation**: dynamic parameters driven by connections are not
+supported for isolated libraries. Run the library in Shared mode, or
+remove the override.
+
+#### `value-hooks-execute-only-on-worker`
+
+A node class in a worker-hosted library overrides `before_value_set`
+/ `after_value_set`. For an isolated library these hooks fire only
+during execute-time input hydration, on the transient worker-side
+node: transforming an incoming value still works, but the hooks do
+not run when a value changes in the editor, and any parameter-list
+mutation they make is discarded with the transient node.
+
+Fires once per node class at library load, during the worker's
+schema probe. Hooks implemented by engine-owned bases and components
+are not flagged.
+
+**Remediation**: keep value hooks to value transformation. If the
+node needs editor-time reactivity (adjusting parameters as values
+change), run the library in Shared mode.

--- a/src/griptape_nodes/common/strict_mode_checks.py
+++ b/src/griptape_nodes/common/strict_mode_checks.py
@@ -142,4 +142,57 @@ RULES: dict[str, StrictModeRule] = {
         ),
         worker_escalation=False,
     ),
+    "connection-hooks-inert-on-worker": StrictModeRule(
+        rule_id="connection-hooks-inert-on-worker",
+        default_severity=StrictModeSeverity.WARNING,
+        correctness=False,
+        description=(
+            "A node class in a worker-hosted library overrides "
+            "connection lifecycle hooks (allow/before/after "
+            "incoming/outgoing connection and their _removed "
+            "variants). Connections are orchestrator-owned state and "
+            "these hooks are invoked there, where a worker-hosted "
+            "library is represented by a synthesized stub that does "
+            "not carry the override -- the author's code never runs, "
+            "silently."
+        ),
+        remediation_template=(
+            "Node class '{node_class}' overrides {hook_names}, which "
+            "never fire for a worker-hosted (Isolated) library: "
+            "connection hooks run on the orchestrator against a stub "
+            "class. Dynamic parameters driven by connections are not "
+            "supported under isolation; run the library in Shared "
+            "mode or remove the override."
+        ),
+        # Reported during library load on the worker; escalating to ERROR
+        # would alarm on a node that otherwise executes fine.
+        worker_escalation=False,
+    ),
+    "value-hooks-execute-only-on-worker": StrictModeRule(
+        rule_id="value-hooks-execute-only-on-worker",
+        default_severity=StrictModeSeverity.WARNING,
+        correctness=False,
+        description=(
+            "A node class in a worker-hosted library overrides "
+            "before_value_set/after_value_set. Editor value edits run "
+            "these hooks on the orchestrator's stub (never the "
+            "author's code); the author's hooks fire on the worker "
+            "only during execute-time input hydration, on a transient "
+            "node discarded after process."
+        ),
+        remediation_template=(
+            "Node class '{node_class}' overrides {hook_names}. For a "
+            "worker-hosted (Isolated) library these fire only during "
+            "execute-time input hydration -- transforming values "
+            "still works, but the hooks do not run when a value "
+            "changes in the editor, and any parameter-list mutation "
+            "they make is discarded with the transient node. If the "
+            "node needs editor-time reactivity, run the library in "
+            "Shared mode."
+        ),
+        # Same load-time reporting channel as
+        # parameter-behaviors-dropped-in-schema; ERROR would be too harsh
+        # for a node that still executes correctly.
+        worker_escalation=False,
+    ),
 }

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -4869,6 +4869,82 @@ class LibraryManager(EngineScoped):
     # discovery. The instance is discarded after its parameters are read.
     _SCHEMA_PROBE_NODE_NAME: str = "__schema_probe__"
 
+    # Hook families that are consulted only on the orchestrator, where a
+    # worker-hosted library is represented by a synthesized stub class (see
+    # _make_worker_stub_class). An author override of any of these never runs
+    # for an Isolated library.
+    _CONNECTION_HOOK_NAMES: tuple[str, ...] = (
+        "allow_incoming_connection",
+        "allow_outgoing_connection",
+        "allow_incoming_connection_by_class",
+        "allow_outgoing_connection_by_class",
+        "before_incoming_connection",
+        "after_incoming_connection",
+        "before_outgoing_connection",
+        "after_outgoing_connection",
+        "before_incoming_connection_removed",
+        "after_incoming_connection_removed",
+        "before_outgoing_connection_removed",
+        "after_outgoing_connection_removed",
+    )
+    # Value hooks fire on the orchestrator stub for editor edits (never the
+    # author's code) and on the worker only during execute-time input
+    # hydration, on a transient node discarded after process returns.
+    _VALUE_HOOK_NAMES: tuple[str, ...] = (
+        "before_value_set",
+        "after_value_set",
+    )
+
+    def _report_inert_worker_hooks(self, probe: BaseNode) -> None:
+        """Report lifecycle-hook overrides that will not fire for a worker-hosted library.
+
+        Connection hooks are invoked exclusively on the orchestrator (connections are
+        orchestrator-owned state), where a worker-hosted library is represented by a
+        synthesized stub that does not carry the override -- the author's code never
+        runs at all. Value hooks fire on the orchestrator stub for editor edits and on
+        the worker only during execute-time input hydration, so value transformation
+        works but editor-time reactivity and parameter-list mutation do not.
+
+        Only overrides defined outside the engine are reported: engine-owned bases and
+        components (modules under ``griptape_nodes.``) also lose these hooks under
+        isolation, but that is the engine's gap to close, not something a library
+        author can remediate.
+        """
+        node_class = type(probe)
+        connection_overrides = [
+            hook for hook in self._CONNECTION_HOOK_NAMES if self._hook_overridden_outside_engine(node_class, hook)
+        ]
+        if connection_overrides:
+            rule = RULES["connection-hooks-inert-on-worker"]
+            STRICT_MODE.report(
+                rule_id=rule.rule_id,
+                message=rule.render(node_class=node_class.__name__, hook_names=", ".join(connection_overrides)),
+            )
+        value_overrides = [
+            hook for hook in self._VALUE_HOOK_NAMES if self._hook_overridden_outside_engine(node_class, hook)
+        ]
+        if value_overrides:
+            rule = RULES["value-hooks-execute-only-on-worker"]
+            STRICT_MODE.report(
+                rule_id=rule.rule_id,
+                message=rule.render(node_class=node_class.__name__, hook_names=", ".join(value_overrides)),
+            )
+
+    @staticmethod
+    def _hook_overridden_outside_engine(node_class: type, hook_name: str) -> bool:
+        """Return True when ``hook_name``'s defining class lives outside the engine package.
+
+        Walks the MRO to the first class whose ``__dict__`` defines the hook -- the
+        implementation that would actually run. ``BaseNode``'s own no-op (and any
+        engine-owned override) attributes to a ``griptape_nodes.`` module and is not
+        the library author's code.
+        """
+        for klass in node_class.__mro__:
+            if hook_name in klass.__dict__:
+                module = klass.__module__ or ""
+                return module != "griptape_nodes" and not module.startswith("griptape_nodes.")
+        return False
+
     def _report_parameter_behavior_losses(self, probe: BaseNode) -> None:
         """Report parameter-behaviors-dropped-in-schema for any probe parameter that has live behaviors.
 
@@ -4941,10 +5017,11 @@ class LibraryManager(EngineScoped):
                 except Exception:
                     logger.debug("Could not probe node class '%s' for schema serialization.", class_name, exc_info=True)
                     continue
-                # Run the parameter-behavior-drop detector inside the scope so
-                # warnings attach to the same LOAD_PROBE scope that owns the
-                # probe attempt.
+                # Run the parameter-behavior-drop and inert-hook detectors
+                # inside the scope so warnings attach to the same LOAD_PROBE
+                # scope that owns the probe attempt.
                 self._report_parameter_behavior_losses(probe)
+                self._report_inert_worker_hooks(probe)
 
             # Drop the class only when a rule flagged drops_class_from_schema
             # fired. Severity is a logging concern; drops_class_from_schema is

--- a/tests/unit/retained_mode/managers/test_library_manager_strict_mode.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_strict_mode.py
@@ -259,3 +259,112 @@ class TestParameterBehaviorsDropped:
         warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
         assert any("p_with_trait" in r.getMessage() for r in warnings)
         assert any("traits" in r.getMessage() for r in warnings)
+
+
+class _ProbeWithConnectionHook:
+    """Node class overriding a connection lifecycle hook in library code."""
+
+    parameters: list = []  # noqa: RUF012
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def after_incoming_connection(self, source_node: Any, source_parameter: Any, target_parameter: Any) -> None:
+        pass
+
+
+class _ProbeWithValueHook:
+    """Node class overriding a value hook in library code."""
+
+    parameters: list = []  # noqa: RUF012
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def after_value_set(self, parameter: Any, value: Any) -> None:
+        pass
+
+
+class _EngineOwnedHookMixin:
+    """Stands in for an engine-owned component whose hook override is not the author's code."""
+
+    def after_value_set(self, parameter: Any, value: Any) -> None:
+        pass
+
+
+# The detector attributes an override to its defining class's module; stamp an
+# engine-namespace module so this mixin reads as engine-owned.
+_EngineOwnedHookMixin.__module__ = "griptape_nodes.exe_types.param_components.fake_component"
+
+
+class _ProbeInheritingEngineHook(_EngineOwnedHookMixin):
+    """Node class whose only hook override comes from an engine-owned base."""
+
+    parameters: list = []  # noqa: RUF012
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class TestInertWorkerHooks:
+    """#5314: hook overrides that never fire under isolation emit a warn violation."""
+
+    @pytest.mark.asyncio
+    async def test_connection_hook_override_reports_warning_but_keeps_schema(
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+    ) -> None:
+        caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
+        manager = GriptapeNodes.LibraryManager()
+        with patched_registry({"WithConnHook": _ProbeWithConnectionHook}):
+            schemas = await manager._serialize_library_node_schemas("libA")
+
+        # Warning, not error: the class still yields a schema.
+        assert [s.class_name for s in schemas] == ["WithConnHook"]
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("after_incoming_connection" in r.getMessage() for r in warnings)
+        assert any("class=WithConnHook" in r.getMessage() for r in warnings)
+        assert any("Shared mode" in r.getMessage() for r in warnings)
+
+    @pytest.mark.asyncio
+    async def test_value_hook_override_reports_warning_but_keeps_schema(
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+    ) -> None:
+        caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
+        manager = GriptapeNodes.LibraryManager()
+        with patched_registry({"WithValueHook": _ProbeWithValueHook}):
+            schemas = await manager._serialize_library_node_schemas("libA")
+
+        assert [s.class_name for s in schemas] == ["WithValueHook"]
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("after_value_set" in r.getMessage() for r in warnings)
+        assert any("class=WithValueHook" in r.getMessage() for r in warnings)
+        assert any("input hydration" in r.getMessage() for r in warnings)
+
+    @pytest.mark.asyncio
+    async def test_engine_owned_hook_override_is_not_reported(
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+    ) -> None:
+        # A hook implemented by an engine-owned base/component (module under
+        # griptape_nodes.) is not the author's code; flagging it would nag on
+        # something the library author cannot remediate.
+        caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
+        manager = GriptapeNodes.LibraryManager()
+        with patched_registry({"EngineHook": _ProbeInheritingEngineHook}):
+            schemas = await manager._serialize_library_node_schemas("libA")
+
+        assert [s.class_name for s in schemas] == ["EngineHook"]
+        assert not any("after_value_set" in r.getMessage() for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_hookless_class_produces_no_hook_violation(
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+    ) -> None:
+        caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
+        manager = GriptapeNodes.LibraryManager()
+        with patched_registry({"Clean": _CleanProbe}):
+            schemas = await manager._serialize_library_node_schemas("libA")
+
+        assert [s.class_name for s in schemas] == ["Clean"]
+        assert not any("hook" in r.getMessage().lower() for r in caplog.records)


### PR DESCRIPTION
First slice of #5314 ("make the gap loud"). Nodes in worker-hosted (**Isolated**) libraries silently lose their connection and value lifecycle hooks: the orchestrator represents the library with a synthesized stub class carrying only `__init__` and `process`, so hook overrides never run where they're invoked, with no error or warning. This PR turns the silent no-op into named strict-mode warnings at library load.

## Two rules, deliberately separate

The two hook families fail differently, so they get different rules and wording:

- **`connection-hooks-inert-on-worker`** — fires when a node class overrides any connection lifecycle hook (`allow_*`, `before/after_incoming/outgoing_connection`, and the `_removed` variants). Connections are orchestrator-owned state and these hooks are invoked there, against the stub — the author's override **never runs at all**. Remediation: run the library in Shared mode or remove the override.
- **`value-hooks-execute-only-on-worker`** — fires on overrides of `before_value_set` / `after_value_set`. These are *not* fully inert: they legitimately fire worker-side during execute-time input hydration, so value transformation still works. What doesn't work is editor-time reactivity (the hooks never run when a value changes in the editor) and parameter-list mutation (discarded with the transient node). The wording says exactly that, so authors using the still-valid transformation pattern aren't told their code is wrong.

Both are ergonomics rules with `worker_escalation=False` (same posture as `parameter-behaviors-dropped-in-schema`): they warn at load and never drop the class from the schema — the node otherwise executes fine.

## Detection

Runs in `_serialize_library_node_schemas`' existing LOAD_PROBE scope, next to the parameter-behaviors detector, so violations attach to the same per-class scope and surface through the established reporting channel.

An override is attributed to its **defining class's module** (first MRO hit): only hooks defined outside the `griptape_nodes.` namespace are reported. Engine-owned bases and components (`base_iterative_nodes`, `SeedParameter`, node groups, …) override these hooks too; those are inert under isolation as well, but they're the engine's gap to close, and flagging them would nag authors about code they cannot change.

## Docs

- Both rules added to the strict-mode catalog (`strict_mode.md`).
- `node_isolation_with_workers.md`: corrected the passage claiming hydration-time hook mutations are "explicitly sanctioned" (they skip `parameter-mutation-during-aprocess` but do not propagate — the exact contradiction called out in #5314), added a section stating connection hooks never fire under isolation, and extended the isolation-ready checklist with both constraints.

## Testing

- New `TestInertWorkerHooks` unit tests: connection-hook and value-hook overrides warn and keep their schema; engine-owned hook inheritance is not flagged; hookless classes stay silent.
- `make check` clean; full unit suite passes (4352 passed, 13 skipped); `mkdocs build --strict` clean.

## Follow-ups (tracked in #5314, not in this PR)

- Probe nodes in the testing library so both rules are triggerable end-to-end from a real library.
- The worker→GUI event relay (node `logs` parameter / progress streaming).
- The design decision on making hooks actually work under isolation.

<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--5321.org.readthedocs.build/en/5321/

<!-- readthedocs-preview griptape-nodes end -->