### PR TITLE
A project's workspace pin outranks an env-set workspace

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -40,8 +40,8 @@ Griptape Nodes employs a specific search order to load settings from environment
         1. **User config** — `~/.config/griptape_nodes/griptape_nodes_config.json`. Global settings for this machine.
         1. **Project-adjacent config** — `<project_dir>/griptape_nodes_config.json`. Loaded when a project is set as active. Use this to distribute shared defaults alongside a project file.
         1. **Workspace config** — `<workspace_dir>/griptape_nodes_config.json`. Loaded after the workspace is resolved. Use this for per-user overrides that take precedence over the shared project config. When the workspace directory is the same as the project directory, this file is the same as the project-adjacent config and is not loaded twice.
-        1. **Per-project workspace override** — When the active project's path matches a key in the `project_workspaces` mapping (in your user config), that workspace directory is applied. This sets only `workspace_directory`, overriding any value from the config files above. See [Workspace](projects/workspace.md#per-project-workspace-overrides) for details.
-        1. **Environment variables** — `GTN_CONFIG_*` prefix (highest priority). See below.
+        1. **Environment variables** — `GTN_CONFIG_*` prefix (highest priority for every setting except `workspace_directory`, where the per-project workspace override below wins). See below.
+        1. **Per-project workspace override** — When the active project declares its own `workspace_dir`, or its path matches a key in the `project_workspaces` mapping (in your user config), that workspace directory is applied. This sets only `workspace_directory` and outranks every other source of that value, including `GTN_CONFIG_WORKSPACE_DIRECTORY` — an environment-set workspace is the engine's default, and a project that pins its own workspace is the more specific intent. See [Workspace](projects/workspace.md#per-project-workspace-overrides) for details.
     - **Override Priority:** Settings in files loaded later override settings from files loaded earlier.
 
 1. **Defaults and Merging**
