### PR TITLE
fix(publishing): bundle static files referenced by a macro path

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,23 @@
 # Unreleased
 
+## `WorkflowPackager.copy_static_files` takes the workflow directory
+
+`copy_static_files` now requires a third argument naming the directory that holds the
+workflow being packaged:
+
+```python
+packager.copy_static_files(file_refs, destination, workflow_dir)
+```
+
+It needs the anchor to work out where each dependency belongs inside the bundle. Passing the
+live `{workflow_dir}` context would resolve against whichever workflow the engine happens to
+have open, so the caller supplies the one being published.
+
+Publishers that call `package_to_folder` — which is most of them, including the Folder and
+Nuke publishers — are unaffected; it derives the directory from the workflow itself. Only a
+publisher calling `copy_static_files` directly needs the change, and it fails loudly with a
+`TypeError` rather than bundling to the wrong place.
+
 ## Agent streaming payloads carry `thread_id`
 
 `AgentStreamEvent`, `AgentThinkingEvent`, `AgentToolCallEvent`, and `AgentToolResultEvent`

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,23 +1,5 @@
 # Unreleased
 
-## `WorkflowPackager.copy_static_files` takes the workflow directory
-
-`copy_static_files` now requires a third argument naming the directory that holds the
-workflow being packaged:
-
-```python
-packager.copy_static_files(file_refs, destination, workflow_dir)
-```
-
-It needs the anchor to work out where each dependency belongs inside the bundle. Passing the
-live `{workflow_dir}` context would resolve against whichever workflow the engine happens to
-have open, so the caller supplies the one being published.
-
-Publishers that call `package_to_folder` — which is most of them, including the Folder and
-Nuke publishers — are unaffected; it derives the directory from the workflow itself. Only a
-publisher calling `copy_static_files` directly needs the change, and it fails loudly with a
-`TypeError` rather than bundling to the wrong place.
-
 ## Agent streaming payloads carry `thread_id`
 
 `AgentStreamEvent`, `AgentThinkingEvent`, `AgentToolCallEvent`, and `AgentToolResultEvent`

--- a/docs/guides/publishing.md
+++ b/docs/guides/publishing.md
@@ -172,6 +172,15 @@ it guarantees the file travels with the published workflow.
     than an absolute path. That keeps the reference valid after the bundle is
     moved to another machine or deployed to the cloud.
 
+!!! warning "Files outside your project don't travel"
+
+    A file that lives outside your project — on an external drive or a network
+    mount, say — has no place inside the bundle, so it is left where it is. The
+    published workflow still looks for it at that same absolute path, which means
+    it only runs on a machine where that path exists. The publisher reports these
+    files as it works, so watch for a `file dependencies not bundled` message. To
+    make one travel, copy it into your project first and reference the copy.
+
 **When do I need this?** Use `SelectFromProject` for any file loaded from your
 project that doesn't show up in the published bundle — for example an image,
 audio clip, video, or text file that a node reads but that goes missing after you

--- a/docs/guides/publishing.md
+++ b/docs/guides/publishing.md
@@ -172,13 +172,18 @@ it guarantees the file travels with the published workflow.
     than an absolute path. That keeps the reference valid after the bundle is
     moved to another machine or deployed to the cloud.
 
-!!! warning "Files outside your project don't travel"
+!!! warning "Files outside your project folder don't travel"
 
-    A file that lives outside your project — on an external drive or a network
-    mount, say — has no place inside the bundle, so it is left where it is. The
-    published workflow still looks for it at that same absolute path, which means
-    it only runs on a machine where that path exists. To make one travel, copy it
-    into your project first and reference the copy.
+    A file reached from outside the folders that travel with the bundle — an
+    external drive or a network mount, whether referenced directly or through a
+    [directory](projects/directories.md) you pointed there — has no place inside
+    the bundle, so it is left where it is. The published workflow still looks for
+    it at that same absolute path, so it runs anywhere that path exists and fails
+    anywhere it doesn't.
+
+    That is what you want for shared storage a render farm already mounts. For a
+    file that should travel, copy it into your project folder and reference the
+    copy.
 
     Each file left out is recorded in the engine log as
     `will not be bundled because ...`, along with the reason. If a published

--- a/docs/guides/publishing.md
+++ b/docs/guides/publishing.md
@@ -177,9 +177,13 @@ it guarantees the file travels with the published workflow.
     A file that lives outside your project — on an external drive or a network
     mount, say — has no place inside the bundle, so it is left where it is. The
     published workflow still looks for it at that same absolute path, which means
