### PR TITLE
Stop concurrent drivers and teardown from corrupting a resolution run

### DIFF
--- a/src/griptape_nodes/machines/control_flow.py
+++ b/src/griptape_nodes/machines/control_flow.py
@@ -237,11 +237,10 @@ class ControlFlowMachine(FSM[ControlFlowContext]):
         self._context.paused = debug_mode
         self._context.resolution_machine.change_debug_mode(debug_mode=debug_mode)
 
-    async def granular_step(self, change_debug_mode: bool) -> None:  # noqa: FBT001
+    async def granular_step(self) -> None:
+        """Advance one step. The caller owns the debug-mode change, if any."""
         resolution_machine = self._context.resolution_machine
 
-        if change_debug_mode:
-            resolution_machine.change_debug_mode(debug_mode=True)
         await resolution_machine.update()
 
         # Tick the control flow if the current machine isn't busy
@@ -253,9 +252,8 @@ class ControlFlowMachine(FSM[ControlFlowContext]):
                 await self.update()
 
     async def node_step(self) -> None:
+        """Advance one whole node. The caller owns the debug-mode change."""
         resolution_machine = self._context.resolution_machine
-
-        resolution_machine.change_debug_mode(debug_mode=False)
 
         # If we're in the resolution phase, step the resolution machine
         if self._current_state is ResolveNodeState:

--- a/src/griptape_nodes/machines/fsm.py
+++ b/src/griptape_nodes/machines/fsm.py
@@ -42,13 +42,9 @@ class FSM[T]:
     def __init__(self, context: T) -> None:
         self._context = context
         self._current_state = None
-        # The task currently advancing this machine, or None. State machines are
-        # single-driver: the states suspend, so two coroutines advancing one
-        # machine interleave inside those awaits and corrupt the shared
-        # context. Concretely, two drivers of a resolution machine both wait on
-        # the same set of node tasks, both wake for the same completed task, and
-        # the second one to look it up finds it already consumed. A second
-        # driver raises instead. Holding the task rather than a bool lets
+        # The task currently advancing this machine, or None. States suspend, so
+        # two coroutines advancing one machine interleave inside those awaits and
+        # corrupt the shared context. Storing the task rather than a bool lets
         # ``_advance`` tell "I hold the claim" from "someone else does".
         self._advancing_task: asyncio.Task | None = None
 
@@ -66,12 +62,7 @@ class FSM[T]:
 
     @property
     def is_advancing(self) -> bool:
-        """True while a coroutine is driving this machine.
-
-        Callers that would otherwise become a second driver check this and skip
-        their drive. The raise in ``_claim_for_advancing`` is the backstop for
-        callers that do not.
-        """
+        """True while a coroutine is driving this machine."""
         return self._advancing_task is not None
 
     async def transition_state(self, new_state: type[State] | None) -> None:
@@ -96,11 +87,11 @@ class FSM[T]:
 
     @contextmanager
     def _claim_for_advancing(self) -> Iterator[None]:
-        """Claim sole right to advance this machine for the duration of the block.
+        """Claim sole right to advance this machine until the block exits.
 
-        Claiming and releasing are paired here so that no entry point can take the
-        claim and forget to release it: a stuck claim would leave the machine
-        permanently un-advanceable.
+        The claim lasts until the driver unwinds, so one parked in a state still
+        holds it. Claim and release are paired here so that no entry point can
+        take the claim and forget to drop it.
         """
         if self._advancing_task is not None:
             msg = (
@@ -116,14 +107,10 @@ class FSM[T]:
             self._advancing_task = None
 
     async def _advance(self, new_state: type[State] | None) -> None:
-        """Drive states until one settles.
+        """Drive states until one settles. Callers must hold the claim.
 
-        Every public entry point claims the machine before calling this, so that
-        one drive holds it end to end. Reaching here without holding the claim
-        means a new entry point skipped ``_claim_for_advancing``, and the
-        single-driver guarantee is not in force. Comparing the task rather than
-        just testing for any claim catches the dangerous case: an unclaimed
-        caller arriving while another task is legitimately driving.
+        Comparing the task, rather than testing for any claim at all, catches the
+        case that matters: an unclaimed caller arriving while another task drives.
         """
         if self._advancing_task is not asyncio.current_task():
             msg = "Attempted to advance a state machine without claiming it. This is a programming error in the caller."

--- a/src/griptape_nodes/machines/fsm.py
+++ b/src/griptape_nodes/machines/fsm.py
@@ -1,3 +1,6 @@
+import asyncio
+from collections.abc import Iterator
+from contextlib import contextmanager
 from enum import StrEnum
 from typing import Any, TypeVar
 
@@ -39,6 +42,15 @@ class FSM[T]:
     def __init__(self, context: T) -> None:
         self._context = context
         self._current_state = None
+        # The task currently advancing this machine, or None. State machines are
+        # single-driver: the states suspend, so two coroutines advancing one
+        # machine interleave inside those awaits and corrupt the shared
+        # context. Concretely, two drivers of a resolution machine both wait on
+        # the same set of node tasks, both wake for the same completed task, and
+        # the second one to look it up finds it already consumed. A second
+        # driver raises instead. Holding the task rather than a bool lets
+        # ``_advance`` tell "I hold the claim" from "someone else does".
+        self._advancing_task: asyncio.Task | None = None
 
     async def start(self, initial_state: type[State]) -> None:
         # Enter the initial state.
@@ -48,15 +60,74 @@ class FSM[T]:
     def current_state(self) -> type[State] | None:
         return self._current_state
 
-    @current_state.setter
-    def current_state(self, value: type[State] | None) -> None:
-        self._current_state = value
-
     @property
     def context(self) -> T:
         return self._context
 
+    @property
+    def is_advancing(self) -> bool:
+        """True while a coroutine is driving this machine.
+
+        Callers that would otherwise become a second driver check this and skip
+        their drive. The raise in ``_claim_for_advancing`` is the backstop for
+        callers that do not.
+        """
+        return self._advancing_task is not None
+
     async def transition_state(self, new_state: type[State] | None) -> None:
+        with self._claim_for_advancing():
+            await self._advance(new_state)
+
+    async def update(self) -> None:
+        with self._claim_for_advancing():
+            if self._current_state is None:
+                new_state = None
+            else:
+                new_state = await self._current_state.on_update(self._context)
+            await self._advance(new_state)
+
+    async def handle_event(self, event: Any) -> None:
+        with self._claim_for_advancing():
+            if self._current_state is None:
+                new_state = None
+            else:
+                new_state = await self._current_state.on_event(self._context, event)
+            await self._advance(new_state)
+
+    @contextmanager
+    def _claim_for_advancing(self) -> Iterator[None]:
+        """Claim sole right to advance this machine for the duration of the block.
+
+        Claiming and releasing are paired here so that no entry point can take the
+        claim and forget to release it: a stuck claim would leave the machine
+        permanently un-advanceable.
+        """
+        if self._advancing_task is not None:
+            msg = (
+                "Attempted to run a workflow step while the workflow was already running. "
+                "Failed because a workflow can only advance one step at a time. "
+                "Wait for the current run to finish before starting another."
+            )
+            raise RuntimeError(msg)
+        self._advancing_task = asyncio.current_task()
+        try:
+            yield
+        finally:
+            self._advancing_task = None
+
+    async def _advance(self, new_state: type[State] | None) -> None:
+        """Drive states until one settles.
+
+        Every public entry point claims the machine before calling this, so that
+        one drive holds it end to end. Reaching here without holding the claim
+        means a new entry point skipped ``_claim_for_advancing``, and the
+        single-driver guarantee is not in force. Comparing the task rather than
+        just testing for any claim catches the dangerous case: an unclaimed
+        caller arriving while another task is legitimately driving.
+        """
+        if self._advancing_task is not asyncio.current_task():
+            msg = "Attempted to advance a state machine without claiming it. This is a programming error in the caller."
+            raise RuntimeError(msg)
         while new_state is not None:
             # Exit the current state.
             if self._current_state is not None and new_state is self._current_state:
