### PR TITLE
fix(workflows): name branched workflows with a title, not a file path

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,35 @@
 # Unreleased
 
+## Branched workflows show a title instead of a file path
+
+Branching a workflow used to set the new workflow's `metadata.name` — the human-readable display
+name — to its registry key, which is derived from the file path. A branch of "Shot 010 Comp" saved
+under `shots/sh010/` came back named `shots/sh010/comp_branch_1`, so anywhere the editor shows a
+workflow title, a branch read as a path while its own source next to it read as a title.
+
+A branch is now named after the workflow it came from:
+
+|                 | before                      | after                                   |
+| --------------- | --------------------------- | --------------------------------------- |
+| registry key    | `shots/sh010/comp_branch_1` | `shots/sh010/comp_branch_1` (unchanged) |
+| `metadata.name` | `shots/sh010/comp_branch_1` | `Shot 010 Comp (branch 1)`              |
+
+Registry keys are unchanged, so anything that looks workflows up by name keeps working. Merging a
+branch no longer overwrites its source's title, and resetting a branch no longer overwrites its own.
+
+`BranchWorkflowRequest` takes an optional `branched_workflow_display_name` if you want to set the
+label yourself:
+
+```python
+BranchWorkflowRequest(workflow_name="shots/sh010/comp", branched_workflow_display_name="Lighting Test")
+```
+
+**Workflows already on disk.** Files written by earlier versions still carry the path in their
+header. The engine shows the readable name (just the file name, e.g. `comp_branch_1`) when it loads
+one, and the header is rewritten the next time that workflow is saved. Nothing is rewritten during
+load, so no files change until you save them. Only a display name that exactly equals its own
+registry key is repaired — a title you deliberately wrote with a `/` in it is left alone.
+
 ## Agent streaming payloads carry `thread_id`
 
 `AgentStreamEvent`, `AgentThinkingEvent`, `AgentToolCallEvent`, and `AgentToolResultEvent`

--- a/src/griptape_nodes/retained_mode/events/workflow_events.py
+++ b/src/griptape_nodes/retained_mode/events/workflow_events.py
@@ -657,13 +657,17 @@ class BranchWorkflowRequest(RequestPayload):
 
     Args:
         workflow_name: Name of the workflow to branch