-    it only runs on a machine where that path exists. The publisher reports these
-    files as it works, so watch for a `file dependencies not bundled` message. To
-    make one travel, copy it into your project first and reference the copy.
+    it only runs on a machine where that path exists. To make one travel, copy it
+    into your project first and reference the copy.
+
+    Each file left out is recorded in the engine log as
+    `will not be bundled because ...`, along with the reason. If a published
+    workflow can't find a file it needs, that log line is the place to start; see
+    [Exporting engine logs](../troubleshooting.md#exporting-engine-logs).
 
 **When do I need this?** Use `SelectFromProject` for any file loaded from your
 project that doesn't show up in the published bundle — for example an image,

--- a/src/griptape_nodes/retained_mode/events/project_events.py
+++ b/src/griptape_nodes/retained_mode/events/project_events.py
@@ -372,7 +372,13 @@ class GetPathForMacroResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess
     """Path resolved successfully from macro.
 
     Args:
-        resolved_path: The relative project path after macro substitution (e.g., "outputs/file.png")
+        resolved_path: The macro string after substitution (e.g., "outputs/file.png"). Relative
+            when the macro resolves relatively, and absolute when a directory or builtin it
+            references resolves to an absolute path -- the v1 default directories anchor on
+            `{workflow_dir}`, so they resolve absolutely. Do NOT join this onto another root to
+            relocate a file: `Path.__truediv__` discards the left operand when the right side is
+            absolute, so the join silently yields the original path. Use `absolute_path` and
+            re-anchor it against the root you are relocating from.
         absolute_path: The absolute filesystem path (e.g., "/workspace/outputs/file.png")
     """
 

--- a/src/griptape_nodes/retained_mode/publishing/workflow_packager.py
+++ b/src/griptape_nodes/retained_mode/publishing/workflow_packager.py
@@ -19,7 +19,7 @@ import uuid
 from contextlib import contextmanager
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, NoReturn
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, NoReturn
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 
@@ -87,6 +87,18 @@ DOWNLOAD_MODELS_SCRIPT_NAME = "download_models.py"
 DOWNLOAD_MODELS_TEMPLATE_NAME = "download_models_script.py"
 
 # TODO: Read and write operations should all be using ReadtoFile and WriteToFile.  https://github.com/griptape-ai/griptape-nodes/issues/4397
+
+
+class ResolvedFileReference(NamedTuple):
+    """A static file reference resolved for bundling.
+
+    Attributes:
+        absolute_path: Where the file lives now, on the publishing machine.
+        bundle_relative_path: Where it belongs inside the bundle, relative to the bundle root.
+    """
+
+    absolute_path: Path
+    bundle_relative_path: Path
 
 
 class WorkflowPackager:
@@ -569,48 +581,128 @@ dependencies = [
         return results
 
     @staticmethod
-    def _resolve_file_reference(value_str: str, project_root: Path | None) -> tuple[Path, Path] | None:
-        """Resolve a file reference to (absolute_path, relative_path) or None."""
+    def _resolve_file_reference(value_str: str, anchors: list[Path]) -> ResolvedFileReference | None:
+        """Resolve a file reference to its source path and its place in the bundle, or None."""
         from griptape_nodes.common.macro_parser import ParsedMacro
 
+        absolute_path: Path | None = None
         try:
             parsed = ParsedMacro(value_str)
             resolve_result = GriptapeNodes.handle_request(GetPathForMacroRequest(parsed_macro=parsed, variables={}))
             if isinstance(resolve_result, GetPathForMacroResultSuccess):
-                return resolve_result.absolute_path, resolve_result.resolved_path
+                absolute_path = resolve_result.absolute_path
         except Exception:
             logger.debug("Macro resolution failed for %r; falling back to path resolution.", value_str, exc_info=True)
 
-        candidate = Path(value_str)
-        if candidate.is_absolute() and project_root and candidate.is_relative_to(project_root):
-            return candidate, candidate.relative_to(project_root)
+        if absolute_path is None:
+            candidate = Path(value_str)
+            if not candidate.is_absolute():
+                return None
+            absolute_path = candidate
 
-        return None
+        # Derived from absolute_path, never from GetPathForMacroResultSuccess.resolved_path.
+        # That field holds the macro string after substitution, which is absolute whenever a
+        # directory macro is absolute-rooted -- the v1 defaults anchor `inputs` and `outputs`
+        # on `{workflow_dir}`. Joining an absolute path onto the bundle destination discards
+        # the destination, so every macro-referenced dependency silently missed the bundle.
+        bundle_relative_path = WorkflowPackager._bundle_relative_path(absolute_path, anchors)
+        if bundle_relative_path is None:
+            return None
 
-    def copy_static_files(self, file_param_values: list[tuple[str, str]], destination: Path) -> None:
-        """Resolve file references and copy them to the destination."""
-        copied: set[Path] = set()
+        return ResolvedFileReference(absolute_path=absolute_path, bundle_relative_path=bundle_relative_path)
+
+    @staticmethod
+    def _bundle_relative_path(absolute_path: Path, anchors: list[Path]) -> Path | None:
+        """Locate a file under the anchor that becomes the bundle root, or None if under none.
+
+        Publishing collapses every anchor a reference can be rooted at onto one directory: the
+        workflow file is copied to the bundle root, ``project.yml`` is written beside it, and
+        the bundle's config points ``workspace_directory`` at the same place. Stripping the
+        anchor a file sits under therefore reproduces the path the bundle's own macro
+        resolution looks for when the published workflow runs.
+
+        The longest matching anchor wins, so a workflow saved in a subdirectory of the
+        workspace resolves against its own directory rather than the workspace root.
+
+        A file under no anchor at all has nowhere to live in the bundle -- an external volume
+        or network mount resolves to the same absolute path wherever the bundle runs, so there
+        is no bundle-relative location to copy it to.
+        """
+        canonical_path = canonicalize_for_identity(absolute_path)
+
+        best_relative_path: Path | None = None
+        best_anchor_depth = -1
+        for anchor in anchors:
+            canonical_anchor = canonicalize_for_identity(anchor)
+            if not canonical_path.is_relative_to(canonical_anchor):
+                continue
+            anchor_depth = len(canonical_anchor.parts)
+            if anchor_depth > best_anchor_depth:
+                best_anchor_depth = anchor_depth
+                best_relative_path = canonical_path.relative_to(canonical_anchor)
+
+        return best_relative_path
+
+    @staticmethod
+    def _publish_anchors(workflow_dir: Path) -> list[Path]:
+        """Collect the directories a static file reference can be rooted at.
+
+        The workflow directory, the workspace, and the project base directory all become the
+        bundle root once published, so a file under any of them has a place in the bundle. An
+        anchor that cannot be determined is simply absent.
+        """
+        anchors = [workflow_dir, GriptapeNodes.ConfigManager().workspace_path]
 
         project_result = GriptapeNodes.handle_request(GetCurrentProjectRequest())
-        project_root: Path | None = None
         if isinstance(project_result, GetCurrentProjectResultSuccess):
-            project_root = project_result.project_info.project_base_dir
+            anchors.append(project_result.project_info.project_base_dir)
+
+        return anchors
+
+    def copy_static_files(
+        self, file_param_values: list[tuple[str, str]], destination: Path, workflow_dir: Path
+    ) -> None:
+        """Resolve file references and copy them to the destination.
+
+        Args:
+            file_param_values: (node_name, file_reference) pairs to bundle.
+            destination: The bundle directory to copy into.
+            workflow_dir: Directory holding the workflow being packaged. Taken from the
+                workflow rather than the live ``{workflow_dir}`` context so the anchor a
+                reference is resolved against is the one being published.
+        """
+        copied: set[Path] = set()
+        anchors = self._publish_anchors(workflow_dir)
+        unbundled: list[str] = []
 
         for node_name, value_str in file_param_values:
-            resolved = self._resolve_file_reference(value_str, project_root)
+            resolved = self._resolve_file_reference(value_str, anchors)
             if resolved is None:
-                msg = f"Couldn't resolve file reference for {node_name}. It will not be bundled."
-                logger.warning(msg)
+                unbundled.append(value_str)
+                logger.warning(
+                    "File '%s' for node '%s' does not resolve to a location inside the project, "
+                    "so there is nowhere in the bundle to put it. It will not be bundled.",
+                    value_str,
+                    node_name,
+                )
                 continue
 
-            absolute_path, resolved_relative = resolved
+            absolute_path = resolved.absolute_path
 
-            if not absolute_path.exists() or absolute_path in copied:
-                msg = f"Couldn't resolve file reference for {node_name}. The absolute path does not exist. It will not be bundled."
-                logger.warning(msg)
+            if not absolute_path.exists():
+                unbundled.append(value_str)
+                logger.warning(
+                    "File '%s' for node '%s' does not exist at '%s'. It will not be bundled.",
+                    value_str,
+                    node_name,
+                    absolute_path,
+                )
                 continue
 
-            dest = destination / resolved_relative
+            if absolute_path in copied:
+                continue
+
+            dest = destination / resolved.bundle_relative_path
 
             # The destination can resolve to the same file as the source when the package
             # destination lives inside the project root (e.g. the Nuke publisher writes the
@@ -631,6 +723,12 @@ dependencies = [
 
             copied.add(absolute_path)
             logger.info("Copied static file for node '%s': %s -> %s", node_name, absolute_path, dest)
+
+        # Reported alongside the publish rather than left to the log: a dependency that
+        # missed the bundle only surfaces when the published workflow runs, far from the
+        # publish that caused it.
+        if unbundled:
+            self.emit_progress(0.0, f"{len(unbundled)} file dependencies not bundled: {', '.join(unbundled)}")
 
     # -- HuggingFace model download --
 
@@ -922,7 +1020,7 @@ dependencies = [
         all_nodes = self.collect_all_nodes()
         file_refs = self.gather_static_file_references(all_nodes)
         if file_refs:
-            self.copy_static_files(file_refs, destination)
+            self.copy_static_files(file_refs, destination, Path(full_path).parent)
 
         # Write HuggingFace model download script if needed
         self.emit_progress(3.0, "Checking for HuggingFace model dependencies...")

--- a/src/griptape_nodes/retained_mode/publishing/workflow_packager.py
+++ b/src/griptape_nodes/retained_mode/publishing/workflow_packager.py
@@ -25,9 +25,14 @@ from urllib.request import url2pathname
 
 from dotenv.main import DotEnv
 
+from griptape_nodes.common.macro_parser import MacroSyntaxError, ParsedMacro
 from griptape_nodes.exe_types.node_groups.base_node_group import BaseNodeGroup
 from griptape_nodes.exe_types.param_components.huggingface.huggingface_model_parameter import HuggingFaceModelParameter
-from griptape_nodes.files.path_utils import canonicalize_for_identity, resolve_path_safely
+from griptape_nodes.files.path_utils import (
+    canonicalize_for_identity,
+    resolve_path_safely,
+    strip_windows_long_path_prefix,
+)
 from griptape_nodes.node_library.library_registry import LibraryNameAndVersion, LibraryRegistry
 from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
 from griptape_nodes.retained_mode.events.app_events import (
@@ -60,7 +65,6 @@ from griptape_nodes.retained_mode.events.project_events import (
     GetCurrentProjectRequest,
     GetCurrentProjectResultSuccess,
     GetPathForMacroRequest,
-    GetPathForMacroResultFailure,
     GetPathForMacroResultSuccess,
 )
 from griptape_nodes.retained_mode.events.secrets_events import (
@@ -86,6 +90,10 @@ SELECT_FROM_PROJECT_PARAM_NAME = "selected_path"
 # Model download script written into the bundle, and run by consumers when present
 DOWNLOAD_MODELS_SCRIPT_NAME = "download_models.py"
 DOWNLOAD_MODELS_TEMPLATE_NAME = "download_models_script.py"
+
+# Resolved to locate the workflow's own directory, one of the anchors a static file reference
+# can be rooted at.
+WORKFLOW_DIR_MACRO = "{workflow_dir}"
 
 # TODO: Read and write operations should all be using ReadtoFile and WriteToFile.  https://github.com/griptape-ai/griptape-nodes/issues/4397
 
@@ -590,7 +598,11 @@ dependencies = [
             deps = node.get_node_dependencies()
             if deps is None:
                 continue
-            for file_ref in deps.static_files:
+            # Sorted because static_files is a set: when two references land on the same place in
+            # the bundle only the first is copied, and set iteration order varies between
+            # processes, so without this two publishes of one workflow can ship different bytes
+            # at the same bundle path.
+            for file_ref in sorted(deps.static_files):
                 if file_ref and file_ref not in seen_values:
                     seen_values.add(file_ref)
                     results.append((node.name, file_ref))
@@ -600,45 +612,75 @@ dependencies = [
     @staticmethod
     def _resolve_file_reference(value_str: str, anchors: list[Path]) -> FileReferenceOutcome:
         """Resolve a file reference to its source path and its place in the bundle."""
-        from griptape_nodes.common.macro_parser import ParsedMacro
-
         absolute_path: Path | None = None
+        bundle_relative_path: Path | None = None
         macro_failure: str | None = None
+
+        parsed: ParsedMacro | None = None
         try:
             parsed = ParsedMacro(value_str)
+        except MacroSyntaxError:
+            logger.debug("Could not parse %r as a macro; treating it as a plain path.", value_str, exc_info=True)
+            macro_failure = "it is not valid macro syntax"
+
+        if parsed is not None:
             resolve_result = GriptapeNodes.handle_request(GetPathForMacroRequest(parsed_macro=parsed, variables={}))
             if isinstance(resolve_result, GetPathForMacroResultSuccess):
                 absolute_path = resolve_result.absolute_path
-            elif isinstance(resolve_result, GetPathForMacroResultFailure):
-                macro_failure = f"its macro could not be resolved ({resolve_result.failure_reason})"
-                if resolve_result.missing_variables:
-                    macro_failure += f", with no value for {', '.join(sorted(resolve_result.missing_variables))}"
-        except Exception:
-            logger.debug("Macro resolution failed for %r; falling back to path resolution.", value_str, exc_info=True)
-            macro_failure = "its macro could not be parsed"
+                # A RELATIVE resolved_path that the resolver did nothing but join onto the
+                # workspace is already the destination the bundle will look in, and is
+                # authoritative: the bundle's workspace IS the bundle root. Anchor-stripping must
+                # not second-guess it -- for a workflow saved inside a directory that also
+                # contains the file, the deepest anchor is the workflow's folder, which would
+                # drop a leading path segment the run time still expects.
+                if not resolve_result.resolved_path.is_absolute() and WorkflowPackager._is_joined_suffix(
+                    resolve_result.absolute_path, resolve_result.resolved_path
+                ):
+                    bundle_relative_path = resolve_result.resolved_path
+            else:
+                # result_details carries the artist-readable reason ProjectManager built --
+                # which directory or builtin failed, and why. failure_reason alone would say
+                # only MACRO_RESOLUTION_ERROR.
+                macro_failure = f"its macro could not be resolved ({resolve_result.result_details})"
 
         # A value the macro layer rejected can still be a usable path -- an absolute Windows
-        # path is not valid macro syntax -- so the macro failure is only reported if the
-        # fallback cannot use it either.
+        # path is not valid macro syntax, and resolution can fail for reasons unrelated to the
+        # value itself, such as there being no current project. But a macro that NAMES variables
+        # and failed to resolve still carries its braces, so it can never be a usable path:
+        # taking it as one reports a location instead of the variable that had no value.
         if absolute_path is None:
             candidate = Path(value_str)
-            if not candidate.is_absolute():
+            names_variables = parsed is not None and bool(parsed.get_variables())
+            if names_variables or not candidate.is_absolute():
                 return FileReferenceOutcome(
                     reference=None,
                     failure=macro_failure or "it is neither a resolvable macro nor an absolute path",
                 )
             absolute_path = candidate
 
-        # Derived from absolute_path, never from GetPathForMacroResultSuccess.resolved_path.
-        # That field holds the macro string after substitution, which is absolute whenever a
+        # Otherwise derived from absolute_path, and never from an ABSOLUTE resolved_path: that
+        # field holds the macro string after substitution, which is absolute whenever a
         # directory macro is absolute-rooted -- the v1 defaults anchor `inputs` and `outputs`
         # on `{workflow_dir}`. Joining an absolute path onto the bundle destination discards
         # the destination, so every macro-referenced dependency silently missed the bundle.
-        bundle_relative_path = WorkflowPackager._bundle_relative_path(absolute_path, anchors)
+        # Checked before either way of deriving the destination, so it holds for a reference that
+        # resolved relatively as much as one that was anchor-stripped: naming an anchor names the
+        # folder the bundle replaces, not something inside it.
+        if WorkflowPackager._matches_an_anchor(absolute_path, anchors):
+            return FileReferenceOutcome(
+                reference=None,
+                failure=(
+                    f"it resolves to '{absolute_path}', which is the folder the bundle itself "
+                    f"replaces rather than something inside it"
+                ),
+            )
+
+        if bundle_relative_path is None:
+            bundle_relative_path = WorkflowPackager._bundle_relative_path(absolute_path, anchors)
         if bundle_relative_path is None:
             return FileReferenceOutcome(
                 reference=None,
-                failure=f"it resolves to '{absolute_path}', which is outside the project",
+                failure=(f"it resolves to '{absolute_path}', which is outside the folders that travel with the bundle"),
             )
 
         return FileReferenceOutcome(
@@ -647,75 +689,160 @@ dependencies = [
         )
 
     @staticmethod
+    def _is_joined_suffix(absolute_path: Path, relative_path: Path) -> bool:
+        """Whether ``absolute_path`` is ``relative_path`` joined onto a root and nothing more.
+
+        The resolver expands ``~`` and environment variables and collapses ``..`` while building
+        the absolute path, but leaves the substituted string it returns alone. Both ``../out/x.png``
+        and ``~/media/x.png`` are therefore "relative" while naming somewhere the bundle has no
+        say over: joining either onto the bundle destination writes outside the bundle, or creates
+        a literal ``~`` directory inside it. Comparing the tail proves the join was all that
+        happened, so a reference that needs real anchor-stripping falls through to it.
+        """
+        relative_parts = relative_path.parts
+        if not relative_parts:
+            return False
+        return absolute_path.parts[-len(relative_parts) :] == relative_parts
+
+    @staticmethod
     def _bundle_relative_path(absolute_path: Path, anchors: list[Path]) -> Path | None:
         """Locate a file under the anchor that becomes the bundle root, or None if under none.
 
         Publishing collapses every anchor a reference can be rooted at onto one directory: the
-        workflow file is copied to the bundle root, ``project.yml`` is written beside it, and
-        the bundle's config points ``workspace_directory`` at the same place. Stripping the
+        workflow file is copied to the bundle root, the project template is written beside it,
+        and the bundle's config points ``workspace_directory`` at the same place. Stripping the
         anchor a file sits under therefore reproduces the path the bundle's own macro
         resolution looks for when the published workflow runs.
 
         The longest matching anchor wins, so a workflow saved in a subdirectory of the
         workspace resolves against its own directory rather than the workspace root.
 
+        Known limitation: the substituted path alone cannot say which anchor a directory macro
+        was rooted on, and the deepest containing anchor is only a very good guess. It is right
+        for every directory in the v0 and v1 defaults, but a hand-written macro naming a path
+        inside the workflow's own folder from the workspace -- ``plates:
+        "{workspace_dir}/shots/plates"`` with the workflow saved in ``shots`` -- is stripped
+        against the workflow folder and bundled a level too shallow. Distinguishing them needs
+        the directory's own ``path_macro``, which lives in the project layer.
+
+        A reference that IS an anchor rather than something inside one gets None, even when a
+        shallower anchor could place it. Every anchor collapses onto the bundle root, so
+        `{workflow_dir}` resolves there when the published workflow runs and a copy made under
+        the shallower anchor's name is somewhere nothing looks. Worse, when the bundle is written
+        inside the referenced folder -- which the Nuke publisher does deliberately -- the
+        destination sits inside the source, and ``copy_tree`` walks the source lazily while
+        creating directories in it, so the copy never terminates. Refusing is the safer failure.
+        ``_resolve_file_reference`` tests for that case ahead of this call to say so specifically;
+        the refusal is repeated here so it holds for any caller that does not.
+
         A file under no anchor at all has nowhere to live in the bundle -- an external volume
         or network mount resolves to the same absolute path wherever the bundle runs, so there
         is no bundle-relative location to copy it to.
 
-        Matched on logically normalized paths, NOT symlink-resolved ones, which is why this
-        uses ``resolve_path_safely`` rather than ``canonicalize_for_identity``. A project that
-        symlinks a media directory onto shared storage is an ordinary setup, and following the
-        link would take `{inputs}/image.jpg` to the storage mount, match no anchor, and report
-        a file plainly inside the project as being outside it. Bundling through the link is
-        also the better outcome: the copy makes the bundle self-contained. This matches how
-        ``ProjectManager`` inverts an absolute path back to macro form.
+        Tried without following symlinks first, then with. A project that symlinks a media
+        directory onto shared storage is an ordinary setup, and following the link on the first
+        pass would take `{inputs}/image.jpg` to the storage mount, match no anchor, and report a
+        file plainly inside the project as being outside it -- so the logical spelling wins when
+        it matches. The symlink-resolved pass then catches the opposite case, where an anchor
+        and the path reach the same directory by different spellings (``workspace_path``
+        resolves symlinks, a ``{workflow_dir}`` path does not), which would otherwise drop every
+        dependency in a workspace reached through a symlinked parent.
         """
-        normalized_path = resolve_path_safely(absolute_path)
+        logical_match = WorkflowPackager._strip_longest_anchor(absolute_path, anchors, follow_symlinks=False)
+        if logical_match is not None:
+            return logical_match
+        return WorkflowPackager._strip_longest_anchor(absolute_path, anchors, follow_symlinks=True)
+
+    @staticmethod
+    def _strip_longest_anchor(absolute_path: Path, anchors: list[Path], *, follow_symlinks: bool) -> Path | None:
+        """Strip the deepest anchor containing ``absolute_path``, under one normalization.
+
+        None when the deepest match leaves nothing to strip, i.e. the path IS that anchor. A
+        shallower anchor is deliberately NOT tried in that case, so no caller can be handed
+        ``Path(".")`` and turn it into a copy of a whole anchor into the bundle root.
+        """
+        normalize = canonicalize_for_identity if follow_symlinks else resolve_path_safely
+        normalized_path = WorkflowPackager._comparable(normalize(absolute_path))
 
         best_relative_path: Path | None = None
         best_anchor_depth = -1
         for anchor in anchors:
-            normalized_anchor = resolve_path_safely(anchor)
+            normalized_anchor = WorkflowPackager._comparable(normalize(anchor))
             if not normalized_path.is_relative_to(normalized_anchor):
                 continue
+            relative_path = normalized_path.relative_to(normalized_anchor)
             anchor_depth = len(normalized_anchor.parts)
             if anchor_depth > best_anchor_depth:
                 best_anchor_depth = anchor_depth
-                best_relative_path = normalized_path.relative_to(normalized_anchor)
+                best_relative_path = relative_path
+
+        if best_relative_path == Path():
+            return None
 
         return best_relative_path
 
     @staticmethod
-    def _publish_anchors(workflow_dir: Path) -> list[Path]:
+    def _matches_an_anchor(absolute_path: Path, anchors: list[Path]) -> bool:
+        """Whether the reference names an anchor itself rather than something inside one.
+
+        Separates "the bundle replaces this folder" from "this is somewhere the bundle does not
+        reach": both leave nothing to copy, but only the second is the user's to act on.
+        """
+        for follow_symlinks in (False, True):
+            normalize = canonicalize_for_identity if follow_symlinks else resolve_path_safely
+            normalized_path = WorkflowPackager._comparable(normalize(absolute_path))
+            if any(normalized_path == WorkflowPackager._comparable(normalize(anchor)) for anchor in anchors):
+                return True
+        return False
+
+    @staticmethod
+    def _comparable(path: Path) -> Path:
+        r"""Strip the Windows long-path prefix so containment checks are meaningful.
+
+        ``\\?\`` changes a path's anchor rather than just its spelling, so
+        ``relative_to`` raises for a file that is plainly inside a directory when only one
+        side carries it. Both sides go through here before being compared.
+        """
+        return Path(strip_windows_long_path_prefix(path))
+
+    @staticmethod
+    def _publish_anchors() -> list[Path]:
         """Collect the directories a static file reference can be rooted at.
 
         The workflow directory, the workspace, and the project base directory all become the
         bundle root once published, so a file under any of them has a place in the bundle. An
         anchor that cannot be determined is simply absent.
+
+        ``{workflow_dir}`` is resolved through the same request the references themselves go
+        through, rather than passed in, so the anchor is spelled exactly like the paths being
+        matched against it and always belongs to the workflow whose references are being
+        resolved.
         """
-        anchors = [workflow_dir, GriptapeNodes.ConfigManager().workspace_path]
+        anchors = [GriptapeNodes.ConfigManager().workspace_path]
 
         project_result = GriptapeNodes.handle_request(GetCurrentProjectRequest())
         if isinstance(project_result, GetCurrentProjectResultSuccess):
             anchors.append(project_result.project_info.project_base_dir)
 
+        workflow_dir_result = GriptapeNodes.handle_request(
+            GetPathForMacroRequest(parsed_macro=ParsedMacro(WORKFLOW_DIR_MACRO), variables={})
+        )
+        if isinstance(workflow_dir_result, GetPathForMacroResultSuccess):
+            anchors.append(workflow_dir_result.absolute_path)
+        else:
+            # Expected whenever the workflow has not been saved; the remaining anchors still
+            # place anything under the workspace or the project.
+            logger.debug("Could not resolve %s as a publish anchor: %s", WORKFLOW_DIR_MACRO, workflow_dir_result)
+
         return anchors
 
-    def copy_static_files(
-        self, file_param_values: list[tuple[str, str]], destination: Path, workflow_dir: Path
-    ) -> None:
-        """Resolve file references and copy them to the destination.
-
-        Args:
-            file_param_values: (node_name, file_reference) pairs to bundle.
-            destination: The bundle directory to copy into.
-            workflow_dir: Directory holding the workflow being packaged. Taken from the
-                workflow rather than the live ``{workflow_dir}`` context so the anchor a
-                reference is resolved against is the one being published.
-        """
-        copied: set[Path] = set()
-        anchors = self._publish_anchors(workflow_dir)
+    def copy_static_files(self, file_param_values: list[tuple[str, str]], destination: Path) -> None:
+        """Resolve file references and copy them to the destination."""
+        # Keyed on where a file lands in the bundle rather than where it came from: one source
+        # can legitimately need two destinations (one reference resolving relatively, another
+        # anchor-stripped), and keying on the source would bundle only the first of them.
+        claimed_destinations: dict[Path, Path] = {}
+        anchors = self._publish_anchors()
 
         for node_name, value_str in file_param_values:
             outcome = self._resolve_file_reference(value_str, anchors)
@@ -729,6 +856,7 @@ dependencies = [
                 continue
 
             absolute_path = outcome.reference.absolute_path
+            identity = canonicalize_for_identity(absolute_path)
 
             if not absolute_path.exists():
                 logger.warning(
@@ -739,30 +867,60 @@ dependencies = [
                 )
                 continue
 
-            if absolute_path in copied:
+            bundle_relative_path = outcome.reference.bundle_relative_path
+            previous_source = claimed_destinations.get(bundle_relative_path)
+            if previous_source == identity:
                 logger.debug("Static file for node '%s' was already bundled: %s", node_name, absolute_path)
                 continue
+            # Every anchor collapses onto the bundle root, so two DIFFERENT files can want the
+            # same place in the bundle. They would also resolve to that one place when the
+            # published workflow runs, so the collision cannot be fixed by moving either copy --
+            # but it must not pass silently, since one node then reads the other node's file.
+            # The first claim is kept so the outcome does not depend on node iteration order.
+            if previous_source is not None:
+                logger.warning(
+                    "Files '%s' and '%s' both belong at '%s' in the bundle. Only the first is "
+                    "bundled, so a node may read the wrong file in the published workflow.",
+                    previous_source,
+                    absolute_path,
+                    bundle_relative_path,
+                )
+                continue
+            claimed_destinations[bundle_relative_path] = identity
 
-            dest = destination / outcome.reference.bundle_relative_path
+            dest = destination / bundle_relative_path
 
             # The destination can resolve to the same file as the source when the package
             # destination lives inside the project root (e.g. the Nuke publisher writes the
             # bundle next to files the workflow already references). Copying a file onto
             # itself raises SameFileError, so treat it as already-in-place and skip.
-            if canonicalize_for_identity(absolute_path) == canonicalize_for_identity(dest):
-                copied.add(absolute_path)
+            if identity == canonicalize_for_identity(dest):
                 logger.info(
                     "Static file for node '%s' is already in place; skipping copy: %s", node_name, absolute_path
                 )
                 continue
 
             if absolute_path.is_dir():
+                # A destination inside the source does not terminate: OSManager walks the source
+                # with a lazy os.walk while creating directories in it, so it keeps descending
+                # into what it just wrote. Reachable whenever a publisher writes the bundle
+                # inside a folder a node references, which the Nuke publisher does deliberately.
+                # Checked on the destination rather than on anchor identity, so it also covers a
+                # referenced folder that is no anchor but still contains the bundle.
+                if canonicalize_for_identity(dest).is_relative_to(identity):
+                    logger.warning(
+                        "Directory '%s' for node '%s' will not be bundled because the bundle is "
+                        "being written inside it, at '%s'.",
+                        value_str,
+                        node_name,
+                        dest,
+                    )
+                    continue
                 self.copy_tree(absolute_path, dest)
             else:
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 self.copy_file(absolute_path, dest)
 
-            copied.add(absolute_path)
             logger.info("Copied static file for node '%s': %s -> %s", node_name, absolute_path, dest)
 
     # -- HuggingFace model download --
@@ -1055,7 +1213,7 @@ dependencies = [
         all_nodes = self.collect_all_nodes()
         file_refs = self.gather_static_file_references(all_nodes)
         if file_refs:
-            self.copy_static_files(file_refs, destination, Path(full_path).parent)
+            self.copy_static_files(file_refs, destination)
 
         # Write HuggingFace model download script if needed
         self.emit_progress(3.0, "Checking for HuggingFace model dependencies...")

--- a/src/griptape_nodes/retained_mode/publishing/workflow_packager.py
+++ b/src/griptape_nodes/retained_mode/publishing/workflow_packager.py
@@ -27,7 +27,7 @@ from dotenv.main import DotEnv
 
 from griptape_nodes.exe_types.node_groups.base_node_group import BaseNodeGroup
 from griptape_nodes.exe_types.param_components.huggingface.huggingface_model_parameter import HuggingFaceModelParameter
-from griptape_nodes.files.path_utils import canonicalize_for_identity
+from griptape_nodes.files.path_utils import canonicalize_for_identity, resolve_path_safely
 from griptape_nodes.node_library.library_registry import LibraryNameAndVersion, LibraryRegistry
 from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
 from griptape_nodes.retained_mode.events.app_events import (
@@ -60,6 +60,7 @@ from griptape_nodes.retained_mode.events.project_events import (
     GetCurrentProjectRequest,
     GetCurrentProjectResultSuccess,
     GetPathForMacroRequest,
+    GetPathForMacroResultFailure,
     GetPathForMacroResultSuccess,
 )
 from griptape_nodes.retained_mode.events.secrets_events import (
@@ -99,6 +100,22 @@ class ResolvedFileReference(NamedTuple):
 
     absolute_path: Path
     bundle_relative_path: Path
+
+
+class FileReferenceOutcome(NamedTuple):
+    """The result of resolving a static file reference for bundling.
+
+    Attributes:
+        reference: The resolved reference, or None when the file cannot be bundled.
+        failure: Why it cannot be bundled, phrased to complete "will not be bundled because
+            ...". None when ``reference`` is set. Carried out to the caller rather than logged
+            here so every "not bundled" line comes from one place, and so the distinct
+            causes -- an unresolvable macro, a path outside the project -- stay distinct
+            instead of collapsing into one message that guesses.
+    """
+
+    reference: ResolvedFileReference | None
+    failure: str | None
 
 
 class WorkflowPackager:
@@ -581,23 +598,35 @@ dependencies = [
         return results
 
     @staticmethod
-    def _resolve_file_reference(value_str: str, anchors: list[Path]) -> ResolvedFileReference | None:
-        """Resolve a file reference to its source path and its place in the bundle, or None."""
+    def _resolve_file_reference(value_str: str, anchors: list[Path]) -> FileReferenceOutcome:
+        """Resolve a file reference to its source path and its place in the bundle."""
         from griptape_nodes.common.macro_parser import ParsedMacro
 
         absolute_path: Path | None = None
+        macro_failure: str | None = None
         try:
             parsed = ParsedMacro(value_str)
             resolve_result = GriptapeNodes.handle_request(GetPathForMacroRequest(parsed_macro=parsed, variables={}))
             if isinstance(resolve_result, GetPathForMacroResultSuccess):
                 absolute_path = resolve_result.absolute_path
+            elif isinstance(resolve_result, GetPathForMacroResultFailure):
+                macro_failure = f"its macro could not be resolved ({resolve_result.failure_reason})"
+                if resolve_result.missing_variables:
+                    macro_failure += f", with no value for {', '.join(sorted(resolve_result.missing_variables))}"
         except Exception:
             logger.debug("Macro resolution failed for %r; falling back to path resolution.", value_str, exc_info=True)
+            macro_failure = "its macro could not be parsed"
 
+        # A value the macro layer rejected can still be a usable path -- an absolute Windows
+        # path is not valid macro syntax -- so the macro failure is only reported if the
+        # fallback cannot use it either.
         if absolute_path is None:
             candidate = Path(value_str)
             if not candidate.is_absolute():
-                return None
+                return FileReferenceOutcome(
+                    reference=None,
+                    failure=macro_failure or "it is neither a resolvable macro nor an absolute path",
+                )
             absolute_path = candidate
 
         # Derived from absolute_path, never from GetPathForMacroResultSuccess.resolved_path.
@@ -607,9 +636,15 @@ dependencies = [
         # the destination, so every macro-referenced dependency silently missed the bundle.
         bundle_relative_path = WorkflowPackager._bundle_relative_path(absolute_path, anchors)
         if bundle_relative_path is None:
-            return None
+            return FileReferenceOutcome(
+                reference=None,
+                failure=f"it resolves to '{absolute_path}', which is outside the project",
+            )
 
-        return ResolvedFileReference(absolute_path=absolute_path, bundle_relative_path=bundle_relative_path)
+        return FileReferenceOutcome(
+            reference=ResolvedFileReference(absolute_path=absolute_path, bundle_relative_path=bundle_relative_path),
+            failure=None,
+        )
 
     @staticmethod
     def _bundle_relative_path(absolute_path: Path, anchors: list[Path]) -> Path | None:
@@ -627,19 +662,27 @@ dependencies = [
         A file under no anchor at all has nowhere to live in the bundle -- an external volume
         or network mount resolves to the same absolute path wherever the bundle runs, so there
         is no bundle-relative location to copy it to.
+
+        Matched on logically normalized paths, NOT symlink-resolved ones, which is why this
+        uses ``resolve_path_safely`` rather than ``canonicalize_for_identity``. A project that
+        symlinks a media directory onto shared storage is an ordinary setup, and following the
+        link would take `{inputs}/image.jpg` to the storage mount, match no anchor, and report
+        a file plainly inside the project as being outside it. Bundling through the link is
+        also the better outcome: the copy makes the bundle self-contained. This matches how
+        ``ProjectManager`` inverts an absolute path back to macro form.
         """
-        canonical_path = canonicalize_for_identity(absolute_path)
+        normalized_path = resolve_path_safely(absolute_path)
 
         best_relative_path: Path | None = None
         best_anchor_depth = -1
         for anchor in anchors:
-            canonical_anchor = canonicalize_for_identity(anchor)
-            if not canonical_path.is_relative_to(canonical_anchor):
+            normalized_anchor = resolve_path_safely(anchor)
+            if not normalized_path.is_relative_to(normalized_anchor):
                 continue
-            anchor_depth = len(canonical_anchor.parts)
+            anchor_depth = len(normalized_anchor.parts)
             if anchor_depth > best_anchor_depth:
                 best_anchor_depth = anchor_depth
-                best_relative_path = canonical_path.relative_to(canonical_anchor)
+                best_relative_path = normalized_path.relative_to(normalized_anchor)
 
         return best_relative_path
 
@@ -673,26 +716,23 @@ dependencies = [
         """
         copied: set[Path] = set()
         anchors = self._publish_anchors(workflow_dir)
-        unbundled: list[str] = []
 
         for node_name, value_str in file_param_values:
-            resolved = self._resolve_file_reference(value_str, anchors)
-            if resolved is None:
-                unbundled.append(value_str)
+            outcome = self._resolve_file_reference(value_str, anchors)
+            if outcome.reference is None:
                 logger.warning(
-                    "File '%s' for node '%s' does not resolve to a location inside the project, "
-                    "so there is nowhere in the bundle to put it. It will not be bundled.",
+                    "File '%s' for node '%s' will not be bundled because %s.",
                     value_str,
                     node_name,
+                    outcome.failure,
                 )
                 continue
 
-            absolute_path = resolved.absolute_path
+            absolute_path = outcome.reference.absolute_path
 
             if not absolute_path.exists():
-                unbundled.append(value_str)
                 logger.warning(
-                    "File '%s' for node '%s' does not exist at '%s'. It will not be bundled.",
+                    "File '%s' for node '%s' will not be bundled because there is no file at '%s'.",
                     value_str,
                     node_name,
                     absolute_path,
@@ -700,9 +740,10 @@ dependencies = [
                 continue
 
             if absolute_path in copied:
+                logger.debug("Static file for node '%s' was already bundled: %s", node_name, absolute_path)
                 continue
 
-            dest = destination / resolved.bundle_relative_path
+            dest = destination / outcome.reference.bundle_relative_path
 
             # The destination can resolve to the same file as the source when the package
             # destination lives inside the project root (e.g. the Nuke publisher writes the
@@ -723,12 +764,6 @@ dependencies = [
 
             copied.add(absolute_path)
             logger.info("Copied static file for node '%s': %s -> %s", node_name, absolute_path, dest)
-
-        # Reported alongside the publish rather than left to the log: a dependency that
-        # missed the bundle only surfaces when the published workflow runs, far from the
-        # publish that caused it.
-        if unbundled:
-            self.emit_progress(0.0, f"{len(unbundled)} file dependencies not bundled: {', '.join(unbundled)}")
 
     # -- HuggingFace model download --
 

--- a/tests/unit/retained_mode/publishing/test_workflow_packager.py
+++ b/tests/unit/retained_mode/publishing/test_workflow_packager.py
@@ -20,6 +20,8 @@ from griptape_nodes.retained_mode.events.os_events import (
     WriteFileResultSuccess,
 )
 from griptape_nodes.retained_mode.events.project_events import (
+    GetCurrentProjectRequest,
+    GetCurrentProjectResultSuccess,
     GetPathForMacroRequest,
     GetPathForMacroResultFailure,
     GetPathForMacroResultSuccess,
@@ -32,6 +34,7 @@ from griptape_nodes.retained_mode.events.secrets_events import (
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.publishing.workflow_packager import (
     DOWNLOAD_MODELS_SCRIPT_NAME,
+    WORKFLOW_DIR_MACRO,
     FileReferenceOutcome,
     ResolvedFileReference,
     WorkflowPackager,
@@ -166,17 +169,34 @@ class TestCollectPipInstallFlagsTransitive:
         assert "--extra-index-url=https://b.example.com" in result
 
 
-def _macro_resolution_patch(resolved_path: Path, absolute_path: Path):  # noqa: ANN202
-    """Patch handle_request so a macro reference resolves to the given pair of paths.
+def _macro_handler(  # noqa: ANN202
+    resolved_path: Path,
+    absolute_path: Path,
+    workflow_dir: Path | None = None,
+):
+    """Build a handle_request stub answering macro resolution for one file reference.
 
     Mirrors ProjectManager.on_get_path_for_macro_request, whose ``resolved_path`` is the macro
     string after substitution: absolute when a directory macro is absolute-rooted, relative
-    otherwise. Any other request returns a MagicMock, so the current-project lookup fails its
-    isinstance check and leaves the project anchor out.
+    otherwise. ``{workflow_dir}`` is answered separately because copy_static_files resolves it
+    on its own to locate the workflow anchor; None makes it unresolvable, as it is for a
+    workflow that has never been saved. Any other request returns a MagicMock, so the
+    current-project lookup fails its isinstance check and leaves the project anchor out.
     """
 
     def handle_request(request: object) -> object:
         if isinstance(request, GetPathForMacroRequest):
+            if request.parsed_macro.template == WORKFLOW_DIR_MACRO:
+                if workflow_dir is None:
+                    return GetPathForMacroResultFailure(
+                        failure_reason=PathResolutionFailureReason.MACRO_RESOLUTION_ERROR,
+                        result_details="no current workflow",
+                    )
+                return GetPathForMacroResultSuccess(
+                    resolved_path=workflow_dir,
+                    absolute_path=workflow_dir,
+                    result_details="resolved",
+                )
             return GetPathForMacroResultSuccess(
                 resolved_path=resolved_path,
                 absolute_path=absolute_path,
@@ -184,10 +204,24 @@ def _macro_resolution_patch(resolved_path: Path, absolute_path: Path):  # noqa: 
             )
         return MagicMock()
 
+    return handle_request
+
+
+def _handle_request_patch(handler):  # noqa: ANN001, ANN202
+    """Patch the packager's handle_request with the given stub."""
     return patch(
         "griptape_nodes.retained_mode.publishing.workflow_packager.GriptapeNodes.handle_request",
-        side_effect=handle_request,
+        side_effect=handler,
     )
+
+
+def _macro_resolution_patch(  # noqa: ANN202
+    resolved_path: Path,
+    absolute_path: Path,
+    workflow_dir: Path | None = None,
+):
+    """Patch handle_request so a macro reference resolves to the given pair of paths."""
+    return _handle_request_patch(_macro_handler(resolved_path, absolute_path, workflow_dir))
 
 
 def _workspace_patch(workspace_dir: Path):  # noqa: ANN202
@@ -216,12 +250,12 @@ class TestCopyStaticFilesBundleDestination:
         destination = tmp_path / "bundle"
 
         with (
-            _macro_resolution_patch(resolved_path=source, absolute_path=source),
+            _macro_resolution_patch(resolved_path=source, absolute_path=source, workflow_dir=workspace),
             _workspace_patch(workspace),
             patch.object(packager, "copy_file") as mock_copy_file,
             patch.object(packager, "copy_tree") as mock_copy_tree,
         ):
-            packager.copy_static_files([("node", "{inputs}/image.jpg")], destination, workspace)
+            packager.copy_static_files([("node", "{inputs}/image.jpg")], destination)
 
         mock_copy_file.assert_called_once_with(source, destination / "inputs" / "image.jpg")
         mock_copy_tree.assert_not_called()
@@ -242,12 +276,12 @@ class TestCopyStaticFilesBundleDestination:
         destination = tmp_path / "bundle"
 
         with (
-            _macro_resolution_patch(resolved_path=source, absolute_path=source),
+            _macro_resolution_patch(resolved_path=source, absolute_path=source, workflow_dir=workflow_dir),
             _workspace_patch(workspace),
             patch.object(packager, "copy_file") as mock_copy_file,
             patch.object(packager, "copy_tree") as mock_copy_tree,
         ):
-            packager.copy_static_files([("node", "{inputs}/image.jpg")], destination, workflow_dir)
+            packager.copy_static_files([("node", "{inputs}/image.jpg")], destination)
 
         mock_copy_file.assert_called_once_with(source, destination / "inputs" / "image.jpg")
         mock_copy_tree.assert_not_called()
@@ -262,15 +296,417 @@ class TestCopyStaticFilesBundleDestination:
         destination = tmp_path / "bundle"
 
         with (
-            _macro_resolution_patch(resolved_path=Path("inputs/image.jpg"), absolute_path=source),
+            _macro_resolution_patch(
+                resolved_path=Path("inputs/image.jpg"), absolute_path=source, workflow_dir=workspace
+            ),
             _workspace_patch(workspace),
             patch.object(packager, "copy_file") as mock_copy_file,
             patch.object(packager, "copy_tree") as mock_copy_tree,
         ):
-            packager.copy_static_files([("node", "inputs/image.jpg")], destination, workspace)
+            packager.copy_static_files([("node", "inputs/image.jpg")], destination)
 
         mock_copy_file.assert_called_once_with(source, destination / "inputs" / "image.jpg")
         mock_copy_tree.assert_not_called()
+
+    def test_relative_resolution_wins_over_a_deeper_anchor(self, tmp_path: Path) -> None:
+        """A workspace-relative reference keeps its own path even when a deeper anchor contains it.
+
+        A v0 project resolves `{outputs}` relative to the workspace. With the workflow saved at
+        `<ws>/outputs/render.py`, the workflow's own directory is the deepest anchor containing
+        the file, and stripping it would drop the `outputs/` segment the bundle still resolves
+        `{outputs}` to.
+        """
+        packager = WorkflowPackager("test_workflow")
+        workspace = tmp_path / "ws"
+        workflow_dir = workspace / "outputs"
+        source = workflow_dir / "plate.png"
+        source.parent.mkdir(parents=True)
+        source.write_text("data")
+        destination = tmp_path / "bundle"
+
+        with (
+            _macro_resolution_patch(
+                resolved_path=Path("outputs/plate.png"), absolute_path=source, workflow_dir=workflow_dir
+            ),
+            _workspace_patch(workspace),
+            patch.object(packager, "copy_file") as mock_copy_file,
+        ):
+            packager.copy_static_files([("node", "{outputs}/plate.png")], destination)
+
+        mock_copy_file.assert_called_once_with(source, destination / "outputs" / "plate.png")
+
+    @pytest.mark.parametrize("escaping_reference", ["../shared/image.jpg", "~/media/image.jpg"])
+    def test_does_not_write_outside_the_bundle_for_an_escaping_reference(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture, escaping_reference: str
+    ) -> None:
+        """A relative reference the resolver rewrote is anchor-checked, not trusted verbatim.
+
+        `..` and `~` are both "relative" but name somewhere the bundle has no say over. Joining
+        either onto the destination writes outside the bundle, or creates a literal `~` inside
+        it, and reports the dependency as bundled either way.
+        """
+        packager = WorkflowPackager("test_workflow")
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        source = tmp_path / "shared" / "image.jpg"
+        source.parent.mkdir(parents=True)
+        source.write_text("data")
+        destination = tmp_path / "bundle"
+
+        with (
+            # resolved_path keeps the raw substituted string; absolute_path is what the resolver
+            # made of it, exactly as ProjectManager returns them.
+            _macro_resolution_patch(
+                resolved_path=Path(escaping_reference), absolute_path=source, workflow_dir=workspace
+            ),
+            _workspace_patch(workspace),
+            patch.object(packager, "copy_file") as mock_copy_file,
+            caplog.at_level(logging.WARNING, logger="workflow_packager"),
+        ):
+            packager.copy_static_files([("node", escaping_reference)], destination)
+
+        mock_copy_file.assert_not_called()
+        assert "outside the folders that travel with the bundle" in caplog.text
+
+    def test_bundles_one_source_needed_at_two_destinations(self, tmp_path: Path) -> None:
+        """A file two references place differently is copied to both places.
+
+        One reference can resolve relatively and another be anchor-stripped, so the same source
+        legitimately has two homes in the bundle. Skipping by source would bundle only the first.
+        """
+        packager = WorkflowPackager("test_workflow")
+        workspace = tmp_path / "ws"
+        workflow_dir = workspace / "shots"
+        source = workflow_dir / "inputs" / "image.jpg"
+        source.parent.mkdir(parents=True)
+        source.write_text("data")
+        destination = tmp_path / "bundle"
+
+        def handle_request(request: object) -> object:
+            if isinstance(request, GetPathForMacroRequest):
+                template = request.parsed_macro.template
+                if template == WORKFLOW_DIR_MACRO:
+                    return GetPathForMacroResultSuccess(
+                        resolved_path=workflow_dir, absolute_path=workflow_dir, result_details="resolved"
+                    )
+                # The plain relative spelling stays relative through substitution; the macro
+                # spelling resolves absolutely against the workflow directory.
+                resolved = Path("shots/inputs/image.jpg") if template.startswith("shots/") else source
+                return GetPathForMacroResultSuccess(
+                    resolved_path=resolved, absolute_path=source, result_details="resolved"
+                )
+            return MagicMock()
+
+        with (
+            _handle_request_patch(handle_request),
+            _workspace_patch(workspace),
+            patch.object(packager, "copy_file") as mock_copy_file,
+        ):
+            packager.copy_static_files([("a", "shots/inputs/image.jpg"), ("b", "{inputs}/image.jpg")], destination)
+
+        destinations = {call.args[1] for call in mock_copy_file.call_args_list}
+        assert destinations == {
+            destination / "shots" / "inputs" / "image.jpg",
+            destination / "inputs" / "image.jpg",
+        }
+
+    def test_refuses_an_anchor_reference_even_when_a_shallower_anchor_exists(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A reference equal to the workflow directory is refused, not placed under the workspace.
+
+        Every anchor collapses onto the bundle root, so `{workflow_dir}` resolves there when the
+        published workflow runs and a copy under the workspace-relative name (`shots/`) is
+        somewhere nothing looks. It is also the shape that makes `copy_tree` walk a source
+        containing its own destination when the bundle is written inside that folder.
+        """
+        packager = WorkflowPackager("test_workflow")
+        workspace = tmp_path / "ws"
+        workflow_dir = workspace / "shots"
+        workflow_dir.mkdir(parents=True)
+        destination = workflow_dir / "bundle"
+
+        with (
+            _macro_resolution_patch(resolved_path=workflow_dir, absolute_path=workflow_dir, workflow_dir=workflow_dir),
+            _workspace_patch(workspace),
+            patch.object(packager, "copy_tree") as mock_copy_tree,
+            patch.object(packager, "copy_file") as mock_copy_file,
+            caplog.at_level(logging.WARNING, logger="workflow_packager"),
+        ):
+            packager.copy_static_files([("node", "{workflow_dir}")], destination)
+
+        mock_copy_tree.assert_not_called()
+        mock_copy_file.assert_not_called()
+        assert "the folder the bundle itself replaces" in caplog.text
+
+    def test_refuses_a_relatively_resolved_reference_that_is_an_anchor(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The anchor refusal holds for a reference that resolved relatively, not just absolutely.
+
+        A v0 project resolves `shots` against the workspace onto the workflow's own directory, so
+        the relative shortcut supplies the destination and would otherwise reach `copy_tree`.
+        """
+        packager = WorkflowPackager("test_workflow")
+        workspace = tmp_path / "ws"
+        workflow_dir = workspace / "shots"
+        workflow_dir.mkdir(parents=True)
+        destination = workflow_dir / "bundle"
+
+        with (
+            _macro_resolution_patch(resolved_path=Path("shots"), absolute_path=workflow_dir, workflow_dir=workflow_dir),
+            _workspace_patch(workspace),
+            patch.object(packager, "copy_tree") as mock_copy_tree,
+            caplog.at_level(logging.WARNING, logger="workflow_packager"),
+        ):
+            packager.copy_static_files([("node", "shots")], destination)
+
+        mock_copy_tree.assert_not_called()
+        assert "the folder the bundle itself replaces" in caplog.text
+
+    def test_refuses_a_directory_that_contains_the_bundle(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A referenced directory the bundle is written inside is refused, anchor or not.
+
+        `copy_tree` walks the source lazily while creating directories in it, so copying a folder
+        into a bundle nested inside that folder never terminates. `{outputs}` is no anchor, so no
+        anchor comparison can catch this one.
+        """
+        packager = WorkflowPackager("test_workflow")
+        workspace = tmp_path / "ws"
+        source = workspace / "outputs"
+        source.mkdir(parents=True)
+        destination = source / "mybundle"
+
+        with (
+            _macro_resolution_patch(resolved_path=source, absolute_path=source, workflow_dir=workspace),
+            _workspace_patch(workspace),
+            patch.object(packager, "copy_tree") as mock_copy_tree,
+            caplog.at_level(logging.WARNING, logger="workflow_packager"),
+        ):
+            packager.copy_static_files([("node", "{outputs}")], destination)
+
+        mock_copy_tree.assert_not_called()
+        assert "the bundle is being written inside it" in caplog.text
+
+    def test_reports_an_unresolvable_absolute_macro_by_its_cause(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An absolute macro with an unset variable names the variable, not a location.
+
+        The string still carries its braces, so treating it as a plain absolute path would report
+        where it "resolves to" and bury the reason.
+        """
+        packager = WorkflowPackager("test_workflow")
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        destination = tmp_path / "bundle"
+
+        def handle_request(request: object) -> object:
+            if isinstance(request, GetPathForMacroRequest):
+                return GetPathForMacroResultFailure(
+                    failure_reason=PathResolutionFailureReason.MISSING_REQUIRED_VARIABLES,
+                    missing_variables={"shot"},
+                    result_details="missing shot",
+                )
+            return MagicMock()
+
+        with (
+            _handle_request_patch(handle_request),
+            _workspace_patch(workspace),
+            patch.object(packager, "copy_file") as mock_copy_file,
+            caplog.at_level(logging.WARNING, logger="workflow_packager"),
+        ):
+            packager.copy_static_files([("node", "/Volumes/plates/{shot}/bg.exr")], destination)
+
+        mock_copy_file.assert_not_called()
+        assert "missing shot" in caplog.text
+        assert "outside the folders that travel with the bundle" not in caplog.text
+
+    def test_bundles_an_absolute_path_when_the_macro_layer_cannot_resolve(self, tmp_path: Path) -> None:
+        """A variable-free absolute path still bundles when resolution fails for other reasons.
+
+        Resolution fails with no current project, but the value is a literal path, so the
+        fallback can still place it.
+        """
+        packager = WorkflowPackager("test_workflow")
+        workspace = tmp_path / "ws"
+        source = workspace / "inputs" / "image.jpg"
+        source.parent.mkdir(parents=True)
+        source.write_text("data")
+        destination = tmp_path / "bundle"
+
+        def handle_request(request: object) -> object:
+            if isinstance(request, GetPathForMacroRequest):
+                return GetPathForMacroResultFailure(
+                    failure_reason=PathResolutionFailureReason.MACRO_RESOLUTION_ERROR,
+                    result_details="no current project",
+                )
+            return MagicMock()
+
+        with (
+            _handle_request_patch(handle_request),
+            _workspace_patch(workspace),
+            patch.object(packager, "copy_file") as mock_copy_file,
+        ):
+            packager.copy_static_files([("node", str(source))], destination)
+
+        mock_copy_file.assert_called_once_with(source, destination / "inputs" / "image.jpg")
+
+    def test_bundles_a_directory_under_an_anchor(self, tmp_path: Path) -> None:
+        """A directory reference inside an anchor is copied as a tree."""
+        packager = WorkflowPackager("test_workflow")
+        workspace = tmp_path / "ws"
+        source = workspace / "inputs" / "plates"
+        source.mkdir(parents=True)
+        (source / "p.exr").write_text("data")
+        destination = tmp_path / "bundle"
+
+        with (
+            _macro_resolution_patch(resolved_path=source, absolute_path=source, workflow_dir=workspace),
+            _workspace_patch(workspace),
+            patch.object(packager, "copy_tree") as mock_copy_tree,
+            patch.object(packager, "copy_file") as mock_copy_file,
+        ):
+            packager.copy_static_files([("node", "{inputs}/plates")], destination)
+
+        mock_copy_tree.assert_called_once_with(source, destination / "inputs" / "plates")
+        mock_copy_file.assert_not_called()
+
+    def test_bundles_a_file_under_the_project_anchor(self, tmp_path: Path) -> None:
+        """A file under the project base directory but outside the workspace still bundles.
+
+        The project directory can sit above the workspace, so it is the only anchor that places
+        such a file.
+        """
+        packager = WorkflowPackager("test_workflow")
+        project_dir = tmp_path / "project"
+        workspace = project_dir / "workspace"
+        workspace.mkdir(parents=True)
+        source = project_dir / "assets" / "logo.png"
+        source.parent.mkdir(parents=True)
+        source.write_text("data")
+        destination = tmp_path / "bundle"
+
+        def handle_request(request: object) -> object:
+            if isinstance(request, GetPathForMacroRequest):
+                if request.parsed_macro.template == WORKFLOW_DIR_MACRO:
+                    return GetPathForMacroResultSuccess(
+                        resolved_path=workspace, absolute_path=workspace, result_details="resolved"
+                    )
+                return GetPathForMacroResultSuccess(
+                    resolved_path=source, absolute_path=source, result_details="resolved"
+                )
+            if isinstance(request, GetCurrentProjectRequest):
+                return GetCurrentProjectResultSuccess(
+                    project_info=MagicMock(project_base_dir=project_dir), result_details="current"
+                )
+            return MagicMock()
+
+        with (
+            _handle_request_patch(handle_request),
+            _workspace_patch(workspace),
+            patch.object(packager, "copy_file") as mock_copy_file,
+        ):
+            packager.copy_static_files([("node", "{project_dir}/assets/logo.png")], destination)
+
+        mock_copy_file.assert_called_once_with(source, destination / "assets" / "logo.png")
+
+    def test_skips_a_reference_that_is_an_anchor_itself(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """A directory reference resolving to an anchor is not copied into the bundle root.
+
+        `relative_to` yields `.` for a path equal to its anchor, which would make the whole
+        workspace -- including the bundle being written inside it -- the thing being copied. The
+        reason given says the bundle replaces that folder, not that it lies outside the project.
+        """
+        packager = WorkflowPackager("test_workflow")
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        destination = workspace / "bundle"
+
+        with (
+            _macro_resolution_patch(resolved_path=workspace, absolute_path=workspace, workflow_dir=workspace),
+            _workspace_patch(workspace),
+            patch.object(packager, "copy_file") as mock_copy_file,
+            patch.object(packager, "copy_tree") as mock_copy_tree,
+            caplog.at_level(logging.WARNING, logger="workflow_packager"),
+        ):
+            packager.copy_static_files([("node", "{workspace_dir}")], destination)
+
+        mock_copy_tree.assert_not_called()
+        mock_copy_file.assert_not_called()
+        assert "the folder the bundle itself replaces" in caplog.text
+        assert "outside the folders that travel with the bundle" not in caplog.text
+
+    def test_bundles_when_an_anchor_and_the_file_are_spelled_differently(self, tmp_path: Path) -> None:
+        """An anchor that resolved its symlinks still matches a path that did not.
+
+        ``ConfigManager.workspace_path`` resolves symlinks; a `{workflow_dir}`-derived path keeps
+        the spelling the context was entered with. A workspace reached through a symlinked parent
+        would otherwise match no anchor and drop every dependency.
+        """
+        packager = WorkflowPackager("test_workflow")
+        real_workspace = tmp_path / "real_ws"
+        (real_workspace / "inputs").mkdir(parents=True)
+        (real_workspace / "inputs" / "image.jpg").write_text("data")
+        linked_workspace = tmp_path / "linked_ws"
+        linked_workspace.symlink_to(real_workspace, target_is_directory=True)
+        source = linked_workspace / "inputs" / "image.jpg"
+        destination = tmp_path / "bundle"
+
+        with (
+            _macro_resolution_patch(resolved_path=source, absolute_path=source),
+            _workspace_patch(real_workspace),
+            patch.object(packager, "copy_file") as mock_copy_file,
+        ):
+            packager.copy_static_files([("node", "{inputs}/image.jpg")], destination)
+
+        mock_copy_file.assert_called_once_with(source, destination / "inputs" / "image.jpg")
+
+    def test_warns_when_two_files_claim_one_bundle_destination(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Two sources landing on one bundle path is reported, since one node reads the other's file."""
+        packager = WorkflowPackager("test_workflow")
+        workspace = tmp_path / "ws"
+        workflow_dir = workspace / "shots"
+        from_workspace = workspace / "inputs" / "image.jpg"
+        from_workflow = workflow_dir / "inputs" / "image.jpg"
+        for source in (from_workspace, from_workflow):
+            source.parent.mkdir(parents=True)
+            source.write_text("data")
+        destination = tmp_path / "bundle"
+
+        resolutions = {
+            "{workspace_dir}/inputs/image.jpg": from_workspace,
+            "{inputs}/image.jpg": from_workflow,
+        }
+
+        def handle_request(request: object) -> object:
+            if isinstance(request, GetPathForMacroRequest):
+                template = request.parsed_macro.template
+                if template == WORKFLOW_DIR_MACRO:
+                    return GetPathForMacroResultSuccess(
+                        resolved_path=workflow_dir, absolute_path=workflow_dir, result_details="resolved"
+                    )
+                resolved = resolutions[template]
+                return GetPathForMacroResultSuccess(
+                    resolved_path=resolved, absolute_path=resolved, result_details="resolved"
+                )
+            return MagicMock()
+
+        with (
+            _handle_request_patch(handle_request),
+            _workspace_patch(workspace),
+            patch.object(packager, "copy_file"),
+            caplog.at_level(logging.WARNING, logger="workflow_packager"),
+        ):
+            packager.copy_static_files(
+                [("a", "{workspace_dir}/inputs/image.jpg"), ("b", "{inputs}/image.jpg")], destination
+            )
+
+        assert "both belong at" in caplog.text
 
     def test_bundles_file_through_a_symlinked_project_directory(self, tmp_path: Path) -> None:
         """A media directory symlinked onto other storage still bundles.
@@ -289,12 +725,12 @@ class TestCopyStaticFilesBundleDestination:
         destination = tmp_path / "bundle"
 
         with (
-            _macro_resolution_patch(resolved_path=source, absolute_path=source),
+            _macro_resolution_patch(resolved_path=source, absolute_path=source, workflow_dir=workspace),
             _workspace_patch(workspace),
             patch.object(packager, "copy_file") as mock_copy_file,
             patch.object(packager, "copy_tree") as mock_copy_tree,
         ):
-            packager.copy_static_files([("node", "{inputs}/images/image.jpg")], destination, workspace)
+            packager.copy_static_files([("node", "{inputs}/images/image.jpg")], destination)
 
         mock_copy_file.assert_called_once_with(source, destination / "inputs" / "images" / "image.jpg")
         mock_copy_tree.assert_not_called()
@@ -312,18 +748,18 @@ class TestCopyStaticFilesBundleDestination:
         destination = tmp_path / "bundle"
 
         with (
-            _macro_resolution_patch(resolved_path=source, absolute_path=source),
+            _macro_resolution_patch(resolved_path=source, absolute_path=source, workflow_dir=workspace),
             _workspace_patch(workspace),
             patch.object(packager, "copy_file") as mock_copy_file,
             patch.object(packager, "copy_tree") as mock_copy_tree,
             caplog.at_level(logging.WARNING, logger="workflow_packager"),
         ):
-            packager.copy_static_files([("node", "{external}/image.jpg")], destination, workspace)
+            packager.copy_static_files([("node", "{external}/image.jpg")], destination)
 
         mock_copy_file.assert_not_called()
         mock_copy_tree.assert_not_called()
         assert "{external}/image.jpg" in caplog.text
-        assert "outside the project" in caplog.text
+        assert "outside the folders that travel with the bundle" in caplog.text
 
     def test_reports_an_unresolvable_macro_as_such(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
         """A macro that will not resolve is not reported as a path outside the project.
@@ -354,11 +790,11 @@ class TestCopyStaticFilesBundleDestination:
             patch.object(packager, "copy_file") as mock_copy_file,
             caplog.at_level(logging.WARNING, logger="workflow_packager"),
         ):
-            packager.copy_static_files([("node", "{inputs}/{shot_name}.jpg")], destination, workspace)
+            packager.copy_static_files([("node", "{inputs}/{shot_name}.jpg")], destination)
 
         mock_copy_file.assert_not_called()
         assert "shot_name" in caplog.text
-        assert "outside the project" not in caplog.text
+        assert "outside the folders that travel with the bundle" not in caplog.text
 
 
 class TestCopyStaticFiles:
@@ -387,7 +823,7 @@ class TestCopyStaticFiles:
             patch.object(packager, "copy_file") as mock_copy_file,
             patch.object(packager, "copy_tree") as mock_copy_tree,
         ):
-            packager.copy_static_files([("node", "img.jpg")], tmp_path, tmp_path)
+            packager.copy_static_files([("node", "img.jpg")], tmp_path)
 
         mock_copy_file.assert_not_called()
         mock_copy_tree.assert_not_called()
@@ -416,7 +852,7 @@ class TestCopyStaticFiles:
             patch.object(packager, "copy_file") as mock_copy_file,
             patch.object(packager, "copy_tree") as mock_copy_tree,
         ):
-            packager.copy_static_files([("node", "img.jpg")], destination, tmp_path)
+            packager.copy_static_files([("node", "img.jpg")], destination)
 
         mock_copy_file.assert_called_once_with(source, destination / relative)
         mock_copy_tree.assert_not_called()

--- a/tests/unit/retained_mode/publishing/test_workflow_packager.py
+++ b/tests/unit/retained_mode/publishing/test_workflow_packager.py
@@ -18,6 +18,10 @@ from griptape_nodes.retained_mode.events.os_events import (
     RenameFileResultFailure,
     WriteFileResultSuccess,
 )
+from griptape_nodes.retained_mode.events.project_events import (
+    GetPathForMacroRequest,
+    GetPathForMacroResultSuccess,
+)
 from griptape_nodes.retained_mode.events.secrets_events import (
     GetAllSecretValuesRequest,
     GetAllSecretValuesResultSuccess,
@@ -25,6 +29,7 @@ from griptape_nodes.retained_mode.events.secrets_events import (
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.publishing.workflow_packager import (
     DOWNLOAD_MODELS_SCRIPT_NAME,
+    ResolvedFileReference,
     WorkflowPackager,
 )
 
@@ -157,6 +162,136 @@ class TestCollectPipInstallFlagsTransitive:
         assert "--extra-index-url=https://b.example.com" in result
 
 
+def _macro_resolution_patch(resolved_path: Path, absolute_path: Path):  # noqa: ANN202
+    """Patch handle_request so a macro reference resolves to the given pair of paths.
+
+    Mirrors ProjectManager.on_get_path_for_macro_request, whose ``resolved_path`` is the macro
+    string after substitution: absolute when a directory macro is absolute-rooted, relative
+    otherwise. Any other request returns a MagicMock, so the current-project lookup fails its
+    isinstance check and leaves the project anchor out.
+    """
+
+    def handle_request(request: object) -> object:
+        if isinstance(request, GetPathForMacroRequest):
+            return GetPathForMacroResultSuccess(
+                resolved_path=resolved_path,
+                absolute_path=absolute_path,
+                result_details="resolved",
+            )
+        return MagicMock()
+
+    return patch(
+        "griptape_nodes.retained_mode.publishing.workflow_packager.GriptapeNodes.handle_request",
+        side_effect=handle_request,
+    )
+
+
+def _workspace_patch(workspace_dir: Path):  # noqa: ANN202
+    """Patch the config manager so the workspace anchor is ``workspace_dir``."""
+    return patch(
+        "griptape_nodes.retained_mode.publishing.workflow_packager.GriptapeNodes.ConfigManager",
+        return_value=MagicMock(workspace_path=workspace_dir),
+    )
+
+
+class TestCopyStaticFilesBundleDestination:
+    """copy_static_files places a dependency where the published bundle looks for it."""
+
+    def test_bundles_file_referenced_by_absolute_macro_path(self, tmp_path: Path) -> None:
+        """A macro that substitutes to an absolute path still lands inside the bundle.
+
+        The v1 default anchors `{inputs}` on `{workflow_dir}`, so `{inputs}/image.jpg`
+        substitutes to an absolute string. Joining that onto the destination discards the
+        destination, which silently dropped every macro-referenced dependency.
+        """
+        packager = WorkflowPackager("test_workflow")
+        workspace = tmp_path / "ws"
+        source = workspace / "inputs" / "image.jpg"
+        source.parent.mkdir(parents=True)
+        source.write_text("data")
+        destination = tmp_path / "bundle"
+
+        with (
+            _macro_resolution_patch(resolved_path=source, absolute_path=source),
+            _workspace_patch(workspace),
+            patch.object(packager, "copy_file") as mock_copy_file,
+            patch.object(packager, "copy_tree") as mock_copy_tree,
+        ):
+            packager.copy_static_files([("node", "{inputs}/image.jpg")], destination, workspace)
+
+        mock_copy_file.assert_called_once_with(source, destination / "inputs" / "image.jpg")
+        mock_copy_tree.assert_not_called()
+
+    def test_bundles_file_relative_to_the_workflow_not_the_workspace(self, tmp_path: Path) -> None:
+        """A workflow in a subdirectory resolves against its own directory, not the workspace.
+
+        The bundle copies the workflow file to its root, so `{inputs}` resolves there at run
+        time. Anchoring on the workspace instead would bundle the file under `shots/inputs/`,
+        where nothing looks for it.
+        """
+        packager = WorkflowPackager("test_workflow")
+        workspace = tmp_path / "ws"
+        workflow_dir = workspace / "shots"
+        source = workflow_dir / "inputs" / "image.jpg"
+        source.parent.mkdir(parents=True)
+        source.write_text("data")
+        destination = tmp_path / "bundle"
+
+        with (
+            _macro_resolution_patch(resolved_path=source, absolute_path=source),
+            _workspace_patch(workspace),
+            patch.object(packager, "copy_file") as mock_copy_file,
+            patch.object(packager, "copy_tree") as mock_copy_tree,
+        ):
+            packager.copy_static_files([("node", "{inputs}/image.jpg")], destination, workflow_dir)
+
+        mock_copy_file.assert_called_once_with(source, destination / "inputs" / "image.jpg")
+        mock_copy_tree.assert_not_called()
+
+    def test_bundles_file_referenced_by_relative_path(self, tmp_path: Path) -> None:
+        """A reference that substitutes to a relative path keeps bundling as it did before."""
+        packager = WorkflowPackager("test_workflow")
+        workspace = tmp_path / "ws"
+        source = workspace / "inputs" / "image.jpg"
+        source.parent.mkdir(parents=True)
+        source.write_text("data")
+        destination = tmp_path / "bundle"
+
+        with (
+            _macro_resolution_patch(resolved_path=Path("inputs/image.jpg"), absolute_path=source),
+            _workspace_patch(workspace),
+            patch.object(packager, "copy_file") as mock_copy_file,
+            patch.object(packager, "copy_tree") as mock_copy_tree,
+        ):
+            packager.copy_static_files([("node", "inputs/image.jpg")], destination, workspace)
+
+        mock_copy_file.assert_called_once_with(source, destination / "inputs" / "image.jpg")
+        mock_copy_tree.assert_not_called()
+
+    def test_reports_a_file_that_resolves_outside_every_anchor(self, tmp_path: Path) -> None:
+        """A file on an external volume has no place in the bundle, and the publish says so."""
+        packager = WorkflowPackager("test_workflow")
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        source = tmp_path / "external" / "image.jpg"
+        source.parent.mkdir(parents=True)
+        source.write_text("data")
+        destination = tmp_path / "bundle"
+
+        with (
+            _macro_resolution_patch(resolved_path=source, absolute_path=source),
+            _workspace_patch(workspace),
+            patch.object(packager, "copy_file") as mock_copy_file,
+            patch.object(packager, "copy_tree") as mock_copy_tree,
+            patch.object(packager, "emit_progress") as mock_emit_progress,
+        ):
+            packager.copy_static_files([("node", "{external}/image.jpg")], destination, workspace)
+
+        mock_copy_file.assert_not_called()
+        mock_copy_tree.assert_not_called()
+        assert "{external}/image.jpg" in mock_emit_progress.call_args.args[1]
+
+
 class TestCopyStaticFiles:
     """copy_static_files handles the case where the destination resolves back onto the source."""
 
@@ -166,19 +301,20 @@ class TestCopyStaticFiles:
         source = tmp_path / "inputs" / "images" / "img.jpg"
         source.parent.mkdir(parents=True)
         source.write_text("data")
-        relative = Path("inputs/images/img.jpg")
+        resolved = ResolvedFileReference(absolute_path=source, bundle_relative_path=Path("inputs/images/img.jpg"))
 
         # destination is the project root itself, so dest == source.
         with (
-            patch.object(packager, "_resolve_file_reference", return_value=(source, relative)),
+            patch.object(packager, "_resolve_file_reference", return_value=resolved),
             patch(
                 "griptape_nodes.retained_mode.publishing.workflow_packager.GriptapeNodes.handle_request",
                 return_value=MagicMock(),
             ),
+            _workspace_patch(tmp_path),
             patch.object(packager, "copy_file") as mock_copy_file,
             patch.object(packager, "copy_tree") as mock_copy_tree,
         ):
-            packager.copy_static_files([("node", "img.jpg")], tmp_path)
+            packager.copy_static_files([("node", "img.jpg")], tmp_path, tmp_path)
 
         mock_copy_file.assert_not_called()
         mock_copy_tree.assert_not_called()
@@ -190,18 +326,20 @@ class TestCopyStaticFiles:
         source.parent.mkdir(parents=True)
         source.write_text("data")
         relative = Path("inputs/images/img.jpg")
+        resolved = ResolvedFileReference(absolute_path=source, bundle_relative_path=relative)
         destination = tmp_path / "bundle"
 
         with (
-            patch.object(packager, "_resolve_file_reference", return_value=(source, relative)),
+            patch.object(packager, "_resolve_file_reference", return_value=resolved),
             patch(
                 "griptape_nodes.retained_mode.publishing.workflow_packager.GriptapeNodes.handle_request",
                 return_value=MagicMock(),
             ),
+            _workspace_patch(tmp_path),
             patch.object(packager, "copy_file") as mock_copy_file,
             patch.object(packager, "copy_tree") as mock_copy_tree,
         ):
-            packager.copy_static_files([("node", "img.jpg")], destination)
+            packager.copy_static_files([("node", "img.jpg")], destination, tmp_path)
 
         mock_copy_file.assert_called_once_with(source, destination / relative)
         mock_copy_tree.assert_not_called()

--- a/tests/unit/retained_mode/publishing/test_workflow_packager.py
+++ b/tests/unit/retained_mode/publishing/test_workflow_packager.py
@@ -1,6 +1,7 @@
 """Tests for WorkflowPackager: library dependency resolution and clean-rebuild publishing."""
 
 import json
+import logging
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -20,7 +21,9 @@ from griptape_nodes.retained_mode.events.os_events import (
 )
 from griptape_nodes.retained_mode.events.project_events import (
     GetPathForMacroRequest,
+    GetPathForMacroResultFailure,
     GetPathForMacroResultSuccess,
+    PathResolutionFailureReason,
 )
 from griptape_nodes.retained_mode.events.secrets_events import (
     GetAllSecretValuesRequest,
@@ -29,6 +32,7 @@ from griptape_nodes.retained_mode.events.secrets_events import (
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.publishing.workflow_packager import (
     DOWNLOAD_MODELS_SCRIPT_NAME,
+    FileReferenceOutcome,
     ResolvedFileReference,
     WorkflowPackager,
 )
@@ -268,8 +272,37 @@ class TestCopyStaticFilesBundleDestination:
         mock_copy_file.assert_called_once_with(source, destination / "inputs" / "image.jpg")
         mock_copy_tree.assert_not_called()
 
-    def test_reports_a_file_that_resolves_outside_every_anchor(self, tmp_path: Path) -> None:
-        """A file on an external volume has no place in the bundle, and the publish says so."""
+    def test_bundles_file_through_a_symlinked_project_directory(self, tmp_path: Path) -> None:
+        """A media directory symlinked onto other storage still bundles.
+
+        Matching on symlink-resolved paths would take the file to the link target, match no
+        anchor, and report a file plainly inside the project as being outside it.
+        """
+        packager = WorkflowPackager("test_workflow")
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        shared = tmp_path / "shared_storage"
+        (shared / "images").mkdir(parents=True)
+        (shared / "images" / "image.jpg").write_text("data")
+        (workspace / "inputs").symlink_to(shared, target_is_directory=True)
+        source = workspace / "inputs" / "images" / "image.jpg"
+        destination = tmp_path / "bundle"
+
+        with (
+            _macro_resolution_patch(resolved_path=source, absolute_path=source),
+            _workspace_patch(workspace),
+            patch.object(packager, "copy_file") as mock_copy_file,
+            patch.object(packager, "copy_tree") as mock_copy_tree,
+        ):
+            packager.copy_static_files([("node", "{inputs}/images/image.jpg")], destination, workspace)
+
+        mock_copy_file.assert_called_once_with(source, destination / "inputs" / "images" / "image.jpg")
+        mock_copy_tree.assert_not_called()
+
+    def test_reports_a_file_that_resolves_outside_every_anchor(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A file on an external volume has no place in the bundle, and the log says why."""
         packager = WorkflowPackager("test_workflow")
         workspace = tmp_path / "ws"
         workspace.mkdir()
@@ -283,13 +316,49 @@ class TestCopyStaticFilesBundleDestination:
             _workspace_patch(workspace),
             patch.object(packager, "copy_file") as mock_copy_file,
             patch.object(packager, "copy_tree") as mock_copy_tree,
-            patch.object(packager, "emit_progress") as mock_emit_progress,
+            caplog.at_level(logging.WARNING, logger="workflow_packager"),
         ):
             packager.copy_static_files([("node", "{external}/image.jpg")], destination, workspace)
 
         mock_copy_file.assert_not_called()
         mock_copy_tree.assert_not_called()
-        assert "{external}/image.jpg" in mock_emit_progress.call_args.args[1]
+        assert "{external}/image.jpg" in caplog.text
+        assert "outside the project" in caplog.text
+
+    def test_reports_an_unresolvable_macro_as_such(self, tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """A macro that will not resolve is not reported as a path outside the project.
+
+        The two failures are unrelated and the user acts on them differently, so the message
+        names the missing variable rather than guessing at a location.
+        """
+        packager = WorkflowPackager("test_workflow")
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        destination = tmp_path / "bundle"
+
+        def handle_request(request: object) -> object:
+            if isinstance(request, GetPathForMacroRequest):
+                return GetPathForMacroResultFailure(
+                    failure_reason=PathResolutionFailureReason.MISSING_REQUIRED_VARIABLES,
+                    missing_variables={"shot_name"},
+                    result_details="missing shot_name",
+                )
+            return MagicMock()
+
+        with (
+            patch(
+                "griptape_nodes.retained_mode.publishing.workflow_packager.GriptapeNodes.handle_request",
+                side_effect=handle_request,
+            ),
+            _workspace_patch(workspace),
+            patch.object(packager, "copy_file") as mock_copy_file,
+            caplog.at_level(logging.WARNING, logger="workflow_packager"),
+        ):
+            packager.copy_static_files([("node", "{inputs}/{shot_name}.jpg")], destination, workspace)
+
+        mock_copy_file.assert_not_called()
+        assert "shot_name" in caplog.text
+        assert "outside the project" not in caplog.text
 
 
 class TestCopyStaticFiles:
@@ -305,7 +374,11 @@ class TestCopyStaticFiles:
 
         # destination is the project root itself, so dest == source.
         with (
-            patch.object(packager, "_resolve_file_reference", return_value=resolved),
+            patch.object(
+                packager,
+                "_resolve_file_reference",
+                return_value=FileReferenceOutcome(reference=resolved, failure=None),
+            ),
             patch(
                 "griptape_nodes.retained_mode.publishing.workflow_packager.GriptapeNodes.handle_request",
                 return_value=MagicMock(),
@@ -330,7 +403,11 @@ class TestCopyStaticFiles:
         destination = tmp_path / "bundle"
 
         with (
-            patch.object(packager, "_resolve_file_reference", return_value=resolved),
+            patch.object(
+                packager,
+                "_resolve_file_reference",
+                return_value=FileReferenceOutcome(reference=resolved, failure=None),
+            ),
             patch(
                 "griptape_nodes.retained_mode.publishing.workflow_packager.GriptapeNodes.handle_request",
                 return_value=MagicMock(),


### PR DESCRIPTION
Closes #5316

## The bug

A node's static file dependency was silently left out of a published bundle whenever the path parameter was written as a macro. The same file bundled correctly without the macro:

- `LoadImage` with `{inputs}/image.jpg` → **not** bundled
- `LoadImage` with `inputs/image.jpg` → bundled

Publish reported success either way, so the missing dependency only surfaced when the published workflow ran.

## Why

`copy_static_files` built the destination as `destination / resolved_path`, treating `GetPathForMacroResultSuccess.resolved_path` as project-relative. It isn't — it's the macro string after substitution, and it comes back absolute whenever a directory macro is absolute-rooted. The v1 default template anchors `inputs` and `outputs` on `{workflow_dir}`, which resolves to an absolute directory.

`Path.__truediv__` discards the left operand when the right side is absolute, so `destination / resolved_path` evaluated to `resolved_path` itself — identical to the source. The guard that exists to avoid `SameFileError` then matched unconditionally and logged the file as `already in place; skipping copy`.

## The fix

**A relative `resolved_path` is authoritative.** The resolver builds `absolute_path` by joining it onto the workspace, and the bundle's workspace *is* the bundle root, so it already names the destination. Anchor-stripping must not second-guess it: a v0 workflow saved at `<ws>/outputs/render.py` referencing `{outputs}/plate.png` would have the `outputs/` segment stripped against its own folder and land where nothing looks.

That holds only when the join was all that happened. The resolver expands `~` and collapses `..` while leaving the substituted string alone, so `../shared/x.jpg` and `~/media/x.jpg` are both "relative" while naming somewhere the bundle has no say over — taken verbatim the first writes *outside* the staging directory and reports success. `_is_joined_suffix` compares the tail, so those fall through to anchor-stripping.

**Otherwise strip the deepest matching publish anchor** — workflow directory, workspace, or project base directory. Publishing collapses all three onto the bundle root (workflow copied there, project template beside it, config pointing `workspace_directory` at the same place), so stripping the anchor a file sits under reproduces the path the bundle's own resolution looks for. Deepest-match is why this doesn't just anchor on the project root as the issue suggested: for a workflow in a subdirectory, `{inputs}` must land at `inputs/`, not `shots/inputs/`.

Matching runs on **logically normalized** paths first (`resolve_path_safely`), then on symlink-resolved ones. A project that symlinks a media directory onto shared storage is ordinary, and following the link on the first pass reports a file plainly inside the project as outside it; the second pass catches the reverse, where `workspace_path` resolves symlinks but a `{workflow_dir}` path keeps the context spelling. Both sides lose the Windows long-path prefix first — it changes a path's anchor, so `relative_to` raises for a file that is plainly inside. Identity checks still canonicalize, since those want two spellings of one file to collide.

**Two shapes are refused rather than placed.** A reference that *is* an anchor names the folder the bundle replaces, so bundling it under a shallower anchor's name puts it where nothing looks. And a referenced directory that *contains* the bundle destination can't be copied at all: `OSManager` walks a copy source with a lazy `os.walk` while creating directories in it, so the copy never terminates — reachable whenever a publisher writes the bundle inside a referenced folder, which the Nuke publisher does deliberately.

**Destinations are tracked, not sources.** One source can legitimately need two bundle destinations (one reference resolving relatively, another anchor-stripped); keying on the source bundled only the first. Keying on the destination also turns the collision case — two different files wanting one bundle path — into a warning instead of a silent overwrite.

## Behavior at the edges

A reference resolving outside every anchor (external drive, network mount) has no bundle-relative location, so it is still skipped — its macro resolves to the same absolute path wherever the bundle runs. Raising instead would break workflows that deliberately reference shared storage, which is a normal render-farm setup.

Each skip now says which of the distinct causes applies, rather than reporting all of them as "outside the project": a macro that won't resolve names the reason and the missing variable (the failure payload carried both and nothing read them), a missing file names the path, and only a path genuinely outside the project claims to be. Those go to the engine log, which is where the durable record is — an earlier revision of this branch also emitted a publish progress event, but the GUI holds one transient message and `package_to_folder` emits the next phase immediately after this call returns, so it was overwritten before it could be read. A publish-warnings channel that survives to the UI is worth having and is a publisher API change, not part of this fix.

Also split the combined `exists`/`already-copied` branch: a duplicate reference was reporting that the file did not exist.

## No API change

An earlier revision added a `workflow_dir` parameter to `copy_static_files` and a `MIGRATION.md` entry for it. Both are gone: resolution reads `{workflow_dir}` from the live context either way, so a caller-supplied anchor guaranteed nothing and could disagree with the very paths it was matched against. Resolving it through the same request keeps anchor and references consistent by construction and leaves the public signature — and third-party publishers — untouched.

## Contract

`resolved_path`'s docstring claimed "the relative project path after macro substitution". `ProjectManager`'s own tests already assert absolute values for it, so the docstring was the wrong half. It now describes what the field holds and warns against the join that reading it as relative invites. The field itself is unchanged — it can't be made always-relative (a macro can point at an external volume) and `files/derivation.py` wants the substituted string.

## Testing

- `make check` clean, `mkdocs build --strict` clean
- `tests/unit` 4563 passed, `tests/e2e` 32 passed
- `tests/integration` has 5 failures + 3 errors that reproduce identically on pristine `origin/main` in a separate worktree — environmental (an OS-set `SECRET_KEY`), not from this change
- Confirmed the new tests are load-bearing rather than tautological, by restoring each old behavior and watching the matching test fail: the original destination computation fails 3 of the 4 destination tests (and passes the relative-path one, which is the case that already worked); symlink-resolved anchor matching fails the symlink test; the anchor-equality and relative-authority guards each fail their own test

This branch went through five rounds of adversarial review, and the first three of its own commits had bugs in them — the `..` escape, the whole-workspace copy, the stripped-segment regression, and the anchor refusal being bypassed twice were all found that way, and each has a test that fails without its fix.

## Not in this PR

`griptape-nodes-library-deadline-cloud`'s `DeadlineCloudPublisher._resolve_and_copy_static_files` has the same `static_files_dir / resolve_result.resolved_path` join with no same-file guard, so it writes assets outside its bundle rather than skipping them. Separate repo, and it writes its own project template so its anchor rule needs its own thought.

Three more surfaced while reviewing this, all pre-existing and each worth its own issue:

- **The bundle's project template is written to a name discovery never finds.** `write_project_template` writes `project.yml`, but `ProjectManager` looks for `griptape-nodes-project.yml` and `project_packager.py` uses the discoverable name. Published bundles therefore run on system defaults, so a project with customized directory macros still mis-places files regardless of this fix.
- **`copy_tree` has no dest-inside-source guard.** The packager now avoids the shape, but the engine-level hazard remains for any other caller of `CopyTreeRequest`.
- **Anchor ambiguity**, documented in `_bundle_relative_path`'s docstring. The substituted path cannot say which anchor a directory macro was rooted on, so a hand-written `plates: "{workspace_dir}/shots/plates"` with the workflow saved in `shots` is stripped a level too shallow. Fixing it properly needs the directory's own `path_macro`, which lives in the project layer. Does not affect the v0 or v1 defaults — all 14 directory definitions check out.