@@ -68,21 +139,3 @@ class FSM[T]:
             self._current_state = new_state
             # Enter the now-current state
             new_state = await self._current_state.on_enter(self._context)
-
-    async def update(self) -> None:
-        if self._current_state is None:
-            new_state = None
-        else:
-            new_state = await self._current_state.on_update(self._context)
-
-        if new_state is not None:
-            await self.transition_state(new_state)
-
-    async def handle_event(self, event: Any) -> None:
-        if self._current_state is None:
-            new_state = None
-        else:
-            new_state = await self._current_state.on_event(self._context, event)
-
-        if new_state is not None:
-            await self.transition_state(new_state)

--- a/src/griptape_nodes/machines/parallel_resolution.py
+++ b/src/griptape_nodes/machines/parallel_resolution.py
@@ -67,6 +67,7 @@ class ParallelResolutionContext(EngineScoped):
     node_priority_queue: NodePriorityQueue
     dag_builder: DagBuilder | None
     last_resolved_node: BaseNode | None  # Track the last node that was resolved
+    generation: int  # Bumped on reset so a resuming driver can tell its run was torn down
 
     def __init__(
         self,
@@ -88,6 +89,15 @@ class ParallelResolutionContext(EngineScoped):
         self.max_nodes_in_parallel = max_nodes_in_parallel if max_nodes_in_parallel is not None else 5
         self.running_tasks_count = 0
         self.task_to_node = {}
+        # Identifies the current run. `reset` bumps it, so a driver that resumes
+        # from any await can tell its run was torn down and its task map and DAG
+        # no longer exist. Teardown arrives from synchronous code in another
+        # coroutine (clear-all-state, and through it run-from-scratch,
+        # load-with-clean-slate and library reload). Drivers check this at every
+        # resumption rather than only where a suspension happens to be possible
+        # today: whether a given await yields depends on unrelated code, such as
+        # the event queue being unbounded and request handlers being synchronous.
+        self.generation = 0
 
     @property
     def node_to_reference(self) -> dict[str, DagNode]:
@@ -105,7 +115,21 @@ class ParallelResolutionContext(EngineScoped):
             raise ValueError(msg)
         return self.dag_builder.graphs
 
+    def was_reset_since(self, generation: int) -> bool:
+        """Whether this run was torn down since ``generation`` was captured.
+
+        Teardown arrives from synchronous code in another coroutine, so nothing a
+        driver holds -- its task map, its DAG -- is guaranteed to still exist
+        after an await. A driver captures ``generation`` on entry and checks this
+        whenever it resumes, before touching that bookkeeping again.
+        """
+        return self.generation != generation
+
     def reset(self, *, cancel: bool = False) -> None:
+        # Ends the current run as far as any parked driver is concerned: it sees
+        # the bump on waking and abandons the run instead of reaping tasks this
+        # reset is about to discard.
+        self.generation += 1
         self.paused = False
         if cancel:
             self.workflow_state = WorkflowState.CANCELED
@@ -116,8 +140,13 @@ class ParallelResolutionContext(EngineScoped):
         else:
             self.workflow_state = WorkflowState.NO_ERROR
             self.error_message = None
-            self.task_to_node.clear()
             self.last_resolved_node = None
+
+        # Drop task bookkeeping on both paths. An abandoning driver no longer
+        # drains it, so leaving finished tasks behind would hand them to the next
+        # run on this context: its first wait would return an already-completed
+        # task from the previous run and error out having executed nothing.
+        self.task_to_node.clear()
 
         # Reset task counter
         self.running_tasks_count = 0
@@ -447,6 +476,7 @@ class ExecuteDagState(State):
 
     @staticmethod
     async def pop_done_states(context: ParallelResolutionContext) -> None:
+        generation = context.generation
         networks = context.networks
         handled_nodes = set()  # Track nodes we've already processed to avoid duplicates
 
@@ -480,6 +510,12 @@ class ExecuteDagState(State):
                         handled_nodes.add(node)
                         # handle_done_nodes will append control successors to the set
                         await ExecuteDagState.handle_done_nodes(context, context.node_to_reference[node], network_name)
+                        if context.was_reset_since(generation):
+                            # `networks` is a snapshot, so its graphs still name
+                            # nodes a teardown has dropped from node_to_reference;
+                            # the lookups below would not find them.
+                            ExecuteDagState._log_abandoned(context)
+                            return
 
             # After processing completions in this network, check if any remaining leaf nodes can now be queued
             remaining_leaf_nodes = [n for n in network.nodes() if network.in_degree(n) == 0]
@@ -512,6 +548,13 @@ class ExecuteDagState(State):
 
     @staticmethod
     async def on_update(context: ParallelResolutionContext) -> type[State] | None:  # noqa: C901, PLR0911, PLR0912, PLR0915
+        # Identifies this run for the rest of the call. Every await below can in
+        # principle hand control to a teardown, which drops the task map and the
+        # DAG this method is mid-way through using, so each resumption re-checks
+        # before carrying on. Abandoning returns None rather than a state, which
+        # also avoids reviving the machine the teardown just reset.
+        generation = context.generation
+
         # Check if execution is paused
         if context.paused:
             return None
@@ -564,9 +607,16 @@ class ExecuteDagState(State):
                         )
                     )
                 )
+                if context.was_reset_since(generation):
+                    ExecuteDagState._log_abandoned(context)
+                    return None
                 context.error_message = f"Parameter passthrough failed for node '{error_node_name}': {e}"
                 context.workflow_state = WorkflowState.ERRORED
                 return ErrorState
+
+            if context.was_reset_since(generation):
+                ExecuteDagState._log_abandoned(context)
+                return None
 
             # Clear all of the current output values but don't broadcast the clearing.
             # to avoid any flickering in subscribers (UI).
@@ -587,6 +637,9 @@ class ExecuteDagState(State):
                         )
                     )
                 )
+                if context.was_reset_since(generation):
+                    ExecuteDagState._log_abandoned(context)
+                    return None
                 context.error_message = msg
                 context.workflow_state = WorkflowState.ERRORED
                 return ErrorState
@@ -647,6 +700,12 @@ class ExecuteDagState(State):
         if context.task_to_node:
             done, _ = await asyncio.wait(context.task_to_node.keys(), return_when=asyncio.FIRST_COMPLETED)
 
+            if context.was_reset_since(generation):
+                # Reaping here would look up tasks the teardown already discarded,
+                # which is the crash this guard exists for.
+                ExecuteDagState._log_abandoned(context)
+                return None
+
             # Decrement counter for completed tasks
             context.running_tasks_count -= len(done)
             # New node has finished - priorities are stale
@@ -676,6 +735,9 @@ class ExecuteDagState(State):
                             )
                         )
                     )
+                    if context.was_reset_since(generation):
+                        ExecuteDagState._log_abandoned(context)
+                        return None
                     context.error_message = msg
                     context.workflow_state = WorkflowState.ERRORED
                     return ErrorState
