### PR TITLE
Give data URI uploads a real storage filename

### DIFF
--- a/src/griptape_nodes/exe_types/param_components/artifact_url/public_artifact_url_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/artifact_url/public_artifact_url_parameter.py
@@ -1,3 +1,4 @@
+import mimetypes
 import os
 from pathlib import Path
 from typing import Any, ClassVar
@@ -175,7 +176,7 @@ class PublicArtifactUrlParameter:
         from griptape_nodes.files.file import File
 
         file_contents = File(url).read_bytes()
-        filename = Path(urlparse(url).path).name
+        filename = self._derive_upload_filename(url)
 
         self.gtc_file_path = Path("artifact_url_storage") / uuid4().hex / filename
 
@@ -188,3 +189,19 @@ class PublicArtifactUrlParameter:
         if not self.gtc_file_path:
             return
         self._storage_driver.delete_file(self.gtc_file_path)
+
+    @staticmethod
+    def _derive_upload_filename(url: str) -> str:
+        """Pick the storage filename for a value being uploaded.
+
+        A data URI has no path component to take a name from -- deriving one from the URI
+        would embed the (potentially megabytes-long) base64 payload in the storage key --
+        so it gets a generated name instead. The extension matters beyond aesthetics: the
+        presigned download URL's content type is guessed from the uploaded path's
+        extension, so a bare name would serve the media without a content type.
+        """
+        if url.startswith("data:"):
+            mime_type = url.removeprefix("data:").split(";", 1)[0].split(",", 1)[0]
+            extension = mimetypes.guess_extension(mime_type) or ""
+            return f"{uuid4().hex}{extension}"
+        return Path(urlparse(url).path).name or uuid4().hex

