### PR TITLE
feat(undo): add undo manager and dispatch recording

### DIFF
--- a/src/griptape_nodes/retained_mode/engine.py
+++ b/src/griptape_nodes/retained_mode/engine.py
@@ -81,6 +81,7 @@ if TYPE_CHECKING:
         StaticFilesManager,
     )
     from griptape_nodes.retained_mode.managers.sync_manager import SyncManager
+    from griptape_nodes.retained_mode.managers.undo import UndoManager
     from griptape_nodes.retained_mode.managers.user_manager import UserManager
     from griptape_nodes.retained_mode.managers.variable_manager import (
         VariablesManager,
@@ -170,6 +171,7 @@ class Engine:
     _artifact_manager: ArtifactManager
     _manifest_manager: ManifestManager
     _worker_manager: WorkerManager
+    _undo_manager: UndoManager
 
     def __init__(self) -> None:  # noqa: PLR0915
         from griptape_nodes.retained_mode.managers.access_manager import AccessManager
@@ -201,6 +203,7 @@ class Engine:
             StaticFilesManager,
         )
         from griptape_nodes.retained_mode.managers.sync_manager import SyncManager
+        from griptape_nodes.retained_mode.managers.undo import UndoManager
         from griptape_nodes.retained_mode.managers.user_manager import UserManager
         from griptape_nodes.retained_mode.managers.variable_manager import (
             VariablesManager,
@@ -214,6 +217,8 @@ class Engine:
         )
 
         self._event_manager = EventManager(engine=self)
+        # Created early so domain managers can register their undo policy below.
+        self._undo_manager = UndoManager(self._event_manager, engine=self)
         self._resource_manager = ResourceManager(self._event_manager)
         self._config_manager = ConfigManager(self._event_manager, engine=self)
         self._os_manager = OSManager(self._event_manager, engine=self)
@@ -362,6 +367,10 @@ class Engine:
     def worker_manager(self) -> WorkerManager:
         return self._worker_manager
 
+    @property
+    def undo_manager(self) -> UndoManager:
+        return self._undo_manager
+
     # Node libraries and saved workflows do `app = GriptapeNodes()` and then call these
     # PascalCase accessors on the result. `GriptapeNodes()` hands back an `Engine`, so
     # the compat surface has to live here. Engine-internal code uses the snake_case
@@ -450,6 +459,9 @@ class Engine:
 
     def WorkerManager(self) -> WorkerManager:
         return self._worker_manager
+
+    def UndoManager(self) -> UndoManager:
+        return self._undo_manager
 
     def get_instance(self) -> Engine:
         """Back-compat for callers that reach for the instance through an instance."""

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -53,6 +53,7 @@ if TYPE_CHECKING:
         StaticFilesManager,
     )
     from griptape_nodes.retained_mode.managers.sync_manager import SyncManager
+    from griptape_nodes.retained_mode.managers.undo import UndoManager
     from griptape_nodes.retained_mode.managers.user_manager import UserManager
     from griptape_nodes.retained_mode.managers.variable_manager import (
         VariablesManager,
@@ -226,3 +227,7 @@ class GriptapeNodes(metaclass=_EngineRootMeta):
     @classmethod
     def WorkerManager(cls) -> WorkerManager:
         return current_engine().worker_manager
+
+    @classmethod
+    def UndoManager(cls) -> UndoManager:
+        return current_engine().undo_manager

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -1118,12 +1118,19 @@ class EventManager(EngineScoped):
                 context=result_context,
             )
 
+        # Let the UndoManager observe the dispatch so user-initiated mutations can be recorded
+        # (or invalidate history when they cannot be).
+        undo_manager = self.engine.undo_manager
+        undo_capture = undo_manager.begin_request_dispatch(request, result_context.get("request_id"))
+        dispatched_result: ResultPayload | None = None
+
         # Expose the dispatching request type to detectors (see current_request_type).
         token = _active_request_type.set(request_type)
         try:
             try:
                 # Actually make the handler callback (support both sync and async):
                 result_payload: ResultPayload = await call_function(callback, request)
+                dispatched_result = result_payload
 
                 # Queue flush request for async context (unless result type should skip flush)
                 with operation_depth_mgr:
@@ -1139,6 +1146,9 @@ class EventManager(EngineScoped):
                 context=result_context,
             )
         finally:
+            # Runs after _handle_request_core so the result's altered_workflow_state has been
+            # squelch-adjusted. A None result means the callback raised.
+            undo_manager.end_request_dispatch(undo_capture, request, dispatched_result)
             _active_request_type.reset(token)
 
     def handle_request(
@@ -1176,11 +1186,18 @@ class EventManager(EngineScoped):
                 context=result_context,
             )
 
+        # Let the UndoManager observe the dispatch so user-initiated mutations can be recorded
+        # (or invalidate history when they cannot be).
+        undo_manager = self.engine.undo_manager
+        undo_capture = undo_manager.begin_request_dispatch(request, result_context.get("request_id"))
+        dispatched_result: ResultPayload | None = None
+
         # Expose the dispatching request type to detectors (see current_request_type).
         token = _active_request_type.set(request_type)
         try:
             try:
                 result_payload = self._invoke_handler_from_sync(callback, request)
+                dispatched_result = result_payload
 
                 # Queue flush request for sync context (unless result type should skip flush)
                 with operation_depth_mgr:
@@ -1196,6 +1213,9 @@ class EventManager(EngineScoped):
                 context=result_context,
             )
         finally:
+            # Runs after _handle_request_core so the result's altered_workflow_state has been
+            # squelch-adjusted. A None result means the callback raised.
+            undo_manager.end_request_dispatch(undo_capture, request, dispatched_result)
             _active_request_type.reset(token)
 
     def _invoke_handler_from_sync(self, callback: Callable, request: RequestPayload) -> ResultPayload:

--- a/src/griptape_nodes/retained_mode/managers/undo/__init__.py
+++ b/src/griptape_nodes/retained_mode/managers/undo/__init__.py
@@ -1,9 +1,27 @@
 """Undo/redo subsystem.
 
-Public surface: `UndoEntryReplayError`, the failure a reversal raises when it cannot complete and the
-undo history can no longer be trusted.
+Public surface:
+    - `UndoManager`: the mechanism (undo/redo stacks, replay, request handlers, recording API).
+    - The vocabulary domains use to describe reversals: `UndoEntry`, `UndoBatch`,
+      `UndoEntryReplayError`, and the `RecordingStrategy` contract a recording strategy implements.
+
+The concrete recording strategy (currently the whole-flow `SnapshotRecordingSession`) lives in its
+own module and is selected by `UndoManager`. `RecordingStrategy` is the extension seam for layering
+in finer-grained strategies later.
 """
 
-from griptape_nodes.retained_mode.managers.undo.core import UndoEntryReplayError
+from griptape_nodes.retained_mode.managers.undo.core import (
+    RecordingStrategy,
+    UndoBatch,
+    UndoEntry,
+    UndoEntryReplayError,
+)
+from griptape_nodes.retained_mode.managers.undo.manager import UndoManager
 
-__all__ = ["UndoEntryReplayError"]
+__all__ = [
+    "RecordingStrategy",
+    "UndoBatch",
+    "UndoEntry",
+    "UndoEntryReplayError",
+    "UndoManager",
+]