@@ -684,10 +746,18 @@ class ExecuteDagState(State):
 
         # Once a task has finished, loop back to the top.
         await ExecuteDagState.pop_done_states(context)
+        if context.was_reset_since(generation):
+            ExecuteDagState._log_abandoned(context)
+            return None
         # Remove all nodes that are done
         if context.paused:
             return None
         return ExecuteDagState
+
+    @staticmethod
+    def _log_abandoned(context: ParallelResolutionContext) -> None:
+        """Record that a drive was dropped because its run was torn down under it."""
+        logger.debug("Abandoning resolution of flow '%s': the run was torn down.", context.flow_name)
 
 
 class ErrorState(State):
@@ -783,8 +853,12 @@ class ParallelResolutionMachine(FSM[ParallelResolutionContext]):
         # explicit CancelExecuteNodeRequest to each affected worker so its
         # aprocess task is cancelled on the worker side too. No-op for nodes
         # running locally on the orchestrator.
+        # Snapshot before awaiting: dispatching to a worker suspends, and a driver
+        # waking in that window can publish a finished node, which adds to
+        # node_to_reference and would break iteration mid-cancel -- leaving the
+        # remaining workers uncancelled and the flow stuck reporting "running".
         node_manager = self.context.engine.node_manager
-        for dag_node in self.context.node_to_reference.values():
+        for dag_node in list(self.context.node_to_reference.values()):
             await node_manager.cancel_worker_execution(dag_node.node_reference.name)
 
         # Cancel all running tasks

--- a/src/griptape_nodes/machines/parallel_resolution.py
+++ b/src/griptape_nodes/machines/parallel_resolution.py
@@ -89,14 +89,6 @@ class ParallelResolutionContext(EngineScoped):
         self.max_nodes_in_parallel = max_nodes_in_parallel if max_nodes_in_parallel is not None else 5
         self.running_tasks_count = 0
         self.task_to_node = {}
-        # Identifies the current run. `reset` bumps it, so a driver that resumes
-        # from any await can tell its run was torn down and its task map and DAG
-        # no longer exist. Teardown arrives from synchronous code in another
-        # coroutine (clear-all-state, and through it run-from-scratch,
-        # load-with-clean-slate and library reload). Drivers check this at every
-        # resumption rather than only where a suspension happens to be possible
-        # today: whether a given await yields depends on unrelated code, such as
-        # the event queue being unbounded and request handlers being synchronous.
         self.generation = 0
 
     @property
@@ -118,17 +110,18 @@ class ParallelResolutionContext(EngineScoped):
     def was_reset_since(self, generation: int) -> bool:
         """Whether this run was torn down since ``generation`` was captured.
 
-        Teardown arrives from synchronous code in another coroutine, so nothing a
-        driver holds -- its task map, its DAG -- is guaranteed to still exist
-        after an await. A driver captures ``generation`` on entry and checks this
-        whenever it resumes, before touching that bookkeeping again.
+        Teardown arrives from synchronous code in another coroutine (clear-all
+        state, and through it run-from-scratch, load-with-clean-slate and library
+        reload), so nothing a driver holds -- its task map, its DAG -- is
+        guaranteed to still exist after an await. A driver captures ``generation``
+        on entry and checks this on resuming, before touching that bookkeeping
+        again.
         """
         return self.generation != generation
 
     def reset(self, *, cancel: bool = False) -> None:
         # Ends the current run as far as any parked driver is concerned: it sees
-        # the bump on waking and abandons the run instead of reaping tasks this
-        # reset is about to discard.
+        # the bump on waking and abandons the run.
         self.generation += 1
         self.paused = False
         if cancel:
@@ -142,10 +135,8 @@ class ParallelResolutionContext(EngineScoped):
             self.error_message = None
             self.last_resolved_node = None
 
-        # Drop task bookkeeping on both paths. An abandoning driver no longer
-        # drains it, so leaving finished tasks behind would hand them to the next
-        # run on this context: its first wait would return an already-completed
-        # task from the previous run and error out having executed nothing.
+        # Both paths: an abandoning driver no longer drains this, and a leftover
+        # finished task would end the next run on this context before it ran.
         self.task_to_node.clear()
 
         # Reset task counter
@@ -512,8 +503,7 @@ class ExecuteDagState(State):
                         await ExecuteDagState.handle_done_nodes(context, context.node_to_reference[node], network_name)
                         if context.was_reset_since(generation):
                             # `networks` is a snapshot, so its graphs still name
-                            # nodes a teardown has dropped from node_to_reference;
-                            # the lookups below would not find them.
+                            # nodes a teardown dropped from node_to_reference.
                             ExecuteDagState._log_abandoned(context)
                             return
 
@@ -548,11 +538,8 @@ class ExecuteDagState(State):
 
     @staticmethod
     async def on_update(context: ParallelResolutionContext) -> type[State] | None:  # noqa: C901, PLR0911, PLR0912, PLR0915
-        # Identifies this run for the rest of the call. Every await below can in
-        # principle hand control to a teardown, which drops the task map and the
-        # DAG this method is mid-way through using, so each resumption re-checks
-        # before carrying on. Abandoning returns None rather than a state, which
-        # also avoids reviving the machine the teardown just reset.
+        # See `ParallelResolutionContext.was_reset_since`. Abandoning returns None
+        # rather than a state, which avoids reviving the machine the teardown reset.
         generation = context.generation
 
         # Check if execution is paused
@@ -853,10 +840,8 @@ class ParallelResolutionMachine(FSM[ParallelResolutionContext]):
         # explicit CancelExecuteNodeRequest to each affected worker so its
         # aprocess task is cancelled on the worker side too. No-op for nodes
         # running locally on the orchestrator.
-        # Snapshot before awaiting: dispatching to a worker suspends, and a driver
-        # waking in that window can publish a finished node, which adds to
-        # node_to_reference and would break iteration mid-cancel -- leaving the
-        # remaining workers uncancelled and the flow stuck reporting "running".
+        # Snapshot: dispatching suspends, and a driver waking in that window can
+        # add to node_to_reference, breaking this iteration mid-cancel.
         node_manager = self.context.engine.node_manager
         for dag_node in list(self.context.node_to_reference.values()):
             await node_manager.cancel_worker_execution(dag_node.node_reference.name)

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -4658,10 +4658,11 @@ class FlowManager(EngineScoped):
         """True while a coroutine is already driving the running flow's machines.
 
         A continuously running flow drives itself, so a step or continue request
-        arriving mid-drive has nothing to do. Stepping anyway would make that
-        request a second driver of the same machine, which corrupts the
-        resolution machine's task bookkeeping. A paused flow is not advancing
-        (its states return immediately), so debug stepping is unaffected.
+        arriving mid-drive has nothing to do, and driving anyway would make it a
+        second driver of the same machine. A driver parked on a running node is
+        still advancing even once the paused flag is set -- it observes the flag
+        and stops when that node finishes -- which is why callers apply their
+        debug-mode change before consulting this.
         """
         if self._global_control_flow_machine is None:
             return False
@@ -4871,15 +4872,11 @@ class FlowManager(EngineScoped):
             return
         if self._global_control_flow_machine is None:
             return