-        branched_workflow_name: Name for the branched workflow (None for auto-generated)
+        branched_workflow_name: Registry key for the branched workflow (None for auto-generated)
+        branched_workflow_display_name: Human-readable label (``metadata.name``) for the branch.
+            None derives one from the source workflow's display name, e.g. branching
+            "Shot 010 Comp" yields "Shot 010 Comp (branch 1)". Must not be blank when provided.
 
     Results: BranchWorkflowResultSuccess (with branch name) | BranchWorkflowResultFailure (branch error)
     """
 
     workflow_name: str
     branched_workflow_name: str | None = None
+    branched_workflow_display_name: str | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -1105,6 +1105,10 @@ class WorkflowManager(EngineScoped):
             if isinstance(request.metadata, dict):
                 request.metadata = WorkflowMetadata(**request.metadata)
 
+            request.metadata.name = self._repair_path_shaped_display_name(
+                display_name=request.metadata.name, registry_key=registry_key
+            )
+
             WorkflowRegistry.generate_new_workflow(
                 registry_key=registry_key, metadata=request.metadata, file_path=request.file_name
             )
@@ -1118,6 +1122,39 @@ class WorkflowManager(EngineScoped):
                 level=logging.DEBUG,
             ),
         )
+
+    def _repair_path_shaped_display_name(self, *, display_name: str, registry_key: str) -> str:
+        """Repair a display name that an older branch/merge/reset wrote as a registry key.
+
+        Those three sites used to write the path-derived registry key straight into ``metadata.name``,
+        so a branch of "Shot 010 Comp" living under ``shots/sh010/`` loaded as
+        "shots/sh010/comp_branch_1" everywhere the editor shows a workflow title. Files written by
+        those versions are still on disk, and they carry the *current* schema version -- the bug was
+        never a schema change -- so there is no version to gate on. We key on the damage itself.
+
+        Exact equality with the registry key is the fingerprint: a title someone actually typed does
+        not coincide with its own file path. Everything else is left alone, including a name that
+        merely happens to contain a separator, which may well be deliberate.
+
+        In-memory only. Rewriting headers during load would touch a pile of user files, churning
+        mtimes and git diffs for a cosmetic label; the repaired name persists on its own the next
+        time the workflow is saved for any other reason.
+        """
+        if display_name != registry_key:
+            return display_name
+        if "/" not in registry_key:
+            # A workspace-root workflow whose title matches its file stem. Nothing path-shaped here,
+            # and nothing the three sites broke -- they only read badly with directories in the key.
+            return display_name
+
+        repaired_name = PurePosixPath(registry_key).name
+        logger.debug(
+            "Workflow '%s' carries its registry key as its display name (written by a pre-fix branch, "
+            "merge, or reset). Showing it as '%s'; the file keeps the old name until its next save.",
+            registry_key,
+            repaired_name,
+        )
+        return repaired_name
 
     async def on_import_workflow_request(self, request: ImportWorkflowRequest) -> ResultPayload:
         # First, attempt to load metadata from the file
@@ -6094,15 +6131,20 @@ class WorkflowManager(EngineScoped):
             )
             return BranchWorkflowResultFailure(result_details=details)
 
-        # Generate branch name if not provided
-        branch_name = request.branched_workflow_name
-        if branch_name is None:
-            base_name = request.workflow_name
-            counter = 1
-            branch_name = f"{base_name}_branch_{counter}"
-            while WorkflowRegistry.has_workflow_with_name(branch_name):
-                counter += 1
-                branch_name = f"{base_name}_branch_{counter}"
+        # A caller-supplied display name has to actually say something; a blank label would leave the
+        # branch looking nameless everywhere the editor shows a workflow title.
+        requested_display_name = request.branched_workflow_display_name
+        if requested_display_name is not None and not requested_display_name.strip():
+            details = (
+                f"Attempted to branch workflow '{request.workflow_name}' with an empty display name. "
+                "Provide a display name with at least one non-whitespace character, or leave it unset "
+                "to name the branch after the workflow it came from."
+            )
+            return BranchWorkflowResultFailure(result_details=details)
+
+        branch_naming = self._resolve_branch_naming(request=request, source_workflow=source_workflow)
+        branch_name = branch_naming.registry_key
+        branch_display_name = branch_naming.display_name
 
         # Check if branch name already exists
         if WorkflowRegistry.has_workflow_with_name(branch_name):
@@ -6112,7 +6154,8 @@ class WorkflowManager(EngineScoped):
         try:
             # Create branch metadata by copying source metadata
             branch_metadata = WorkflowMetadata(
-                name=branch_name,
+                # The display name, not the registry key: `branch_name` is a file path.
+                name=branch_display_name,
                 schema_version=source_workflow.metadata.schema_version,
                 engine_version_created_with=source_workflow.metadata.engine_version_created_with,
                 node_libraries_referenced=source_workflow.metadata.node_libraries_referenced.copy(),
@@ -6170,6 +6213,81 @@ class WorkflowManager(EngineScoped):
 
             traceback.print_exc()
             return BranchWorkflowResultFailure(result_details=details)
+
+    class _BranchNaming(NamedTuple):
+        """The two distinct names a new branch needs.
+
+        `registry_key` is the workspace-relative file path minus its extension, used to key the
+        registry. `display_name` is the human-readable title stored as `metadata.name`. Conflating
+        them is what made branches show up in the editor as file paths.
+        """
+
+        registry_key: str
+        display_name: str
+
+    def _resolve_branch_naming(self, *, request: BranchWorkflowRequest, source_workflow: Workflow) -> _BranchNaming:
+        """Pick the registry key and display name for a new branch of ``source_workflow``.
+
+        The two are resolved together because the label depends on how the key was chosen: an
+        auto-generated key contributes its ``_branch_<n>`` counter to the label, while a
+        caller-supplied key does not. ``request.branched_workflow_display_name``, when given, wins
+        over either derivation; ``on_branch_workflow_request`` has already rejected a blank one.
+        """
+        branch_counter = None
+        branch_registry_key = request.branched_workflow_name
+        if branch_registry_key is None:
+            branch_counter = 1
+            branch_registry_key = f"{request.workflow_name}_branch_{branch_counter}"
+            while WorkflowRegistry.has_workflow_with_name(branch_registry_key):
+                branch_counter += 1
+                branch_registry_key = f"{request.workflow_name}_branch_{branch_counter}"
+
+        requested_display_name = request.branched_workflow_display_name
+        if requested_display_name is not None:
+            return self._BranchNaming(registry_key=branch_registry_key, display_name=requested_display_name.strip())
+
+        derived_display_name = self._derive_branch_display_name(
+            source_display_name=source_workflow.metadata.name,
+            source_registry_key=request.workflow_name,
+            branch_registry_key=branch_registry_key,
+            branch_counter=branch_counter,
+        )
+        return self._BranchNaming(registry_key=branch_registry_key, display_name=derived_display_name)
+
+    def _derive_branch_display_name(
+        self,
+        *,
+        source_display_name: str | None,
+        source_registry_key: str,
+        branch_registry_key: str,
+        branch_counter: int | None,
+    ) -> str:
+        """Compute the human-readable label (``metadata.name``) for a new branch.
+
+        A registry key is a file path; ``metadata.name`` is a title. Using the key as the label makes
+        a branch of "Shot 010 Comp" read as "shots/sh010/comp_branch_1" everywhere the editor shows a
+        workflow name, and the deeper the folder structure the worse it reads.
+
+        * ``branch_counter`` is set when the caller auto-generated the branch key as
+          ``<source key>_branch_<counter>``. The label mirrors that counter so it stays in step with
+          the key: "Shot 010 Comp (branch 1)".
+        * ``branch_counter`` is None when the caller supplied ``branched_workflow_name`` themselves.
+          They chose the key, so its final path segment is the most faithful label available.
+        """
+        if branch_counter is None:
+            return PurePosixPath(branch_registry_key).name
+
+        source_label = (source_display_name or "").strip()
+        if source_label:
+            # Keep only the final segment. A path-shaped source label is exactly the bug this
+            # derivation exists to fix -- branches created before it carry their full registry key as
+            # their name -- so deriving from one verbatim would carry the path forward.
+            source_label = PurePosixPath(source_label).name.strip()
+        if not source_label:
+            # A blank (or purely separator) display name means the source's own metadata is corrupt.
+            # A label off the file path beats propagating emptiness onto the branch.
+            source_label = PurePosixPath(source_registry_key).name
+        return f"{source_label} (branch {branch_counter})"
 
     def on_create_workflow_from_template_request(self, request: CreateWorkflowFromTemplateRequest) -> ResultPayload:
         """Create a new workflow file from a template (Griptape-provided or user-provided)."""
@@ -6287,7 +6405,11 @@ class WorkflowManager(EngineScoped):
         try:
             # Create updated metadata for source workflow - update timestamp
             merged_metadata = WorkflowMetadata(
-                name=source_workflow_name,
+                # Carry the source's existing display name across. `source_workflow_name` came from
+                # the branch's `branched_from`, which holds a registry key (a file path), so using it
+                # here would overwrite the source's correct title with a path and persist that to disk.
+                # A merge changes the source's contents, never what it is called.
+                name=source_workflow.metadata.name,
                 schema_version=source_workflow.metadata.schema_version,
                 engine_version_created_with=source_workflow.metadata.engine_version_created_with,
                 node_libraries_referenced=source_workflow.metadata.node_libraries_referenced.copy(),
@@ -6388,7 +6510,11 @@ class WorkflowManager(EngineScoped):
 
             # Create updated metadata for branch workflow - preserve branch relationship and source timestamp
             reset_metadata = WorkflowMetadata(
-                name=request.workflow_name,
+                # Keep the branch's own display name. A reset discards the branch's *content* changes;
+                # its identity fields below (creation_date, branched_from, is_template) are likewise
+                # kept from the branch, and its title belongs with them. `request.workflow_name` is a
+                # registry key, so using it would overwrite the branch's title with a path on disk.
+                name=branch_workflow.metadata.name,
                 schema_version=source_workflow.metadata.schema_version,
                 engine_version_created_with=source_workflow.metadata.engine_version_created_with,
                 node_libraries_referenced=source_workflow.metadata.node_libraries_referenced.copy(),

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -18,11 +18,20 @@ if TYPE_CHECKING:
 
 from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.exe_types.node_types import NodeDependencies
-from griptape_nodes.node_library.workflow_registry import Workflow, WorkflowMetadata, WorkflowRegistry, WorkflowShape
+from griptape_nodes.node_library.workflow_registry import (
+    Workflow,
+    WorkflowMetadata,
+    WorkflowRegistry,
+    WorkflowShape,
+    read_workflow_metadata,
+)
 from griptape_nodes.retained_mode.engine import Engine
 from griptape_nodes.retained_mode.events.base_events import ResultDetails
 from griptape_nodes.retained_mode.events.flow_events import SerializedFlowCommands
 from griptape_nodes.retained_mode.events.workflow_events import (
+    BranchWorkflowRequest,
+    BranchWorkflowResultFailure,
+    BranchWorkflowResultSuccess,
     CreateWorkflowFromTemplateRequest,
     CreateWorkflowFromTemplateResultFailure,
     CreateWorkflowFromTemplateResultSuccess,
@@ -45,11 +54,16 @@ from griptape_nodes.retained_mode.events.workflow_events import (
     LoadWorkflowMetadata,
     LoadWorkflowMetadataResultFailure,
     LoadWorkflowMetadataResultSuccess,
+    MergeWorkflowBranchRequest,
+    MergeWorkflowBranchResultSuccess,
     MoveWorkflowRequest,
     MoveWorkflowResultFailure,
     MoveWorkflowResultSuccess,
+    RegisterWorkflowRequest,
     RegisterWorkflowResultFailure,
     RegisterWorkflowResultSuccess,
+    ResetWorkflowBranchRequest,
+    ResetWorkflowBranchResultSuccess,
     SetWorkflowMetadataRequest,
     SetWorkflowMetadataResultSuccess,
     WorkflowDependencyInfo,
@@ -4508,3 +4522,348 @@ class TestSaveWorkflowOverwriteProtection:
 
             assert isinstance(result, SaveWorkflowResultSuccess)
             assert victim_path.read_text() != "# theirs"
+
+
+class TestWorkflowBranchDisplayNames:
+    """Regression coverage: a branch's ``metadata.name`` must be a title, not a registry key.
+
+    A registry key is a file path (``shots/sh010/comp``); ``metadata.name`` is the human-readable
+    label the editor shows. Three sites used to write the key into the label, so any branch of a
+    workflow living in a subdirectory read as a file path in the UI. Two of them overwrote a
+    previously-correct label and persisted it to disk, so each test asserts the registry entry *and*
+    the on-disk header.
+
+    Driven through ``GriptapeNodes.handle_request`` with real files in a real temp workspace, since
+    the persisted header is half the bug.
+    """
+
+    SOURCE_KEY = "shots/sh010/comp"
+    SOURCE_DISPLAY_NAME = "Shot 010 Comp"
+
+    @pytest.fixture
+    def temp_dir(self, tmp_path: Path) -> Path:
+        return tmp_path.resolve()
+
+    @pytest.fixture(autouse=True)
+    def workspace(self, temp_dir: Path, griptape_nodes: Engine) -> "Generator[None, None, None]":
+        """Point the workspace at a temp dir so registry keys resolve to real files."""
+        original_workspace = griptape_nodes.ConfigManager().workspace_path
+        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        with patch.dict(WorkflowRegistry._workflows, {}, clear=True):
+            yield
+        griptape_nodes.ConfigManager().workspace_path = original_workspace
+
+    @staticmethod
+    def _register_workflow(griptape_nodes: Engine, temp_dir: Path, *, registry_key: str, display_name: str) -> Path:
+        """Write a workflow file carrying a real metadata header and register it."""
+        metadata = WorkflowMetadata(
+            name=display_name,
+            schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+            engine_version_created_with="test",
+            node_libraries_referenced=[],
+            creation_date=datetime.now(UTC),
+        )
+        header = griptape_nodes.WorkflowManager()._generate_workflow_metadata_header(metadata)
+        assert header is not None
+
+        relative_file_path = f"{registry_key}.py"
+        file_path = temp_dir / relative_file_path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(f"{header}\n\nprint('body')\n", encoding="utf-8")
+
+        WorkflowRegistry.generate_new_workflow(
+            registry_key=registry_key, metadata=metadata, file_path=relative_file_path
+        )
+        return file_path
+
+    @staticmethod
+    def _persisted_display_name(temp_dir: Path, registry_key: str) -> str:
+        """Read ``metadata.name`` back out of the workflow file on disk."""
+        return read_workflow_metadata(temp_dir / f"{registry_key}.py").name
+
+    def _register_source(self, griptape_nodes: Engine, temp_dir: Path) -> Path:
+        return self._register_workflow(
+            griptape_nodes, temp_dir, registry_key=self.SOURCE_KEY, display_name=self.SOURCE_DISPLAY_NAME
+        )
+
+    def test_branch_of_nested_workflow_gets_readable_display_name(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+        """The reported bug: the branch's label was the full registry key path.
+
+        The key still carries the directories (it is a file path), but the label is derived from the
+        source's display name.
+        """
+        self._register_source(griptape_nodes, temp_dir)
+
+        result = GriptapeNodes.handle_request(BranchWorkflowRequest(workflow_name=self.SOURCE_KEY))
+
+        assert isinstance(result, BranchWorkflowResultSuccess)
+        branch_key = result.branched_workflow_name
+        assert branch_key == "shots/sh010/comp_branch_1"
+
+        branch = WorkflowRegistry.get_workflow_by_name(branch_key)
+        assert branch.metadata.name == "Shot 010 Comp (branch 1)"
+        assert self._persisted_display_name(temp_dir, branch_key) == "Shot 010 Comp (branch 1)"
+        # The branch relationship is keyed on the registry key, not the label.
+        assert branch.metadata.branched_from == self.SOURCE_KEY
+
+    def test_branch_leaves_source_display_name_alone(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+        """Branching must not touch the source's label."""
+        self._register_source(griptape_nodes, temp_dir)
+
+        result = GriptapeNodes.handle_request(BranchWorkflowRequest(workflow_name=self.SOURCE_KEY))
+
+        assert isinstance(result, BranchWorkflowResultSuccess)
+        source = WorkflowRegistry.get_workflow_by_name(self.SOURCE_KEY)
+        assert source.metadata.name == self.SOURCE_DISPLAY_NAME
+        assert self._persisted_display_name(temp_dir, self.SOURCE_KEY) == self.SOURCE_DISPLAY_NAME
+
+    def test_branch_counter_stays_in_step_with_registry_key(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+        """The label's counter tracks the key's counter, so branches stay distinguishable."""
+        self._register_source(griptape_nodes, temp_dir)
+
+        first = GriptapeNodes.handle_request(BranchWorkflowRequest(workflow_name=self.SOURCE_KEY))
+        second = GriptapeNodes.handle_request(BranchWorkflowRequest(workflow_name=self.SOURCE_KEY))
+
+        assert isinstance(first, BranchWorkflowResultSuccess)
+        assert isinstance(second, BranchWorkflowResultSuccess)
+        assert first.branched_workflow_name == "shots/sh010/comp_branch_1"
+        assert second.branched_workflow_name == "shots/sh010/comp_branch_2"
+        assert WorkflowRegistry.get_workflow_by_name(first.branched_workflow_name).metadata.name == (
+            "Shot 010 Comp (branch 1)"
+        )
+        assert WorkflowRegistry.get_workflow_by_name(second.branched_workflow_name).metadata.name == (
+            "Shot 010 Comp (branch 2)"
+        )
+
+    def test_branch_uses_explicit_display_name_when_provided(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+        """A caller-supplied label wins over the derivation, and is stripped."""
+        self._register_source(griptape_nodes, temp_dir)
+
+        result = GriptapeNodes.handle_request(
+            BranchWorkflowRequest(workflow_name=self.SOURCE_KEY, branched_workflow_display_name="  Lighting Test  ")
+        )
+
+        assert isinstance(result, BranchWorkflowResultSuccess)
+        branch_key = result.branched_workflow_name
+        assert WorkflowRegistry.get_workflow_by_name(branch_key).metadata.name == "Lighting Test"
+        assert self._persisted_display_name(temp_dir, branch_key) == "Lighting Test"
+
+    def test_branch_rejects_blank_display_name(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+        """A whitespace-only label would leave the branch looking nameless, so refuse it."""
+        self._register_source(griptape_nodes, temp_dir)
+
+        result = GriptapeNodes.handle_request(
+            BranchWorkflowRequest(workflow_name=self.SOURCE_KEY, branched_workflow_display_name="   ")
+        )
+
+        assert isinstance(result, BranchWorkflowResultFailure)
+        assert "empty display name" in str(result.result_details)
+        # Nothing was created.
+        assert WorkflowRegistry.get_branches_of_workflow(self.SOURCE_KEY) == []
+
+    def test_branch_with_caller_supplied_key_labels_from_final_segment(
+        self, griptape_nodes: Engine, temp_dir: Path
+    ) -> None:
+        """When the caller picks the key, its last segment is the label -- never the whole path."""
+        self._register_source(griptape_nodes, temp_dir)
+
+        result = GriptapeNodes.handle_request(
+            BranchWorkflowRequest(workflow_name=self.SOURCE_KEY, branched_workflow_name="shots/sh010/my_experiment")
+        )
+
+        assert isinstance(result, BranchWorkflowResultSuccess)
+        branch_key = result.branched_workflow_name
+        assert branch_key == "shots/sh010/my_experiment"
+        assert WorkflowRegistry.get_workflow_by_name(branch_key).metadata.name == "my_experiment"
+        assert self._persisted_display_name(temp_dir, branch_key) == "my_experiment"
+
+    def test_branch_of_path_shaped_label_does_not_propagate_the_path(
+        self, griptape_nodes: Engine, temp_dir: Path
+    ) -> None:
+        """Branches created before this fix carry their key as their label; don't carry it forward."""
+        self._register_workflow(
+            griptape_nodes,
+            temp_dir,
+            registry_key="shots/sh010/comp_branch_1",
+            display_name="shots/sh010/comp_branch_1",
+        )
+
+        result = GriptapeNodes.handle_request(BranchWorkflowRequest(workflow_name="shots/sh010/comp_branch_1"))
+
+        assert isinstance(result, BranchWorkflowResultSuccess)
+        branch_key = result.branched_workflow_name
+        assert WorkflowRegistry.get_workflow_by_name(branch_key).metadata.name == "comp_branch_1 (branch 1)"
+
+    def test_branch_falls_back_to_key_segment_when_source_label_blank(
+        self, griptape_nodes: Engine, temp_dir: Path
+    ) -> None:
+        """A corrupt (blank) source label falls back to the file name, not to emptiness."""
+        self._register_workflow(griptape_nodes, temp_dir, registry_key=self.SOURCE_KEY, display_name="   ")
+
+        result = GriptapeNodes.handle_request(BranchWorkflowRequest(workflow_name=self.SOURCE_KEY))
+
+        assert isinstance(result, BranchWorkflowResultSuccess)
+        branch_key = result.branched_workflow_name
+        assert WorkflowRegistry.get_workflow_by_name(branch_key).metadata.name == "comp (branch 1)"
+
+    def test_merge_preserves_source_display_name(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+        """Merging changes the source's contents, never its title.
+
+        This site read the branch's ``branched_from`` (a registry key) into the source's
+        ``metadata.name``, overwriting a correct label with a path and writing it to disk.
+        """
+        self._register_source(griptape_nodes, temp_dir)
+        branch_result = GriptapeNodes.handle_request(BranchWorkflowRequest(workflow_name=self.SOURCE_KEY))
+        assert isinstance(branch_result, BranchWorkflowResultSuccess)
+
+        merge_result = GriptapeNodes.handle_request(
+            MergeWorkflowBranchRequest(workflow_name=branch_result.branched_workflow_name)
+        )
+
+        assert isinstance(merge_result, MergeWorkflowBranchResultSuccess)
+        source = WorkflowRegistry.get_workflow_by_name(self.SOURCE_KEY)
+        assert source.metadata.name == self.SOURCE_DISPLAY_NAME
+        assert self._persisted_display_name(temp_dir, self.SOURCE_KEY) == self.SOURCE_DISPLAY_NAME
+
+    def test_reset_preserves_branch_display_name(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+        """Resetting discards the branch's content changes, not its title.
+
+        This site wrote the branch's own registry key into its ``metadata.name`` and persisted it,
+        so a reset silently renamed the branch to its file path.
+        """
+        self._register_source(griptape_nodes, temp_dir)
+        branch_result = GriptapeNodes.handle_request(
+            BranchWorkflowRequest(workflow_name=self.SOURCE_KEY, branched_workflow_display_name="Lighting Test")
+        )
+        assert isinstance(branch_result, BranchWorkflowResultSuccess)
+        branch_key = branch_result.branched_workflow_name
+
+        reset_result = GriptapeNodes.handle_request(ResetWorkflowBranchRequest(workflow_name=branch_key))
+
+        assert isinstance(reset_result, ResetWorkflowBranchResultSuccess)
+        assert WorkflowRegistry.get_workflow_by_name(branch_key).metadata.name == "Lighting Test"
+        assert self._persisted_display_name(temp_dir, branch_key) == "Lighting Test"
+
+
+class TestRepairPathShapedDisplayName:
+    """Workflows already on disk carry a registry key as their ``metadata.name``.
+
+    The pre-fix branch/merge/reset sites wrote the path-derived key into the display name and
+    persisted it, so those files are still out there. They carry the *current* schema version -- the
+    bug was never a schema change -- so registration keys on the damage itself: a display name that
+    exactly equals its own registry key.
+
+    Repair is in-memory. The file keeps the old header until its next save, so each test asserts the
+    registry entry shows the readable name while the file on disk is untouched.
+    """
+
+    @pytest.fixture
+    def temp_dir(self, tmp_path: Path) -> Path:
+        return tmp_path.resolve()
+
+    @pytest.fixture(autouse=True)
+    def workspace(self, temp_dir: Path, griptape_nodes: Engine) -> "Generator[None, None, None]":
+        original_workspace = griptape_nodes.ConfigManager().workspace_path
+        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        with patch.dict(WorkflowRegistry._workflows, {}, clear=True):
+            yield
+        griptape_nodes.ConfigManager().workspace_path = original_workspace
+
+    @staticmethod
+    def _write_and_register(
+        griptape_nodes: Engine, temp_dir: Path, *, relative_file_path: str, display_name: str
+    ) -> Path:
+        """Write a real workflow file with `display_name` in its header, then register it from disk."""
+        metadata = WorkflowMetadata(
+            name=display_name,
+            schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+            engine_version_created_with="test",
+            node_libraries_referenced=[],
+            creation_date=datetime.now(UTC),
+        )
+        header = griptape_nodes.WorkflowManager()._generate_workflow_metadata_header(metadata)
+        assert header is not None
+
+        file_path = temp_dir / relative_file_path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(f"{header}\n\nprint('body')\n", encoding="utf-8")
+
+        result = GriptapeNodes.handle_request(RegisterWorkflowRequest(metadata=metadata, file_name=relative_file_path))
+        assert isinstance(result, RegisterWorkflowResultSuccess)
+        return file_path
+
+    def test_legacy_branch_name_is_repaired_on_load(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+        """The reported symptom, loaded from a file a pre-fix build wrote."""
+        file_path = self._write_and_register(
+            griptape_nodes,
+            temp_dir,
+            relative_file_path="shots/sh010/comp_branch_1.py",
+            display_name="shots/sh010/comp_branch_1",
+        )
+
+        workflow = WorkflowRegistry.get_workflow_by_name("shots/sh010/comp_branch_1")
+        assert workflow.metadata.name == "comp_branch_1"
+        # In-memory only: the header on disk is deliberately left for the next save to rewrite.
+        assert read_workflow_metadata(file_path).name == "shots/sh010/comp_branch_1"
+
+    def test_legacy_merged_source_name_is_repaired_on_load(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+        """The merge site overwrote a *source* workflow's title with its key; same fingerprint."""
+        self._write_and_register(
+            griptape_nodes, temp_dir, relative_file_path="shots/sh010/comp.py", display_name="shots/sh010/comp"
+        )
+
+        assert WorkflowRegistry.get_workflow_by_name("shots/sh010/comp").metadata.name == "comp"
+
+    def test_deeper_nesting_keeps_only_the_final_segment(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+        """The deeper the folder structure the worse the old label read; only the file name survives."""
+        self._write_and_register(
+            griptape_nodes,
+            temp_dir,
+            relative_file_path="show/seq/shots/sh010/comp_branch_2.py",
+            display_name="show/seq/shots/sh010/comp_branch_2",
+        )
+
+        workflow = WorkflowRegistry.get_workflow_by_name("show/seq/shots/sh010/comp_branch_2")
+        assert workflow.metadata.name == "comp_branch_2"
+
+    def test_real_display_name_is_left_alone(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+        """A proper title never equals its own registry key, so it is never touched."""
+        self._write_and_register(
+            griptape_nodes,
+            temp_dir,
+            relative_file_path="shots/sh010/comp.py",
+            display_name="Shot 010 Comp",
+        )
+
+        assert WorkflowRegistry.get_workflow_by_name("shots/sh010/comp").metadata.name == "Shot 010 Comp"
+
+    def test_deliberate_separator_in_a_title_is_left_alone(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+        """Only exact key equality triggers repair -- a slash someone typed on purpose survives."""
+        self._write_and_register(
+            griptape_nodes,
+            temp_dir,
+            relative_file_path="shots/sh010/comp.py",
+            display_name="Lighting / Comp",
+        )
+
+        assert WorkflowRegistry.get_workflow_by_name("shots/sh010/comp").metadata.name == "Lighting / Comp"
+
+    def test_workspace_root_workflow_matching_its_stem_is_left_alone(
+        self, griptape_nodes: Engine, temp_dir: Path
+    ) -> None:
+        """Name == key with no directories is the normal unnamed-workflow case, not the bug."""
+        self._write_and_register(griptape_nodes, temp_dir, relative_file_path="my_flow.py", display_name="my_flow")
+
+        assert WorkflowRegistry.get_workflow_by_name("my_flow").metadata.name == "my_flow"
+
+    def test_repaired_workflow_branches_with_a_readable_label(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+        """The payoff: branching a legacy workflow no longer carries the path forward."""
+        self._write_and_register(
+            griptape_nodes, temp_dir, relative_file_path="shots/sh010/comp.py", display_name="shots/sh010/comp"
+        )
+
+        result = GriptapeNodes.handle_request(BranchWorkflowRequest(workflow_name="shots/sh010/comp"))
+
+        assert isinstance(result, BranchWorkflowResultSuccess)
+        branch = WorkflowRegistry.get_workflow_by_name(result.branched_workflow_name)
+        assert branch.metadata.name == "comp (branch 1)"


### PR DESCRIPTION
Closes #5357

Reported by Jason Schleifer: branched workflows showed the full registry key path where a display name was expected, while source workflows returned a proper short name.

## The bug

Branching set the new workflow's `metadata.name` — the human-readable display name — to its registry key, which is derived from the file path. Branching a workflow keyed `shots/sh010/comp` and displayed as "Shot 010 Comp" gave:

| | before | after |
| --- | --- | --- |
| registry key | `shots/sh010/comp_branch_1` | `shots/sh010/comp_branch_1` (unchanged) |
| `metadata.name` | `shots/sh010/comp_branch_1` | `Shot 010 Comp (branch 1)` |

The source kept its proper short name, so anywhere the UI shows `data.name`, a branch read as a file path while its own source next to it read as a title. The deeper the folder structure the worse it reads — and organizing workflows into folders is exactly the case where branching is most useful.

## Three sites

- **`on_branch_workflow_request`** set the branch's name to the generated registry key. Now derives the label from the source's display name, reusing the counter that resolved the key collision so `_branch_2` ↔ `(branch 2)` stay in step.
- **`on_merge_workflow_branch_request`** wrote the branch's `branched_from` (a registry key) into the *source's* name — overwriting a previously correct title and persisting it to disk. A merge changes the source's contents, never what it is called.
- **`on_reset_workflow_branch_request`** wrote the branch's own key into its name and persisted it, silently renaming the branch to its file path. A reset discards the branch's content changes, not its identity — the fields around it (`creation_date`, `branched_from`, `is_template`) were already kept from the branch.

The latter two are worse than cosmetic: they overwrite a name that was previously correct and write it to the file on disk.

Registry keys and `branched_from` are unchanged — both are path-derived by design, and `branched_from` is matched against keys (`workflow_registry.py:433`).

`BranchWorkflowRequest` also takes an optional `branched_workflow_display_name` to set the label directly. It's optional with a `None` default, so existing callers are unaffected; provided-but-blank is rejected before any file is written.

## Workflows already on disk

Files written by earlier versions still carry the path in their header, and they carry the *current* schema version — this was never a schema change — so there's nothing to gate a migration on, and bumping the schema would flag every pre-existing workflow rather than the affected branches.

Registration keys on the damage instead: a display name that **exactly equals** its own registry key is shown as that key's final segment. All three sites left `name == registry_key`, so this fires on precisely the damage and nothing else — a title someone deliberately wrote with a `/` in it survives.

Repair is in-memory. Rewriting headers during load would touch a pile of user files, churning mtimes and git diffs for a cosmetic label; the corrected name persists on its own at the workflow's next save.

## Testing

17 new tests across two classes, driven through `GriptapeNodes.handle_request` against real files in a real temp workspace, asserting both the registry entry and the persisted TOML header (the on-disk write is half the bug).

Verified they catch the regression: reverting the source fixes fails 9 of the 10 branch/merge/reset tests, and removing the repair call fails 3 of the 7 legacy tests. The tests that pass either way are deliberate guards asserting *no* change — a real title, a deliberate `Lighting / Comp`, a root-level workflow whose name matches its stem, and the source workflow that branching must not touch.

| | result |
| --- | --- |
| `make check` | clean, 0 type errors |
| `make test/unit` | 4587 passed, 13 skipped |
| `make test/integration` | 4 failed / 3 errors — identical on `main`, all in `test_lock_nodes.py`, pre-existing |
| `make test/e2e` | 32 passed |

## Notes for review

- The label format `"Shot 010 Comp (branch 1)"` is a UI-visible product decision — easy to change if you'd prefer something else.
- `_resolve_branch_naming` was extracted because the added branches pushed `on_branch_workflow_request` past the C901 complexity limit — extracted rather than suppressed.
- No docs changed: the branch/merge/reset event family isn't documented under `docs/`. `MIGRATION.md` covers the behavior change. Happy to add a docs page if wanted.
- The path-stripping in `_derive_branch_display_name` and the read-time repair overlap for one case (branching a legacy path-named workflow). Kept both: the branch-layer strip is defense in depth if a path-shaped name ever reaches it another way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

