### PR TITLE
Client: bounded reconnect for consumers whose peers churn

### DIFF
--- a/src/griptape_nodes/api_client/client.py
+++ b/src/griptape_nodes/api_client/client.py
@@ -52,14 +52,31 @@ class Client:
         self,
         api_key: str | None = None,
         url: str | None = None,
+        *,
+        max_reconnect_delay_s: float | None = None,
+        pre_reconnect_check: Callable[[], Awaitable[bool]] | None = None,
     ):
         """Initialize Nodes API client.
 
         Args:
             api_key: API key for authentication (defaults to GT_CLOUD_API_KEY from SecretsManager)
             url: WebSocket URL to connect to (defaults to Nodes API endpoint)
+            max_reconnect_delay_s: Cap on the wait between reconnect attempts.
+                The default reconnect path (the websockets library's iterator)
+                backs off exponentially to a ~90s ceiling, which suits a
+                long-lived cloud relay but strands a consumer whose peers
+                CHURN: a fresh server on a recycled address can sit unreached
+                for up to that ceiling. Setting this switches to a bounded
+                retry loop. None keeps the library behavior.
+            pre_reconnect_check: Awaited before each bounded reconnect attempt;
+                returning False skips the dial (and its log line) for one
+                delay. Lets a consumer substitute a cheap, silent liveness
+                test (e.g. a TCP probe) for dial-and-fail against an address
+                that is usually dead. Implies the bounded retry loop.
         """
         self.url = url if url is not None else get_default_websocket_url()
+        self._max_reconnect_delay_s = max_reconnect_delay_s
+        self._pre_reconnect_check = pre_reconnect_check
 
         # Get API key from SecretsManager if not provided
         if api_key is None:
@@ -221,10 +238,13 @@ class Client:
         automatically reconnecting on failures.
         """
         try:
-            async for websocket in connect(self.url, additional_headers=self.headers):
-                should_reconnect = await self._handle_websocket_session(websocket)
-                if not should_reconnect:
-                    break
+            if self._max_reconnect_delay_s is not None or self._pre_reconnect_check is not None:
+                await self._manage_connection_bounded()
+            else:
+                async for websocket in connect(self.url, additional_headers=self.headers):
+                    should_reconnect = await self._handle_websocket_session(websocket)
+                    if not should_reconnect:
+                        break
         except InvalidStatus as e:
             if e.response.status_code in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN):
                 logger.error(
@@ -257,6 +277,29 @@ class Client:
             )
         except asyncio.CancelledError:
             logger.debug("Connection manager task cancelled")
+
+    async def _manage_connection_bounded(self) -> None:
+        """Reconnect on a bounded cadence instead of the library's backoff.
+
+        Fatal configuration failures (bad URL, rejected credentials, SSL) still
+        bubble to _manage_connection's handlers and end the manager, exactly as
+        the iterator path does; only transient dial failures retry here.
+        """
+        delay = self._max_reconnect_delay_s if self._max_reconnect_delay_s is not None else 5.0
+        while True:
+            if self._pre_reconnect_check is not None and not await self._pre_reconnect_check():
+                await asyncio.sleep(delay)
+                continue
+            try:
+                websocket = await connect(self.url, additional_headers=self.headers)
+            except (OSError, TimeoutError):
+                # The address was reachable a moment ago (or unchecked) but the
+                # dial failed; one bounded wait, then look again.
+                await asyncio.sleep(delay)
+                continue
+            should_reconnect = await self._handle_websocket_session(websocket)
+            if not should_reconnect:
+                return
 
     async def _handle_websocket_session(self, websocket: Any) -> bool:
         """Handle a single WebSocket session: log, resubscribe, and receive messages.

--- a/src/griptape_nodes/retained_mode/managers/execution_lease_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/execution_lease_manager.py
@@ -403,10 +403,14 @@ class ExecutionLeaseManager(EngineScoped):
             )
             raise RuntimeError(msg)
         if self._balancer_last_seen == 0.0:
+            # Usually a fresh engine the balancer has not re-dialed yet -- a
+            # transient measured in seconds -- so the message leads with the
+            # action that will actually work, not with escalation.
             msg = (
-                "Attempted to start execution on a managed engine. Failed because no "
-                "load balancer has connected to this engine yet; this engine refuses "
-                "to run unmanaged. Contact your administrator."
+                "Attempted to start execution on a managed engine. Failed because the "
+                "execution manager (load balancer) has not connected to this engine "
+                "yet. This usually resolves within a few seconds -- try again. If it "
+                "persists, contact your administrator."
             )
             raise RuntimeError(msg)
         return self._transport

--- a/tests/unit/api_client/test_client.py
+++ b/tests/unit/api_client/test_client.py
@@ -51,3 +51,93 @@ class TestClientLargePayloadWarning:
         await client._send_message(message)
 
         client._websocket.send.assert_called_once_with(json.dumps(message))