-        # Raising the paused flag is what pauses a live run, and this is the only
-        # path that does it, so it has to happen whether or not we go on to drive
-        # the machine below. A driver parked on a node observes the flag and
-        # stops itself once that node finishes.
+        # The only path that pauses a live run, so it applies whether or not we go
+        # on to drive.
         if change_debug_mode:
             self._global_control_flow_machine.resolution_machine.change_debug_mode(debug_mode=True)
         if self.execution_is_advancing():
-            # The run is driving itself; stepping here would make this request a
-            # second driver of the same machine.
             return
         await self._global_control_flow_machine.granular_step()
         if self._global_control_flow_machine.resolution_machine.is_complete():
@@ -4899,12 +4896,9 @@ class FlowManager(EngineScoped):
         if self._global_control_flow_machine is None:
             return
         # Clearing the paused flag is what resumes a paused run, so it applies
-        # whether or not we go on to drive. Dropping it would leave a run that
-        # the user asked to step sitting paused.
+        # whether or not we go on to drive.
         self._global_control_flow_machine.resolution_machine.change_debug_mode(debug_mode=False)
         if self.execution_is_advancing():
-            # The run is driving itself; stepping here would make this request a
-            # second driver of the same machine.
             return
         await self._global_control_flow_machine.node_step()
         # Start the next resolution step now please.
@@ -4916,14 +4910,11 @@ class FlowManager(EngineScoped):
         )
         if not self.check_for_existing_running_flow():
             return
-        # Turn all debugging to false and continue on. This is what resumes a
-        # paused run, so it applies whether or not we go on to drive: dropping it
-        # would leave the run paused after the user asked it to continue.
+        # Turn all debugging to false and continue on. This resumes a paused run,
+        # so it applies whether or not we go on to drive.
         if self._global_control_flow_machine is not None:
             self._global_control_flow_machine.change_debug_mode(False)
         if self.execution_is_advancing():
-            # The run is driving itself; driving here would make this request a
-            # second driver of the same machine. The resume above is enough.
             return
         if self._global_control_flow_machine is not None:
             if self._global_single_node_resolution:

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -4654,6 +4654,22 @@ class FlowManager(EngineScoped):
             and self._global_control_flow_machine.context.resolution_machine.is_started()
         )
 
