### PR TITLE
Keep the retained workflow path in sync with the workflow's location

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/context_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/context_manager.py
@@ -505,14 +505,16 @@ class ContextManager(EngineScoped):
     def get_current_workflow_file_path(self) -> str | None:
         """Get the file path the current Workflow context was entered with, if any.
 
-        Returns the path passed to `push_workflow(file_path=...)`, or None when the context
-        was entered by name. Unlike `get_current_workflow_name()`, this does not depend on
+        Returns the path this context was entered with: either the one passed to
+        `push_workflow(file_path=...)`, or the one resolved from the registry at push time
+        when entered by name. Unlike `get_current_workflow_name()`, this does not depend on
         the active workspace: the name is a registry key derived against the workspace at
         push time, so switching projects re-registers workflows under a different key and
         leaves the name stale. Prefer this when you need the workflow's LOCATION.
 
         Returns:
-            The absolute file path, or None if the context was entered by name.
+            The absolute file path, or None when entered by name for a workflow that was
+            unregistered or unsaved at push time.
 
         Raises:
             NoActiveWorkflowError: If no Workflow context is active.
@@ -537,6 +539,28 @@ class ContextManager(EngineScoped):
             raise self.NoActiveWorkflowError(msg)
 
         self._workflow_stack[-1]._name = new_name
+
+    def set_current_workflow_file_path(self, new_file_path: str | None) -> None:
+        """Update the file path retained on the current Workflow context.
+
+        Anything that relocates the current workflow's file on disk (Move, Rename) must call
+        this alongside `set_current_workflow_name`. The retained path is the authoritative
+        answer for the workflow's location -- `get_current_workflow_file_path` is preferred
+        over a registry lookup precisely because it survives a workspace switch -- so leaving
+        it at the pre-move value keeps `workflow_dir` pointing at the old directory even
+        though the registry is correct.
+
+        Args:
+            new_file_path: The workflow's new path, or None when it no longer has one.
+
+        Raises:
+            NoActiveWorkflowError: If no Workflow context is active.
+        """
+        if not self.has_current_workflow():
+            msg = "No active Workflow context"
+            raise self.NoActiveWorkflowError(msg)
+
+        self._workflow_stack[-1]._file_path = new_file_path
 
     def get_current_flow(self) -> ControlFlow:
         """Get the current Flow object.
