### PR TITLE
feat(execution): start an injected node as soon as the run has room

### DIFF
--- a/docs/guides/editor/running_workflows.md
+++ b/docs/guides/editor/running_workflows.md
@@ -20,8 +20,10 @@ already running, and while no workflow is open.
 ## Running a single node
 
 Two more buttons next to Run Workflow let you run less than the whole
-graph. The buttons require exactly one node to be selected, and both are
-disabled while the workflow is already running.
+graph. The buttons require exactly one node to be selected. Run From
+Selected is disabled while the workflow is already running; Run To
+Selected is not — see [Running a node during a
+run](#running-a-node-during-a-run) below.
 
 - **Run To Selected** resolves the selected node — and everything upstream
     of it that isn't already resolved — without touching anything
@@ -41,6 +43,38 @@ selected — it runs to each of them.
 
 Both single-node actions are also available from the node's right-click
 context menu, and from the multi-node toolbar when applicable.
+
+## Running a node during a run
+
+You don't have to wait for a run to finish to try a node. **Run To
+Selected** stays available while the workflow is running, and the node
+joins the run that's already in progress instead of starting a new one.
+Anything upstream of it that isn't resolved yet is pulled into the same
+run and resolved first, exactly as it would be from a standing start.
+
+When the node actually begins depends on how much of the run is already
+in flight:
+
+- In **Parallel** execution mode it starts as soon as the run has a free
+    slot, which may be immediately. The number of nodes that can run at
+    once is the `max_nodes_in_parallel` setting (5 by default).
+- In **Sequential** execution mode one node runs at a time, so the node
+    you played starts once the node currently running finishes.
+
+Both modes are described in
+[Configuration](../configuration.md).
+
+Two cases are worth knowing about:
+
+- **If the run is paused**, the node is added to it but does not start.
+    It runs when you step or continue the run.
+- **If the node is already part of the run** — already finished, running,
+    or queued behind its dependencies — playing it is refused rather than
+    run twice, and the editor reports that the node is already executing.
+    Cancel the run if you want to start it over.
+
+**Run Workflow** and **Run From Selected** still require an idle
+workflow; they stay disabled until the current run ends.
 
 ## Stopping a run
 

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -335,6 +335,26 @@ class BaseNode(ABC):
     def parent_group(self, parent_group: BaseNode | None) -> None:
         self._parent_group = parent_group
 
+    def prepare_to_run_again(self) -> None:
+        """Clear this node's resolution so it executes again, and tell the editor it did.
+
+        Locked nodes keep the values they were locked with, so they are left alone.
+
+        Unlike a bare ``make_node_unresolved``, the change event fires from every state
+        rather than only from the ones that made visible progress: a node that is about to
+        run needs its status cleared in the editor even if it already looked unresolved.
+        """
+        if self.lock:
+            return
+
+        self.make_node_unresolved(
+            current_states_to_trigger_change_event={
+                NodeResolutionState.UNRESOLVED,
+                NodeResolutionState.RESOLVED,
+                NodeResolutionState.RESOLVING,
+            }
+        )
+
     # This is gross and we need to have a universal pass on resolution state changes and emission of events. That's what this ticket does!
     # https://github.com/griptape-ai/griptape-nodes/issues/994
     def make_node_unresolved(self, current_states_to_trigger_change_event: set[NodeResolutionState] | None) -> None:

--- a/src/griptape_nodes/machines/control_flow.py
+++ b/src/griptape_nodes/machines/control_flow.py
@@ -102,12 +102,7 @@ class ResolveNodeState(State):
 
         # Mark all current nodes unresolved and broadcast events
         for current_node in context.current_nodes:
-            if not current_node.lock:
-                current_node.make_node_unresolved(
-                    current_states_to_trigger_change_event=set(
-                        {NodeResolutionState.UNRESOLVED, NodeResolutionState.RESOLVED, NodeResolutionState.RESOLVING}
-                    )
-                )
+            current_node.prepare_to_run_again()
             # Now broadcast that we have a current control node.
             context.engine.event_manager.put_event(
                 ExecutionGriptapeNodeEvent(

--- a/src/griptape_nodes/machines/parallel_resolution.py
+++ b/src/griptape_nodes/machines/parallel_resolution.py
@@ -349,22 +349,15 @@ class ExecuteDagState(State):
             )
             next_node.set_entry_control_parameter(next_parameter)
             # Prepare next node for execution
+            next_node.prepare_to_run_again()
+            # Locked nodes are not becoming the current control node, so they get no event.
             if not next_node.lock:
-                next_node.make_node_unresolved(
-                    current_states_to_trigger_change_event=set(
-                        {
-                            NodeResolutionState.UNRESOLVED,
-                            NodeResolutionState.RESOLVED,
-                            NodeResolutionState.RESOLVING,
-                        }
-                    )
-                )
                 context.engine.event_manager.put_event(
                     ExecutionGriptapeNodeEvent(
                         wrapped_event=ExecutionEvent(payload=CurrentControlNodeEvent(node_name=next_node.name))
                     )
                 )
-            ExecuteDagState._add_and_queue_nodes(context, next_node, network_name)
+            ExecuteDagState.add_and_queue_nodes(context, next_node, network_name)
 
     @staticmethod
     def _emit_involved_nodes_update(context: ParallelResolutionContext) -> None:
@@ -378,17 +371,29 @@ class ExecuteDagState(State):
             )
 
     @staticmethod
-    def _add_and_queue_nodes(context: ParallelResolutionContext, next_node: BaseNode, network_name: str) -> None:
-        """Add nodes to DAG and queue them if ready."""
-        if context.dag_builder is not None:
-            added_nodes = context.dag_builder.add_node_with_dependencies(next_node, network_name)
-            if next_node not in added_nodes:
-                added_nodes.append(next_node)
+    def add_and_queue_nodes(
+        context: ParallelResolutionContext, next_node: BaseNode, network_name: str
+    ) -> list[BaseNode]:
+        """Add a node and its dependencies to the DAG, queueing whatever is ready to run.
 
-            # Queue nodes that are ready for execution
-            if added_nodes:
-                for added_node in added_nodes:
-                    ExecuteDagState._try_queue_waiting_node(context, added_node.name)
+        Public because ``ParallelResolutionMachine.inject_node`` shares it: adding to the DAG
+        and queueing what that pulled in is one invariant, and it must not drift between the
+        control-flow path and the injection path.
+
+        Returns the nodes added to the DAG, for callers that report them as involved nodes.
+        """
+        if context.dag_builder is None:
+            return []
+
+        added_nodes = context.dag_builder.add_node_with_dependencies(next_node, network_name)
+        if next_node not in added_nodes:
+            added_nodes.append(next_node)
+
+        # Queue nodes that are ready for execution
+        for added_node in added_nodes:
+            ExecuteDagState._try_queue_waiting_node(context, added_node.name)
+
+        return added_nodes
 
     @staticmethod
     def _try_queue_waiting_node(context: ParallelResolutionContext, node_name: str) -> None:
@@ -724,11 +729,8 @@ class ExecuteDagState(State):
             # that map (the reap below, ErrorState, cancel_all_nodes' gather) treats its
             # members as node tasks. Cancelling in a finally, rather than on each way out
             # of on_update, makes every return path below leak-free by construction.
-            # The cancel is deliberately not awaited: Event.wait can only ever raise
-            # CancelledError (so it never warns about an unretrieved exception), it unhooks
-            # itself from Event._waiters on the next loop turn, and Event.set skips
-            # already-done futures - so no wakeup is lost and nothing accumulates. Awaiting
-            # it here would instead risk masking a cancellation aimed at this driver, which
+            # The cancel is deliberately not awaited. Awaiting here would add a suspension
+            # point that could swallow a cancellation aimed at this driver, which
             # isolated-subflow teardown relies on propagating.
             wakeup_waiter = asyncio.create_task(context.new_work_event.wait())
             try:
@@ -913,11 +915,7 @@ class ParallelResolutionMachine(FSM[ParallelResolutionContext]):
             msg = f"Attempted to run '{node.name}' as part of the current run, but that run has no dependency graph to add it to. Cancel the run and try again."
             raise ValueError(msg)
 
-        added_nodes = context.dag_builder.add_node_with_dependencies(node, graph_name or node.name)
-        if node not in added_nodes:
-            added_nodes.append(node)
-        for added_node in added_nodes:
-            ExecuteDagState._try_queue_waiting_node(context, added_node.name)
+        added_nodes = ExecuteDagState.add_and_queue_nodes(context, node, graph_name or node.name)
         context.signal_new_work()
 
         if context.paused:

--- a/src/griptape_nodes/machines/parallel_resolution.py
+++ b/src/griptape_nodes/machines/parallel_resolution.py
@@ -724,6 +724,12 @@ class ExecuteDagState(State):
             # that map (the reap below, ErrorState, cancel_all_nodes' gather) treats its
             # members as node tasks. Cancelling in a finally, rather than on each way out
             # of on_update, makes every return path below leak-free by construction.
+            # The cancel is deliberately not awaited: Event.wait can only ever raise
+            # CancelledError (so it never warns about an unretrieved exception), it unhooks
+            # itself from Event._waiters on the next loop turn, and Event.set skips
+            # already-done futures - so no wakeup is lost and nothing accumulates. Awaiting
+            # it here would instead risk masking a cancellation aimed at this driver, which
+            # isolated-subflow teardown relies on propagating.
             wakeup_waiter = asyncio.create_task(context.new_work_event.wait())
             try:
                 done, _ = await asyncio.wait(
@@ -786,11 +792,8 @@ class ExecuteDagState(State):
             # through the FSM's advance loop with no suspension point in between, which
             # would wedge the whole event loop - including the injector that could
             # unblock us. Yield on the new-work flag so the retry loop is preserved but
-            # the loop keeps turning.
-            logger.warning(
-                "Flow '%s': no nodes are running and none can be dispatched yet; waiting for new work.",
-                context.flow_name,
-            )
+            # the loop keeps turning. Deliberately not logged: this branch re-runs every
+            # _IDLE_RECHECK_SECONDS while parked, so even a debug line would be spam.
             with contextlib.suppress(TimeoutError):
                 await asyncio.wait_for(context.new_work_event.wait(), timeout=_IDLE_RECHECK_SECONDS)
             if context.was_reset_since(generation):

--- a/src/griptape_nodes/machines/parallel_resolution.py
+++ b/src/griptape_nodes/machines/parallel_resolution.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from typing import TYPE_CHECKING, NamedTuple
 
@@ -42,6 +43,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("griptape_nodes")
 
+# How long a driver waits on the new-work flag when it has nothing running and nothing it
+# can dispatch. Short enough to stay responsive, long enough not to busy-loop.
+_IDLE_RECHECK_SECONDS = 0.05
+
 
 class NodeStatesResult(NamedTuple):
     """Result of building node states from the DAG networks.
@@ -68,6 +73,7 @@ class ParallelResolutionContext(EngineScoped):
     dag_builder: DagBuilder | None
     last_resolved_node: BaseNode | None  # Track the last node that was resolved
     generation: int  # Bumped on reset so a resuming driver can tell its run was torn down
+    new_work_event: asyncio.Event  # Set when the priority queue changes, so a parked driver wakes
 
     def __init__(
         self,
@@ -90,6 +96,7 @@ class ParallelResolutionContext(EngineScoped):
         self.running_tasks_count = 0
         self.task_to_node = {}
         self.generation = 0
+        self.new_work_event = asyncio.Event()
 
     @property
     def node_to_reference(self) -> dict[str, DagNode]:
@@ -119,6 +126,15 @@ class ParallelResolutionContext(EngineScoped):
         """
         return self.generation != generation
 
+    def signal_new_work(self) -> None:
+        """Announce that this run's priority queue changed, unparking the driver.
+
+        Safe to call from a coroutine other than the driver. Level-triggered on
+        purpose: the driver consumes the flag immediately before it reads the
+        queue, so a signal that races the driver's wait is never lost.
+        """
+        self.new_work_event.set()
+
     def reset(self, *, cancel: bool = False) -> None:
         # Ends the current run as far as any parked driver is concerned: it sees
         # the bump on waking and abandons the run.
@@ -145,6 +161,13 @@ class ParallelResolutionContext(EngineScoped):
         # Clear the priority queue when resetting
         # Create a new instance to ensure clean state
         self.node_priority_queue = NodePriorityQueue(self)
+
+        # Unpark a driver sitting in asyncio.wait so it takes its abandon path now,
+        # rather than holding the FSM's single-driver claim until some old node task
+        # finishes. Note the Event object itself is deliberately NOT replaced the way
+        # the priority queue above is: an abandoning driver may still be waiting on a
+        # waiter derived from it, and rebinding would orphan that waiter forever.
+        self.new_work_event.set()
 
         # Clear DAG builder state to allow re-adding nodes on subsequent runs
         if self.dag_builder:
@@ -560,6 +583,15 @@ class ExecuteDagState(State):
             # Set state to workflow complete.
             context.workflow_state = WorkflowState.CANCELED
             return DagCompleteState
+
+        # Consume the new-work flag before reading the queue. Anything signalled from
+        # here on survives into the wait below; anything signalled before here is
+        # honored by the drain that immediately follows, because there is no await
+        # between this clear and that drain. Keeping those two adjacent is what makes
+        # wakeups lossless AND keeps the waiter below from completing instantly on a
+        # stale flag and spinning this loop.
+        context.new_work_event.clear()
+
         # Create tasks only while we have capacity
         while context.running_tasks_count < context.max_nodes_in_parallel:
             # Get next highest priority node
@@ -683,9 +715,22 @@ class ExecuteDagState(State):
                 ExecutionGriptapeNodeEvent(wrapped_event=ExecutionEvent(payload=CurrentDataNodeEvent(node_name=node)))
             )
 
-        # Wait for a task to finish - only if there are tasks running
+        # Wait for a running node to finish, or for work to be injected into this run -
+        # whichever comes first. asyncio.wait snapshots its awaitable set, so without a
+        # waiter on the new-work flag a node injected into a live run could not start
+        # until some already-running node happened to finish.
         if context.task_to_node:
-            done, _ = await asyncio.wait(context.task_to_node.keys(), return_when=asyncio.FIRST_COMPLETED)
+            # The waiter is deliberately kept OUT of task_to_node: everything that walks
+            # that map (the reap below, ErrorState, cancel_all_nodes' gather) treats its
+            # members as node tasks. Cancelling in a finally, rather than on each way out
+            # of on_update, makes every return path below leak-free by construction.
+            wakeup_waiter = asyncio.create_task(context.new_work_event.wait())
+            try:
+                done, _ = await asyncio.wait(
+                    {*context.task_to_node, wakeup_waiter}, return_when=asyncio.FIRST_COMPLETED
+                )
+            finally:
+                wakeup_waiter.cancel()
 
             if context.was_reset_since(generation):
                 # Reaping here would look up tasks the teardown already discarded,
@@ -693,12 +738,17 @@ class ExecuteDagState(State):
                 ExecuteDagState._log_abandoned(context)
                 return None
 
-            # Decrement counter for completed tasks
-            context.running_tasks_count -= len(done)
-            # New node has finished - priorities are stale
-            context.node_priority_queue.mark_priorities_stale()
+            # Membership in task_to_node is the authoritative "is a node task" test, so
+            # filter on it rather than popping everything that came back done.
+            done_node_tasks = [task for task in done if task in context.task_to_node]
+
+            if done_node_tasks:
+                # Decrement counter for completed tasks
+                context.running_tasks_count -= len(done_node_tasks)
+                # New node has finished - priorities are stale
+                context.node_priority_queue.mark_priorities_stale()
             # Check for task exceptions and handle them properly.
-            for task in done:
+            for task in done_node_tasks:
                 dag_node = context.task_to_node.pop(task)
                 if task.cancelled():
                     # Task was cancelled - this is expected during flow cancellation
@@ -730,6 +780,22 @@ class ExecuteDagState(State):
                     return ErrorState
 
                 dag_node.node_state = NodeState.DONE
+        else:
+            # Nothing running and nothing dispatchable, but leaf nodes remain (something
+            # is gating them). Returning ExecuteDagState from here re-enters on_update
+            # through the FSM's advance loop with no suspension point in between, which
+            # would wedge the whole event loop - including the injector that could
+            # unblock us. Yield on the new-work flag so the retry loop is preserved but
+            # the loop keeps turning.
+            logger.warning(
+                "Flow '%s': no nodes are running and none can be dispatched yet; waiting for new work.",
+                context.flow_name,
+            )
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(context.new_work_event.wait(), timeout=_IDLE_RECHECK_SECONDS)
+            if context.was_reset_since(generation):
+                ExecuteDagState._log_abandoned(context)
+                return None
 
         # Once a task has finished, loop back to the top.
         await ExecuteDagState.pop_done_states(context)
@@ -826,6 +892,38 @@ class ParallelResolutionMachine(FSM[ParallelResolutionContext]):
         if self.context.dag_builder is None:
             self.context.dag_builder = self.context.engine.flow_manager.global_dag_builder
         await self.start(ExecuteDagState)
+
+    def inject_node(self, node: BaseNode, graph_name: str | None = None) -> list[BaseNode]:
+        """Add a node and its unresolved dependencies to this already-running run.
+
+        Queues whatever is ready and unparks the driver, so the node starts as soon as a
+        parallel slot frees up instead of waiting for an in-flight node to finish.
+
+        Synchronous on purpose. The driver only sees an injection as one atomic change to
+        its DAG and queue because the caller does its liveness check and this call with no
+        await in between. Do not make this ``async``.
+
+        Returns the nodes added to the DAG, for the caller to report as involved nodes.
+        """
+        context = self.context
+        if context.dag_builder is None:
+            msg = f"Attempted to run '{node.name}' as part of the current run, but that run has no dependency graph to add it to. Cancel the run and try again."
+            raise ValueError(msg)
+
+        added_nodes = context.dag_builder.add_node_with_dependencies(node, graph_name or node.name)
+        if node not in added_nodes:
+            added_nodes.append(node)
+        for added_node in added_nodes:
+            ExecuteDagState._try_queue_waiting_node(context, added_node.name)
+        context.signal_new_work()
+
+        if context.paused:
+            logger.info(
+                "Node '%s' was added to the paused run on flow '%s'. It will run when the run is stepped or continued.",
+                node.name,
+                context.flow_name,
+            )
+        return added_nodes
 
     async def cancel_all_nodes(self) -> None:
         """Cancel all executing tasks and set cancellation flags on all nodes."""

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -4797,7 +4797,25 @@ class FlowManager(EngineScoped):
         # We are now going to have different behavior depending on how the node is behaving.
         if self.check_for_existing_running_flow():
             # Now we know something is running, it's ParallelResolutionMachine, and that we are in single_node_resolution.
-            self._global_dag_builder.add_node_with_dependencies(node, node.name)
+            # Nothing below awaits before inject_node: that is what lets the running driver
+            # see this as one atomic change, rather than catching it half-applied or tearing
+            # the DAG down between the check above and the mutation.
+            machine = self._global_control_flow_machine
+            if machine is None:
+                msg = f"Attempted to run '{node.name}' as part of the workflow already in progress, but that workflow could not be found. Wait for it to finish and try again."
+                raise RuntimeError(msg)
+            # The cold path below unresolves the node before queueing it, and so must this
+            # one: otherwise an already-resolved node is treated as a duplicate completion
+            # and never re-runs, and the editor keeps showing it as resolved.
+            if not node.lock:
+                node.make_node_unresolved(
+                    current_states_to_trigger_change_event={
+                        NodeResolutionState.UNRESOLVED,
+                        NodeResolutionState.RESOLVED,
+                        NodeResolutionState.RESOLVING,
+                    }
+                )
+            machine.resolution_machine.inject_node(node)
             # Emit involved nodes update after adding node to DAG
             involved_nodes = list(self._global_dag_builder.node_to_reference.keys())
             self.engine.event_manager.put_event(

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -4807,14 +4807,7 @@ class FlowManager(EngineScoped):
             # The cold path below unresolves the node before queueing it, and so must this
             # one: otherwise an already-resolved node is treated as a duplicate completion
             # and never re-runs, and the editor keeps showing it as resolved.
-            if not node.lock:
-                node.make_node_unresolved(
-                    current_states_to_trigger_change_event={
-                        NodeResolutionState.UNRESOLVED,
-                        NodeResolutionState.RESOLVED,
-                        NodeResolutionState.RESOLVING,
-                    }
-                )
+            node.prepare_to_run_again()
             machine.resolution_machine.inject_node(node)
             # Emit involved nodes update after adding node to DAG
             involved_nodes = list(self._global_dag_builder.node_to_reference.keys())

--- a/tests/unit/machines/conftest.py
+++ b/tests/unit/machines/conftest.py
@@ -1,0 +1,35 @@
+"""Fixtures for the scheduler tests. Shared non-fixture scaffolding lives in scheduler_stubs.py."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+import pytest
+
+from griptape_nodes.machines.parallel_resolution import ExecuteDagState
+
+if TYPE_CHECKING:
+    from griptape_nodes.machines.dag_builder import DagNode
+
+
+@pytest.fixture
+def held_node_execution(monkeypatch: pytest.MonkeyPatch) -> asyncio.Event:
+    """These reach into the full engine (events, connections, library registry).
+
+    Stub them so these stay focused scheduler tests: they care about when a node is
+    dispatched, not what executing it does. `execute_node` blocks on the returned event
+    so a dispatched node stays PROCESSING long enough to assert on, instead of
+    completing in the same scheduler pass that started it.
+    """
+    monkeypatch.setattr(ExecuteDagState, "handle_done_nodes", AsyncMock())
+    monkeypatch.setattr(ExecuteDagState, "collect_values_from_upstream_nodes", AsyncMock())
+
+    hold = asyncio.Event()
+
+    async def _hold_until_released(_engine: object, _dag_node: DagNode) -> None:
+        await hold.wait()
+
+    monkeypatch.setattr(ExecuteDagState, "execute_node", _hold_until_released)
+    return hold

--- a/tests/unit/machines/scheduler_stubs.py
+++ b/tests/unit/machines/scheduler_stubs.py
@@ -1,0 +1,105 @@
+"""Shared scaffolding for the parallel-resolution scheduler tests.
+
+These build a machine that is already mid-run - one node PROCESSING, its task still
+pending - because that is the state every interesting scheduler question is about: what
+happens to a live DAG when something changes underneath the parked driver.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import NamedTuple
+from unittest.mock import AsyncMock, MagicMock
+
+from griptape_nodes.common.directed_graph import DirectedGraph
+from griptape_nodes.exe_types.node_types import BaseNode, NodeResolutionState
+from griptape_nodes.machines.dag_builder import DagBuilder, DagNode, NodeState
+from griptape_nodes.machines.parallel_resolution import ExecuteDagState, ParallelResolutionMachine
+
+
+class RunningMachine(NamedTuple):
+    machine: ParallelResolutionMachine
+    release: asyncio.Event
+    dag_builder: DagBuilder
+
+
+def node_stub(name: str) -> BaseNode:
+    """A node that is inert enough to be scheduled but never really executed."""
+    node = MagicMock(spec=BaseNode)
+    node.name = name
+    node.lock = False
+    node.state = NodeResolutionState.UNRESOLVED
+    node.parameters = []
+    # Instance attributes, so spec=BaseNode does not supply them. on_update touches both
+    # on the way to dispatching a node; validate must report no problems or we land in
+    # ErrorState instead of executing.
+    node.parameter_output_values = MagicMock()
+    node.validate_before_node_run = MagicMock(return_value=None)
+    return node
+
+
+def machine_running_one_node(max_nodes_in_parallel: int) -> RunningMachine:
+    """A machine with one PROCESSING node whose task is still pending.
+
+    Driving it parks it in `ExecuteDagState.on_update`'s `asyncio.wait`, which is
+    exactly the window an injection has to be able to interrupt.
+    """
+    running_node = node_stub("running")
+    running_node.state = NodeResolutionState.RESOLVING
+
+    graph = DirectedGraph()
+    graph.add_node("running")
+
+    # A stub engine keeps EngineScoped.engine from falling back to current_engine(),
+    # which would stand up the process-root engine here.
+    engine = MagicMock()
+    # Dispatching a node awaits this; a bare MagicMock is not awaitable.
+    engine.event_manager.aput_event = AsyncMock()
+    dag_builder = DagBuilder(engine)
+    dag_builder.graphs["running"] = graph
+    dag_builder.graph_to_nodes["running"] = {"running"}
+    dag_builder.node_to_reference["running"] = DagNode(node_reference=running_node, node_state=NodeState.PROCESSING)
+
+    machine = ParallelResolutionMachine(
+        "flow", max_nodes_in_parallel=max_nodes_in_parallel, dag_builder=dag_builder, engine=engine
+    )
+
+    release = asyncio.Event()
+    node_task = asyncio.ensure_future(release.wait())
+    machine.context.task_to_node[node_task] = dag_builder.node_to_reference["running"]
+    dag_builder.node_to_reference["running"].task_reference = node_task
+    machine.context.running_tasks_count = 1
+
+    return RunningMachine(machine=machine, release=release, dag_builder=dag_builder)
+
+
+def add_waiting_node(dag_builder: DagBuilder, name: str, graph_name: str) -> DagNode:
+    """Add a WAITING node to a graph, creating the graph if this is its first node."""
+    node = node_stub(name)
+    graph = dag_builder.graphs.setdefault(graph_name, DirectedGraph())
+    graph.add_node(name)
+    dag_builder.graph_to_nodes.setdefault(graph_name, set()).add(name)
+    dag_node = DagNode(node_reference=node, node_state=NodeState.WAITING)
+    dag_builder.node_to_reference[name] = dag_node
+    return dag_node
+
+
+def add_dependency(dag_builder: DagBuilder, graph_name: str, upstream: str, downstream: str) -> None:
+    """Make `downstream` depend on `upstream`, so it cannot be queued until `upstream` leaves."""
+    dag_builder.graphs[graph_name].add_edge(upstream, downstream)
+
+
+def queue_node(machine: ParallelResolutionMachine, name: str) -> None:
+    """Route a WAITING node through the real queueing funnel."""
+    ExecuteDagState._try_queue_waiting_node(machine.context, name)
+
+
+async def let_the_run_finish(driver: asyncio.Task, release: asyncio.Event, hold: asyncio.Event) -> None:
+    """Release both the pre-seeded node task and any dispatched node, then join.
+
+    The timeout is what turns "the driver never woke up" into a failure rather than a
+    hung test run.
+    """
+    release.set()
+    hold.set()
+    await asyncio.wait_for(driver, timeout=1)

--- a/tests/unit/machines/test_parallel_resolution_injection.py
+++ b/tests/unit/machines/test_parallel_resolution_injection.py
@@ -1,0 +1,205 @@
+"""A node added to a live run must start as soon as there is room for it.
+
+Running a single node while another single node is already resolving used to add the
+new node to the DAG and then leave it there: nothing queued it, and the driver was
+parked in `asyncio.wait`, whose awaitable set is snapshotted at call time. The node
+only started once some unrelated in-flight node happened to finish, so injection
+latency was "however long the shortest running node takes".
+
+These cover the two halves of the fix - queueing at injection time, and a wakeup that
+can actually break the driver's wait - plus the properties that make the wakeup safe
+to add to a loop that is also reaping node tasks.
+"""
+
+import asyncio
+
+import pytest
+
+from griptape_nodes.machines.dag_builder import NodeState
+from tests.unit.machines.scheduler_stubs import (
+    let_the_run_finish,
+    machine_running_one_node,
+    node_stub,
+)
+
+
+class TestInjectedNodeStartsImmediately:
+    @pytest.mark.asyncio
+    async def test_injected_node_runs_without_waiting_for_the_running_node(
+        self, held_node_execution: asyncio.Event
+    ) -> None:
+        machine, release, dag_builder = machine_running_one_node(max_nodes_in_parallel=2)
+
+        driver = asyncio.create_task(machine.resolve_node())
+        await asyncio.sleep(0)
+        assert machine.is_advancing, "driver should be parked on the running node"
+
+        injected = node_stub("injected")
+        machine.inject_node(injected)
+
+        # No release of the running node: the whole point is that the injected node
+        # does not have to wait for it.
+        for _ in range(20):
+            if dag_builder.node_to_reference["injected"].node_state is NodeState.PROCESSING:
+                break
+            await asyncio.sleep(0)
+
+        assert dag_builder.node_to_reference["injected"].node_state is NodeState.PROCESSING, (
+            "injected node should have been dispatched while the other node is still running"
+        )
+        expected_running = 2  # the pre-seeded node plus the injected one
+        assert machine.context.running_tasks_count == expected_running
+
+        await let_the_run_finish(driver, release, held_node_execution)
+
+    @pytest.mark.asyncio
+    async def test_injection_queues_the_node_even_with_no_driver_running(self) -> None:
+        machine, _release, dag_builder = machine_running_one_node(max_nodes_in_parallel=2)
+
+        injected = node_stub("injected")
+        added = machine.inject_node(injected)
+
+        assert injected in added
+        assert dag_builder.node_to_reference["injected"].node_state is NodeState.QUEUED
+        assert machine.context.new_work_event.is_set()
+
+
+class TestInjectionRespectsTheConcurrencyCap:
+    @pytest.mark.asyncio
+    async def test_injected_node_waits_for_a_free_slot(self, held_node_execution: asyncio.Event) -> None:
+        machine, release, dag_builder = machine_running_one_node(max_nodes_in_parallel=1)
+
+        driver = asyncio.create_task(machine.resolve_node())
+        await asyncio.sleep(0)
+
+        injected = node_stub("injected")
+        machine.inject_node(injected)
+
+        # Give the woken driver every chance to overshoot the cap.
+        for _ in range(20):
+            await asyncio.sleep(0)
+
+        assert dag_builder.node_to_reference["injected"].node_state is NodeState.QUEUED, (
+            "the pool is full, so the injected node must stay queued"
+        )
+        assert machine.context.running_tasks_count == 1, "must not oversubscribe max_nodes_in_parallel"
+
+        await let_the_run_finish(driver, release, held_node_execution)
+
+
+class TestTheWakeupIsSafeToAddToTheReapLoop:
+    @pytest.mark.asyncio
+    async def test_a_wakeup_does_not_reap_the_still_running_node(self, held_node_execution: asyncio.Event) -> None:
+        """The waiter is not a node task, so it must not be popped from task_to_node."""
+        machine, release, _dag_builder = machine_running_one_node(max_nodes_in_parallel=2)
+
+        driver = asyncio.create_task(machine.resolve_node())
+        await asyncio.sleep(0)
+
+        machine.inject_node(node_stub("injected"))
+        for _ in range(20):
+            await asyncio.sleep(0)
+
+        node_names = {dag_node.node_reference.name for dag_node in machine.context.task_to_node.values()}
+        assert "running" in node_names, "waking for an injection must not retire the running node"
+        assert machine.context.running_tasks_count == len(machine.context.task_to_node)
+
+        await let_the_run_finish(driver, release, held_node_execution)
+
+    @pytest.mark.asyncio
+    async def test_wakeup_waiter_does_not_leak(self, held_node_execution: asyncio.Event) -> None:
+        machine, release, _dag_builder = machine_running_one_node(max_nodes_in_parallel=2)
+        before = asyncio.all_tasks()
+
+        driver = asyncio.create_task(machine.resolve_node())
+        await asyncio.sleep(0)
+        machine.inject_node(node_stub("injected"))
+        await let_the_run_finish(driver, release, held_node_execution)
+        # Let the cancelled waiters actually finish unwinding.
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+        leaked = {task for task in asyncio.all_tasks() if task not in before and task is not driver}
+        leaked = {task for task in leaked if not task.done()}
+        assert not leaked, f"scheduling waiters should not outlive the drive: {leaked}"
+
+    @pytest.mark.asyncio
+    async def test_driver_does_not_spin_when_nothing_can_be_dispatched(
+        self, held_node_execution: asyncio.Event
+    ) -> None:
+        """A set flag with nothing dispatchable must suspend, not busy-loop.
+
+        The flag is consumed at the top of every dispatch pass, so a node the queue
+        refuses cannot leave the driver re-entering on_update forever at 100% CPU.
+        """
+        machine, release, _dag_builder = machine_running_one_node(max_nodes_in_parallel=2)
+
+        driver = asyncio.create_task(machine.resolve_node())
+        await asyncio.sleep(0)
+
+        # Signal work that does not exist: nothing was added to the queue.
+        machine.context.signal_new_work()
+        for _ in range(50):
+            await asyncio.sleep(0)
+
+        assert not driver.done(), "driver should still be parked on the running node"
+        assert not machine.context.new_work_event.is_set(), "the spurious signal was consumed, not left to spin"
+
+        await let_the_run_finish(driver, release, held_node_execution)
+
+
+class TestInjectionIntoAPausedRun:
+    @pytest.mark.asyncio
+    async def test_paused_run_queues_the_node_but_does_not_start_it(self, held_node_execution: asyncio.Event) -> None:
+        machine, release, dag_builder = machine_running_one_node(max_nodes_in_parallel=2)
+
+        driver = asyncio.create_task(machine.resolve_node())
+        await asyncio.sleep(0)
+        machine.change_debug_mode(debug_mode=True)
+
+        machine.inject_node(node_stub("injected"))
+        for _ in range(20):
+            await asyncio.sleep(0)
+
+        assert dag_builder.node_to_reference["injected"].node_state is NodeState.QUEUED, (
+            "a paused run must not start the injected node"
+        )
+
+        release.set()
+        held_node_execution.set()
+        await asyncio.wait_for(driver, timeout=1)
+        assert not machine.is_advancing
+
+        # Continuing the run picks the queued node up. Hold the DagNode itself: finishing
+        # the run clears node_to_reference, so it cannot be looked up by name afterwards.
+        injected_dag_node = dag_builder.node_to_reference["injected"]
+        machine.change_debug_mode(debug_mode=False)
+        await machine.update()
+        assert injected_dag_node.node_state is NodeState.DONE, "continuing the run must run the queued node"
+
+
+class TestTeardownWhileParkedOnTheWakeup:
+    @pytest.mark.asyncio
+    async def test_reset_unparks_the_driver_without_waiting_for_the_running_node(self) -> None:
+        """reset() must release the FSM's single-driver claim promptly.
+
+        It clears task_to_node but cannot itself break the driver's wait, so before the
+        wakeup existed the driver held the claim until some *old* node task finished,
+        and any resolve_node in that window died on the single-driver guard.
+        """
+        machine, release, _dag_builder = machine_running_one_node(max_nodes_in_parallel=2)
+
+        driver = asyncio.create_task(machine.resolve_node())
+        await asyncio.sleep(0)
+        assert machine.is_advancing
+
+        machine.reset_machine()
+
+        # The running node is deliberately never released.
+        await asyncio.wait_for(driver, timeout=1)
+
+        assert not machine.is_advancing, "the abandoned driver released the machine"
+        assert machine.current_state is None, "teardown left the machine reset, not resurrected"
+        assert not machine.context.task_to_node
+
+        release.set()


### PR DESCRIPTION
closes https://github.com/griptape-ai/griptape-nodes-engine/issues/4461 
Running a single node while another single-node resolution is already in flight added the node to the live DAG and stopped there. Nothing queued it, and the driver was parked in `asyncio.wait`, whose awaitable set is snapshotted at call time — so the new node only started once some unrelated in-flight node happened to finish. Injection latency was "however long the shortest running node takes".

Two halves to the fix:

`ParallelResolutionMachine.inject_node` adds the node plus its unresolved dependencies, routes every added node through `_try_queue_waiting_node` (the single queueing funnel, so lock and dependency gating still apply), and signals the driver. It is synchronous on purpose: the driver sees an injection as one atomic change to its DAG and queue only because the caller does its liveness check and this call with no await in between.

`ParallelResolutionContext.new_work_event` plus a per-iteration waiter task in the dispatch loop's `asyncio.wait` is what can actually break that wait. Supporting properties, all load-bearing:

- The waiter is kept out of `task_to_node`. Everything that walks that map treats its members as node tasks, so the reap now filters on membership in it rather than popping everything that came back done.
- `reset()` sets the flag so an abandoning driver takes its abandon path immediately instead of holding the FSM's single-driver claim until some old node task finishes. It deliberately does not rebind the Event the way it replaces the priority queue — a parked driver may still hold a waiter derived from it.
- Every `clear()` is followed by a full queue drain with no await in between. Clearing later swallows an injection that lands while the driver is suspended; clearing only when the waiter fires spins the loop at 100% CPU.
- When nothing is running and nothing is dispatchable but leaves remain, the loop yields on the flag with a short timeout instead of returning `ExecuteDagState`. `FSM._advance` re-enters `on_update` on a self-loop with no yield to the event loop, so returning from there wedges the loop — including the injector that could unblock it.

`resolve_singular_node`'s injection branch also unresolves the node before injecting, matching the cold path. Without it an already-resolved node trips `handle_done_nodes`' duplicate-completion guard, never re-runs, and the editor keeps showing it resolved.