+    def execution_is_advancing(self) -> bool:
+        """True while a coroutine is already driving the running flow's machines.
+
+        A continuously running flow drives itself, so a step or continue request
+        arriving mid-drive has nothing to do. Stepping anyway would make that
+        request a second driver of the same machine, which corrupts the
+        resolution machine's task bookkeeping. A paused flow is not advancing
+        (its states return immediately), so debug stepping is unaffected.
+        """
+        if self._global_control_flow_machine is None:
+            return False
+        return (
+            self._global_control_flow_machine.is_advancing
+            or self._global_control_flow_machine.resolution_machine.is_advancing
+        )
+
     async def _await_flow_completion(self, timeout_ms: int | None) -> str | None:
         """Block until the current flow resolves, erroring, or the timeout elapses.
 
@@ -4853,13 +4869,21 @@ class FlowManager(EngineScoped):
         )
         if not self.check_for_existing_running_flow():
             return
-        if self._global_control_flow_machine is not None:
-            await self._global_control_flow_machine.granular_step(change_debug_mode)
-            resolution_machine = self._global_control_flow_machine.resolution_machine
-            if self._global_single_node_resolution:
-                resolution_machine = self._global_control_flow_machine.resolution_machine
-            if resolution_machine.is_complete():
-                self._global_single_node_resolution = False
+        if self._global_control_flow_machine is None:
+            return
+        # Raising the paused flag is what pauses a live run, and this is the only
+        # path that does it, so it has to happen whether or not we go on to drive
+        # the machine below. A driver parked on a node observes the flag and
+        # stops itself once that node finishes.
+        if change_debug_mode:
+            self._global_control_flow_machine.resolution_machine.change_debug_mode(debug_mode=True)
+        if self.execution_is_advancing():
+            # The run is driving itself; stepping here would make this request a
+            # second driver of the same machine.
+            return
+        await self._global_control_flow_machine.granular_step()
+        if self._global_control_flow_machine.resolution_machine.is_complete():
+            self._global_single_node_resolution = False
 
     async def single_node_step(self, flow: ControlFlow) -> None:
         # It won't call single_node_step without an existing flow running from US.
@@ -4872,8 +4896,17 @@ class FlowManager(EngineScoped):
         if self._global_single_node_resolution:
             msg = "Cannot step through the Control Flow in Single Node Execution"
             raise RuntimeError(msg)
-        if self._global_control_flow_machine is not None:
-            await self._global_control_flow_machine.node_step()
+        if self._global_control_flow_machine is None:
+            return
+        # Clearing the paused flag is what resumes a paused run, so it applies
+        # whether or not we go on to drive. Dropping it would leave a run that
+        # the user asked to step sitting paused.
+        self._global_control_flow_machine.resolution_machine.change_debug_mode(debug_mode=False)
+        if self.execution_is_advancing():
+            # The run is driving itself; stepping here would make this request a
+            # second driver of the same machine.
+            return
+        await self._global_control_flow_machine.node_step()
         # Start the next resolution step now please.
         await self._handle_post_execution_queue_processing(debug_mode=True)
 
@@ -4883,9 +4916,16 @@ class FlowManager(EngineScoped):
         )
         if not self.check_for_existing_running_flow():
             return
-        # Turn all debugging to false and continue on
-        if self._global_control_flow_machine is not None and self._global_control_flow_machine is not None:
+        # Turn all debugging to false and continue on. This is what resumes a
+        # paused run, so it applies whether or not we go on to drive: dropping it
+        # would leave the run paused after the user asked it to continue.
+        if self._global_control_flow_machine is not None:
             self._global_control_flow_machine.change_debug_mode(False)
+        if self.execution_is_advancing():
+            # The run is driving itself; driving here would make this request a
+            # second driver of the same machine. The resume above is enough.
+            return
+        if self._global_control_flow_machine is not None:
             if self._global_single_node_resolution:
                 if self._global_control_flow_machine.resolution_machine.is_complete():
                     self._global_single_node_resolution = False

--- a/src/griptape_nodes/retained_mode/managers/object_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/object_manager.py
@@ -111,8 +111,24 @@ class ObjectManager(EngineScoped):
             logger.warning(details)
             return ClearAllObjectStateResultFailure(result_details=details)
 
+        # Cancel any in-flight run before tearing its bookkeeping down. The reset
+        # below clears the task map and nulls the machine state, which makes the
+        # flow look idle, so the cancel in clear_current_workflow_data would be
+        # skipped and the previous run's node tasks would keep going: still
+        # billing API calls and still emitting parameter updates keyed by node
+        # name, which land on the same-named nodes of whatever run comes next.
+        #
+        # Best-effort: a node that refuses to cancel must not block the teardown
+        # the user asked for. A driver left running is handled downstream, because
+        # the reset marks its run as ended and the driver abandons it on waking.
+        if self.engine.flow_manager.check_for_existing_running_flow():
+            try:
+                await self.engine.flow_manager.cancel_flow_run()
+            except Exception as e:
+                logger.warning("Could not cancel the running workflow before clearing it. Continuing anyway: %s", e)
+
         try:
-            # Reset global execution state first to eliminate all references before deletion
+            # Eliminate all execution references before deletion
             self.engine.flow_manager.reset_global_execution_state()
         except Exception as e:
             details = f"Attempted to reset global execution state. Failed with exception: {e}"

--- a/src/griptape_nodes/retained_mode/managers/object_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/object_manager.py
@@ -111,16 +111,15 @@ class ObjectManager(EngineScoped):
             logger.warning(details)
             return ClearAllObjectStateResultFailure(result_details=details)
 
-        # Cancel any in-flight run before tearing its bookkeeping down. The reset
-        # below clears the task map and nulls the machine state, which makes the
-        # flow look idle, so the cancel in clear_current_workflow_data would be
-        # skipped and the previous run's node tasks would keep going: still
-        # billing API calls and still emitting parameter updates keyed by node
-        # name, which land on the same-named nodes of whatever run comes next.
+        # Cancel any in-flight run before tearing its bookkeeping down: the reset
+        # below makes the flow look idle, so the cancel in
+        # clear_current_workflow_data is skipped and the previous run's node tasks
+        # keep going -- billing API calls, and emitting parameter updates keyed by
+        # node name onto the same-named nodes of whatever run comes next.
         #
-        # Best-effort: a node that refuses to cancel must not block the teardown
-        # the user asked for. A driver left running is handled downstream, because
-        # the reset marks its run as ended and the driver abandons it on waking.
+        # Best-effort: a node that refuses to cancel must not block the teardown.
+        # A driver still parked holds its FSM claim until it wakes and abandons the
+        # run; harmless here because deleting the flows drops the machine it holds.
         if self.engine.flow_manager.check_for_existing_running_flow():
             try:
                 await self.engine.flow_manager.cancel_flow_run()

--- a/tests/unit/machines/test_fsm.py
+++ b/tests/unit/machines/test_fsm.py
@@ -1,0 +1,95 @@
+"""Tests for the FSM single-driver guard.
+
+State machines are single-driver: two coroutines advancing the same machine
+interleave inside the states' awaits and corrupt shared context. In the field a
+step request arriving during a running flow became a second driver of that
+flow's resolution machine and surfaced as a KeyError in ExecuteDagState. The
+guard makes the second driver fail fast with a clear error instead.
+"""
+
+import asyncio
+
+import pytest
+
+from griptape_nodes.machines.fsm import FSM, State
+
+
+class _Context:
+    def __init__(self) -> None:
+        self.entered_update = asyncio.Event()
+        self.release_update = asyncio.Event()
+        self.update_calls = 0
+
+
+class _BlockingState(State):
+    """State whose on_update suspends until the test releases it."""
+
+    @staticmethod
+    async def on_enter(context: _Context) -> type[State] | None:  # noqa: ARG004
+        return _BlockingState
+
+    @staticmethod
+    async def on_update(context: _Context) -> type[State] | None:
+        context.update_calls += 1
+        context.entered_update.set()
+        await context.release_update.wait()
+        return None
+
+
+class TestFsmSingleDriverGuard:
+    @pytest.mark.asyncio
+    async def test_second_driver_rejected_while_machine_advancing(self) -> None:
+        context = _Context()
+        machine = FSM(context)
+
+        driver = asyncio.create_task(machine.start(_BlockingState))
+        await context.entered_update.wait()
+
+        # The machine is suspended inside on_update; a second driver must not
+        # be able to advance it concurrently.
+        # Every entry point that advances the machine must refuse. Each is
+        # bounded by a timeout: if the guard regresses these calls block on the
+        # blocking state instead of raising, and an unbounded await would hang
+        # the whole test run rather than failing it.
+        with pytest.raises(RuntimeError, match="already running"):
+            await asyncio.wait_for(machine.update(), timeout=5)
+        with pytest.raises(RuntimeError, match="already running"):
+            await asyncio.wait_for(machine.transition_state(_BlockingState), timeout=5)
+        with pytest.raises(RuntimeError, match="already running"):
+            await asyncio.wait_for(machine.handle_event("some-event"), timeout=5)
+
+        context.release_update.set()
+        await driver
+        assert context.update_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_guard_clears_after_drive_completes(self) -> None:
+        context = _Context()
+        context.release_update.set()
+        machine = FSM(context)
+
+        await machine.start(_BlockingState)
+        first_drive_calls = context.update_calls
+
+        # Sequential driving is fine: the guard resets once a drive finishes.
+        await machine.update()
+        assert context.update_calls == first_drive_calls + 1
+
+    @pytest.mark.asyncio
+    async def test_guard_clears_after_state_raises(self) -> None:
+        class _RaisingState(State):
+            @staticmethod
+            async def on_enter(context: _Context) -> type[State] | None:  # noqa: ARG004
+                msg = "boom"
+                raise RuntimeError(msg)
+
+        context = _Context()
+        context.release_update.set()
+        machine = FSM(context)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await machine.start(_RaisingState)
+
+        # A failed drive must not leave the machine permanently "advancing".
+        await machine.start(_BlockingState)
+        assert context.update_calls == 1

--- a/tests/unit/machines/test_parallel_resolution_single_driver.py
+++ b/tests/unit/machines/test_parallel_resolution_single_driver.py
@@ -1,0 +1,211 @@
+"""Nothing may pull task bookkeeping out from under a parked driver.
+
+Field crash: a run died with `KeyError: <Task finished ... execute_node ...>` from
+`ExecuteDagState.on_update`'s `task_to_node.pop(task)`. A driver suspended in
+`asyncio.wait(task_to_node.keys())` woke for a completed node task and found it
+already gone from the map. Two different things produce that, both covered here.
+
+**A second driver.** Request handlers are dispatched as concurrent tasks, so once
+a run is committed, `single_execution_step`, `single_node_step` and
+`continue_executing` all pass the "is a flow already running?" check and go on to
+drive `_global_control_flow_machine`'s resolution machine, which the run's own
+driver is already advancing. Both park on the same task set, both wake for one
+completed task, and the second `pop` finds it consumed.
+
+**A teardown.** `ParallelResolutionContext.reset()` clears `task_to_node`
+outright, from synchronous code in another coroutine (clear-all-state, and
+through it run-from-scratch, load-with-clean-slate and library reload). The
+parked driver then wakes to an empty map.
+"""
+
+import asyncio
+from typing import NamedTuple
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from griptape_nodes.common.directed_graph import DirectedGraph
+from griptape_nodes.exe_types.node_types import BaseNode, NodeResolutionState
+from griptape_nodes.machines.dag_builder import DagBuilder, DagNode, NodeState
+from griptape_nodes.machines.parallel_resolution import ExecuteDagState, ParallelResolutionMachine
+
+
+class _ParkedMachine(NamedTuple):
+    machine: ParallelResolutionMachine
+    release: asyncio.Event
+
+
+def _machine_parked_on_a_node_task() -> _ParkedMachine:
+    """A machine with one PROCESSING node whose task is still pending.
+
+    Driving it lands in `ExecuteDagState.on_update`'s `asyncio.wait` and stays
+    there until the returned event is set, which is the window a second driver
+    used to slip into.
+    """
+    node = MagicMock(spec=BaseNode)
+    node.name = "n"
+    node.lock = False
+    node.state = NodeResolutionState.RESOLVING
+
+    graph = DirectedGraph()
+    graph.add_node("n")
+
+    # A stub engine keeps EngineScoped.engine from falling back to
+    # current_engine(), which would stand up the process-root engine here.
+    engine = MagicMock()
+    dag_builder = DagBuilder(engine)
+    dag_builder.graphs["n"] = graph
+    dag_builder.node_to_reference["n"] = DagNode(node_reference=node, node_state=NodeState.PROCESSING)
+
+    machine = ParallelResolutionMachine("flow", max_nodes_in_parallel=1, dag_builder=dag_builder, engine=engine)
+
+    release = asyncio.Event()
+    node_task = asyncio.ensure_future(release.wait())
+    machine.context.task_to_node[node_task] = dag_builder.node_to_reference["n"]
+    machine.context.running_tasks_count = 1
+
+    return _ParkedMachine(machine=machine, release=release)
+
+
+@pytest.fixture(autouse=True)
+def _stub_handle_done_nodes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """handle_done_nodes touches the full engine (events, connections, library registry).
+
+    Stub it so these stay focused scheduler tests; they only care about who is
+    allowed to drive the machine, not what happens after a node finishes.
+    """
+    monkeypatch.setattr(ExecuteDagState, "handle_done_nodes", AsyncMock())
+
+
+class TestParallelResolutionSingleDriver:
+    @pytest.mark.asyncio
+    async def test_second_driver_raises_instead_of_corrupting_task_bookkeeping(self) -> None:
+        machine, release = _machine_parked_on_a_node_task()
+
+        first_driver = asyncio.create_task(machine.resolve_node())
+        # Let the first driver reach the asyncio.wait inside on_update.
+        await asyncio.sleep(0)
+        assert machine.context.task_to_node, "first driver should still be tracking the node task"
+
+        # Let the node task finish while a second driver would be waiting on it.
+        # Without the guard that driver parks in the same asyncio.wait, both wake
+        # for this one completed task, and the second `task_to_node.pop` raises
+        # the KeyError seen in the field. With the guard the rejection below
+        # happens before the second driver ever reaches the wait.
+        release.set()
+
+        with pytest.raises(RuntimeError, match="already running"):
+            await machine.resolve_node()
+
+        await first_driver
+
+    @pytest.mark.asyncio
+    async def test_sequential_drivers_are_allowed(self) -> None:
+        machine, release = _machine_parked_on_a_node_task()
+
+        release.set()
+        await machine.resolve_node()
+        assert not machine.is_advancing, "the drive released the machine when it returned"
+
+        # The guard must not latch: the machine is drivable again once the
+        # previous drive returned.
+        await machine.resolve_node()
+        assert not machine.is_advancing
+
+
+class TestTeardownWhileDriverParked:
+    """A run torn down mid-flight must abandon its driver, not crash it.
+
+    `reset()` clears `task_to_node` synchronously from another coroutine, so a
+    driver parked in `asyncio.wait` cannot assume the map it is holding keys
+    into still exists when it wakes.
+    """
+
+    @pytest.mark.asyncio
+    async def test_reset_while_parked_abandons_the_run_instead_of_crashing(self) -> None:
+        machine, release = _machine_parked_on_a_node_task()
+
+        driver = asyncio.create_task(machine.resolve_node())
+        await asyncio.sleep(0)
+        assert machine.is_advancing, "driver should hold the claim while parked"
+
+        # A concurrent clear-all-state tears the run down, clearing the very map
+        # the parked driver is waiting on keys from.
+        machine.reset_machine()
+        assert not machine.context.task_to_node
+
+        release.set()
+        # Before the generation check this raised
+        # `KeyError: <Task finished ...>` out of on_update's reap loop.
+        await driver
+
+        assert not machine.is_advancing, "the abandoned driver released the machine"
+        assert machine.current_state is None, "teardown left the machine reset, not resurrected"
+
+    @pytest.mark.asyncio
+    async def test_cancelling_reset_also_drops_task_bookkeeping(self) -> None:
+        machine, release = _machine_parked_on_a_node_task()
+
+        driver = asyncio.create_task(machine.resolve_node())
+        await asyncio.sleep(0)
+
+        machine.reset_machine(cancel=True)
+
+        release.set()
+        await driver
+
+        # The abandoning driver no longer drains the map itself, so the reset has
+        # to. A leftover finished task would be handed to the next run on this
+        # context, whose first wait would return it immediately and error out
+        # having executed nothing.
+        assert not machine.context.task_to_node
+
+
+class TestPausingAParkedDriver:
+    """FlowManager declines to drive a running flow but still sets its paused flag.
+
+    That only works if a parked driver observes the flag and stops itself, and if
+    clearing the flag lets it carry on. These pin that against real objects: mock
+    based tests would keep passing if `ExecuteDagState` stopped checking `paused`.
+    """
+
+    @pytest.mark.asyncio
+    async def test_pause_set_from_outside_parks_the_driver_and_leaves_it_resumable(self) -> None:
+        machine, release = _machine_parked_on_a_node_task()
+
+        driver = asyncio.create_task(machine.resolve_node())
+        await asyncio.sleep(0)
+        assert machine.is_advancing, "driver should hold the claim while parked"
+
+        # Pause arriving from a concurrent request handler.
+        machine.change_debug_mode(debug_mode=True)
+        release.set()
+        await driver
+
+        # Stopped without completing, and released the claim so a later step can drive.
+        assert not machine.is_advancing
+        assert machine.current_state is ExecuteDagState
+        assert not machine.is_complete()
+        assert machine.is_started()
+
+        # Continue: clear the flag, then drive.
+        machine.change_debug_mode(debug_mode=False)
+        await machine.update()
+        assert machine.is_complete()
+
+    @pytest.mark.asyncio
+    async def test_resume_while_still_parked_keeps_the_run_going(self) -> None:
+        machine, release = _machine_parked_on_a_node_task()
+
+        driver = asyncio.create_task(machine.resolve_node())
+        await asyncio.sleep(0)
+
+        # Pause then Continue, both while the driver is still on the node. The
+        # resume must win, or the run halts once the node finishes even though
+        # the user asked it to continue.
+        machine.change_debug_mode(debug_mode=True)
+        machine.change_debug_mode(debug_mode=False)
+        release.set()
+        await driver
+
+        assert machine.is_complete()

--- a/tests/unit/machines/test_parallel_resolution_single_driver.py
+++ b/tests/unit/machines/test_parallel_resolution_single_driver.py
@@ -3,19 +3,9 @@
 Field crash: a run died with `KeyError: <Task finished ... execute_node ...>` from
 `ExecuteDagState.on_update`'s `task_to_node.pop(task)`. A driver suspended in
 `asyncio.wait(task_to_node.keys())` woke for a completed node task and found it
-already gone from the map. Two different things produce that, both covered here.
-
-**A second driver.** Request handlers are dispatched as concurrent tasks, so once
-a run is committed, `single_execution_step`, `single_node_step` and
-`continue_executing` all pass the "is a flow already running?" check and go on to
-drive `_global_control_flow_machine`'s resolution machine, which the run's own
-driver is already advancing. Both park on the same task set, both wake for one
-completed task, and the second `pop` finds it consumed.
-
-**A teardown.** `ParallelResolutionContext.reset()` clears `task_to_node`
-outright, from synchronous code in another coroutine (clear-all-state, and
-through it run-from-scratch, load-with-clean-slate and library reload). The
-parked driver then wakes to an empty map.
+already gone from the map. Two things produce that, both covered here: a second
+coroutine driving the same machine, and a teardown (`ParallelResolutionContext.reset()`)
+clearing the map from synchronous code in another coroutine.
 """
 
 import asyncio