@@ -599,16 +623,16 @@ class ContextManager(EngineScoped):
     def push_workflow(self, workflow_name: str | None = None, *, file_path: str | None = None) -> str:
         """Push a new Workflow context onto the stack.
 
-        Args:
-            workflow_name: The name of the Workflow to enter. Use this when the registry key is already known.
-            file_path: Path to the workflow file. The registry key will be derived from this path,
-                using a workspace-relative path if possible. Mutually exclusive with workflow_name.
-
         The workflow's file path is captured here, while the registry key is still valid, and
         retained on the context (see `get_current_workflow_file_path`). `resolved_name` is a key
         derived against the CURRENT workspace, so it goes stale as soon as the workspace changes:
         switching projects re-registers every workflow under the new workspace, after which a
         lookup by the old key misses even though nothing about the file changed.
+
+        Args:
+            workflow_name: The name of the Workflow to enter. Use this when the registry key is already known.
+            file_path: Path to the workflow file. The registry key will be derived from this path,
+                using a workspace-relative path if possible. Mutually exclusive with workflow_name.
 
         Returns:
             The name of the Workflow that was entered.
@@ -632,7 +656,7 @@ class ContextManager(EngineScoped):
                     file_path = None
                 else:
                     if workflow.file_path is not None:
-                        file_path = str(WorkflowRegistry.get_complete_file_path(workflow.file_path))
+                        file_path = WorkflowRegistry.get_complete_file_path(workflow.file_path)
         elif file_path is not None:
             resolved = canonicalize_for_identity(file_path)
             workspace_path = canonicalize_for_identity(self.engine.config_manager.workspace_path)

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -1588,11 +1588,26 @@ class ProjectManager(EngineScoped):
         # underlying exception text so users can tell which precondition is missing.
         for var_info in variable_infos:
             unavailable_reason = builtin_resolution.unavailable.get(var_info.name)
-            if unavailable_reason is not None and var_info.is_required:
+            if unavailable_reason is None:
+                continue
+            if var_info.is_required:
                 return GetPathForMacroResultFailure(
                     failure_reason=PathResolutionFailureReason.MACRO_RESOLUTION_ERROR,
                     result_details=f"Attempted to resolve macro path. Failed because builtin variable '{var_info.name}' cannot be resolved: {unavailable_reason}",
                 )
+            # Logged for the same reason as the equivalent degradation in
+            # _ProjectVariableResolver._resolve_macro_string: the degraded result is a
+            # PLAUSIBLE path, not an obviously broken one. Dropping `{workflow_dir}` from
+            # `{workflow_dir?:/}outputs` relocates writes and reads from the workflow's folder
+            # to the workspace root, and without this line the only symptom is media that
+            # resolves to a file which was never written there.
+            logger.warning(
+                "Optional builtin '%s' could not be resolved while resolving macro '%s'; "
+                "dropping it from the path (%s)",
+                var_info.name,
+                request.parsed_macro.template,
+                unavailable_reason,
+            )
         if builtin_resolution.conflicts:
             return GetPathForMacroResultFailure(
                 failure_reason=PathResolutionFailureReason.RESERVED_NAME_COLLISION,

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -1326,10 +1326,13 @@ class WorkflowManager(EngineScoped):
                 )
 
         # If the renamed workflow is the current context, update the context name so the
-        # heartbeat and other callers reflect the new registry key immediately.
+        # heartbeat and other callers reflect the new registry key immediately. The retained
+        # path moves with it: rename keeps the directory, so `workflow_dir` is unaffected, but
+        # the path itself would otherwise name a file that no longer exists.
         context_manager = self.engine.context_manager
         if context_manager.has_current_workflow() and context_manager.get_current_workflow_name() == old_workflow_name:
             context_manager.set_current_workflow_name(new_workflow_name)
+            context_manager.set_current_workflow_file_path(str(save_result.file_path))
 
         return None
 
@@ -1764,6 +1767,11 @@ class WorkflowManager(EngineScoped):
                     and context_manager.get_current_workflow_name() == old_registry_key
                 ):
                     context_manager.set_current_workflow_name(new_registry_key)
+                    # The context also retains the workflow's path, and that is what
+                    # `workflow_dir` answers with. Move is the one operation that changes the
+                    # directory, so without this the builtin keeps resolving to the folder the
+                    # file just left.
+                    context_manager.set_current_workflow_file_path(str(new_absolute_path))
 
         except OSError as e:
             error_messages = []
@@ -2503,6 +2511,11 @@ class WorkflowManager(EngineScoped):
             for workflow_context_state in self.engine.context_manager._workflow_stack:
                 if workflow_context_state._name == unsaved_source_key:
                     workflow_context_state._name = registry_key
+                    # The context also retains the workflow's path, and `workflow_dir` prefers
+                    # it over a registry lookup. An unsaved context has no path; this save is
+                    # where it gets one, so record it here or the builtin keeps falling back to
+                    # the registry key -- the thing that goes stale on the next project switch.
+                    workflow_context_state._file_path = str(save_file_result.file_path)
             registered_workflows = WorkflowRegistry.list_workflows()
 
         if registry_key not in registered_workflows:

--- a/tests/unit/retained_mode/managers/test_context_manager.py
+++ b/tests/unit/retained_mode/managers/test_context_manager.py
@@ -2,10 +2,13 @@
 
 import ast
 import tempfile
+from datetime import UTC, datetime
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
+from griptape_nodes.node_library.workflow_registry import WorkflowMetadata, WorkflowRegistry
 from griptape_nodes.retained_mode.engine import Engine
 
 
@@ -103,6 +106,53 @@ class TestPushWorkflow:
             assert context_manager.get_current_workflow_file_path() is None
         finally:
             context_manager.pop_workflow()
+
+    def test_push_workflow_by_name_resolves_registered_path_and_keeps_it(self, griptape_nodes: Engine) -> None:
+        """A registered workflow entered by key gets its complete path cached, and keeps it.
+
+        This is the branch the interactive open-workflow flow takes for every already-saved
+        workflow (`SetWorkflowContextRequest` -> `push_workflow(workflow_name=...)`). Resolving
+        at push time is the whole point: the key only resolves against the workspace that is
+        active right now, so the workspace switch below would otherwise leave nothing to answer
+        with.
+        """
+        context_manager = griptape_nodes.ContextManager()
+        config_manager = griptape_nodes.ConfigManager()
+
+        with tempfile.TemporaryDirectory() as workspace_dir, tempfile.TemporaryDirectory() as other_dir:
+            workspace = Path(workspace_dir)
+            workflow_file = workspace / "subdir" / "my_flow.py"
+            workflow_file.parent.mkdir()
+            # Workflow.from_disk verifies the file exists; a stub is enough here.
+            workflow_file.write_text("# stub")
+            metadata = WorkflowMetadata(
+                name="my_flow",
+                schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+                engine_version_created_with="test",
+                node_libraries_referenced=[],
+                creation_date=datetime.now(UTC),
+            )
+            original = config_manager.workspace_path
+            config_manager.workspace_path = workspace
+            try:
+                with patch.dict(WorkflowRegistry._workflows, {}, clear=True):
+                    # Registered workspace-RELATIVE, so resolving the key genuinely depends on
+                    # which workspace is active.
+                    WorkflowRegistry.generate_new_workflow(
+                        registry_key="subdir/my_flow", metadata=metadata, file_path="subdir/my_flow.py"
+                    )
+                    context_manager.push_workflow(workflow_name="subdir/my_flow")
+                    try:
+                        expected = str(workflow_file.resolve())
+                        assert context_manager.get_current_workflow_file_path() == expected
+
+                        # Simulate a project switch: the key is now meaningless, the path is not.
+                        config_manager.workspace_path = Path(other_dir)
+                        assert context_manager.get_current_workflow_file_path() == expected
+                    finally:
+                        context_manager.pop_workflow()
+            finally:
+                config_manager.workspace_path = original
 
     def test_get_current_workflow_file_path_requires_a_workflow(self, griptape_nodes: Engine) -> None:
         """Asking outside a workflow context is an error, matching get_current_workflow_name."""

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -833,6 +833,41 @@ class TestProjectManagerBuiltinVariables:
         assert isinstance(result, GetPathForMacroResultSuccess)
         assert result.resolved_path == Path("staticfiles/output.txt")
 
+    def test_builtin_optional_degradation_is_logged(
+        self,
+        project_manager_with_template: ProjectManager,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Dropping an unresolvable optional builtin is observable, not silent.
+
+        `{workflow_dir?:/}outputs/image.png` degrades to a PLAUSIBLE workspace-relative path
+        rather than an error, so without a log line the only symptom is media that resolves to a
+        file which was never written there. `_ProjectVariableResolver._resolve_macro_string` warns
+        on its own copy of this degradation; this is the path GetPathForMacro takes, and it is the
+        one the `workflow_dir` regression tests above drive.
+        """
+        from griptape_nodes.common.macro_parser import ParsedMacro
+
+        cast("Mock", project_manager_with_template._config_manager).workspace_path = Path("/workspace")
+
+        mock_context_manager = Mock()
+        mock_context_manager.has_current_workflow.return_value = False
+        project_manager_with_template._engine = MagicMock()
+        project_manager_with_template._engine.context_manager = mock_context_manager
+
+        parsed_macro = ParsedMacro("{workflow_dir?:/}outputs/image.png")
+        request = GetPathForMacroRequest(parsed_macro=parsed_macro, variables={})
+
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+            result = project_manager_with_template.on_get_path_for_macro_request(request)
+
+        assert isinstance(result, GetPathForMacroResultSuccess)
+        assert result.resolved_path == Path("outputs/image.png")
+        warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("workflow_dir" in msg and "dropping it from the path" in msg for msg in warning_messages), (
+            f"Expected a warning about the dropped optional builtin, got: {warning_messages}"
+        )
+
     @patch("griptape_nodes.retained_mode.managers.project_manager.WorkflowRegistry")
     def test_builtin_workflow_dir_survives_stale_registry_key(
         self,

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -602,11 +602,15 @@ class TestWorkflowManager:
             patch.object(context_mgr, "has_current_workflow", return_value=True),
             patch.object(context_mgr, "get_current_workflow_name", return_value="my_workflow"),
             patch.object(context_mgr, "set_current_workflow_name") as mock_set_name,
+            patch.object(context_mgr, "set_current_workflow_file_path") as mock_set_file_path,
         ):
             result = workflow_manager.on_move_workflow_request(request)
 
         assert isinstance(result, MoveWorkflowResultSuccess)
         mock_set_name.assert_called_once_with("subdir/my_workflow")
