### PR TITLE
Asset URLs reflect where the file is, not where a new import would land

### DIFF
--- a/src/griptape_nodes/drivers/storage/local_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/local_storage_driver.py
@@ -5,11 +5,8 @@ from urllib.parse import urljoin
 
 import httpx
 
-from griptape_nodes.common.project_templates.situation import BuiltInSituation
 from griptape_nodes.drivers.storage.base_storage_driver import BaseStorageDriver, CreateSignedUploadUrlResponse
-from griptape_nodes.files.file import FileLoadError
 from griptape_nodes.files.path_utils import canonicalize_to_posix, strip_windows_long_path_prefix
-from griptape_nodes.files.project_file import ProjectFileDestination
 from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy, WriteFileRequest, WriteFileResultSuccess
 from griptape_nodes.retained_mode.file_metadata.sidecar_metadata import SidecarContent
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
@@ -223,19 +220,15 @@ class LocalStorageDriver(BaseStorageDriver):
     def get_asset_url(self, path: Path) -> str:
         """Get the permanent URL for a local asset.
 
-        Builds the canonical path using the ``copy_external_file`` situation and returns
-        it as an absolute path string.  Falls back to the absolute path of the original
-        file if the situation cannot be resolved (e.g. no project loaded).
+        The caller hands in the file's actual location (already resolved via its
+        situation where one applies); this must not re-derive a location from a
+        write situation, which would point at where a hypothetical new file would
+        land rather than where this file is.
 
         Args:
-            path: The path of the file
+            path: The path of the file, workspace-relative or absolute
 
         Returns:
-            Absolute path string for the resolved asset path
+            Absolute path string for the asset
         """
-        destination = ProjectFileDestination.from_situation(path.name, BuiltInSituation.COPY_EXTERNAL_FILE)
-        try:
-            resolved_path = Path(destination.resolve())
-        except FileLoadError:
-            return str(resolve_workspace_path(path, self.workspace_directory))
-        return str(resolved_path)
+        return str(resolve_workspace_path(path, self.workspace_directory))

--- a/tests/unit/drivers/storage/test_local_storage_driver.py
+++ b/tests/unit/drivers/storage/test_local_storage_driver.py
@@ -363,3 +363,49 @@ class TestSignedDownloadUrlRoundTrip:
 
         assert "?t=1000" in url
         assert "?t=" not in str(parse_static_server_url(url, Path("/workspace")))
+
+
+class TestLocalStorageDriverGetAssetUrl:
+    """Test LocalStorageDriver.get_asset_url() method.
+
+    ``get_asset_url`` must be path-faithful: callers hand in the file's actual,
+    already-resolved location. Re-deriving one from the ``copy_external_file``
+    situation pointed at where a hypothetical NEW import would land instead --
+    for a thumbnail living in ``.griptape-nodes-thumbnails/`` it fabricated
+    ``<workspace>/inputs/<name>``, and resolving ``{inputs}`` logged an
+    "Optional builtin 'workflow_dir'" warning on every read-only request
+    (e.g. once per thumbnail in the File -> Open workflow list).
+    https://github.com/griptape-ai/griptape-nodes-engine/issues/5330
+
+    The only mocking here is the ConfigManager workspace lookup that every
+    driver method shares; the absence of situation/macro mocking is deliberate,
+    because the method must not touch that machinery at all.
+    """
+
+    @pytest.fixture
+    def mock_workspace_path(self) -> Generator[None, None, None]:
+        """Mock ConfigManager to return /workspace for all tests."""
+        with patch("griptape_nodes.retained_mode.griptape_nodes.GriptapeNodes") as mock_griptape:
+            mock_config_manager = Mock()
+            mock_config_manager.workspace_path = Path("/workspace")
+            mock_griptape.ConfigManager.return_value = mock_config_manager
+            yield
+
+    def test_relative_path_keeps_its_directory(
+        self,
+        mock_workspace_path: Any,  # noqa: ARG002
+    ) -> None:
+        """A workspace-relative path resolves in place, not re-derived from the filename."""
+        driver = LocalStorageDriver(Path("/workspace"))
+
+        url = driver.get_asset_url(Path(".griptape-nodes-thumbnails/thumb.png"))
+
+        assert url == str((Path("/workspace") / ".griptape-nodes-thumbnails/thumb.png").resolve())
+
+    def test_absolute_path_is_returned_resolved(self) -> None:
+        """An absolute path passes through untouched apart from normalization."""
+        driver = LocalStorageDriver(Path("/workspace"))
+
+        url = driver.get_asset_url(Path("/elsewhere/media/photo.png"))
+
+        assert url == str(Path("/elsewhere/media/photo.png").resolve())