--- a/tests/unit/exe_types/param_components/artifact_url/test_public_artifact_url_parameter.py
+++ b/tests/unit/exe_types/param_components/artifact_url/test_public_artifact_url_parameter.py
@@ -6,6 +6,7 @@ from an upstream failure -- in addition to the original UrlArtifact / bare-strin
 paths. See griptape-ai/griptape-nodes-engine#4688.
 """
 
+import re
 from typing import Any, NamedTuple
 from unittest.mock import Mock
 
@@ -20,6 +21,10 @@ from griptape_nodes.exe_types.param_components.artifact_url.public_artifact_url_
 from tests.unit.exe_types.mocks import MockNode
 
 PUBLIC_URL = "https://cloud.example/public/artifact.png"
+DATA_URI_PNG = "data:image/png;base64,iVBORw0KGgo="
+
+# _derive_upload_filename generates uuid4().hex names for values with no usable path name.
+GENERATED_NAME = r"[0-9a-f]{32}"
 
 
 class ComponentFixture(NamedTuple):
@@ -74,6 +79,44 @@ class TestGetPublicUrlForParameter:
         # The error should name the parameter so the editor points at the real cause.
         assert "image" in str(excinfo.value)
         driver.upload_file.assert_not_called()
+
+    def test_data_uri_uploads_under_generated_filename(self, mocker: Any) -> None:
+        # A data URI has no path name; the storage key must get a generated name with a
+        # real extension (the presigned download's content type is guessed from it), not
+        # a name derived from the base64 payload.
+        component, driver = _make_component(DATA_URI_PNG)
+        read_bytes_mock = mocker.patch("griptape_nodes.files.file.File.read_bytes", return_value=b"png-bytes")
+
+        assert component.get_public_url_for_parameter() == PUBLIC_URL
+
+        read_bytes_mock.assert_called_once()
+        uploaded_path = driver.upload_file.call_args.kwargs["path"]
+        assert re.fullmatch(rf"{GENERATED_NAME}\.png", uploaded_path.name)
+        assert uploaded_path.parts[0] == "artifact_url_storage"
+        assert driver.upload_file.call_args.kwargs["file_content"] == b"png-bytes"
+        assert component.gtc_file_path == uploaded_path
+
+
+class TestDeriveUploadFilename:
+    def test_url_path_name_is_preserved(self) -> None:
+        name = PublicArtifactUrlParameter._derive_upload_filename("https://example.com/dir/a.png")
+        assert name == "a.png"
+
+    def test_local_path_name_is_preserved(self) -> None:
+        name = PublicArtifactUrlParameter._derive_upload_filename("/inputs/frame.jpeg")
+        assert name == "frame.jpeg"
+
+    def test_data_uri_gets_generated_name_with_extension(self) -> None:
+        name = PublicArtifactUrlParameter._derive_upload_filename(DATA_URI_PNG)
+        assert re.fullmatch(rf"{GENERATED_NAME}\.png", name)
+
+    def test_data_uri_with_unknown_mime_gets_extensionless_generated_name(self) -> None:
+        name = PublicArtifactUrlParameter._derive_upload_filename("data:application/x-unknown-thing;base64,AAAA")
+        assert re.fullmatch(GENERATED_NAME, name)
+
+    def test_url_with_empty_path_name_gets_generated_name(self) -> None:
+        name = PublicArtifactUrlParameter._derive_upload_filename("https://example.com/")
+        assert re.fullmatch(GENERATED_NAME, name)
 
 
 class TestGetBucketId:


### PR DESCRIPTION
## Problem

`PublicArtifactUrlParameter.get_public_url_for_parameter` derives the upload filename from the value's URL path:

```python
filename = Path(urlparse(url).path).name
```

For a `data:` URI there is no path component, so `urlparse` hands back `image/png;base64,<payload>` and the base64 payload itself becomes the filename. Measured with a 1MB image:

```
derived filename length: 1000011
first 60 chars: 'png;base64,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
```

That is the object key. Both S3 and Azure Blob cap keys at 1024, so the upload fails outright rather than merely producing an ugly name.

The extension matters too, independently: the presigned download URL's `ResponseContentType` is guessed from the uploaded path's extension (`aws_service_storage.py`), so a key with no extension serves the media with no content type.

## Change

Route the filename through a new `_derive_upload_filename`:

- `data:` value → `f"{uuid4().hex}{mimetypes.guess_extension(mime)}"`, taking the mime from the URI prefix.
- Anything else → unchanged `Path(urlparse(url).path).name`, with a generated name as a fallback when that is empty.

Reading the bytes already worked for data URIs via `DataUriFileDriver`; only the naming was broken.

## Blast radius

Nil for existing callers. Every current consumer passes a path or an `http(s)` URL, which takes the unchanged branch byte-for-byte:

| input shape | key before | key after |
|---|---|---|
| `/Users/me/inputs/style.png` | `style.png` | `style.png` |
| `http://localhost:8124/static/style.png` | `style.png` | `style.png` |
| `{inputs}/style.png` | `style.png` | `style.png` |
| `data:image/png;base64,…` (1MB) | 1,000,011 chars — fails | `<uuid>.png` |

This is also why the bug has never been reported despite the component being used by Kling, Wan, OmniHuman, Topaz, Qwen and others: they all hand over `UrlArtifact`s, so nothing has ever passed a data URI in.

## Why now

Found while fixing griptape-ai/griptape-cloud#2191, where Seedance reference images move from inline base64 to presigned URLs (griptape-ai/griptape-nodes-library-standard#540). That PR does **not** depend on this one — it keeps data-URI inputs inline precisely because of this bug, and ships against the current engine pin. This lands on its own merits, and lets that PR drop its remaining special case in a one-line follow-up.

## Verification

`make check` clean; full unit suite 4498 passed, 13 skipped.

New tests cover the data-URI upload path end to end (generated name matches `^[0-9a-f]{32}\.png$`, decoded bytes uploaded, key under `artifact_url_storage/`) plus `_derive_upload_filename` directly: path name preserved, data URI → uuid+extension, unknown mime → extensionless, empty path → generated.