+        # The retained path travels with the key: `workflow_dir` reads it in preference to the
+        # registry, so a rekey without a repoint leaves the builtin on the pre-move directory.
+        mock_set_file_path.assert_called_once_with(str(config_mgr.workspace_path / "subdir" / "my_workflow.py"))
 
     def test_on_move_workflow_request_does_not_update_context_for_other_workflow(self, griptape_nodes: Engine) -> None:
         workflow_manager = griptape_nodes.WorkflowManager()
@@ -633,6 +637,58 @@ class TestWorkflowManager:
 
         assert isinstance(result, MoveWorkflowResultSuccess)
         mock_set_name.assert_not_called()
+
+    def test_on_move_workflow_request_updates_context_file_path_for_current_workflow(
+        self, griptape_nodes: Engine, tmp_path: Path
+    ) -> None:
+        """Moving the open workflow repoints the context's retained path at the new directory.
+
+        `workflow_dir` answers from the retained path in preference to the registry, so a Move
+        that rekeys the registry but leaves that path alone keeps resolving `{workflow_dir?:/}`
+        against the folder the file just left -- media written and read somewhere the workflow
+        no longer lives, with no error. Driven against the real registry and filesystem because
+        the bug is precisely that the two disagree.
+        """
+        from datetime import UTC, datetime
+
+        from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
+
+        workflow_manager = griptape_nodes.WorkflowManager()
+        context_manager = griptape_nodes.ContextManager()
+        config_manager = griptape_nodes.ConfigManager()
+
+        workspace = tmp_path.resolve()
+        (workspace / "my_workflow.py").write_text("# stub")
+        metadata = WorkflowMetadata(
+            name="my_workflow",
+            schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+            engine_version_created_with="test",
+            node_libraries_referenced=[],
+            creation_date=datetime.now(UTC),
+        )
+
+        original_workspace = config_manager.workspace_path
+        config_manager.workspace_path = workspace
+        try:
+            with patch.dict(WorkflowRegistry._workflows, {}, clear=True):
+                WorkflowRegistry.generate_new_workflow(
+                    registry_key="my_workflow", metadata=metadata, file_path="my_workflow.py"
+                )
+                context_manager.push_workflow(workflow_name="my_workflow")
+                try:
+                    result = workflow_manager.on_move_workflow_request(
+                        MoveWorkflowRequest(workflow_name="my_workflow", target_directory="subdir")
+                    )
+
+                    assert isinstance(result, MoveWorkflowResultSuccess)
+                    assert context_manager.get_current_workflow_name() == "subdir/my_workflow"
+                    assert context_manager.get_current_workflow_file_path() == str(
+                        workspace / "subdir" / "my_workflow.py"
+                    )
+                finally:
+                    context_manager.pop_workflow()
+        finally:
+            config_manager.workspace_path = original_workspace
 
     # --- Save workflow: unsaved -> saved transition ---
 