@@ -88,10 +78,8 @@ class TestParallelResolutionSingleDriver:
         assert machine.context.task_to_node, "first driver should still be tracking the node task"
 
         # Let the node task finish while a second driver would be waiting on it.
-        # Without the guard that driver parks in the same asyncio.wait, both wake
-        # for this one completed task, and the second `task_to_node.pop` raises
-        # the KeyError seen in the field. With the guard the rejection below
-        # happens before the second driver ever reaches the wait.
+        # Unguarded, both wake for this one task and the second `pop` raises the
+        # KeyError seen in the field.
         release.set()
 
         with pytest.raises(RuntimeError, match="already running"):
@@ -155,9 +143,7 @@ class TestTeardownWhileDriverParked:
         await driver
 
         # The abandoning driver no longer drains the map itself, so the reset has
-        # to. A leftover finished task would be handed to the next run on this
-        # context, whose first wait would return it immediately and error out
-        # having executed nothing.
+        # to, or the leftover task lands on the next run on this context.
         assert not machine.context.task_to_node
 
 

--- a/tests/unit/retained_mode/managers/test_flow_manager_advancing_policy.py
+++ b/tests/unit/retained_mode/managers/test_flow_manager_advancing_policy.py
@@ -1,0 +1,91 @@
+"""Step and continue requests must not become a second driver of a running flow.
+
+A continuously running flow is one long drive held by whoever started it, so a
+step or continue request arriving mid-drive cannot advance the machine without
+corrupting its task bookkeeping. FlowManager checks `execution_is_advancing()`
+and declines to drive.
+
+Pausing is the exception: `single_execution_step` is the only path that pauses a
+live run, so it must still raise the paused flag even when it declines to drive.
+The running driver then stops itself once its current node finishes.
+"""
+
+from typing import NamedTuple
+from unittest.mock import MagicMock
+
+import pytest
+
+from griptape_nodes.retained_mode.managers.event_manager import EventManager
+from griptape_nodes.retained_mode.managers.flow_manager import FlowManager
+
+
+class _AdvancingRun(NamedTuple):
+    flow_manager: FlowManager
+    machine: MagicMock
+
+
+def _flow_manager_with_advancing_machine() -> _AdvancingRun:
+    """A FlowManager whose committed run is mid-drive."""
+    flow_manager = FlowManager(MagicMock(spec=EventManager), engine=MagicMock())
+
+    machine = MagicMock()
+    machine.is_advancing = True
+    machine.resolution_machine.is_advancing = True
+    flow_manager._global_control_flow_machine = machine
+
+    return _AdvancingRun(flow_manager=flow_manager, machine=machine)
+
+
+class TestExecutionIsAdvancing:
+    def test_reports_false_with_no_machine(self) -> None:
+        flow_manager = FlowManager(MagicMock(spec=EventManager), engine=MagicMock())
+        assert flow_manager.execution_is_advancing() is False
+
+    def test_reports_true_when_only_the_resolution_machine_is_advancing(self) -> None:
+        flow_manager, machine = _flow_manager_with_advancing_machine()
+        machine.is_advancing = False
+        assert flow_manager.execution_is_advancing() is True
+
+    def test_reports_false_when_nothing_is_advancing(self) -> None:
+        flow_manager, machine = _flow_manager_with_advancing_machine()
+        machine.is_advancing = False
+        machine.resolution_machine.is_advancing = False
+        assert flow_manager.execution_is_advancing() is False
+
+
+class TestStepRequestsDeclineToDoubleDrive:
+    @pytest.mark.asyncio
+    async def test_single_execution_step_pauses_instead_of_driving(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        flow_manager, machine = _flow_manager_with_advancing_machine()
+
+        monkeypatch.setattr(flow_manager, "check_for_existing_running_flow", lambda: True)
+        await flow_manager.single_execution_step(MagicMock(), change_debug_mode=True)
+
+        # Pausing a live run is the whole point of this request; dropping it
+        # would leave the flow unpausable while reporting success.
+        machine.resolution_machine.change_debug_mode.assert_called_once_with(debug_mode=True)
+        machine.granular_step.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_single_node_step_resumes_instead_of_driving(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        flow_manager, machine = _flow_manager_with_advancing_machine()
+
+        monkeypatch.setattr(flow_manager, "check_for_existing_running_flow", lambda: True)
+        await flow_manager.single_node_step(MagicMock())
+
+        # Dropping the resume would leave a run the user asked to step sitting
+        # paused, with the request reporting success.
+        machine.resolution_machine.change_debug_mode.assert_called_once_with(debug_mode=False)
+        machine.node_step.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_continue_executing_resumes_instead_of_driving(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        flow_manager, machine = _flow_manager_with_advancing_machine()
+
+        monkeypatch.setattr(flow_manager, "check_for_existing_running_flow", lambda: True)
+        await flow_manager.continue_executing(MagicMock())
+
+        # A Continue pressed while the current node is still running must still
+        # clear the paused flag, or the run halts once that node finishes.
+        machine.change_debug_mode.assert_called_once_with(False)
+        machine.node_step.assert_not_called()

--- a/tests/unit/retained_mode/managers/test_object_manager_clear_all.py
+++ b/tests/unit/retained_mode/managers/test_object_manager_clear_all.py
@@ -1,0 +1,57 @@
+"""Clearing all object state must cancel an in-flight run before tearing it down.
+
+`reset_global_execution_state()` drops the run's task bookkeeping and nulls its
+machine state, which makes the flow look idle. Anything that cancels on the
+strength of `check_for_existing_running_flow()` afterwards -- including
+`Engine.clear_current_workflow_data`, whose whole job here is to "cancel any
+running flow so the delete path doesn't race with execution" -- is then a no-op,
+and the previous run's node tasks carry on: still billing API calls, and still
+emitting parameter updates keyed by node name that land on the same-named nodes
+of whatever run is loaded next.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from griptape_nodes.retained_mode.events.object_events import (
+    ClearAllObjectStateRequest,
+    ClearAllObjectStateResultSuccess,
+)
+from griptape_nodes.retained_mode.managers.object_manager import ObjectManager
+
+
+class TestClearAllObjectStateCancelsFirst:
+    @pytest.mark.asyncio
+    async def test_running_flow_is_cancelled_before_execution_state_is_reset(self) -> None:
+        calls: list[str] = []
+
+        engine = MagicMock()
+        engine.flow_manager.check_for_existing_running_flow.return_value = True
+        engine.flow_manager.cancel_flow_run = AsyncMock(side_effect=lambda: calls.append("cancel"))
+        engine.flow_manager.reset_global_execution_state = MagicMock(side_effect=lambda: calls.append("reset"))
+        engine.context_manager.has_current_workflow.return_value = False
+
+        object_manager = ObjectManager(MagicMock(), engine=engine)
+        result = await object_manager.on_clear_all_object_state_request(
+            ClearAllObjectStateRequest(i_know_what_im_doing=True)
+        )
+
+        assert isinstance(result, ClearAllObjectStateResultSuccess)
+        assert calls == ["cancel", "reset"], "the reset must not run ahead of the cancel"
+
+    @pytest.mark.asyncio
+    async def test_idle_engine_is_not_cancelled(self) -> None:
+        engine = MagicMock()
+        engine.flow_manager.check_for_existing_running_flow.return_value = False
+        engine.flow_manager.cancel_flow_run = AsyncMock()
+        engine.context_manager.has_current_workflow.return_value = False
+
+        object_manager = ObjectManager(MagicMock(), engine=engine)
+        result = await object_manager.on_clear_all_object_state_request(
+            ClearAllObjectStateRequest(i_know_what_im_doing=True)
+        )
+
+        assert isinstance(result, ClearAllObjectStateResultSuccess)
+        engine.flow_manager.cancel_flow_run.assert_not_awaited()
+        engine.flow_manager.reset_global_execution_state.assert_called_once()


### PR DESCRIPTION
Closes griptape-ai/internal#209 — fixes the fatal `KeyError` reported there. Closes **both** producers of that crash; see the last section for what in #209 this does *not* cover.

## The crash

```
ERROR Failed to resolve "OpenAI Image Generation_2".  Error: <Task finished name='Task-79638'
      coro=<ExecuteDagState.execute_node() done, defined at .../parallel_resolution.py:482> result=None>
KeyError: <Task finished name='Task-79638' ...>
```

`ExecuteDagState.on_update` suspends in:

```python
done, _ = await asyncio.wait(context.task_to_node.keys(), return_when=asyncio.FIRST_COMPLETED)
```

and then reaps whatever finished with `context.task_to_node.pop(task)`. Two independent things make it wake to a task the map no longer holds. Both emit this identical traceback, which is why both are fixed here — closing one alone would leave a field report indistinguishable from a regression.

## Producer 1: a second driver

Request handlers are dispatched as concurrent tasks. Once a run is committed, `single_execution_step` / `single_node_step` / `continue_executing` all pass the "is a flow already running?" check and go on to drive `_global_control_flow_machine`'s resolution machine — which the run's own driver is already advancing. Both park on the same task set, both wake for one completed task, and the second `pop` finds it consumed.

**Detection — `FSM`.** A single-driver claim. `transition_state`, `update` and `handle_event` each claim the machine for the whole drive via `_claim_for_advancing()`, a context manager pairing claim with release so no entry point can take the claim and forget to drop it. The driving loop moved into `_advance()`, which verifies the caller holds the claim. The claim stores the owning task rather than a bare bool, so that check distinguishes "I hold it" from "another task holds it" — the second being exactly the case a bool would wave through. The `current_state` setter is gone with this: nothing outside the class used it, and the two subclasses that reset state assign `_current_state` directly.

**Policy — `FlowManager`.** The guard raises, but `on_single_execution_step_request` wraps its drive in a blanket `except Exception` that calls `cancel_flow_run()`, so raising there would cancel the very workflow the request was trying to step. Instead `execution_is_advancing()` reports whether the run is already driving itself, and the three step/continue sites skip only the drive. The raise remains as a backstop for callers that do not check.

**Debug-mode side effects still apply**, because they are what the user asked for rather than part of the drive:

- `single_execution_step` raising the paused flag is the **only** thing in the engine that pauses a live run. Declining before it would leave a flow that cannot be paused while reporting success.
- The `change_debug_mode(False)` in `single_node_step` and `continue_executing` is what **resumes** a paused run. Declining before it would silently drop a Continue pressed while the current node was still running, leaving the run paused and halted while reporting success.

A driver parked on a node observes the flag once that node finishes and stops or carries on accordingly. Note this means a flow can be both paused and still advancing: the flag is set, but the parked driver has not yet reached a point where it can observe it. That is why the debug-mode change is applied *before* `execution_is_advancing()` is consulted.

> Not a race between two flow *starts*. An earlier revision of this PR locked the four start sites; that was removed as provably inert. Nothing suspends between `check_for_existing_running_flow()` and the machine setting `_current_state` — `_process_nodes_for_dag` is `async def` but contains no `await`, its helpers and `put_event` are synchronous, and `transition_state` assigns state before its first real await — so that window has zero width.

## Producer 2: a teardown

`ParallelResolutionContext.reset()` clears `task_to_node` from synchronous code in another coroutine. Its reachable caller is `FlowManager.reset_global_execution_state()` via `ObjectManager.on_clear_all_object_state_request`, and so from library reload, run-from-scratch and load-with-clean-slate. A parked driver wakes to an empty map and raises.

**A generation stamp on the context**, bumped by `reset()`. A driver captures it before waiting and abandons the run if it changed, instead of reaping tasks the teardown discarded. Returning no state (rather than a state) also avoids reviving the machine the teardown just reset. This is not a fallback that hides a failure: `reset()`'s only production callers are deliberate teardowns, so a genuine bookkeeping bug leaves the generation untouched and still raises.

**`reset()` now drops task bookkeeping on both paths.** An abandoning driver no longer drains the map, and a leftover finished task would be inherited by the next run on that context — whose first wait would return it immediately and error out having executed nothing.

**The clear-all handler now cancels before it resets.** The reset makes the flow look idle, so the cancel in `clear_current_workflow_data` — whose stated job is to "cancel any running flow so the delete path doesn't race with execution" — was skipped, and the previous run's node tasks kept going: still billing API calls, and still emitting parameter updates keyed by node *name*, which land on the same-named nodes of whatever run is loaded next. That cancel now actually reaches `cancel_all_nodes`, so that function snapshots its node map before awaiting: dispatching a worker cancel suspends, and a driver waking in that window can add to the map, which would break the iteration mid-cancel and leave the flow stuck reporting "running".

**A parked driver keeps its FSM claim until it wakes**, since the claim is released by the driver's own unwind rather than by the reset. Nothing inherits it: the driver releases on waking (pinned by a test), and clear-all deletes the flows, which nulls `_global_control_flow_machine`, so the machine holding the claim is dropped outright. A reset that instead cleared the claim on the machine's behalf would be unsafe — the old driver's `finally` would later clear whatever *new* driver held it, reopening the two-driver window this PR closes.

## Testing

- `tests/unit/machines/test_parallel_resolution_single_driver.py` — drives a **real** `ParallelResolutionMachine`. Reproduces the field signature verbatim for **both** producers: removing either guard yields `KeyError: <Task finished ...>` out of the reap loop. Also pins, against real objects, that an externally set paused flag parks a live driver and leaves it resumable, that a resume landing while the driver is still parked keeps the run going, and that a cancelling reset drops task bookkeeping.
- `tests/unit/machines/test_fsm.py` — every entry point refuses a second driver; the claim clears after success and after a state raises. Each rejection is bounded by `asyncio.wait_for`, so a regression fails fast instead of hanging CI (the suite sets no default timeout and runs `-n auto`).
- `tests/unit/retained_mode/managers/test_flow_manager_advancing_policy.py` — the decline policy: pause preserved, resume preserved, no drive. Reverting either hoist fails these.
- `tests/unit/retained_mode/managers/test_object_manager_clear_all.py` — the cancel happens before the reset, and an idle engine is not cancelled.
- Full suite: 4543 unit passed / 13 skipped, 32 e2e passed, `make check` clean. Integration was not re-run for the final comment-only pass; on the code as landed its failures matched `main`'s (pre-existing environment issues, verified by diffing failure lists).

## Scope note on griptape-ai/internal#209

That issue bundles three findings from one log scan. This PR closes the fatal crash (finding 1) and nothing else. Still open and **not** addressed here:

- **The 401 reconnect storm** — 13,629 of the ~13.7k warnings in that log. Session renewal fails and the engine retries every ~2s indefinitely against a non-retryable 401, with no backoff and no re-auth. This is the bulk of the log and deserves its own issue.
- **Minor items** — the rename-collision double log, the ~80 strict-mode parameter-mutation warnings from the standard library's OpenAI image node (deliberate transient upload params, unrelated to this crash), and two "created in RESOLVING" nodes.

Also worth correcting for the record: #209's title attributes the crash to mid-resolution parameter mutation. That hypothesis does not hold — the mutation is a documented pattern in the node and is not involved. The cause is the concurrency described above.