+
+
+MIN_BOUNDED_ITERATIONS = 3
+
+
+class TestBoundedReconnect:
+    """The bounded reconnect path (max_reconnect_delay_s / pre_reconnect_check).
+
+    The library iterator's exponential backoff caps near 90s, which suits a
+    long-lived cloud relay but strands a consumer whose peers churn: a fresh
+    server on a recycled address can sit unreached for the whole ceiling.
+    These tests pin the bounded loop's contract without a real socket.
+    """
+
+    @pytest.mark.asyncio
+    async def test_pre_reconnect_check_false_skips_the_dial(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A failing check must wait one bounded delay and never dial (or log)."""
+        checks = 0
+
+        async def never_ready() -> bool:
+            nonlocal checks
+            checks += 1
+            return False
+
+        client = Client(
+            api_key="k", url="ws://localhost:1", max_reconnect_delay_s=0.01, pre_reconnect_check=never_ready
+        )
+        dialed = AsyncMock()
+        monkeypatch.setattr("griptape_nodes.api_client.client.connect", dialed)
+
+        import asyncio
+
+        task = asyncio.create_task(client._manage_connection_bounded())
+        await asyncio.sleep(0.1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert checks >= MIN_BOUNDED_ITERATIONS  # kept looking on the bounded cadence
+        dialed.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dial_failure_retries_on_the_bounded_cadence(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """OSError from a dial is a transient: retry, never die, never back off past the cap."""
+        client = Client(api_key="k", url="ws://localhost:1", max_reconnect_delay_s=0.01)
+        attempts = 0
+
+        async def refused(*_args: object, **_kwargs: object) -> object:
+            nonlocal attempts
+            attempts += 1
+            msg = "connection refused"
+            raise OSError(msg)
+
+        monkeypatch.setattr("griptape_nodes.api_client.client.connect", refused)
+
+        import asyncio
+
+        task = asyncio.create_task(client._manage_connection_bounded())
+        await asyncio.sleep(0.1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert attempts >= MIN_BOUNDED_ITERATIONS
+
+    @pytest.mark.asyncio
+    async def test_connects_and_hands_off_when_ready(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A passing check dials once and hands the socket to the session handler."""
+
+        async def ready() -> bool:
+            return True
+
+        client = Client(api_key="k", url="ws://localhost:1", max_reconnect_delay_s=0.01, pre_reconnect_check=ready)
+        fake_socket = object()
+
+        async def dial(*_args: object, **_kwargs: object) -> object:
+            return fake_socket
+
+        sessions: list[object] = []
+
+        async def session(websocket: object) -> bool:
+            sessions.append(websocket)
+            return False  # do not reconnect: the loop must exit
+
+        monkeypatch.setattr("griptape_nodes.api_client.client.connect", dial)
+        monkeypatch.setattr(client, "_handle_websocket_session", session)
+
+        await client._manage_connection_bounded()
+
+        assert sessions == [fake_socket]

--- a/tests/unit/retained_mode/managers/test_execution_lease_manager.py
+++ b/tests/unit/retained_mode/managers/test_execution_lease_manager.py
@@ -585,7 +585,7 @@ class TestBalancerLiveness:
         manager, _, _ = make_manager(engine, monkeypatch)
         manager._balancer_last_seen = 0.0
 
-        with pytest.raises(RuntimeError, match=r"no .*load balancer has connected"):
+        with pytest.raises(RuntimeError, match=r"load balancer\) has not connected to this engine yet"):
             await manager.gate_execution_start()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What (stacked on #5343)

The websockets iterator's exponential backoff caps near 90 seconds — right for a long-lived cloud relay, wrong for a consumer dialing addresses where servers are born and die: a fresh engine on a recycled port can sit unreached for the whole ceiling, refusing runs ("the load balancer has not connected to this engine yet") while its artist watches. Observed live: three refusals over 21 seconds, self-healing at the next retry tick.

Two opt-in constructor knobs, defaults preserving the iterator path for the relay: `max_reconnect_delay_s` bounds the retry cadence, and `pre_reconnect_check` lets the consumer substitute a cheap silent liveness test (a TCP probe) for dial-and-fail against an address that is usually dead. Fatal configuration failures keep their existing semantics. The balancer's `EngineLink` consumes both (balancer PR #4).

Also rewords the gate's no-beacon refusal to lead with "try again in a few seconds" — it is a transient that self-heals, not an incident.

## Verification

3 new Client unit tests (check-gating, bounded dial-failure retry, handoff); E2E `s13-port-reuse-rearm` in the app repo proves the rearm end to end; full admission suite 67/67 across 13 scenarios.