@@ -735,6 +791,10 @@ class TestWorkflowManager:
 
                 # Context stack: the active workflow name is the new key
                 assert context_manager.get_current_workflow_name() == saved_key
+                # ...and it now carries the location it gained by being saved. `workflow_dir`
+                # prefers this over a registry lookup, and the lookup is what goes stale on the
+                # next project switch.
+                assert context_manager.get_current_workflow_file_path() == str(saved_full_path)
             finally:
                 if context_manager.has_current_workflow():
                     context_manager.pop_workflow()
@@ -995,6 +1055,33 @@ class TestWorkflowManager:
         # The new absolute path is handed to the external-registration helper.
         persist_calls = captured["persist_calls"]
         assert persist_calls == [call("/ext/new_name.py")]
+
+    def test_rename_updates_context_file_path(self, griptape_nodes: Engine) -> None:
+        """Renaming the open workflow moves the context's retained path onto the new file.
+
+        Rename keeps the directory, so `workflow_dir` survives either way; the path itself would
+        otherwise keep naming a file that no longer exists on disk.
+        """
+        context_manager = griptape_nodes.ContextManager()
+
+        context_manager.push_workflow(workflow_name="bar/workflow")
+        context_manager.set_current_workflow_file_path("/workspace/bar/workflow.py")
+        try:
+            self._run_rename(
+                griptape_nodes.WorkflowManager(),
+                self._RenameScenario(
+                    workflow_name="bar/workflow",
+                    requested_name="new_name",
+                    source_file_path="bar/workflow.py",
+                    save_file_path="/workspace/bar/new_name.py",
+                    save_workflow_name="bar/new_name",
+                ),
+            )
+
+            assert context_manager.get_current_workflow_name() == "bar/new_name"
+            assert context_manager.get_current_workflow_file_path() == "/workspace/bar/new_name.py"
+        finally:
+            context_manager.pop_workflow()
 
     def test_rename_returns_new_registry_key(self, griptape_nodes: Engine) -> None:
         """The returned new_workflow_name is the real directory-qualified key, not the bare stem."""


