### PR TITLE
fix: anchor relative paths on workspace

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,35 @@ jobs:
         # make (e=2): The system cannot find the file specified.
         # make: *** [Makefile:24: test/unit] Error 2
         run: uv run pytest -n auto tests/unit
+  integration-test-ubuntu:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
+    steps:
+      - name: Checkout actions
+        uses: actions/checkout@v7
+      - name: Init environment
+        uses: ./.github/actions/init-environment
+      - name: Run integration tests
+        run: make test/integration
+  integration-test-windows:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout actions
+        uses: actions/checkout@v7
+      - name: Init environment
+        uses: ./.github/actions/init-environment
+      - name: Run integration tests
+        run: uv run pytest tests/integration
   e2e-test-ubuntu:
     runs-on: ubuntu-latest
     strategy:

--- a/docs/guides/projects/workspace.md
+++ b/docs/guides/projects/workspace.md
@@ -196,7 +196,9 @@ Because `workspace_dir` is the highest-priority source, this wins over any `proj
 
 ## How paths resolve
 
-All relative paths in the project system resolve against the **workspace directory**. If your workspace is `/Users/you/workspace/` and a situation macro resolves to `outputs/render_001.png`, the final absolute path is `/Users/you/workspace/outputs/render_001.png`.
+Relative file paths in your workflows resolve against the **workspace directory**. If your workspace is `/Users/you/workspace/` and a situation macro resolves to `outputs/render_001.png`, the final absolute path is `/Users/you/workspace/outputs/render_001.png`.
+
+Relative paths written in the project file resolve against the folder that holds the project YAML, which is how the `workspace_dir: ./workspace` example above finds its workspace.
 
 Libraries are the exception: they install and resolve under the workspace-relative `libraries` directory by default, but a project can relocate them (and share them across a project tree) with the [`libraries_dir`](projects.md#libraries-directory) field, independent of the workspace.
 

--- a/src/griptape_nodes/files/drivers/local_file_driver.py
+++ b/src/griptape_nodes/files/drivers/local_file_driver.py
@@ -10,8 +10,10 @@ from griptape_nodes.files.path_utils import (
     normalize_path_for_platform,
     parse_file_uri,
     path_needs_expansion,
+    resolve_path_safely,
     sanitize_path_string,
 )
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 
 class LocalFileDriver(BaseFileDriver):
@@ -21,7 +23,8 @@ class LocalFileDriver(BaseFileDriver):
     For writing files, use OSManager directly.
 
     This driver is automatically registered last (priority 100) as it matches all
-    absolute paths and file:// URIs (fallback driver).
+    absolute paths, workspace-relative paths, and file:// URIs (fallback driver).
+    Relative paths are anchored on the workspace directory, never the process CWD.
     """
 
     @property
@@ -51,11 +54,12 @@ class LocalFileDriver(BaseFileDriver):
     def _resolve_path(self, location: str) -> Path:
         """Resolve a location string to a local filesystem Path.
 
-        Handles file:// URI parsing, path sanitization, expansion, and
-        platform normalization.
+        Handles file:// URI parsing, path sanitization, expansion, anchoring of
+        relative paths on the workspace directory, and platform normalization.
 
         Args:
-            location: Absolute file path, file:// URI, or path with ~
+            location: Absolute file path, file:// URI, path with ~, or a path
+                relative to the workspace directory
 
         Returns:
             Resolved Path object
@@ -84,6 +88,13 @@ class LocalFileDriver(BaseFileDriver):
         else:
             path = Path(clean_location)
 
+        # Anchor a relative path on the workspace directory. Mirrors File.resolve()
+        # logic so reported path matches opened path.
+        if not path.is_absolute():
+            workspace_path = GriptapeNodes.ConfigManager().workspace_path
+            # Normalise joined path without evaluating symlinks en route.
+            path = resolve_path_safely(workspace_path / path)
+
         # Normalize for platform (Windows long paths, etc.)
         return Path(normalize_path_for_platform(path))
 
@@ -91,7 +102,8 @@ class LocalFileDriver(BaseFileDriver):
         """Read file from local filesystem with validation.
 
         Args:
-            location: Absolute file path, file:// URI, or path with ~
+            location: Absolute file path, file:// URI, path with ~, or a path
+                relative to the workspace directory
             timeout: Ignored for local files
 
         Returns:
@@ -119,7 +131,8 @@ class LocalFileDriver(BaseFileDriver):
         """Check if file exists on local filesystem.
 
         Args:
-            location: Absolute file path or file:// URI
+            location: Absolute file path, file:// URI, path with ~, or a path
+                relative to the workspace directory
 
         Returns:
             True if file exists and is a file (not directory)
@@ -135,7 +148,8 @@ class LocalFileDriver(BaseFileDriver):
         """Get file size from local filesystem.
 
         Args:
-            location: Absolute file path or file:// URI
+            location: Absolute file path, file:// URI, path with ~, or a path
+                relative to the workspace directory
 
         Returns:
             File size in bytes

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -543,7 +543,9 @@ class OSManager(EngineScoped):
             path_str: Path string that may contain ~, environment variables, or special folder names
 
         Returns:
-            Expanded Path object
+            Expanded, absolute Path object. A result that is still relative after expansion is
+            anchored on the workspace directory. Windows special folders resolve to their
+            actual system paths (e.g. OneDrive redirection).
         """
         resolved = None
         if self.is_windows():
@@ -562,17 +564,25 @@ class OSManager(EngineScoped):
             expanded_user = os.path.expanduser(expanded_vars)  # noqa: PTH111
             final_path = Path(expanded_user)
 
+        # Anchor a relative expansion result on the workspace directory. Expansion leaves a
+        # path relative when the string contains '%' or '$' but no resolvable variable
+        # (e.g. "foo%20bar.txt", "report$.txt", "$UNSET_VAR/sub").
+        if not final_path.is_absolute():
+            final_path = self._get_workspace_path() / final_path
+
         return resolve_path_safely(final_path)
 
     def _resolve_file_path(self, path_str: str, *, workspace_only: bool = False) -> Path:
         """Resolve a file path, handling absolute, relative, and tilde paths.
 
         Args:
-            path_str: Path string that may be absolute, relative, or start with ~
+            path_str: Path string that may be absolute, start with ~, or be a path relative
+                to the workspace directory
             workspace_only: If True and path is invalid, fall back to workspace directory
 
         Returns:
-            Resolved Path object
+            Absolute, resolved Path object. Relative paths resolve against the workspace
+            directory.
         """
         try:
             if path_needs_expansion(path_str):

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -4,10 +4,7 @@ from __future__ import annotations
 
 import json
 import os
-import tempfile
-from pathlib import Path
 from typing import TYPE_CHECKING
-from unittest.mock import patch
 
 import pytest
 
@@ -25,10 +22,11 @@ from griptape_nodes.utils.version_utils import engine_version
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, Sequence
+    from pathlib import Path
 
 
 @pytest.fixture(autouse=True)
-def _isolated_engine_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+def _isolated_engine_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Iterator[None]:
     """Boot each test against empty temp config/secrets and a clean registry.
 
     ``SecretsManager`` installs ``ENV_VAR_PATH``'s contents into ``os.environ`` at init;
@@ -47,16 +45,14 @@ def _isolated_engine_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
         if key.startswith(("GT_CLOUD_", "GTN_CONFIG_")):
             monkeypatch.delenv(key, raising=False)
     try:
-        with tempfile.TemporaryDirectory() as temp_dir:
-            temp_config_path = Path(temp_dir) / "griptape_nodes_config.json"
-            temp_config_path.write_text(json.dumps({}, indent=2))
-            temp_env_path = Path(temp_dir) / ".env"
-            temp_env_path.write_text("")
-            with (
-                patch.object(config_manager_module, "USER_CONFIG_PATH", temp_config_path),
-                patch.object(secrets_manager_module, "ENV_VAR_PATH", temp_env_path),
-            ):
-                yield
+        temp_workspace_path = tmp_path / "workspace"
+        temp_config_path = tmp_path / "griptape_nodes_config.json"
+        temp_config_path.write_text(json.dumps({"workspace_directory": str(temp_workspace_path)}, indent=2))
+        temp_env_path = tmp_path / ".env"
+        temp_env_path.write_text("")
+        monkeypatch.setattr(config_manager_module, "USER_CONFIG_PATH", temp_config_path)
+        monkeypatch.setattr(secrets_manager_module, "ENV_VAR_PATH", temp_env_path)
+        yield
     finally:
         reset_root_engine()
         LibraryRegistry._clear()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,12 +1,49 @@
+import json
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
 import pytest  # type: ignore[reportMissingImports]
 
+from griptape_nodes.node_library.library_registry import LibraryRegistry
+from griptape_nodes.retained_mode.engine import reset_root_engine
 from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers import config_manager as config_manager_module
+from griptape_nodes.retained_mode.managers import secrets_manager as secrets_manager_module
 from griptape_nodes.utils import install_file_url_support
 
 # Install file:// URL support for httpx/requests in integration tests
 install_file_url_support()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_engine_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Iterator[None]:
+    """Boot each test against empty temp config/secrets and a clean registry.
+
+    Dropping the root engine forces the managers to re-initialize against the patched paths
+    and gives each test a fresh object registry. ``LibraryRegistry`` keeps its state in
+    ``ClassVar`` dicts that the engine does not own, so it is reset explicitly.
+    """
+    reset_root_engine()
+    LibraryRegistry._clear()
+
+    for key in list(os.environ):
+        if key.startswith(("GT_CLOUD_", "GTN_CONFIG_")):
+            monkeypatch.delenv(key, raising=False)
+    try:
+        temp_workspace_path = tmp_path / "workspace"
+        temp_config_path = tmp_path / "griptape_nodes_config.json"
+        temp_config_path.write_text(json.dumps({"workspace_directory": str(temp_workspace_path)}, indent=2))
+        temp_env_path = tmp_path / ".env"
+        temp_env_path.write_text("")
+        monkeypatch.setattr(config_manager_module, "USER_CONFIG_PATH", temp_config_path)
+        monkeypatch.setattr(secrets_manager_module, "ENV_VAR_PATH", temp_env_path)
+        yield
+    finally:
+        reset_root_engine()
+        LibraryRegistry._clear()
 
 
 @pytest.fixture

--- a/tests/integration/files/test_files.py
+++ b/tests/integration/files/test_files.py
@@ -1,0 +1,38 @@
+"""End-to-end round trips through the real engine for `File` paths."""
+
+from pathlib import Path
+
+import pytest
+
+from griptape_nodes.files.file import File
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+
+class TestRelativePathRoundTrip:
+    @pytest.fixture
+    def cwd_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        """Run the test from a directory that is *not* the workspace.
+
+        Depends on `workspace_path` purely for ordering: the engine and its
+        ConfigManager must exist before the process working directory moves.
+        `monkeypatch.chdir` restores the original directory automatically.
+        """
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        return cwd
+
+    @pytest.mark.parametrize(
+        "relative_path",
+        ["config.json", "data/nested.json", pytest.param("foo%20bar.txt"), pytest.param("report$.txt")],
+    )
+    def test_write_then_read_resolves_to_the_workspace(self, relative_path: str, cwd_path: Path) -> None:
+        content = f"round trip content for {relative_path}"
+
+        written_path = File(relative_path).write_text(content)
+
+        assert File(relative_path).read_text() == content
+        # Compare against the ConfigManager's own getter, which is `.resolve()`d, so a
+        # symlinked temp directory (macOS `/tmp` -> `/private/tmp`) does not fail this.
+        assert written_path == GriptapeNodes.ConfigManager().workspace_path / relative_path
+        assert not (cwd_path / relative_path).exists()

--- a/tests/integration/retained_mode/events/test_config_events.py
+++ b/tests/integration/retained_mode/events/test_config_events.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from griptape_nodes.retained_mode.events.config_events import (
     GetConfigValueRequest,
     GetConfigValueResultSuccess,
@@ -14,6 +16,7 @@ from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 
 class TestConfigEvents:
+    @pytest.mark.xfail(strict=True, reason="Drifted due to not running on CI - see #5237")
     def test_get_config_value(self) -> None:
         GriptapeNodes.handle_request(SetSecretValueRequest(key="SECRET_KEY", value="secret foo"))
         GriptapeNodes.handle_request(SetConfigValueRequest(category_and_key="nodes.foo.bar", value="$SECRET_KEY"))

--- a/tests/integration/retained_mode/events/test_lock_nodes.py
+++ b/tests/integration/retained_mode/events/test_lock_nodes.py
@@ -46,6 +46,7 @@ class TestLockNodes:
         assert hasattr(r2, "node_name")
         return r1.node_name, r2.node_name  # type: ignore[attr-defined]
 
+    @pytest.mark.xfail(strict=True, reason="Drifted due to not running on CI - see #5237")
     def test_lock_single_node_by_name(self, create_node: str) -> None:
         node_name = create_node
         # Lock
@@ -71,6 +72,7 @@ class TestLockNodes:
         assert isinstance(info_res2, GetAllNodeInfoResultSuccess)
         assert info_res2.locked is False
 
+    @pytest.mark.xfail(strict=True, reason="Drifted due to not running on CI - see #5237")
     def test_lock_multiple_nodes(self, create_two_nodes: tuple[str, str]) -> None:
         node_a, node_b = create_two_nodes
 
@@ -102,6 +104,7 @@ class TestLockNodes:
         assert info_a2.locked is False
         assert info_b2.locked is False
 
+    @pytest.mark.xfail(strict=True, reason="Drifted due to not running on CI - see #5237")
     def test_lock_with_current_context_when_name_missing(self) -> None:
         # Create a node and set as current context
         create_req = CreateNodeRequest(
@@ -122,6 +125,7 @@ class TestLockNodes:
         assert isinstance(info_res, GetAllNodeInfoResultSuccess)
         assert info_res.locked is True
 
+    @pytest.mark.xfail(strict=True, reason="Drifted due to not running on CI - see #5237")
     def test_lock_multiple_with_missing_node_returns_failure(self, create_node: str) -> None:
         existing = create_node
         missing = "does_not_exist_123"

--- a/tests/integration/retained_mode/events/test_node_events.py
+++ b/tests/integration/retained_mode/events/test_node_events.py
@@ -12,6 +12,8 @@ from griptape_nodes.retained_mode.events.node_events import (
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
+pytestmark = pytest.mark.xfail(strict=True, reason="Drifted due to not running on CI - see #5237")
+
 
 class TestNodeEvents:
     @pytest.fixture

--- a/tests/unit/files/drivers/test_local_file_driver.py
+++ b/tests/unit/files/drivers/test_local_file_driver.py
@@ -1,12 +1,17 @@
 """Unit tests for LocalFileDriver."""
 
 import platform
+import sys
+from collections.abc import Iterator
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
 from griptape_nodes.files.drivers.local_file_driver import LocalFileDriver
 from griptape_nodes.files.path_utils import parse_file_uri
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
 
 
 class TestLocalFileDriver:
@@ -272,3 +277,217 @@ class TestLocalFileDriverFileURI:
 
         with pytest.raises(ValueError, match="Invalid file:// URI"):
             driver.get_size(invalid_uri)
+
+
+class TestLocalFileDriverRelativePaths:
+    """Tests that relative paths anchor on the workspace directory, never the process CWD."""
+
+    @pytest.fixture
+    def driver(self) -> LocalFileDriver:
+        """Create a LocalFileDriver instance."""
+        return LocalFileDriver()
+
+    @pytest.fixture
+    def workspace_path(self, tmp_path: Path) -> Path:
+        """Create a workspace directory holding the files the driver should find."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        (workspace / "config.json").write_text("workspace copy")
+        (workspace / "foo%20bar.png").write_text("workspace percent copy")
+        (workspace / "report$.txt").write_text("workspace dollar copy")
+        (workspace / "workspace_only.json").write_text("workspace only copy")
+        nested_dir = workspace / "data"
+        nested_dir.mkdir()
+        (nested_dir / "nested.json").write_text("workspace nested copy")
+        return workspace
+
+    @pytest.fixture
+    def cwd_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        """Create a decoy directory with same-named, different-content files, and chdir into it."""
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        (cwd / "config.json").write_text("cwd copy")
+        (cwd / "foo%20bar.png").write_text("cwd percent copy")
+        (cwd / "report$.txt").write_text("cwd dollar copy")
+        (cwd / "cwd_only.json").write_text("cwd only copy")
+        nested_dir = cwd / "data"
+        nested_dir.mkdir()
+        (nested_dir / "nested.json").write_text("cwd nested copy")
+        monkeypatch.chdir(cwd)
+        return cwd
+
+    @pytest.fixture
+    def home_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        """Create a fake home directory and point ~ expansion at it."""
+        home = tmp_path / "home"
+        home.mkdir()
+        (home / "config.json").write_text("home copy")
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("USERPROFILE", str(home))
+        return home
+
+    @pytest.fixture
+    def mock_config_manager(self, workspace_path: Path) -> Mock:
+        """Mock the ConfigManager so its workspace_path is our test workspace."""
+        config_manager = Mock(spec=ConfigManager)
+        config_manager.workspace_path = workspace_path
+        return config_manager
+
+    @pytest.fixture
+    def mock_config_manager_accessor(self, mock_config_manager: Mock) -> Iterator[Mock]:
+        """Patch the facade accessor the driver uses to reach the ConfigManager.
+
+        Deliberately not `monkeypatch.setattr`: it snapshots `getattr(GriptapeNodes,
+        "ConfigManager")`, which for a classmethod is the *bound* method, and on teardown
+        writes that bound method into `GriptapeNodes.__dict__` instead of the original
+        classmethod descriptor. That permanently mutates a process-global facade class every
+        other test shares. Saving and restoring `__dict__` puts the real descriptor back.
+        """
+        original_descriptor = GriptapeNodes.__dict__["ConfigManager"]
+        accessor = Mock(spec=GriptapeNodes.ConfigManager, return_value=mock_config_manager)
+        GriptapeNodes.ConfigManager = accessor  # type: ignore[method-assign]
+        try:
+            yield accessor
+        finally:
+            GriptapeNodes.ConfigManager = original_descriptor  # type: ignore[method-assign]
+
+    @pytest.mark.asyncio
+    async def test_read_bare_relative_path_uses_workspace_not_cwd(
+        self,
+        driver: LocalFileDriver,
+        cwd_path: Path,  # noqa: ARG002
+        mock_config_manager_accessor: Mock,
+    ) -> None:
+        """Test a bare relative path reads the workspace copy, not the same-named CWD copy."""
+        content = await driver.read("config.json", timeout=10.0)
+
+        assert content == b"workspace copy"
+        mock_config_manager_accessor.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_read_relative_path_with_subdirectories_uses_workspace(
+        self,
+        driver: LocalFileDriver,
+        cwd_path: Path,  # noqa: ARG002
+        mock_config_manager_accessor: Mock,
+    ) -> None:
+        """Test a relative path with subdirectories anchors under the workspace."""
+        content = await driver.read("data/nested.json", timeout=10.0)
+
+        assert content == b"workspace nested copy"
+        mock_config_manager_accessor.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_read_percent_encoded_relative_path_uses_workspace(
+        self,
+        driver: LocalFileDriver,
+        cwd_path: Path,  # noqa: ARG002
+        mock_config_manager_accessor: Mock,
+    ) -> None:
+        """Test a relative name containing '%' still anchors on the workspace after expansion.
+
+        '%' makes `path_needs_expansion` True, so expansion runs, but a URL-encoded filename
+        has no env var to substitute and comes back relative. It must still be anchored.
+        """
+        content = await driver.read("foo%20bar.png", timeout=10.0)
+
+        assert content == b"workspace percent copy"
+        mock_config_manager_accessor.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_read_dollar_relative_path_with_no_matching_env_var_uses_workspace(
+        self,
+        driver: LocalFileDriver,
+        cwd_path: Path,  # noqa: ARG002
+        mock_config_manager_accessor: Mock,
+    ) -> None:
+        """Test a relative name containing '$' with no matching env var anchors on the workspace."""
+        content = await driver.read("report$.txt", timeout=10.0)
+
+        assert content == b"workspace dollar copy"
+        mock_config_manager_accessor.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_exists_finds_relative_path_present_only_in_workspace(
+        self,
+        driver: LocalFileDriver,
+        cwd_path: Path,  # noqa: ARG002
+        mock_config_manager_accessor: Mock,
+    ) -> None:
+        """Test exists() is True for a relative name that exists only in the workspace."""
+        assert await driver.exists("workspace_only.json") is True
+        mock_config_manager_accessor.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_exists_misses_relative_path_present_only_in_cwd(
+        self,
+        driver: LocalFileDriver,
+        cwd_path: Path,  # noqa: ARG002
+        mock_config_manager_accessor: Mock,
+    ) -> None:
+        """Test exists() is False for a relative name that exists only in the process CWD."""
+        assert await driver.exists("cwd_only.json") is False
+        mock_config_manager_accessor.assert_called_once_with()
+
+    def test_get_size_bare_relative_path_measures_workspace_not_cwd(
+        self,
+        driver: LocalFileDriver,
+        cwd_path: Path,  # noqa: ARG002
+        mock_config_manager_accessor: Mock,
+    ) -> None:
+        """Test get_size() measures the workspace copy, not the shorter same-named CWD copy."""
+        size = driver.get_size("config.json")
+
+        assert size == len("workspace copy")
+        mock_config_manager_accessor.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_read_absolute_path_does_not_consult_workspace(
+        self,
+        driver: LocalFileDriver,
+        tmp_path: Path,
+        mock_config_manager_accessor: Mock,
+    ) -> None:
+        """Test an absolute path reads as-is without ever asking for the workspace directory."""
+        absolute_file = tmp_path / "absolute.json"
+        absolute_file.write_text("absolute copy")
+
+        content = await driver.read(str(absolute_file), timeout=10.0)
+
+        assert content == b"absolute copy"
+        mock_config_manager_accessor.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_read_tilde_path_expands_to_home_not_workspace(
+        self,
+        driver: LocalFileDriver,
+        home_path: Path,  # noqa: ARG002
+        mock_config_manager_accessor: Mock,
+    ) -> None:
+        """Test a ~ path expands to the home directory without the workspace prefixed onto it."""
+        content = await driver.read("~/config.json", timeout=10.0)
+
+        assert content == b"home copy"
+        mock_config_manager_accessor.assert_not_called()
+
+    @pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX symlinks")
+    @pytest.mark.asyncio
+    async def test_read_relative_path_through_symlink_collapses_dotdot_lexically(
+        self,
+        driver: LocalFileDriver,
+        tmp_path: Path,
+        workspace_path: Path,
+        mock_config_manager_accessor: Mock,
+    ) -> None:
+        """Test '..' after a symlinked directory cancels the link name instead of walking through it."""
+        outside_dir = tmp_path / "mnt"
+        symlink_target = outside_dir / "target"
+        symlink_target.mkdir(parents=True)
+        (outside_dir / "b").write_bytes(b"mnt b")
+        (workspace_path / "b").write_bytes(b"workspace b")
+        (workspace_path / "link").symlink_to(symlink_target, target_is_directory=True)
+
+        content = await driver.read("link/../b", timeout=10.0)
+
+        assert content == b"workspace b"
+        mock_config_manager_accessor.assert_called_once_with()

--- a/tests/unit/retained_mode/managers/test_os_manager.py
+++ b/tests/unit/retained_mode/managers/test_os_manager.py
@@ -1174,17 +1174,16 @@ class TestExpandPath:
         yield
         griptape_nodes.ConfigManager().workspace_path = original_workspace
 
-    def test_expand_path_relative_resolved_against_cwd(
+    def test_expand_path_relative_anchored_on_workspace(
         self,
         griptape_nodes: GriptapeNodes,
         temp_dir: Path,  # noqa: ARG002
     ) -> None:
-        """Relative path is resolved against current working directory."""
+        """A path that is still relative after expansion is anchored on the workspace directory."""
         os_manager = griptape_nodes.OSManager()
         result = os_manager._expand_path("subdir")
-        # resolve_path_safely resolves relative paths against Path.cwd()
-        assert result.is_absolute()
-        assert result.name == "subdir"
+        expected = griptape_nodes.ConfigManager().workspace_path / "subdir"
+        assert result == expected
 
     def test_expand_path_expands_vars_and_tilde(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
         """Expandvars and expanduser are applied when not a Windows special folder."""
@@ -1220,6 +1219,71 @@ class TestExpandPath:
         result = os_manager._expand_path("~/Downloads")
         expected = resolve_path_safely(Path.home() / "Downloads")
         assert result == expected
+
+
+class TestResolveFilePath:
+    """Test OSManager._resolve_file_path anchoring behaviour."""
+
+    UNSET_VAR_NAME = "GRIPTAPE_UNSET_VAR_FOR_TEST"
+
+    @pytest.fixture
+    def temp_dir(self) -> Generator[Path, None, None]:
+        """Create a temporary directory for testing."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    @pytest.fixture(autouse=True)
+    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+        """Set workspace to temp_dir for tests."""
+        original_workspace = griptape_nodes.ConfigManager().workspace_path
+        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        yield
+        griptape_nodes.ConfigManager().workspace_path = original_workspace
+
+    @pytest.mark.parametrize(
+        "path_str",
+        [
+            "report$.txt",
+            "foo%20bar.txt",
+            "config.json",
+            "data/nested.json",
+        ],
+    )
+    def test_relative_path_anchored_on_workspace(self, griptape_nodes: GriptapeNodes, path_str: str) -> None:
+        """Relative paths resolve against the workspace directory, not the process CWD."""
+        os_manager = griptape_nodes.OSManager()
+        result = os_manager._resolve_file_path(path_str)
+        expected = griptape_nodes.ConfigManager().workspace_path / path_str
+        assert result == expected
+
+    def test_unresolvable_variable_anchored_on_workspace(
+        self, griptape_nodes: GriptapeNodes, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A path naming an undefined variable stays literal and is anchored on the workspace."""
+        monkeypatch.delenv(self.UNSET_VAR_NAME, raising=False)
+        os_manager = griptape_nodes.OSManager()
+        result = os_manager._resolve_file_path(f"${self.UNSET_VAR_NAME}/sub")
+        expected = griptape_nodes.ConfigManager().workspace_path / f"${self.UNSET_VAR_NAME}" / "sub"
+        assert result == expected
+
+    def test_tilde_path_not_anchored_on_workspace(self, griptape_nodes: GriptapeNodes) -> None:
+        """A ~ path expands to the user's home directory rather than the workspace."""
+        if platform.system() == "Windows":
+            pytest.skip("Windows resolves ~/Downloads through the Shell API special folder path")
+        os_manager = griptape_nodes.OSManager()
+        workspace_path = griptape_nodes.ConfigManager().workspace_path
+        result = os_manager._resolve_file_path("~/Downloads")
+        assert result == resolve_path_safely(Path.home() / "Downloads")
+        assert not result.is_relative_to(workspace_path)
+
+    def test_absolute_path_not_anchored_on_workspace(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
+        """An absolute path is returned unchanged rather than being joined onto the workspace."""
+        os_manager = griptape_nodes.OSManager()
+        workspace_path = griptape_nodes.ConfigManager().workspace_path
+        absolute_path = resolve_path_safely(tmp_path / "elsewhere" / "file.txt")
+        result = os_manager._resolve_file_path(str(absolute_path))
+        assert result == absolute_path
+        assert not result.is_relative_to(workspace_path)
 
 
 class TestWindowsLongPathHandling:


### PR DESCRIPTION
Closes #5318.

When a `ReadFileRequest` is made to the engine, the fallback file driver is the LocalFileDriver, used for reads from the file system.  A relative path was previously anchored on whatever the current working directory the engine happened to be launched from. This is inconsistent with various other functions/docs, which assume relative paths should be anchored on the workspace (e.g. `File.resolve()`).

So have the LocalFileDriver anchor relative paths on the workspace directory, using the same logic as `File.resolve()` - that is, with a workspace of `/opt`, a directory `/mnt/target` and a symlink `/opt/link` -> `/mnt/target`, the parameter value `link/../b` becomes `/opt/b`, not `/mnt/b`.

Writing (`WriteFileRequest`) does not use the driver and OSManager resolves relative paths itself.

For paths that do not potentially require expansion (no `~` or `$`), OSManager anchors on the workspace. But for paths which are expanded and remain relative after expansion (e.g. `report$.txt`), OSManager ultimately called `resolve_path_safely()`, which anchors on cwd.

So fix this discrepancy by anchoring on the workspace if a path is relative after expansion.

## Testing

> Note that nodes that use `resolve_to_macro_path` circumvent this problem (mostly - there is a corner case with non-existent files, whereupon a relative path falls back to cwd-anchored). 

At time of writing LoadDictionary uses `File(...).read_text()` directly, so is illustrative:

* Create a `config.json` with `{"is_from_cwd": false}` in the workspace
* In your (different) cwd, create a `config.json` with `{"is_from_cwd": true}`
* Start the engine in that cwd
* Create a LoadDictionary node
* Set the file_path to `config.json`
* Execute the node
* Before: the value `is_from_cwd=True`
* After: the value `is_from_cwd=False`