@@ -150,7 +150,7 @@ A top-level configuration value can be set or overridden using an environment va
 GTN_CONFIG_<SETTING_NAME>=<value>
 ```
 
-Environment variable overrides have the **highest priority** — they win over user config files, project-adjacent config files, the per-project workspace override, and built-in defaults.
+Environment variable overrides have the **highest priority** — they win over user config files, project-adjacent config files, and built-in defaults. The one exception is `workspace_directory`: a project that pins its own workspace (a `workspace_dir` field in the project file, or a `project_workspaces` mapping entry) wins over `GTN_CONFIG_WORKSPACE_DIRECTORY` while that project is active, because the environment value describes the engine's default workspace and the project pin is the more specific intent.
 
 Examples:
 

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -162,9 +162,14 @@ class ConfigManager(EngineScoped):
     def set_workspace_override(self, path: Path | None) -> None:
         """Set a runtime workspace directory override.
 
-        This override takes precedence over config-file-based workspace_directory
-        values (default, user, project, workspace configs) but is still overridden
-        by the GTN_CONFIG_WORKSPACE_DIRECTORY environment variable.
+        This override takes precedence over every other workspace_directory source,
+        including the GTN_CONFIG_WORKSPACE_DIRECTORY environment variable: it is only
+        ever set by decide_workspace branches that deliberately outrank env (a
+        project's own workspace_dir field, the per-user project_workspaces mapping)
+        or that fire only when no env workspace exists (parent inheritance, the
+        global default), so honoring it here is what makes that ladder real. An
+        env-set workspace (e.g. a broker's per-engine scratch stamp) is the engine's
+        default; an activated project's own workspace is the more specific intent.
 
         Used by ProjectManager to apply project_workspaces mappings and
         auto-default-to-project-dir behavior. Also updates workspace_path immediately
@@ -201,19 +206,24 @@ class ConfigManager(EngineScoped):
         """Resolve workspace_directory across the config layers, in load_configs' precedence order.
 
         Single source of truth for how workspace_directory is layered (highest priority first):
-        env var, then the runtime override (only when `include_runtime_override`), then workspace
+        the runtime override (only when `include_runtime_override`), then the env var, then workspace
         config, project-adjacent config, user config, and finally the Settings default. load_configs
         uses this WITH the override to set the active workspace_path; configured_global_workspace_path
         uses it WITHOUT, to get the engine's workspace independent of any single project's pin. Keeping
         both on this one helper is what stops the two precedences from drifting. The Settings default
         always populates default_config, so a value is always returned.
         """
-        # env is applied last in load_configs, so it is highest priority; the runtime override sits
-        # just below env and above the config files.
-        if (env_value := get_dot_value(self.env_config, "workspace_directory", None)) is not None:
-            return env_value
+        # The runtime override outranks the env var, matching decide_workspace's ladder: the
+        # override is only ever set by decisions that deliberately beat env (a project's own
+        # workspace_dir field, the per-user project_workspaces mapping) or that fire only when no
+        # env workspace exists at all (parent inheritance, the global default). An env-set
+        # workspace -- a broker's per-engine scratch stamp, an on-prem deployment default --
+        # describes where the ENGINE's workspace lives, and activating a project that declares
+        # its own workspace is the more specific intent.
         if include_runtime_override and self._workspace_dir_override is not None:
             return self._workspace_dir_override
+        if (env_value := get_dot_value(self.env_config, "workspace_directory", None)) is not None:
+            return env_value
         for layer in (self.workspace_config, self.project_config, self.user_config):
             if (configured := get_dot_value(layer, "workspace_directory", None)) is not None:
                 return configured
@@ -389,7 +399,8 @@ class ConfigManager(EngineScoped):
 
         Sets default_config, user_config, project_config, workspace_config, env_config,
         and merged_config attributes. Priority order (later entries win):
-        defaults → user → project-adjacent → workspace → env vars.
+        defaults → user → project-adjacent → workspace → env vars → runtime workspace override
+        (the override applies to workspace_directory only).
         """
         self.default_config = Settings().model_dump()
         merged_config = self.default_config
@@ -415,15 +426,18 @@ class ConfigManager(EngineScoped):
         else:
             self.workspace_config = {}
 
-        # Apply runtime workspace override (from ProjectManager's project_workspaces lookup
-        # or auto-default-to-project-dir). Sits above config files but below env vars.
-        if self._workspace_dir_override is not None:
-            merged_config["workspace_directory"] = self._workspace_dir_override
-
         self.env_config = self._load_config_from_env_vars()
         if self.env_config:
             merged_config = merge_dicts(merged_config, self.env_config)
             logger.debug("Merged config from environment variables: %s", list(self.env_config.keys()))
+
+        # Apply runtime workspace override (from ProjectManager's project_workspaces lookup
+        # or auto-default-to-project-dir) AFTER the env merge: it outranks env vars, matching
+        # decide_workspace's ladder and _resolve_configured_workspace_directory. A project that
+        # pins its own workspace must win over an env-set engine default (e.g. a broker's
+        # per-engine scratch stamp).
+        if self._workspace_dir_override is not None:
+            merged_config["workspace_directory"] = self._workspace_dir_override
 
         # Re-assign workspace path in case env var or project config overrides it. Uses the shared
         # precedence resolver (WITH the runtime override) so the active workspace and
@@ -474,7 +488,7 @@ class ConfigManager(EngineScoped):
         """Return the merged config a project WOULD activate with, mutating nothing.
 
         Mirrors load_configs()'s layer order (defaults -> user -> project-adjacent ->
-        workspace -> workspace override -> env vars) for the given project and
+        workspace -> env vars -> workspace override) for the given project and
         workspace directories, reading files fresh into a local dict. The
         provisioning preview uses this so its plan reflects the same effective
         `libraries_to_register` / `requires_engine` that _reconcile_libraries_from_config
@@ -512,16 +526,17 @@ class ConfigManager(EngineScoped):
         if workspace_config_path != project_config_path:
             merged = merge_dicts(merged, self._load_config_from_file(workspace_config_path, "workspace"))
 
-        # Apply the runtime workspace override conditionally, mirroring _activate_project:
-        # only the project_workspaces, parent-chain inheritance, and global-default branches
-        # pin it (apply_override), and the value is resolved exactly as set_workspace_override
-        # would so preview and live agree. It sits above config files but below env vars.
-        if apply_override:
-            merged["workspace_directory"] = str(Path(workspace_dir).expanduser().resolve())
-
         env_config = self._load_config_from_env_vars()
         if env_config:
             merged = merge_dicts(merged, env_config)
+
+        # Apply the runtime workspace override conditionally, mirroring _activate_project:
+        # only the template workspace_dir, project_workspaces, parent-chain inheritance, and
+        # global-default branches pin it (apply_override), and the value is resolved exactly as
+        # set_workspace_override would so preview and live agree. Applied AFTER the env merge:
+        # the override outranks env vars, matching load_configs.
+        if apply_override:
+            merged["workspace_directory"] = str(Path(workspace_dir).expanduser().resolve())
 
         return merged
 

--- a/tests/unit/retained_mode/managers/test_config_manager.py
+++ b/tests/unit/retained_mode/managers/test_config_manager.py
@@ -145,6 +145,36 @@ class TestConfigManager:
                 assert manager.workspace_path == override_workspace.resolve()
                 assert manager.get_config_value("workspace_directory") == str(override_workspace)
 
+    def test_project_workspace_override_beats_env_var(self) -> None:
+        """The runtime project override outranks GTN_CONFIG_WORKSPACE_DIRECTORY.
+
+        The override is only ever set by decide_workspace branches that deliberately
+        beat env (a project's own workspace_dir field, the project_workspaces mapping),
+        so the resolver must honor it or the ladder's documented priority is a lie: an
+        engine whose workspace was stamped via env (e.g. a broker's per-engine scratch
+        directory) would silently ignore an activated project's own workspace pin.
+        Clearing the override must restore the env value as the engine default.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            env_workspace = Path(temp_dir) / "env_workspace"
+            env_workspace.mkdir()
+            project_workspace = Path(temp_dir) / "project_workspace"
+            project_workspace.mkdir()
+
+            with patch.dict(os.environ, {"GTN_CONFIG_WORKSPACE_DIRECTORY": str(env_workspace)}, clear=True):
+                manager = ConfigManager()
+                manager.load_configs()
+                assert manager.workspace_path == env_workspace.resolve()
+
+                manager.set_workspace_override(project_workspace)
+                manager.load_configs()
+                assert manager.workspace_path == project_workspace.resolve()
+                assert manager.get_config_value("workspace_directory") == str(project_workspace.resolve())
+
+                manager.set_workspace_override(None)
+                manager.load_configs()
+                assert manager.workspace_path == env_workspace.resolve()
+
     def test_resolved_libraries_root_default_is_global_workspace_relative(self, isolate_user_config: Path) -> None:
         """With no override, the root is libraries_directory resolved against the GLOBAL workspace.
 
@@ -546,22 +576,6 @@ class TestConfigManager:
 
                 assert manager.workspace_path == override_dir.resolve()
                 assert manager.merged_config["workspace_directory"] == str(override_dir.resolve())
-
-    def test_workspace_override_loses_to_env_var(self) -> None:
-        """Test that GTN_CONFIG_WORKSPACE_DIRECTORY still wins over the runtime override."""
-        with tempfile.TemporaryDirectory() as temp_dir:
-            override_dir = Path(temp_dir) / "override"
-            override_dir.mkdir()
-            env_dir = Path(temp_dir) / "env"
-            env_dir.mkdir()
-
-            with patch.dict(os.environ, {"GTN_CONFIG_WORKSPACE_DIRECTORY": str(env_dir)}, clear=True):
-                manager = ConfigManager()
-                manager.set_workspace_override(override_dir)
-
-                manager.load_configs()
-
-                assert manager.workspace_path == env_dir.resolve()
 
     def test_workspace_override_cleared_on_reset(self) -> None:
         """Test that reset_user_config clears the runtime workspace override."""

--- a/tests/unit/retained_mode/managers/test_execution_lease_manager.py
+++ b/tests/unit/retained_mode/managers/test_execution_lease_manager.py
@@ -243,9 +243,7 @@ class TestAdmissionEntitlement:
 
         def denying_hook(checkpoint: AuthorizationCheckpoint) -> CheckpointDenial | None:
             seen.append(checkpoint)
-            return CheckpointDenial(
-                failures=(CheckpointFailure(detail="Your license does not include GPU queueing."),)
-            )
+            return CheckpointDenial(failures=(CheckpointFailure(detail="Your license does not include GPU queueing."),))
 
         engine.event_manager.add_authorization_hook(denying_hook)
         try:


### PR DESCRIPTION
## What

`workspace_directory` precedence, before: env var > runtime project override > config files.
After: **runtime project override > env var** > config files.

## Why

`decide_workspace`'s ladder has always documented that a project's own `workspace_dir` field (branch 0) and the per-user `project_workspaces` mapping (branch 1) beat the env var (branch 2) — but the config resolver contradicted its own ladder by checking env first. The remaining override-setting branches (parent inheritance, global default) only fire when no env workspace exists, so honoring the override unconditionally is exactly the documented priority, not new policy.

Concretely: an engine whose workspace arrives via `GTN_CONFIG_WORKSPACE_DIRECTORY` — a broker's per-engine scratch stamp (app-side `GTN_BROKER_WORKSPACE_TEMPLATE`), an on-prem deployment default — silently ignored an activated self-contained project's workspace pin. Project-relative writes, the workspace file server, and the unset-`libraries_dir` fallback all stayed on the env path while the project claimed otherwise.

## How

The three places that encode the layering move together so live and preview cannot drift:
- `_resolve_configured_workspace_directory`: override checked before env
- `load_configs`: override applied after the env merge
- `compute_project_provisioning_config`: same reorder in the preview mirror

Env remains the engine's default workspace: it wins whenever no project pins one, and is restored when the project deactivates (covered by the new test). Docs updated (`configuration.md` — env is highest priority for every setting *except* `workspace_directory` under an active project pin).

Replaces `test_workspace_override_loses_to_env_var` (which pinned the contradiction) with `test_project_workspace_override_beats_env_var` covering both directions plus override-clear restoring env.

4370 unit tests pass; `make check` clean.

<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--5333.org.readthedocs.build/en/5333/

<!-- readthedocs-preview griptape-nodes end -->