### PR DESCRIPTION
Follow-up to the review on #5296 (https://github.com/griptape-ai/griptape-nodes-engine/pull/5296#pullrequestreview-4964423254). Branched off `main` at 0d9a05b4.

## The blocker

#5296 made the workflow context's retained file path the source of truth for `workflow_dir`, in preference to a registry lookup that goes stale on a project switch. Nothing updated that path after push time, so every operation that changes the current workflow's identity left it pointing at the old location, reintroducing the same silent broken-media failure by a different route.

Three sites, not one:

- **Move** rekeyed the registry and synced the context *name* only, so `workflow_dir` (and `{workflow_dir?:/}outputs`) kept resolving to the folder the file just left. This is the case the review called out.
- **Rename** preserves the directory, so `workflow_dir` was unaffected, but the retained path went on naming a file that no longer exists on disk.
- **First save of an unsaved workflow** was not in the review and has the same defect: the unsaved to saved transition walks the context stack setting `_name` only, leaving the path `None`, so `workflow_dir` falls back to the registry key, which is exactly what goes stale on the next project switch. "New workflow, save, switch project" reproduced the original bug.

Adds `ContextManager.set_current_workflow_file_path` and calls it from all three, so the retained path is repointed wherever the registry key or the file's location is rewritten for the active context.

## The rest of the review

- **Second degradation site now instrumented.** `on_get_path_for_macro_request` dropped an unresolvable *optional* builtin with no log line, and that is the path the `workflow_dir` regression tests drive; #5296 instrumented only `_ProjectVariableResolver`. The warning went at the call site rather than inside `_resolve_builtins_into_bag`, because the helper cannot see `is_required`: it would double-report hard failures and warn during state-analysis and reverse-match queries where unavailability is a normal result.
- **Docstring return contract corrected.** By-name entry populates the path from the registry too, so `None` means "unregistered or unsaved at push time", not "entered by name".
- **Missing test added** for the by-name registry-hit branch, the one every interactive open-workflow takes. Registered workspace-*relative* so resolution genuinely depends on the active workspace, then the workspace is switched under it.
- **Prose in `push_workflow`** moved above `Args:` so the section list is no longer split.
- **Redundant `str()`** around `get_complete_file_path` dropped.

## Verification

4 new regression tests, 2 existing ones extended. Each new guard was confirmed to fail against unmodified source before being kept.

One existing test needed a stub: `test_on_move_workflow_request_updates_context_for_current_workflow` mocks `set_current_workflow_name` but not the new setter, so the real one hit an empty context stack. Extended with an assertion on the new call.

Full unit suite 4400 passed, 13 skipped. `make check` clean. Integration shows 4 failures and 3 errors (secrets, config, lock, node events) that reproduce identically on a pristine clone of the same commit, so they are environmental and unrelated to this diff.