--- a/src/griptape_nodes/retained_mode/managers/undo/core.py
+++ b/src/griptape_nodes/retained_mode/managers/undo/core.py
@@ -1,12 +1,155 @@
 """The vocabulary domains use to describe reversible operations.
 
-This module is domain-agnostic: it defines the failure mode a reversal reports when it can no longer
-be trusted. The concrete reversal mechanism (currently whole-flow snapshots, in `flow_snapshot`)
-builds on these types.
+This module is domain-agnostic: it defines what an undo entry and an undo batch are, the shared
+lifecycle triage every recording strategy applies, and the `RecordingStrategy` contract a strategy
+implements. `UndoManager` (the mechanism) and the concrete strategies (currently the whole-flow
+`SnapshotRecordingSession`) both build on these types.
+
+The `RecordingStrategy` protocol is the extension seam: a future finer-grained strategy (e.g. one
+that captures per-touched-entity state deltas instead of whole-flow snapshots) implements this same
+contract and drops in behind `UndoManager` without changing the dispatch path or the lifecycle
+policy.
 """
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import TYPE_CHECKING, Any, Protocol
+
+from griptape_nodes.retained_mode.events.context_events import SetWorkflowContextRequest
+from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
+from griptape_nodes.retained_mode.events.undo_events import (
+    ClearUndoStateRequest,
+    GetUndoStateRequest,
+    RedoRequest,
+    UndoRequest,
+)
+from griptape_nodes.retained_mode.events.workflow_events import (
+    ImportWorkflowRequest,
+    RunWorkflowFromRegistryRequest,
+    RunWorkflowFromScratchRequest,
+    RunWorkflowWithCurrentStateRequest,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from contextlib import AbstractContextManager
+
+    from griptape_nodes.retained_mode.events.base_events import RequestPayload, ResultPayload
+
+
+# Request types that invalidate all undo history whenever they are dispatched, regardless of origin,
+# because they replace or restructure the whole object graph. This is global lifecycle policy shared
+# by every recording strategy, so it lives here rather than being duplicated in each session.
+CLEAR_HISTORY_REQUEST_TYPES: tuple[type[RequestPayload], ...] = (
+    ClearAllObjectStateRequest,
+    SetWorkflowContextRequest,
+    RunWorkflowFromScratchRequest,
+    RunWorkflowFromRegistryRequest,
+    RunWorkflowWithCurrentStateRequest,
+    ImportWorkflowRequest,
+)
+
+# The undo manager's own request types. They alter workflow state by design (undo/redo) or not at all
+# (state/clear) and must never be recorded or clear history.
+OWN_EVENT_TYPES: tuple[type[RequestPayload], ...] = (
+    UndoRequest,
+    RedoRequest,
+    GetUndoStateRequest,
+    ClearUndoStateRequest,
+)
+
+
+class DispatchTriage(Enum):
+    """The shared lifecycle verdict for a dispatch, applied before any strategy-specific framing.
+
+    IGNORE: the undo system does not track this dispatch at all (its own events, or a replay in
+        progress). CLEAR_HISTORY: a lifecycle request that replaces or restructures the whole object
+        graph; the strategy clears history and flags any open frame. PROCEED: an ordinary dispatch
+        the strategy frames per its own logic.
+    """
+
+    IGNORE = auto()
+    CLEAR_HISTORY = auto()
+    PROCEED = auto()
+
+
+def triage_dispatch(request: RequestPayload, *, is_replaying: bool) -> DispatchTriage:
+    """Classify a dispatch by the shared lifecycle policy, before any strategy-specific framing.
+
+    Replay is isolated before the history-clearing check: a mutation dispatched during undo/redo
+    must never clear history, even if it is (or cascades into) a history-clearing lifecycle type.
+    Every recording strategy calls this so the policy sequence lives in one place and cannot drift.
+    """
+    if type(request) in OWN_EVENT_TYPES:
+        return DispatchTriage.IGNORE
+    if is_replaying:
+        return DispatchTriage.IGNORE
+    if isinstance(request, CLEAR_HISTORY_REQUEST_TYPES):
+        return DispatchTriage.CLEAR_HISTORY
+    return DispatchTriage.PROCEED
+
 
 class UndoEntryReplayError(RuntimeError):
     """Raised when replaying an undo/redo entry fails and the undo history can no longer be trusted."""
+
+
+class UndoEntry(ABC):
+    """A single reversible operation within an undo batch.
+
+    Implementations issue ordinary engine requests to revert (undo) or re-apply (redo)
+    the operation, raising UndoEntryReplayError when replay fails.
+    """
+
+    @abstractmethod
+    def undo(self) -> None:
+        """Revert the recorded operation. Raises UndoEntryReplayError on failure."""
+
+    @abstractmethod
+    def redo(self) -> None:
+        """Re-apply the recorded operation. Raises UndoEntryReplayError on failure."""
+
+
+@dataclass
+class UndoBatch:
+    """One undoable user action, made up of one or more entries replayed together.
+
+    Attributes:
+        label: Human-readable description of the action (e.g. "Create node 'Agent_1'").
+        entries: Entries recorded in application order. Undo replays them in reverse.
+    """
+
+    label: str
+    entries: list[UndoEntry]
+
+
+class RecordingStrategy(Protocol):
+    """The surface UndoManager and the EventManager dispatch path drive, independent of strategy.
+
+    One implementation exists today (the whole-flow SnapshotRecordingSession); this protocol is the
+    seam a future finer-grained strategy plugs into. UndoManager holds a strategy without knowing
+    which, so strategies can diverge in mechanism but not in the surface (or the shared lifecycle
+    policy) they honor.
+    """
+
+    def register_undoable(self, labels: Mapping[type[RequestPayload], str]) -> None:
+        """Declare request types this strategy can capture, each with the semantic name of its operation.
+
+        The name describes the operation, not the request, so it reads the same however the operation
+        was triggered (editor gesture, paste, MCP call, template). It becomes the undo entry's label.
+        """
+        ...
+
+    def transaction(self, label: str) -> AbstractContextManager[None]:
+        """Group every recordable mutation issued within the block into a single undo batch."""
+        ...
+
+    def begin_request_dispatch(self, request: RequestPayload, request_id: str | None) -> Any:
+        """Observe a request before its handler runs; return an opaque capture for end_request_dispatch."""
+        ...
+
+    def end_request_dispatch(self, capture: Any, request: RequestPayload, result: ResultPayload | None) -> None:
+        """Finish observing a dispatch: contribute to the active frame and finalize if it opened one."""
+        ...

--- a/src/griptape_nodes/retained_mode/managers/undo/manager.py
+++ b/src/griptape_nodes/retained_mode/managers/undo/manager.py
@@ -1,0 +1,198 @@
+"""The undo/redo mechanism entry point.
+
+`UndoManager` owns the undo/redo stacks and the replay guard, wires the Undo/Redo/GetState/Clear
+request handlers, and exposes the recording API. Recording itself is delegated to a
+`RecordingStrategy` (currently the whole-flow `SnapshotRecordingSession`); domains declare which of
+their requests the strategy can capture, and what each one's operation is called, via
+`register_undoable`.
+
+`RecordingStrategy` is the extension seam: a finer-grained strategy (e.g. per-touched-entity state
+deltas) can be layered in later by implementing the same contract, without changing the manager or
+the dispatch path.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import deque
+from typing import TYPE_CHECKING
+
+from griptape_nodes.retained_mode.engine import EngineScoped
+from griptape_nodes.retained_mode.events.undo_events import (
+    ClearUndoStateRequest,
+    ClearUndoStateResultSuccess,
+    GetUndoStateRequest,
+    GetUndoStateResultSuccess,
+    RedoRequest,
+    RedoResultFailure,
+    RedoResultSuccess,
+    UndoRequest,
+    UndoResultFailure,
+    UndoResultSuccess,
+)
+from griptape_nodes.retained_mode.managers.undo.core import UndoBatch, UndoEntryReplayError
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from contextlib import AbstractContextManager
+
+    from griptape_nodes.retained_mode.engine import Engine
+    from griptape_nodes.retained_mode.events.base_events import RequestPayload, ResultPayload
+    from griptape_nodes.retained_mode.managers.event_manager import EventManager
+    from griptape_nodes.retained_mode.managers.undo.core import RecordingStrategy
+
+logger = logging.getLogger("griptape_nodes")
+
+# Maximum number of undoable user actions retained. Oldest entries are dropped first.
+MAX_UNDO_BATCHES = 100
+
+
+class UndoManager(EngineScoped):
+    """Owns the undo/redo stacks and replay; delegates recording to a RecordingStrategy."""
+
+    def __init__(self, event_manager: EventManager, *, engine: Engine | None = None) -> None:
+        super().__init__(engine)
+        # Local import: the snapshot strategy pulls in flow/serialization events and the engine
+        # singleton, which would create an import cycle if imported at module load.
+        from griptape_nodes.retained_mode.managers.undo.snapshot import SnapshotRecordingSession
+
+        self._undo_stack: deque[UndoBatch] = deque(maxlen=MAX_UNDO_BATCHES)
+        self._redo_stack: list[UndoBatch] = []
+        self._is_replaying = False
+        self._recording: RecordingStrategy = SnapshotRecordingSession(
+            engine=self.engine,
+            is_replaying=lambda: self._is_replaying,
+            commit_batch=self._commit_batch,
+            invalidate_history=self.clear_history,
+        )
+
+        event_manager.assign_manager_to_request_type(UndoRequest, self.on_undo_request)
+        event_manager.assign_manager_to_request_type(RedoRequest, self.on_redo_request)
+        event_manager.assign_manager_to_request_type(GetUndoStateRequest, self.on_get_undo_state_request)
+        event_manager.assign_manager_to_request_type(ClearUndoStateRequest, self.on_clear_undo_state_request)
+
+    def register_undoable(self, labels: Mapping[type[RequestPayload], str]) -> None:
+        """Declare request types the active strategy can capture, each with its operation's name."""
+        self._recording.register_undoable(labels)
+
+    def transaction(self, label: str) -> AbstractContextManager[None]:
+        """Group every recordable mutation issued within the block into a single undo batch."""
+        return self._recording.transaction(label)
+
+    def begin_request_dispatch(self, request: RequestPayload, request_id: str | None) -> object | None:
+        """Observe a request before its handler runs; returns an opaque capture for end_request_dispatch.
+
+        The capture is produced and consumed by the active recording session; callers treat it as
+        opaque (the inverse and snapshot strategies use different capture shapes).
+        """
+        return self._recording.begin_request_dispatch(request, request_id)
+
+    def end_request_dispatch(
+        self, capture: object | None, request: RequestPayload, result: ResultPayload | None
+    ) -> None:
+        """Finish observing a dispatch: contribute to the active frame and finalize if it was opened."""
+        self._recording.end_request_dispatch(capture, request, result)
+
+    def clear_history(self) -> None:
+        """Drop all undo and redo history."""
+        if self._undo_stack or self._redo_stack:
+            logger.debug("Cleared undo history (%d undo, %d redo).", len(self._undo_stack), len(self._redo_stack))
+        self._undo_stack.clear()
+        self._redo_stack.clear()
+
+    def on_undo_request(self, request: UndoRequest) -> ResultPayload:  # noqa: ARG002
+        if self._is_replaying:
+            details = "Attempted to undo. Failed because an undo or redo is already in progress."
+            return UndoResultFailure(result_details=details)
+        if self.engine.flow_manager.check_for_existing_running_flow():
+            details = "Attempted to undo. Failed because a flow is currently running."
+            return UndoResultFailure(result_details=details)
+        if not self._undo_stack:
+            details = "Attempted to undo. Failed because there is nothing to undo."
+            return UndoResultFailure(result_details=details)
+
+        batch = self._undo_stack.pop()
+        error_details = self._replay_batch(batch, undo=True)
+        if error_details is not None:
+            return UndoResultFailure(result_details=error_details)
+
+        self._redo_stack.append(batch)
+        return UndoResultSuccess(undone_label=batch.label, result_details=f"Undid '{batch.label}'.")
+
+    def on_redo_request(self, request: RedoRequest) -> ResultPayload:  # noqa: ARG002
+        if self._is_replaying:
+            details = "Attempted to redo. Failed because an undo or redo is already in progress."
+            return RedoResultFailure(result_details=details)
+        if self.engine.flow_manager.check_for_existing_running_flow():
+            details = "Attempted to redo. Failed because a flow is currently running."
+            return RedoResultFailure(result_details=details)
+        if not self._redo_stack:
+            details = "Attempted to redo. Failed because there is nothing to redo."
+            return RedoResultFailure(result_details=details)
+
+        batch = self._redo_stack.pop()
+        error_details = self._replay_batch(batch, undo=False)
+        if error_details is not None:
+            return RedoResultFailure(result_details=error_details)
+
+        self._undo_stack.append(batch)
+        return RedoResultSuccess(redone_label=batch.label, result_details=f"Redid '{batch.label}'.")
+
+    def on_get_undo_state_request(self, request: GetUndoStateRequest) -> ResultPayload:  # noqa: ARG002
+        undo_labels = [batch.label for batch in self._undo_stack]
+        redo_labels = [batch.label for batch in self._redo_stack]
+        return GetUndoStateResultSuccess(
+            undo_labels=undo_labels,
+            redo_labels=redo_labels,
+            result_details=f"Undo state retrieved ({len(undo_labels)} undo, {len(redo_labels)} redo).",
+        )
+
+    def on_clear_undo_state_request(self, request: ClearUndoStateRequest) -> ResultPayload:  # noqa: ARG002
+        self.clear_history()
+        return ClearUndoStateResultSuccess(result_details="Undo history cleared.")
+
+    def _commit_batch(self, batch: UndoBatch) -> None:
+        """Push a completed batch onto the undo stack, invalidating the redo stack."""
+        self._undo_stack.append(batch)
+        self._redo_stack.clear()
+
+    def _replay_batch(self, batch: UndoBatch, *, undo: bool) -> str | None:
+        """Replay one batch under the replay guard; return a failure detail string, or None on success.
+
+        Undo replays the batch's entries in reverse via entry.undo(); redo replays them in order via
+        entry.redo(). Any replay failure leaves the workflow partially reverted or re-applied, so the
+        whole history can no longer be trusted: it is cleared and a detail string is returned for the
+        caller to wrap in its typed failure.
+        """
+        if undo:
+            action_noun = "undo"
+            entries = list(reversed(batch.entries))
+        else:
+            action_noun = "redo"
+            entries = list(batch.entries)
+
+        self._is_replaying = True
+        try:
+            for entry in entries:
+                if undo:
+                    entry.undo()
+                else:
+                    entry.redo()
+        except UndoEntryReplayError as err:
+            self.clear_history()
+            return f"Attempted to {action_noun} '{batch.label}'. Failed because {err}. Undo history has been cleared."
+        except Exception as err:
+            # An entry raised something other than UndoEntryReplayError (e.g. an un-deep-copyable
+            # request). The workflow is now partially changed, so history can no longer be trusted;
+            # clear it and surface a typed failure rather than leaking the raw exception.
+            logger.exception(
+                "Unexpected error while replaying %s of '%s'; clearing undo history.", action_noun, batch.label
+            )
+            self.clear_history()
+            return (
+                f"Attempted to {action_noun} '{batch.label}'. Failed with unexpected error: {err}. "
+                "Undo history has been cleared."
+            )
+        finally:
+            self._is_replaying = False
+        return None

--- a/src/griptape_nodes/retained_mode/managers/undo/snapshot.py
+++ b/src/griptape_nodes/retained_mode/managers/undo/snapshot.py
@@ -1,0 +1,281 @@
+"""The whole-flow snapshot recording strategy for undo/redo.
+
+Frames each user action: capture the top-level flow before the action, capture it again after, and
+commit the pair as one undo batch. Reversal is delegated to `flow_snapshot`, which reconciles the
+live flow against the captured image, so this module owns only the framing question -- when does an
+action start, when does it end, and did it change anything worth recording.
+
+Because reversal is state-centric, every way of producing an effect (create a node directly,
+duplicate, paste, import) undoes identically. `RecordingStrategy` (in `undo.core`) is the seam for
+layering in a finer-grained strategy later (e.g. one that captures per-touched-entity deltas instead
+of the whole flow) without changing the manager or the dispatch path.
+
+Framing notes:
+
+- Only what a flow snapshot models is undoable. Requests that mutate state outside the flow are
+  never snapshot points -- domains opt in explicitly via `register_undoable`. See `flow_snapshot`
+  for what the snapshot covers.
+- A batch commits on the dispatch reporting that it altered workflow state, not on a snapshot diff:
+  capture mints fresh UUIDs, so two captures of identical state do not compare equal. A request that
+  reports an edit without changing anything -- setting a parameter to the value it already holds --
+  therefore still consumes an undo slot and replays as a no-op.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from griptape_nodes.retained_mode.managers.undo.core import (
+    DispatchTriage,
+    UndoBatch,
+    UndoEntry,
+    triage_dispatch,
+)
+from griptape_nodes.retained_mode.managers.undo.flow_snapshot import (
+    capture_workflow_snapshot,
+    restore_workflow_snapshot,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator, Mapping
+
+    from griptape_nodes.retained_mode.engine import Engine
+    from griptape_nodes.retained_mode.events.base_events import RequestPayload, ResultPayload
+    from griptape_nodes.retained_mode.managers.undo.flow_snapshot import FlowSnapshot
+
+logger = logging.getLogger("griptape_nodes")
+
+
+@dataclass
+class FlowSnapshotEntry(UndoEntry):
+    """Reverses a user action by restoring the whole-flow snapshot taken before it (undo) or after it (redo)."""
+
+    engine: Engine
+    before: FlowSnapshot
+    after: FlowSnapshot
+
+    def undo(self) -> None:
+        restore_workflow_snapshot(self.engine, self.before)
+
+    def redo(self) -> None:
+        restore_workflow_snapshot(self.engine, self.after)
+
+
+@dataclass
+class _SnapshotDispatch:
+    """Marker returned by begin_request_dispatch so end_request_dispatch knows whether it opened the frame."""
+
+    opened: bool
+
+
+class SnapshotRecordingSession:
+    """Implements RecordingStrategy by recording whole-flow snapshots around each user action.
+
+    Only the requests a domain declares via register_undoable are snapshot points, and the shared
+    lifecycle policy (CLEAR_HISTORY_REQUEST_TYPES, OWN_EVENT_TYPES) applies via triage_dispatch.
+    Declaring is opt-in because a flow snapshot models only flow contents: an undeclared request
+    that mutates something outside the flow would otherwise commit a batch whose before and after
+    are identical, so undoing it would consume a stack slot and revert nothing. It needs no
+    per-request reversal knowledge beyond that: a snapshot captures whole-flow state, so it is
+    agnostic to which declared request produced a change.
+
+    Frame invariant: the open-frame state below (`_before`, `_label`, `_depth`, `_altered`,
+    `_invalidated`) describes one frame at a time and assumes begin/end pairs nest as a single call
+    stack -- an outer dispatch driving inner ones. Overlapping gestures are detected rather than
+    folded together: an externally-initiated request carries a request_id, which a nested dispatch
+    never does, so one arriving while a frame is open means two independent gestures are in flight
+    at once (an async handler yielded and the next request ran as its own task). Both the frame and
+    the history are dropped in that case, costing undoability rather than recording one gesture's
+    edit as part of another's. `_close_frame` fails the same way if begin/end accounting ever goes
+    out of sync.
+    """
+
+    def __init__(
+        self,
+        *,
+        engine: Engine,
+        is_replaying: Callable[[], bool],
+        commit_batch: Callable[[UndoBatch], None],
+        invalidate_history: Callable[[], None],
+    ) -> None:
+        self._engine = engine
+        self._is_replaying = is_replaying
+        self._commit_batch = commit_batch
+        self._invalidate_history = invalidate_history
+        self._undoable_labels: dict[type[RequestPayload], str] = {}
+        self._before: FlowSnapshot | None = None
+        self._label: str | None = None
+        self._depth = 0
+        # Set when a dispatch inside the open frame reported that it altered workflow state. The
+        # frame commits on this union rather than on the framing request's own result, so a handler
+        # that under-reports its own alteration while cascading into mutating requests still yields
+        # an undoable batch instead of a silently unrecorded edit.
+        self._altered = False
+        # Set when a history-clearing lifecycle request is seen while a frame is open, so the frame
+        # finalizes without committing a batch onto the just-cleared stacks.
+        self._invalidated = False
+
+    def register_undoable(self, labels: Mapping[type[RequestPayload], str]) -> None:
+        """Declare request types a flow snapshot can capture, each with the name of its operation.
+
+        The name is keyed by request type rather than by call path, so the same operation reads the
+        same in the undo stack however it was triggered.
+        """
+        self._undoable_labels.update(labels)
+
+    @contextmanager
+    def transaction(self, label: str) -> Iterator[None]:
+        """Group every mutation in the block into one snapshot pair.
+
+        Commits only if some declared-undoable dispatch inside the block reported that it altered
+        workflow state, mirroring the per-dispatch gate. A block that takes a no-op or early-exit path
+        therefore pushes no undo entry, rather than one the user would watch do nothing.
+
+        A raise inside the block still commits: the after-snapshot is taken from live state, so it
+        records whatever the block managed to change, and undoing it backs that partial edit out.
+        """
+        if self._is_replaying() or self._depth > 0:
+            yield
+            return
+        # Unlike begin_request_dispatch, the frame opens even when the capture failed: it suppresses
+        # framing by nested dispatches, and _finalize declines to commit without a before-snapshot.
+        self._before = capture_workflow_snapshot(self._engine)
+        self._label = label
+        self._depth += 1
+        try:
+            yield
+        except Exception:
+            self._close_and_finalize()
+            raise
+        self._close_and_finalize()
+
+    def begin_request_dispatch(self, request: RequestPayload, request_id: str | None) -> _SnapshotDispatch | None:
+        request_type = type(request)
+        triage = triage_dispatch(request, is_replaying=self._is_replaying())
+        if triage is DispatchTriage.IGNORE:
+            return None
+        if triage is DispatchTriage.CLEAR_HISTORY:
+            self._invalidate_history()
+            # If a frame is open, make it finalize without committing onto the just-cleared stacks.
+            if self._depth > 0:
+                self._invalidated = True
+            return None
+
+        if self._depth > 0:
+            return self._join_open_frame(request_type, request_id)
+
+        # Only a user-initiated request (has request_id) whose effects a snapshot can capture opens a
+        # frame. Everything else is inert: it is never snapshotted, so it costs nothing and cannot
+        # commit a batch that would revert nothing.
+        if request_id is None or request_type not in self._undoable_labels:
+            return None
+
+        before = capture_workflow_snapshot(self._engine)
+        if before is None:
+            # Could not snapshot (nothing to capture, or serialization failed): do not open a frame,
+            # so this action is simply not undoable rather than committing an unusable batch.
+            return None
+        self._before = before
+        self._label = self._undoable_labels[request_type]
+        self._depth += 1
+        logger.debug("Snapshot undo: opened frame '%s' (%s).", self._label, request_type.__name__)
+        return _SnapshotDispatch(opened=True)
+
+    def end_request_dispatch(
+        self,
+        capture: _SnapshotDispatch | None,
+        request: RequestPayload,
+        result: ResultPayload | None,
+    ) -> None:
+        if capture is None:
+            return
+        if not self._close_frame():
+            return
+
+        altered = result is not None and result.succeeded() and result.altered_workflow_state
+        # Only declared-undoable types contribute: a snapshot cannot represent anything else, so an
+        # undeclared mutation inside the frame must not make it look like a capturable edit.
+        if altered and type(request) in self._undoable_labels:
+            self._altered = True
+
+        if not capture.opened:
+            return
+        self._finalize(committed=self._altered)
+
+    def _join_open_frame(self, request_type: type[RequestPayload], request_id: str | None) -> _SnapshotDispatch | None:
+        """Fold an inner dispatch into the open frame, or fail closed on an overlapping gesture.
+
+        An externally-initiated request carries a request_id, which an inner dispatch never does, so
+        one arriving mid-frame is a separate gesture in flight at the same time (see the frame
+        invariant on the class). Folding it in would record its edit as part of the open action, so
+        the frame and the history are dropped instead.
+        """
+        if request_id is not None:
+            logger.warning(
+                "Snapshot undo: %s arrived while '%s' was still in progress; clearing undo history to "
+                "avoid recording one edit as part of another.",
+                request_type.__name__,
+                self._label,
+            )
+            self._invalidate_history()
+            self._invalidated = True
+            return None
+        self._depth += 1
+        return _SnapshotDispatch(opened=False)
+
+    def _close_and_finalize(self) -> None:
+        """Close the frame this call opened and commit it if anything inside it altered the flow."""
+        if not self._close_frame():
+            return
+        self._finalize(committed=self._altered)
+
+    def _close_frame(self) -> bool:
+        """Close one nesting level of the open frame; False when frame accounting was out of sync.
+
+        A frame closing that was never open means begin/end pairs did not nest as a single call stack
+        (see the frame invariant on the class). Any batch built from there would be attributed to the
+        wrong action, so the frame and the history are dropped instead.
+        """
+        if self._depth <= 0:
+            logger.warning(
+                "Snapshot undo: dispatch frame tracking went out of sync; clearing undo history to "
+                "avoid recording a misattributed edit."
+            )
+            self._reset()
+            self._invalidate_history()
+            return False
+        self._depth -= 1
+        return True
+
+    def _finalize(self, *, committed: bool) -> None:
+        before = self._before
+        label = self._label or "Edit"
+        invalidated = self._invalidated
+        self._reset()
+        if invalidated or not committed or before is None:
+            logger.debug(
+                "Snapshot undo: discarded frame '%s' (invalidated=%s, altered=%s, captured=%s).",
+                label,
+                invalidated,
+                committed,
+                before is not None,
+            )
+            return
+        after = capture_workflow_snapshot(self._engine)
+        if after is None:
+            logger.debug("Snapshot undo: discarded frame '%s'; could not capture the after state.", label)
+            return
+        logger.debug("Snapshot undo: committed '%s'.", label)
+        self._commit_batch(
+            UndoBatch(label=label, entries=[FlowSnapshotEntry(engine=self._engine, before=before, after=after)])
+        )
+
+    def _reset(self) -> None:
+        self._before = None
+        self._label = None
+        self._depth = 0
+        self._altered = False
+        self._invalidated = False

--- a/tests/unit/retained_mode/managers/test_undo_manager.py
+++ b/tests/unit/retained_mode/managers/test_undo_manager.py
@@ -1,0 +1,277 @@
+"""Unit tests for `UndoManager`: the strategy-agnostic mechanism (stacks, guards, replay, lifecycle).
+
+These exercise the manager itself -- undo/redo stacks, the replay guard, the flow-running guard,
+history invalidation, and the shared lifecycle policy -- independently of which recording strategy
+is installed. Snapshot-specific behavior (capture/reconcile) lives in ``test_undo_snapshot.py``.
+
+User-initiated requests are simulated by dispatching through the EventManager with a ``request_id``
+in the result context, which is what marks a request as originating from an external caller.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, ParameterTypeBuiltin
+from griptape_nodes.exe_types.node_types import BaseNode
+from griptape_nodes.retained_mode.engine import current_engine
+from griptape_nodes.retained_mode.events.context_events import SetWorkflowContextRequest
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
+from griptape_nodes.retained_mode.events.undo_events import (
+    ClearUndoStateRequest,
+    ClearUndoStateResultSuccess,
+    GetUndoStateRequest,
+    GetUndoStateResultSuccess,
+    RedoRequest,
+    RedoResultFailure,
+    UndoRequest,
+    UndoResultFailure,
+    UndoResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.undo import UndoBatch, UndoEntry, UndoEntryReplayError
+from griptape_nodes.retained_mode.managers.undo.manager import MAX_UNDO_BATCHES
+from griptape_nodes.retained_mode.managers.undo.snapshot import SnapshotRecordingSession
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from griptape_nodes.retained_mode.engine import Engine
+    from griptape_nodes.retained_mode.events.base_events import RequestPayload, ResultPayload
+
+
+class _ProbeNode(BaseNode):
+    """Concrete `BaseNode` with a single settable string parameter."""
+
+    def __init__(self, name: str, metadata=None) -> None:  # noqa: ANN001
+        super().__init__(name=name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="text",
+                tooltip="probe text",
+                type=ParameterTypeBuiltin.STR.value,
+                allowed_modes={ParameterMode.PROPERTY, ParameterMode.INPUT, ParameterMode.OUTPUT},
+                default_value="",
+            )
+        )
+
+    def process(self) -> None:
+        return None
+
+
+class _NoopUndoEntry(UndoEntry):
+    """Entry that does nothing; used to populate the stacks in mechanism tests."""
+
+    def undo(self) -> None:
+        return None
+
+    def redo(self) -> None:
+        return None
+
+
+class _RaisingUndoEntry(UndoEntry):
+    """Entry that raises a given error on replay; used to drive the replay-failure paths."""
+
+    def __init__(self, error: Exception) -> None:
+        self._error = error
+
+    def undo(self) -> None:
+        raise self._error
+
+    def redo(self) -> None:
+        raise self._error
+
+
+class TestUndoManager:
+    _LIBRARY_NAME = "undo-manager-test-library"
+    _NODE_TYPE = "_ProbeNode"
+
+    @pytest.fixture
+    def engine(self) -> Iterator[Engine]:
+        """A fresh engine with the undo-manager test library and a test-local undo policy.
+
+        Confirms the UndoManager wires the (default) snapshot recording strategy, then declares
+        CreateNodeRequest undoable here rather than relying on what the node domain declares in
+        production. These tests are about the mechanism (stacks, replay, guards, lifecycle), so they
+        must not start failing because a domain revised its own policy or the label it uses.
+        """
+        from griptape_nodes.node_library.library_registry import LibraryRegistry
+
+        LibraryRegistry._clear()
+        engine = current_engine()
+        assert isinstance(engine.undo_manager._recording, SnapshotRecordingSession)
+        engine.undo_manager.register_undoable({CreateNodeRequest: "Create node"})
+        self._register_library()
+        yield engine
+        LibraryRegistry._clear()
+
+    def _register_library(self) -> None:
+        from griptape_nodes.node_library.library_registry import (
+            LibraryMetadata,
+            LibraryRegistry,
+            LibrarySchema,
+            NodeMetadata,
+        )
+
+        schema = LibrarySchema(
+            name=self._LIBRARY_NAME,
+            library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+            metadata=LibraryMetadata(
+                author="t", description="d", library_version="1.0.0", engine_version="1.0.0", tags=[]
+            ),
+            categories=[],
+            nodes=[],
+        )
+        library = LibraryRegistry.generate_new_library(library_data=schema)
+        library.register_new_node_type(_ProbeNode, NodeMetadata(category="t", description="d", display_name="Probe"))
+
+    def _make_flow(self, griptape_nodes: GriptapeNodes) -> str:
+        from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
+        from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowMetadata
+
+        context_manager = griptape_nodes.ContextManager()
+        if not context_manager.has_current_workflow():
+            workflow_key = "unsaved:undo-manager-test"
+            if workflow_key not in WorkflowRegistry._workflows:
+                metadata = WorkflowMetadata(
+                    name="Untitled",
+                    schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+                    engine_version_created_with="",
+                    node_libraries_referenced=[],
+                    creation_date=datetime.now(UTC),
+                )
+                WorkflowRegistry.generate_new_workflow(registry_key=workflow_key, metadata=metadata, file_path=None)
+            context_manager.push_workflow(workflow_name=workflow_key)
+        create_result = griptape_nodes.handle_request(CreateFlowRequest(parent_flow_name=None))
+        assert isinstance(create_result, CreateFlowResultSuccess)
+        return create_result.flow_name
+
+    @staticmethod
+    def _user_request(request: RequestPayload, request_id: str = "test-request") -> ResultPayload:
+        event_manager = GriptapeNodes.EventManager()
+        return event_manager.handle_request(request, result_context={"request_id": request_id}).result
+
+    def _create_node(self, flow_name: str, node_name: str | None = None) -> str:
+        result = self._user_request(
+            CreateNodeRequest(
+                node_type=self._NODE_TYPE,
+                specific_library_name=self._LIBRARY_NAME,
+                node_name=node_name,
+                override_parent_flow_name=flow_name,
+            )
+        )
+        assert isinstance(result, CreateNodeResultSuccess)
+        return result.node_name
+
+    # ---------- Empty stacks / state reporting ----------
+
+    def test_undo_empty_stack_fails(self, engine: GriptapeNodes) -> None:  # noqa: ARG002
+        assert isinstance(GriptapeNodes.handle_request(UndoRequest()), UndoResultFailure)
+
+    def test_redo_empty_stack_fails(self, engine: GriptapeNodes) -> None:  # noqa: ARG002
+        assert isinstance(GriptapeNodes.handle_request(RedoRequest()), RedoResultFailure)
+
+    def test_get_undo_state_reports_labels(self, engine: GriptapeNodes) -> None:
+        flow_name = self._make_flow(engine)
+        self._create_node(flow_name, node_name="ProbeA")
+
+        state = GriptapeNodes.handle_request(GetUndoStateRequest())
+        assert isinstance(state, GetUndoStateResultSuccess)
+        assert len(state.undo_labels) == 1
+        assert state.redo_labels == []
+
+    def test_clear_undo_state(self, engine: GriptapeNodes) -> None:
+        flow_name = self._make_flow(engine)
+        self._create_node(flow_name, node_name="ProbeA")
+
+        assert isinstance(GriptapeNodes.handle_request(ClearUndoStateRequest()), ClearUndoStateResultSuccess)
+        state = GriptapeNodes.handle_request(GetUndoStateRequest())
+        assert isinstance(state, GetUndoStateResultSuccess)
+        assert state.undo_labels == []
+        assert state.redo_labels == []
+
+    def test_new_recorded_action_clears_redo_stack(self, engine: GriptapeNodes) -> None:
+        flow_name = self._make_flow(engine)
+        self._create_node(flow_name, node_name="ProbeA")
+        assert isinstance(GriptapeNodes.handle_request(UndoRequest()), UndoResultSuccess)
+
+        state = GriptapeNodes.handle_request(GetUndoStateRequest())
+        assert isinstance(state, GetUndoStateResultSuccess)
+        assert state.redo_labels  # a redo is available
+
+        self._create_node(flow_name, node_name="ProbeB")
+        state = GriptapeNodes.handle_request(GetUndoStateRequest())
+        assert isinstance(state, GetUndoStateResultSuccess)
+        assert state.redo_labels == []
+
+    # ---------- Stack bound ----------
+
+    def test_undo_stack_respects_max_batches(self, engine: GriptapeNodes) -> None:  # noqa: ARG002
+        undo_manager = GriptapeNodes.UndoManager()
+        for index in range(MAX_UNDO_BATCHES + 5):
+            undo_manager._commit_batch(UndoBatch(label=f"batch-{index}", entries=[_NoopUndoEntry()]))
+        assert len(undo_manager._undo_stack) == MAX_UNDO_BATCHES
+
+    # ---------- Guards ----------
+
+    def test_undo_blocked_while_replay_in_progress(self, engine: GriptapeNodes) -> None:  # noqa: ARG002
+        undo_manager = GriptapeNodes.UndoManager()
+        undo_manager._undo_stack.append(UndoBatch(label="x", entries=[_NoopUndoEntry()]))
+        undo_manager._is_replaying = True
+        try:
+            assert isinstance(GriptapeNodes.handle_request(UndoRequest()), UndoResultFailure)
+        finally:
+            undo_manager._is_replaying = False
+
+    def test_redo_blocked_while_replay_in_progress(self, engine: GriptapeNodes) -> None:  # noqa: ARG002
+        undo_manager = GriptapeNodes.UndoManager()
+        undo_manager._redo_stack.append(UndoBatch(label="x", entries=[_NoopUndoEntry()]))
+        undo_manager._is_replaying = True
+        try:
+            assert isinstance(GriptapeNodes.handle_request(RedoRequest()), RedoResultFailure)
+        finally:
+            undo_manager._is_replaying = False
+
+    def test_undo_fails_while_flow_running(self, engine: GriptapeNodes, monkeypatch: pytest.MonkeyPatch) -> None:  # noqa: ARG002
+        undo_manager = GriptapeNodes.UndoManager()
+        undo_manager._undo_stack.append(UndoBatch(label="x", entries=[_NoopUndoEntry()]))
+        monkeypatch.setattr(GriptapeNodes.FlowManager(), "check_for_existing_running_flow", lambda: True)
+        assert isinstance(GriptapeNodes.handle_request(UndoRequest()), UndoResultFailure)
+
+    def test_redo_fails_while_flow_running(self, engine: GriptapeNodes, monkeypatch: pytest.MonkeyPatch) -> None:  # noqa: ARG002
+        undo_manager = GriptapeNodes.UndoManager()
+        undo_manager._redo_stack.append(UndoBatch(label="x", entries=[_NoopUndoEntry()]))
+        monkeypatch.setattr(GriptapeNodes.FlowManager(), "check_for_existing_running_flow", lambda: True)
+        assert isinstance(GriptapeNodes.handle_request(RedoRequest()), RedoResultFailure)
+
+    # ---------- Replay failure clears history ----------
+
+    def test_replay_error_clears_history(self, engine: GriptapeNodes) -> None:  # noqa: ARG002
+        undo_manager = GriptapeNodes.UndoManager()
+        undo_manager._undo_stack.append(UndoBatch(label="x", entries=[_RaisingUndoEntry(UndoEntryReplayError("boom"))]))
+        assert isinstance(GriptapeNodes.handle_request(UndoRequest()), UndoResultFailure)
+        assert not undo_manager._undo_stack
+        assert not undo_manager._redo_stack
+
+    def test_unexpected_replay_error_clears_history(self, engine: GriptapeNodes) -> None:  # noqa: ARG002
+        undo_manager = GriptapeNodes.UndoManager()
+        undo_manager._undo_stack.append(UndoBatch(label="x", entries=[_RaisingUndoEntry(ValueError("boom"))]))
+        assert isinstance(GriptapeNodes.handle_request(UndoRequest()), UndoResultFailure)
+        assert not undo_manager._undo_stack
+        assert not undo_manager._redo_stack
+
+    # ---------- Lifecycle policy ----------
+
+    def test_set_workflow_context_clears_history(self, engine: GriptapeNodes) -> None:
+        flow_name = self._make_flow(engine)
+        self._create_node(flow_name, node_name="ProbeA")
+
+        # A whole-graph lifecycle request invalidates all undo history.
+        self._user_request(SetWorkflowContextRequest(workflow_name=None))
+        state = GriptapeNodes.handle_request(GetUndoStateRequest())
+        assert isinstance(state, GetUndoStateResultSuccess)
+        assert state.undo_labels == []


### PR DESCRIPTION
Adds the undo/redo stacks, replay guard, request handlers, and the snapshot recording strategy that frames each dispatch into a batch. Inert: no domain declares anything undoable yet, so undo reports nothing to undo and no user-visible behavior changes.