### PR DESCRIPTION
## Problem

`LocalStorageDriver.get_asset_url()` discarded everything but the filename of the path it was handed and re-derived a location through the `copy_external_file` situation. That situation answers where a hypothetical **new** import would be written (`{inputs}/...`), not where **this** file lives. Two symptoms:

- **Fabricated `file_url`s.** For a thumbnail living in `.griptape-nodes-thumbnails/thumb.png`, the download-URL response's `file_url` claimed `<workspace>/inputs/thumb.png` — a path the file was never written to. The docstring's `FileLoadError` fallback ("absolute path of the original file") never fired, because the optional-macro degradation makes resolution *succeed* with the wrong path instead of failing.
- **Warning spam on read-only flows.** Resolving `{inputs}` drags the optional `{workflow_dir?:/}` reference through every `CreateStaticFileDownloadUrl*` response. With an unsaved workflow open (a fresh canvas is always in this state), that logs `Optional builtin 'workflow_dir' could not be resolved while resolving directory 'inputs'` once per request — e.g. once per thumbnail in the File → Open workflow list, and on startup. Reported by Jason Schleifer; related to #5330 (this PR removes the read-path trigger; the log-level classification for genuine write-path degradations is a separate change).

## Provenance

`get_asset_url` was introduced in #3740 with exactly the behavior this PR restores: `resolve_workspace_path(path, workspace)`. The situation re-derivation was added in #4210, whose actual feature was routing **uploads** through `copy_external_file` so user files land in `{inputs}/` (#4209). That routing lives in the upload handler's `_resolve_static_file_path(file_name, copy_external_file)` call and is untouched here. The `get_asset_url` half of #4210 was addressing the pre-#4210 state (where the handed path was still `staticfiles`-based); the same PR made the handed path inputs-based on its own, so the re-derivation could only ever agree with the handed path (redundant) or disagree with it (pointing at a file other than the one in question).

## Fix

`get_asset_url` now resolves the handed path against the workspace and nothing else — the original #3740 behavior, the behavior of its `except FileLoadError` fallback, and the contract `BaseStorageDriver.get_asset_url` documents ("workspace-relative path of the file → permanent URL for the asset"), which the cloud driver already follows.

## Impact on existing workflows / users

- **Where files are written: unchanged.** No write path is touched. Uploads still route through `copy_external_file` (#4210's feature preserved); `save_static_file`, thumbnails, sidecar metadata all unchanged.
- **Existing saved workflows: unchanged.** Stored parameter values are data; nothing rewrites them. Display-time resolution uses the `url` field (from `create_signed_download_url`), which never came from `get_asset_url`.
- **Only the `file_url` response field changes**, and only when the old value was wrong. Consumer sweep: engine-internal — none; GUI — exactly one (`uploadStaticFile` stores the *upload* response's `file_url` as the new parameter value); desktop app — none; node libraries — none. For that one consumer, old and new are byte-identical in the healthy case (default situation, no collision). They diverge only when the old value pointed at a nonexistent or different file: CREATE_NEW collision renames (old `file_url` referenced the *pre-existing* file, so repeated same-name uploads stored parameter values pointing at the first upload), explicit non-default situations (old claimed `{inputs}/…` for a thumbnail living elsewhere), and the outside-workspace `staticfiles` fallback (old claimed `inputs`). In every divergent case the new value is the file's actual claimed location.

## Testing

- New `TestLocalStorageDriverGetAssetUrl` unit tests pin the path-faithful behavior (workspace-relative path keeps its directory; absolute path passes through) with no situation/macro mocking, so a regression that reintroduces project-machinery calls fails loudly.
- Existing tests only mock or stub `get_asset_url`; nothing asserted the situation-derived form.
- `make check` clean; full unit suite passes (4545 passed). Integration failures are pre-existing on `origin/main` (verified on a pristine detached checkout: identical 4 failed / 3 errors, all in `test_lock_nodes.py` environment bootstrap).
