### PR TITLE
feat(undo): make node, flow, and object edits undoable

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,35 @@
 # Unreleased
 
+## Branched workflows show a title instead of a file path
+
+Branching a workflow used to set the new workflow's `metadata.name` — the human-readable display
+name — to its registry key, which is derived from the file path. A branch of "Shot 010 Comp" saved
+under `shots/sh010/` came back named `shots/sh010/comp_branch_1`, so anywhere the editor shows a
+workflow title, a branch read as a path while its own source next to it read as a title.
+
+A branch is now named after the workflow it came from:
+
+|                 | before                      | after                                   |
+| --------------- | --------------------------- | --------------------------------------- |
+| registry key    | `shots/sh010/comp_branch_1` | `shots/sh010/comp_branch_1` (unchanged) |
+| `metadata.name` | `shots/sh010/comp_branch_1` | `Shot 010 Comp (branch 1)`              |
+
+Registry keys are unchanged, so anything that looks workflows up by name keeps working. Merging a
+branch no longer overwrites its source's title, and resetting a branch no longer overwrites its own.
+
+`BranchWorkflowRequest` takes an optional `branched_workflow_display_name` if you want to set the
+label yourself:
+
+```python
+BranchWorkflowRequest(workflow_name="shots/sh010/comp", branched_workflow_display_name="Lighting Test")
+```
+
+**Workflows already on disk.** Files written by earlier versions still carry the path in their
+header. The engine shows the readable name (just the file name, e.g. `comp_branch_1`) when it loads
+one, and the header is rewritten the next time that workflow is saved. Nothing is rewritten during
+load, so no files change until you save them. Only a display name that exactly equals its own
+registry key is repaired — a title you deliberately wrote with a `/` in it is left alone.
+
 ## Agent streaming payloads carry `thread_id`
 
 `AgentStreamEvent`, `AgentThinkingEvent`, `AgentToolCallEvent`, and `AgentToolResultEvent`

--- a/docs/guides/editor/keyboard_shortcuts.md
+++ b/docs/guides/editor/keyboard_shortcuts.md
@@ -16,16 +16,18 @@ For a tour of the regions these shortcuts act on, see
 
 ## Adding & editing nodes
 
-| Action                                                     | macOS               | Windows / Linux     |
-| ---------------------------------------------------------- | ------------------- | ------------------- |
-| Add a node at the cursor (canvas only)                     | Tab                 | Tab                 |
-| Add a node at the cursor, or select all if not over canvas | Shift+A             | Shift+A             |
-| Open the Add Node menu at the cursor                       | Double-click canvas | Double-click canvas |
-| Create a Note node at the cursor                           | N                   | N                   |
-| Rename the selected node(s)                                | R                   | R                   |
-| Duplicate the selected node(s)                             | Cmd+D               | Ctrl+D              |
-| Lock / unlock the selected node(s)                         | L                   | L                   |
-| Delete the selected node(s) or connection                  | Delete / Backspace  | Delete / Backspace  |
+| Action                                                     | macOS               | Windows / Linux       |
+| ---------------------------------------------------------- | ------------------- | --------------------- |
+| Add a node at the cursor (canvas only)                     | Tab                 | Tab                   |
+| Add a node at the cursor, or select all if not over canvas | Shift+A             | Shift+A               |
+| Open the Add Node menu at the cursor                       | Double-click canvas | Double-click canvas   |
+| Create a Note node at the cursor                           | N                   | N                     |
+| Rename the selected node(s)                                | R                   | R                     |
+| Duplicate the selected node(s)                             | Cmd+D               | Ctrl+D                |
+| Lock / unlock the selected node(s)                         | L                   | L                     |
+| Undo the last edit                                         | Cmd+Z               | Ctrl+Z                |
+| Redo the last undone edit                                  | Shift+Cmd+Z         | Shift+Ctrl+Z / Ctrl+Y |
+| Delete the selected node(s) or connection                  | Delete / Backspace  | Delete / Backspace    |
 
 ## Selection
 

--- a/docs/guides/editor/running_workflows.md
+++ b/docs/guides/editor/running_workflows.md
@@ -20,8 +20,10 @@ already running, and while no workflow is open.
 ## Running a single node
 
 Two more buttons next to Run Workflow let you run less than the whole
-graph. The buttons require exactly one node to be selected, and both are
-disabled while the workflow is already running.
+graph. The buttons require exactly one node to be selected. Run From
+Selected is disabled while the workflow is already running; Run To
+Selected is not — see [Running a node during a
+run](#running-a-node-during-a-run) below.
 
 - **Run To Selected** resolves the selected node — and everything upstream
     of it that isn't already resolved — without touching anything
@@ -41,6 +43,38 @@ selected — it runs to each of them.
 
 Both single-node actions are also available from the node's right-click
 context menu, and from the multi-node toolbar when applicable.
+
+## Running a node during a run
+
+You don't have to wait for a run to finish to try a node. **Run To
+Selected** stays available while the workflow is running, and the node
+joins the run that's already in progress instead of starting a new one.
+Anything upstream of it that isn't resolved yet is pulled into the same
+run and resolved first, exactly as it would be from a standing start.
+
+When the node actually begins depends on how much of the run is already
+in flight:
+
+- In **Parallel** execution mode it starts as soon as the run has a free
+    slot, which may be immediately. The number of nodes that can run at
+    once is the `max_nodes_in_parallel` setting (5 by default).
+- In **Sequential** execution mode one node runs at a time, so the node
+    you played starts once the node currently running finishes.
+
+Both modes are described in
+[Configuration](../configuration.md).
+
+Two cases are worth knowing about:
+
+- **If the run is paused**, the node is added to it but does not start.
+    It runs when you step or continue the run.
+- **If the node is already part of the run** — already finished, running,
+    or queued behind its dependencies — playing it is refused rather than
+    run twice, and the editor reports that the node is already executing.
+    Cancel the run if you want to start it over.
+
+**Run Workflow** and **Run From Selected** still require an idle
+workflow; they stay disabled until the current run ends.
 
 ## Stopping a run
 

--- a/docs/guides/editor/undo_and_redo.md
+++ b/docs/guides/editor/undo_and_redo.md
@@ -1,0 +1,69 @@
+# Undo and Redo
+
+Press `Cmd/Ctrl+Z` to undo your last edit. To redo it, press
+`Shift+Cmd/Ctrl+Z`, or `Ctrl+Y` on Windows and Linux. Hold the shortcut down
+to keep stepping. The editor keeps the last 100 edits, so you can walk back
+through a whole session of work.
+
+While your cursor is in a text field, these shortcuts undo your typing instead
+of your canvas, so editing a parameter's text behaves the way it does
+everywhere else.
+
+Undo covers editing, not running. Running a workflow, stopping it, or resolving
+a single node is never something you undo, and running a workflow doesn't
+disturb the edits already on your undo stack.
+
+## What you can undo
+
+Anything that changes the shape or contents of your canvas:
+
+- Adding, deleting, duplicating, or pasting nodes
+- Changing a parameter value
+- Moving a node, or moving several at once
+- Renaming a node
+- Connecting two parameters, or deleting a connection
+- Resetting a node to its defaults
+- Auto-arranging the canvas
+
+Each of these is one step, however you triggered it. Pasting five nodes is a
+single undo, not five, and it undoes the same way whether you pasted them,
+duplicated them, or added them from a template.
+
+## What you can't undo
+
+Some things live outside the canvas, so an undo has nothing to put back:
+
+- **Workflow variables**, installed **libraries**, and **model or MCP server
+    settings**. These belong to your environment, not to one workflow.
+- **Adding, removing, or renaming a parameter** on a node. The values on your
+    nodes are restored, but the set of parameters a node carries is not.
+- **Moving a node into or out of a group.** Group membership isn't part of what
+    an undo step records.
+- **Saving.** Undo works on the canvas in front of you; it never rewrites a
+    file you've already saved.
+
+## How a step is restored
+
+Undo restores your canvas by putting back only what actually changed. Undoing a
+value edit on one node leaves every other node exactly as it was, so your
+selection, your viewport, and any results already computed on untouched nodes
+survive the undo.
+
+Renaming is the one exception. A node is tracked by its name, so undoing a
+rename rebuilds that node rather than editing it in place. Anything transient
+on it, such as a computed result that hasn't been saved into a parameter, is
+lost, the same as it would be on a freshly added node.
+
+## When history is cleared
+
+The undo stack empties when the edits on it no longer describe the canvas
+you're looking at:
+
+- Opening, creating, or importing a workflow
+- Switching to a different workflow
+
+You also can't undo while a workflow is running. Stop the run first, then undo.
+
+If a step fails to replay, the editor clears the history rather than leave you
+with a canvas that's half reverted. This is rare, and it reports what went
+wrong when it happens.

--- a/docs/guides/projects/environment.md
+++ b/docs/guides/projects/environment.md
@@ -57,13 +57,13 @@ Prefer the `{NAME}` form for all new projects — it composes cleanly, expands c
 
 Builtin variables are automatically available in all macros. You do not define them — the system provides their values at runtime. They cannot be overridden.
 
-| Variable           | Type      | Description                                                                                                                                                                  |
-| ------------------ | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `project_dir`      | directory | Absolute path to the project base directory (the folder containing `griptape-nodes-project.yml`, or the workspace directory when no project file is present)                 |
-| `workspace_dir`    | directory | Absolute path to the workspace directory (defaults to the project directory when no explicit workspace is configured; see [Workspace](workspace.md#config-resolution-order)) |
-| `workflow_name`    | string    | Name of the currently running workflow                                                                                                                                       |
-| `workflow_dir`     | directory | Absolute path to the directory containing the current workflow file                                                                                                          |
-| `static_files_dir` | string    | Name of the static files subdirectory (from settings, defaults to `staticfiles`)                                                                                             |
+| Variable           | Type      | Description                                                                                                                                                                       |
+| ------------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `project_dir`      | directory | Absolute path to the project base directory (the folder containing `griptape-nodes-project.yml`, or the workspace directory when no project file is present)                      |
+| `workspace_dir`    | directory | Absolute path to the workspace directory (defaults to the project directory when no explicit workspace is configured; see [Workspace](workspace.md#config-resolution-order))      |
+| `workflow_name`    | string    | Name of the currently running workflow                                                                                                                                            |
+| `workflow_dir`     | directory | Absolute path to the directory containing the current workflow file, or — for a workflow that has not been saved yet — the folder it was created in, when the editor supplied one |
+| `static_files_dir` | string    | Name of the static files subdirectory (from settings, defaults to `staticfiles`)                                                                                                  |
 
 ### How builtins are resolved
 
@@ -83,7 +83,15 @@ The `save_static_file` situation uses `workflow_dir` and `static_files_dir`:
 {workflow_dir?:/}{static_files_dir}/{file_name_base}.{file_extension}
 ```
 
-If `workflow_dir` is available, the static files go into a subdirectory of the workflow folder. If not (the workflow hasn't been saved yet), the `{workflow_dir?:/}` block is omitted.
+If `workflow_dir` is available, the static files go into a subdirectory of the workflow folder. If not, the `{workflow_dir?:/}` block is omitted and the path becomes workspace-relative.
+
+### Unsaved workflows
+
+A workflow that has never been saved has no file, so there is no directory to derive `workflow_dir` from. When you create a workflow while browsing a folder, the editor tells the engine which folder that was, and `workflow_dir` answers with it until the workflow is saved. Files you generate before the first save land in that folder rather than at the workspace root.
+
+Once the workflow is saved, `workflow_dir` switches to the directory of the saved file — which may be somewhere else, if you saved it to a different folder. The files themselves stay where they were written, but any stored references built on `{workflow_dir}` now resolve into the new folder, so outputs generated before the save may appear missing from the node even though the bytes are on disk.
+
+If the editor did not supply a folder, `workflow_dir` stays unavailable until the first save, and `{workflow_dir?:/}` is omitted as described above.
 
 ## Variable priority
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,7 @@ plugins:
           - guides/editor/index.md: Orientation tour of the visual editor (canvas, header, menus, sidebars)
           - guides/editor/keyboard_shortcuts.md: Complete keyboard shortcut reference
           - guides/editor/working_with_nodes.md: Adding, selecting, wiring, and editing nodes on the canvas
+          - guides/editor/undo_and_redo.md: What undo and redo cover, what they don't, and when history is cleared
           - guides/editor/node_groups.md: Groups, subflows, and iterative group types (ForEach, For Loop, Retry)
           - guides/editor/running_workflows.md: Running, stopping, logs, error history, and saving
           - guides/editor/media_editors.md: Built-in viewers and editors for images, video, audio, 3D, and splats
@@ -279,6 +280,7 @@ nav:
           - Overview: guides/editor/index.md
           - Keyboard Shortcuts: guides/editor/keyboard_shortcuts.md
           - Working with Nodes: guides/editor/working_with_nodes.md
+          - Undo and Redo: guides/editor/undo_and_redo.md
           - Node Groups: guides/editor/node_groups.md
           - Running Workflows: guides/editor/running_workflows.md
           - Media Viewers and Editors: guides/editor/media_editors.md

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -335,6 +335,26 @@ class BaseNode(ABC):
     def parent_group(self, parent_group: BaseNode | None) -> None:
         self._parent_group = parent_group
 
+    def prepare_to_run_again(self) -> None:
+        """Clear this node's resolution so it executes again, and tell the editor it did.
+
+        Locked nodes keep the values they were locked with, so they are left alone.
+
+        Unlike a bare ``make_node_unresolved``, the change event fires from every state
+        rather than only from the ones that made visible progress: a node that is about to
+        run needs its status cleared in the editor even if it already looked unresolved.
+        """
+        if self.lock:
+            return
+
+        self.make_node_unresolved(
+            current_states_to_trigger_change_event={
+                NodeResolutionState.UNRESOLVED,
+                NodeResolutionState.RESOLVED,
+                NodeResolutionState.RESOLVING,
+            }
+        )
+
     # This is gross and we need to have a universal pass on resolution state changes and emission of events. That's what this ticket does!
     # https://github.com/griptape-ai/griptape-nodes/issues/994
     def make_node_unresolved(self, current_states_to_trigger_change_event: set[NodeResolutionState] | None) -> None:

--- a/src/griptape_nodes/machines/control_flow.py
+++ b/src/griptape_nodes/machines/control_flow.py
@@ -102,12 +102,7 @@ class ResolveNodeState(State):
 
         # Mark all current nodes unresolved and broadcast events
         for current_node in context.current_nodes:
-            if not current_node.lock:
-                current_node.make_node_unresolved(
-                    current_states_to_trigger_change_event=set(
-                        {NodeResolutionState.UNRESOLVED, NodeResolutionState.RESOLVED, NodeResolutionState.RESOLVING}
-                    )
-                )
+            current_node.prepare_to_run_again()
             # Now broadcast that we have a current control node.
             context.engine.event_manager.put_event(
                 ExecutionGriptapeNodeEvent(

--- a/src/griptape_nodes/machines/parallel_resolution.py
+++ b/src/griptape_nodes/machines/parallel_resolution.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 from typing import TYPE_CHECKING, NamedTuple
 
@@ -42,6 +43,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("griptape_nodes")
 
+# How long a driver waits on the new-work flag when it has nothing running and nothing it
+# can dispatch. Short enough to stay responsive, long enough not to busy-loop.
+_IDLE_RECHECK_SECONDS = 0.05
+
 
 class NodeStatesResult(NamedTuple):
     """Result of building node states from the DAG networks.
@@ -68,6 +73,7 @@ class ParallelResolutionContext(EngineScoped):
     dag_builder: DagBuilder | None
     last_resolved_node: BaseNode | None  # Track the last node that was resolved
     generation: int  # Bumped on reset so a resuming driver can tell its run was torn down
+    new_work_event: asyncio.Event  # Set when the priority queue changes, so a parked driver wakes
 
     def __init__(
         self,
@@ -90,6 +96,7 @@ class ParallelResolutionContext(EngineScoped):
         self.running_tasks_count = 0
         self.task_to_node = {}
         self.generation = 0
+        self.new_work_event = asyncio.Event()
 
     @property
     def node_to_reference(self) -> dict[str, DagNode]:
@@ -119,6 +126,15 @@ class ParallelResolutionContext(EngineScoped):
         """
         return self.generation != generation
 
+    def signal_new_work(self) -> None:
+        """Announce that this run's priority queue changed, unparking the driver.
+
+        Safe to call from a coroutine other than the driver. Level-triggered on
+        purpose: the driver consumes the flag immediately before it reads the
+        queue, so a signal that races the driver's wait is never lost.
+        """
+        self.new_work_event.set()
+
     def reset(self, *, cancel: bool = False) -> None:
         # Ends the current run as far as any parked driver is concerned: it sees
         # the bump on waking and abandons the run.
@@ -145,6 +161,13 @@ class ParallelResolutionContext(EngineScoped):
         # Clear the priority queue when resetting
         # Create a new instance to ensure clean state
         self.node_priority_queue = NodePriorityQueue(self)
+
+        # Unpark a driver sitting in asyncio.wait so it takes its abandon path now,
+        # rather than holding the FSM's single-driver claim until some old node task
+        # finishes. Note the Event object itself is deliberately NOT replaced the way
+        # the priority queue above is: an abandoning driver may still be waiting on a
+        # waiter derived from it, and rebinding would orphan that waiter forever.
+        self.new_work_event.set()
 
         # Clear DAG builder state to allow re-adding nodes on subsequent runs
         if self.dag_builder:
@@ -326,22 +349,15 @@ class ExecuteDagState(State):
             )
             next_node.set_entry_control_parameter(next_parameter)
             # Prepare next node for execution
+            next_node.prepare_to_run_again()
+            # Locked nodes are not becoming the current control node, so they get no event.
             if not next_node.lock:
-                next_node.make_node_unresolved(
-                    current_states_to_trigger_change_event=set(
-                        {
-                            NodeResolutionState.UNRESOLVED,
-                            NodeResolutionState.RESOLVED,
-                            NodeResolutionState.RESOLVING,
-                        }
-                    )
-                )
                 context.engine.event_manager.put_event(
                     ExecutionGriptapeNodeEvent(
                         wrapped_event=ExecutionEvent(payload=CurrentControlNodeEvent(node_name=next_node.name))
                     )
                 )
-            ExecuteDagState._add_and_queue_nodes(context, next_node, network_name)
+            ExecuteDagState.add_and_queue_nodes(context, next_node, network_name)
 
     @staticmethod
     def _emit_involved_nodes_update(context: ParallelResolutionContext) -> None:
@@ -355,17 +371,29 @@ class ExecuteDagState(State):
             )
 
     @staticmethod
-    def _add_and_queue_nodes(context: ParallelResolutionContext, next_node: BaseNode, network_name: str) -> None:
-        """Add nodes to DAG and queue them if ready."""
-        if context.dag_builder is not None:
-            added_nodes = context.dag_builder.add_node_with_dependencies(next_node, network_name)
-            if next_node not in added_nodes:
-                added_nodes.append(next_node)
+    def add_and_queue_nodes(
+        context: ParallelResolutionContext, next_node: BaseNode, network_name: str
+    ) -> list[BaseNode]:
+        """Add a node and its dependencies to the DAG, queueing whatever is ready to run.
 
-            # Queue nodes that are ready for execution
-            if added_nodes:
-                for added_node in added_nodes:
-                    ExecuteDagState._try_queue_waiting_node(context, added_node.name)
+        Public because ``ParallelResolutionMachine.inject_node`` shares it: adding to the DAG
+        and queueing what that pulled in is one invariant, and it must not drift between the
+        control-flow path and the injection path.
+
+        Returns the nodes added to the DAG, for callers that report them as involved nodes.
+        """
+        if context.dag_builder is None:
+            return []
+
+        added_nodes = context.dag_builder.add_node_with_dependencies(next_node, network_name)
+        if next_node not in added_nodes:
+            added_nodes.append(next_node)
+
+        # Queue nodes that are ready for execution
+        for added_node in added_nodes:
+            ExecuteDagState._try_queue_waiting_node(context, added_node.name)
+
+        return added_nodes
 
     @staticmethod
     def _try_queue_waiting_node(context: ParallelResolutionContext, node_name: str) -> None:
@@ -560,6 +588,15 @@ class ExecuteDagState(State):
             # Set state to workflow complete.
             context.workflow_state = WorkflowState.CANCELED
             return DagCompleteState
+
+        # Consume the new-work flag before reading the queue. Anything signalled from
+        # here on survives into the wait below; anything signalled before here is
+        # honored by the drain that immediately follows, because there is no await
+        # between this clear and that drain. Keeping those two adjacent is what makes
+        # wakeups lossless AND keeps the waiter below from completing instantly on a
+        # stale flag and spinning this loop.
+        context.new_work_event.clear()
+
         # Create tasks only while we have capacity
         while context.running_tasks_count < context.max_nodes_in_parallel:
             # Get next highest priority node
@@ -683,9 +720,25 @@ class ExecuteDagState(State):
                 ExecutionGriptapeNodeEvent(wrapped_event=ExecutionEvent(payload=CurrentDataNodeEvent(node_name=node)))
             )
 
-        # Wait for a task to finish - only if there are tasks running
+        # Wait for a running node to finish, or for work to be injected into this run -
+        # whichever comes first. asyncio.wait snapshots its awaitable set, so without a
+        # waiter on the new-work flag a node injected into a live run could not start
+        # until some already-running node happened to finish.
         if context.task_to_node:
-            done, _ = await asyncio.wait(context.task_to_node.keys(), return_when=asyncio.FIRST_COMPLETED)
+            # The waiter is deliberately kept OUT of task_to_node: everything that walks
+            # that map (the reap below, ErrorState, cancel_all_nodes' gather) treats its
+            # members as node tasks. Cancelling in a finally, rather than on each way out
+            # of on_update, makes every return path below leak-free by construction.
+            # The cancel is deliberately not awaited. Awaiting here would add a suspension
+            # point that could swallow a cancellation aimed at this driver, which
+            # isolated-subflow teardown relies on propagating.
+            wakeup_waiter = asyncio.create_task(context.new_work_event.wait())
+            try:
+                done, _ = await asyncio.wait(
+                    {*context.task_to_node, wakeup_waiter}, return_when=asyncio.FIRST_COMPLETED
+                )
+            finally:
+                wakeup_waiter.cancel()
 
             if context.was_reset_since(generation):
                 # Reaping here would look up tasks the teardown already discarded,
@@ -693,12 +746,17 @@ class ExecuteDagState(State):
                 ExecuteDagState._log_abandoned(context)
                 return None
 
-            # Decrement counter for completed tasks
-            context.running_tasks_count -= len(done)
-            # New node has finished - priorities are stale
-            context.node_priority_queue.mark_priorities_stale()
+            # Membership in task_to_node is the authoritative "is a node task" test, so
+            # filter on it rather than popping everything that came back done.
+            done_node_tasks = [task for task in done if task in context.task_to_node]
+
+            if done_node_tasks:
+                # Decrement counter for completed tasks
+                context.running_tasks_count -= len(done_node_tasks)
+                # New node has finished - priorities are stale
+                context.node_priority_queue.mark_priorities_stale()
             # Check for task exceptions and handle them properly.
-            for task in done:
+            for task in done_node_tasks:
                 dag_node = context.task_to_node.pop(task)
                 if task.cancelled():
                     # Task was cancelled - this is expected during flow cancellation
@@ -730,6 +788,19 @@ class ExecuteDagState(State):
                     return ErrorState
 
                 dag_node.node_state = NodeState.DONE
+        else:
+            # Nothing running and nothing dispatchable, but leaf nodes remain (something
+            # is gating them). Returning ExecuteDagState from here re-enters on_update
+            # through the FSM's advance loop with no suspension point in between, which
+            # would wedge the whole event loop - including the injector that could
+            # unblock us. Yield on the new-work flag so the retry loop is preserved but
+            # the loop keeps turning. Deliberately not logged: this branch re-runs every
+            # _IDLE_RECHECK_SECONDS while parked, so even a debug line would be spam.
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(context.new_work_event.wait(), timeout=_IDLE_RECHECK_SECONDS)
+            if context.was_reset_since(generation):
+                ExecuteDagState._log_abandoned(context)
+                return None
 
         # Once a task has finished, loop back to the top.
         await ExecuteDagState.pop_done_states(context)
@@ -826,6 +897,34 @@ class ParallelResolutionMachine(FSM[ParallelResolutionContext]):
         if self.context.dag_builder is None:
             self.context.dag_builder = self.context.engine.flow_manager.global_dag_builder
         await self.start(ExecuteDagState)
+
+    def inject_node(self, node: BaseNode, graph_name: str | None = None) -> list[BaseNode]:
+        """Add a node and its unresolved dependencies to this already-running run.
+
+        Queues whatever is ready and unparks the driver, so the node starts as soon as a
+        parallel slot frees up instead of waiting for an in-flight node to finish.
+
+        Synchronous on purpose. The driver only sees an injection as one atomic change to
+        its DAG and queue because the caller does its liveness check and this call with no
+        await in between. Do not make this ``async``.
+
+        Returns the nodes added to the DAG, for the caller to report as involved nodes.
+        """
+        context = self.context
+        if context.dag_builder is None:
+            msg = f"Attempted to run '{node.name}' as part of the current run, but that run has no dependency graph to add it to. Cancel the run and try again."
+            raise ValueError(msg)
+
+        added_nodes = ExecuteDagState.add_and_queue_nodes(context, node, graph_name or node.name)
+        context.signal_new_work()
+
+        if context.paused:
+            logger.info(
+                "Node '%s' was added to the paused run on flow '%s'. It will run when the run is stepped or continued.",
+                node.name,
+                context.flow_name,
+            )
+        return added_nodes
 
     async def cancel_all_nodes(self) -> None:
         """Cancel all executing tasks and set cancellation flags on all nodes."""

--- a/src/griptape_nodes/retained_mode/engine.py
+++ b/src/griptape_nodes/retained_mode/engine.py
@@ -81,6 +81,7 @@ if TYPE_CHECKING:
         StaticFilesManager,
     )
     from griptape_nodes.retained_mode.managers.sync_manager import SyncManager
+    from griptape_nodes.retained_mode.managers.undo import UndoManager
     from griptape_nodes.retained_mode.managers.user_manager import UserManager
     from griptape_nodes.retained_mode.managers.variable_manager import (
         VariablesManager,
@@ -170,6 +171,7 @@ class Engine:
     _artifact_manager: ArtifactManager
     _manifest_manager: ManifestManager
     _worker_manager: WorkerManager
+    _undo_manager: UndoManager
 
     def __init__(self) -> None:  # noqa: PLR0915
         from griptape_nodes.retained_mode.managers.access_manager import AccessManager
@@ -201,6 +203,7 @@ class Engine:
             StaticFilesManager,
         )
         from griptape_nodes.retained_mode.managers.sync_manager import SyncManager
+        from griptape_nodes.retained_mode.managers.undo import UndoManager
         from griptape_nodes.retained_mode.managers.user_manager import UserManager
         from griptape_nodes.retained_mode.managers.variable_manager import (
             VariablesManager,
@@ -214,6 +217,8 @@ class Engine:
         )
 
         self._event_manager = EventManager(engine=self)
+        # Created early so domain managers can register their undo policy below.
+        self._undo_manager = UndoManager(self._event_manager, engine=self)
         self._resource_manager = ResourceManager(self._event_manager)
         self._config_manager = ConfigManager(self._event_manager, engine=self)
         self._os_manager = OSManager(self._event_manager, engine=self)
@@ -362,6 +367,10 @@ class Engine:
     def worker_manager(self) -> WorkerManager:
         return self._worker_manager
 
+    @property
+    def undo_manager(self) -> UndoManager:
+        return self._undo_manager
+
     # Node libraries and saved workflows do `app = GriptapeNodes()` and then call these
     # PascalCase accessors on the result. `GriptapeNodes()` hands back an `Engine`, so
     # the compat surface has to live here. Engine-internal code uses the snake_case
@@ -450,6 +459,9 @@ class Engine:
 
     def WorkerManager(self) -> WorkerManager:
         return self._worker_manager
+
+    def UndoManager(self) -> UndoManager:
+        return self._undo_manager
 
     def get_instance(self) -> Engine:
         """Back-compat for callers that reach for the instance through an instance."""

--- a/src/griptape_nodes/retained_mode/engine.py
+++ b/src/griptape_nodes/retained_mode/engine.py
@@ -226,6 +226,10 @@ class Engine:
         self._object_manager = ObjectManager(self._event_manager, engine=self)
         self._node_manager = NodeManager(self._event_manager, engine=self)
         self._flow_manager = FlowManager(self._event_manager, engine=self)
+        # Wire the domain managers' undo policy now that both they and the UndoManager exist.
+        self._object_manager.register_undo_policy(self._undo_manager)
+        self._node_manager.register_undo_policy(self._undo_manager)
+        self._flow_manager.register_undo_policy(self._undo_manager)
         self._context_manager = ContextManager(self._event_manager, engine=self)
         self._worker_manager = WorkerManager(engine=self, event_manager=self._event_manager)
         self._library_manager = LibraryManager(self._event_manager, worker_manager=self._worker_manager, engine=self)

--- a/src/griptape_nodes/retained_mode/events/context_events.py
+++ b/src/griptape_nodes/retained_mode/events/context_events.py
@@ -29,13 +29,24 @@ class SetWorkflowContextRequest(RequestPayload):
                       Ignored when the workflow is already in the registry. Defaults to
                       None; in that case the auto-registered entry gets a placeholder
                       name.
+        working_directory: Folder this workflow belongs to, for a workflow that has no file
+                      of its own yet. `{workflow_dir}` -- and so every project directory
+                      built on it, `{outputs}` among them -- answers with this until the
+                      workflow is saved, at which point the saved file's own directory takes
+                      over. A DIRECTORY, not a file path. Absolute paths are recommended;
+                      if you supply a relative path it is anchored to the workspace directory
+                      (not the project base directory, which may sit one level above). Optional:
+                      when None, an unsaved workflow has no folder and `{workflow_dir?:/}` keeps
+                      degrading to a workspace-relative path as before.
 
     Results: SetWorkflowContextSuccess (carries the resolved workflow_name) |
-             SetWorkflowContextFailure (workflow not found)
+             SetWorkflowContextFailure (workflow not found, working_directory names an
+             existing non-directory)
     """
 
     workflow_name: str | None = None
     display_name: str | None = None
+    working_directory: str | None = None
 
 
 @dataclass
@@ -111,6 +122,9 @@ class EnsureWorkflowAndFlowRequest(RequestPayload):
             workflow_name is supplied.
         flow_name: Name to use if a new flow must be created. Ignored when a flow is
             already in context. Defaults to the engine-assigned name.
+        working_directory: Folder the workflow belongs to until it is saved, forwarded to
+            SetWorkflowContextRequest. Ignored when a workflow is already in context. See
+            SetWorkflowContextRequest for what the value means and how it is normalized.
 
     Results: EnsureWorkflowAndFlowResultSuccess | EnsureWorkflowAndFlowResultFailure
     """
@@ -118,6 +132,7 @@ class EnsureWorkflowAndFlowRequest(RequestPayload):
     workflow_name: str | None = None
     display_name: str | None = None
     flow_name: str | None = None
+    working_directory: str | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/undo_events.py
+++ b/src/griptape_nodes/retained_mode/events/undo_events.py
@@ -1,0 +1,135 @@
+from dataclasses import dataclass, field
+
+from griptape_nodes.retained_mode.events.base_events import (
+    RequestPayload,
+    ResultPayloadFailure,
+    ResultPayloadSuccess,
+    WorkflowAlteredMixin,
+    WorkflowNotAlteredMixin,
+)
+from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
+
+
+@dataclass
+@PayloadRegistry.register
+class UndoRequest(RequestPayload):
+    """Undo the most recent undoable user action.
+
+    Use when: Reverting the last workflow edit (e.g. node creation or deletion) in response
+    to a user-initiated undo (Ctrl/Cmd+Z).
+
+    Results: UndoResultSuccess (with the label of the undone action) | UndoResultFailure
+        (nothing to undo, flow currently running, or replay failed)
+    """
+
+
+@dataclass
+@PayloadRegistry.register
+class UndoResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
+    """Undo applied successfully.
+
+    Args:
+        undone_label: Human-readable label of the action that was undone.
+    """
+
+    undone_label: str
+
+
+@dataclass
+@PayloadRegistry.register
+class UndoResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Undo failed.
+
+    Common causes: undo stack empty, a flow is currently executing, or replaying the
+    inverse operations failed (in which case the undo history is cleared).
+    """
+
+
+@dataclass
+@PayloadRegistry.register
+class RedoRequest(RequestPayload):
+    """Re-apply the most recently undone user action.
+
+    Use when: Restoring an action after an undo (Ctrl/Cmd+Shift+Z).
+
+    Results: RedoResultSuccess (with the label of the redone action) | RedoResultFailure
+        (nothing to redo, flow currently running, or replay failed)
+    """
+
+
+@dataclass
+@PayloadRegistry.register
+class RedoResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
+    """Redo applied successfully.
+
+    Args:
+        redone_label: Human-readable label of the action that was re-applied.
+    """
+
+    redone_label: str
+
+
+@dataclass
+@PayloadRegistry.register
+class RedoResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Redo failed.
+
+    Common causes: redo stack empty, a flow is currently executing, or replaying the
+    operations failed (in which case the undo history is cleared).
+    """
+
+
+@dataclass
+@PayloadRegistry.register
+class GetUndoStateRequest(RequestPayload):
+    """Get the current undo/redo stack state.
+
+    Use when: Enabling/disabling undo and redo UI affordances, displaying the labels of
+    the next undoable/redoable actions in menus.
+
+    Results: GetUndoStateResultSuccess (with stack labels)
+    """
+
+
+@dataclass
+@PayloadRegistry.register
+class GetUndoStateResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """Undo/redo state retrieved successfully.
+
+    Args:
+        undo_labels: Labels of undoable actions, oldest first (the last entry is next to be undone).
+        redo_labels: Labels of redoable actions, oldest first (the last entry is next to be redone).
+    """
+
+    undo_labels: list[str] = field(default_factory=list)
+    redo_labels: list[str] = field(default_factory=list)
+
+
+@dataclass
+@PayloadRegistry.register
+class GetUndoStateResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Undo/redo state retrieval failed."""
+
+
+@dataclass
+@PayloadRegistry.register
+class ClearUndoStateRequest(RequestPayload):
+    """Clear all undo/redo history.
+
+    Use when: Discarding stale history after operations that invalidate it, resetting state
+    in tests, or explicit user request.
+
+    Results: ClearUndoStateResultSuccess
+    """
+
+
+@dataclass
+@PayloadRegistry.register
+class ClearUndoStateResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """Undo/redo history cleared."""
+
+
+@dataclass
+@PayloadRegistry.register
+class ClearUndoStateResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Undo/redo history clearing failed."""

--- a/src/griptape_nodes/retained_mode/events/workflow_events.py
+++ b/src/griptape_nodes/retained_mode/events/workflow_events.py
@@ -657,13 +657,17 @@ class BranchWorkflowRequest(RequestPayload):
 
     Args:
         workflow_name: Name of the workflow to branch
-        branched_workflow_name: Name for the branched workflow (None for auto-generated)
+        branched_workflow_name: Registry key for the branched workflow (None for auto-generated)
+        branched_workflow_display_name: Human-readable label (``metadata.name``) for the branch.
+            None derives one from the source workflow's display name, e.g. branching
+            "Shot 010 Comp" yields "Shot 010 Comp (branch 1)". Must not be blank when provided.
 
     Results: BranchWorkflowResultSuccess (with branch name) | BranchWorkflowResultFailure (branch error)
     """
 
     workflow_name: str
     branched_workflow_name: str | None = None
+    branched_workflow_display_name: str | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -53,6 +53,7 @@ if TYPE_CHECKING:
         StaticFilesManager,
     )
     from griptape_nodes.retained_mode.managers.sync_manager import SyncManager
+    from griptape_nodes.retained_mode.managers.undo import UndoManager
     from griptape_nodes.retained_mode.managers.user_manager import UserManager
     from griptape_nodes.retained_mode.managers.variable_manager import (
         VariablesManager,
@@ -226,3 +227,7 @@ class GriptapeNodes(metaclass=_EngineRootMeta):
     @classmethod
     def WorkerManager(cls) -> WorkerManager:
         return current_engine().worker_manager
+
+    @classmethod
+    def UndoManager(cls) -> UndoManager:
+        return current_engine().undo_manager

--- a/src/griptape_nodes/retained_mode/managers/context_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/context_manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from griptape_nodes.exe_types.flow import ControlFlow
@@ -58,9 +59,10 @@ class ContextManager(EngineScoped):
 
         _name: str
         _file_path: str | None
+        _working_directory: str | None
         _flow_stack: list[ContextManager.FlowContextState]
 
-        def __init__(self, name: str, file_path: str | None = None):
+        def __init__(self, name: str, file_path: str | None = None, working_directory: str | None = None):
             self._name = name
             # The path this context was entered WITH, when it was entered by path. Retained
             # because `_name` is a registry key derived against the workspace that was active
@@ -69,6 +71,11 @@ class ContextManager(EngineScoped):
             # Callers that want the workflow's location (see ProjectManager's `workflow_dir`
             # builtin) read this instead of round-tripping through WorkflowRegistry.
             self._file_path = file_path
+            # The folder this workflow belongs to while it has no file of its own: the folder the
+            # user was browsing when they created it. A DIRECTORY, unlike `_file_path`, which is
+            # a file whose PARENT is the directory. Always loses to `_file_path` -- once the
+            # workflow has been saved, the saved file's own location is the better answer.
+            self._working_directory = working_directory
             self._flow_stack = []
 
         def push_flow(self, flow: ControlFlow) -> ControlFlow:
@@ -275,6 +282,25 @@ class ContextManager(EngineScoped):
             msg = f"Attempted to set the Workflow '{request.workflow_name}' as the Current Context. Failed because an existing workflow, '{self.get_current_workflow_name()}', is already in the Current Context. In order to clear the existing workflow and remove all objects and references to it, issue a ClearAllObjectState request."
             return SetWorkflowContextFailure(result_details=msg)
 
+        # Normalized here rather than at read time so `workflow_dir` never has to care whether
+        # the caller sent an absolute path, a workspace-relative one, or one with a `~` in it.
+        working_directory = None
+        if request.working_directory is not None:
+            working_directory = str(
+                canonicalize_for_identity(request.working_directory, base=self.engine.config_manager.workspace_path)
+            )
+            # A file where a folder was meant is the one mistake worth rejecting: the value
+            # becomes the parent of every path the workflow writes, so accepting it would put
+            # outputs beside the file rather than in the folder the caller named -- a plausible
+            # location, which is what makes it hard to notice.
+            existing = Path(working_directory)
+            if existing.exists() and not existing.is_dir():
+                msg = (
+                    f"Attempted to set the folder for a new Workflow to '{request.working_directory}'. "
+                    f"Failed because that path is a file, not a folder."
+                )
+                return SetWorkflowContextFailure(result_details=msg)
+
         # When no workflow_name is supplied, mint a fresh "unsaved:<uuid>" key here so the
         # engine owns the namespace. Callers doing "create a new workflow" should omit the
         # name and read the resolved key off the success result.
@@ -294,7 +320,7 @@ class ContextManager(EngineScoped):
                 )
                 return SetWorkflowContextFailure(result_details=msg)
 
-        self.push_workflow(resolved_name)
+        self.push_workflow(resolved_name, working_directory=working_directory)
         msg = f"Successfully set the Workflow '{resolved_name}' as the Current Context."
         return SetWorkflowContextSuccess(workflow_name=resolved_name, result_details=msg)
 
@@ -333,6 +359,7 @@ class ContextManager(EngineScoped):
                 SetWorkflowContextRequest(
                     workflow_name=request.workflow_name,
                     display_name=request.display_name,
+                    working_directory=request.working_directory,
                 )
             )
             if not isinstance(set_workflow_result, SetWorkflowContextSuccess):
@@ -525,6 +552,29 @@ class ContextManager(EngineScoped):
 
         return self._workflow_stack[-1]._file_path
 
+    def get_current_workflow_working_directory(self) -> str | None:
+        """Get the folder the current Workflow context belongs to, if one was supplied.
+
+        This is the folder a workflow was created in before it had a file of its own -- the
+        folder the caller was browsing at the time. It is a DIRECTORY, whereas
+        `get_current_workflow_file_path` returns a FILE whose parent is the directory.
+
+        Only meaningful while the workflow is unsaved: `workflow_dir` prefers the retained
+        file path whenever there is one, so this stops mattering the moment the workflow is
+        saved. It is deliberately not cleared on save -- the file path simply wins.
+
+        Returns:
+            The absolute directory path, or None when no folder was supplied.
+
+        Raises:
+            NoActiveWorkflowError: If no Workflow context is active.
+        """
+        if not self.has_current_workflow():
+            msg = "No active Workflow context"
+            raise self.NoActiveWorkflowError(msg)
+
+        return self._workflow_stack[-1]._working_directory
+
     def set_current_workflow_name(self, new_name: str) -> None:
         """Update the name of the current Workflow context.
 
@@ -620,7 +670,13 @@ class ContextManager(EngineScoped):
         current_node = current_flow._node_stack[-1]
         return current_node.get_current_element()
 
-    def push_workflow(self, workflow_name: str | None = None, *, file_path: str | None = None) -> str:
+    def push_workflow(
+        self,
+        workflow_name: str | None = None,
+        *,
+        file_path: str | None = None,
+        working_directory: str | None = None,
+    ) -> str:
         """Push a new Workflow context onto the stack.
 
         The workflow's file path is captured here, while the registry key is still valid, and
@@ -633,6 +689,11 @@ class ContextManager(EngineScoped):
             workflow_name: The name of the Workflow to enter. Use this when the registry key is already known.
             file_path: Path to the workflow file. The registry key will be derived from this path,
                 using a workspace-relative path if possible. Mutually exclusive with workflow_name.
+            working_directory: Folder the Workflow belongs to while it has no file of its own,
+                for a workflow that has never been saved. A DIRECTORY, not a file path. Never
+                affects the registry key, and never overrides `file_path`: a workflow that has
+                a file answers with that file's own directory. Expected to be absolute --
+                `on_set_workflow_context_request` normalizes before it reaches here.
 
         Returns:
             The name of the Workflow that was entered.
@@ -669,7 +730,9 @@ class ContextManager(EngineScoped):
             msg = "Either workflow_name or file_path must be provided."
             raise ValueError(msg)
 
-        workflow_context_state = self.WorkflowContextState(resolved_name, file_path=file_path)
+        workflow_context_state = self.WorkflowContextState(
+            resolved_name, file_path=file_path, working_directory=working_directory
+        )
         self._workflow_stack.append(workflow_context_state)
         return resolved_name
 

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -1118,12 +1118,19 @@ class EventManager(EngineScoped):
                 context=result_context,
             )
 
+        # Let the UndoManager observe the dispatch so user-initiated mutations can be recorded
+        # (or invalidate history when they cannot be).
+        undo_manager = self.engine.undo_manager
+        undo_capture = undo_manager.begin_request_dispatch(request, result_context.get("request_id"))
+        dispatched_result: ResultPayload | None = None
+
         # Expose the dispatching request type to detectors (see current_request_type).
         token = _active_request_type.set(request_type)
         try:
             try:
                 # Actually make the handler callback (support both sync and async):
                 result_payload: ResultPayload = await call_function(callback, request)
+                dispatched_result = result_payload
 
                 # Queue flush request for async context (unless result type should skip flush)
                 with operation_depth_mgr:
@@ -1139,6 +1146,9 @@ class EventManager(EngineScoped):
                 context=result_context,
             )
         finally:
+            # Runs after _handle_request_core so the result's altered_workflow_state has been
+            # squelch-adjusted. A None result means the callback raised.
+            undo_manager.end_request_dispatch(undo_capture, request, dispatched_result)
             _active_request_type.reset(token)
 
     def handle_request(
@@ -1176,11 +1186,18 @@ class EventManager(EngineScoped):
                 context=result_context,
             )
 
+        # Let the UndoManager observe the dispatch so user-initiated mutations can be recorded
+        # (or invalidate history when they cannot be).
+        undo_manager = self.engine.undo_manager
+        undo_capture = undo_manager.begin_request_dispatch(request, result_context.get("request_id"))
+        dispatched_result: ResultPayload | None = None
+
         # Expose the dispatching request type to detectors (see current_request_type).
         token = _active_request_type.set(request_type)
         try:
             try:
                 result_payload = self._invoke_handler_from_sync(callback, request)
+                dispatched_result = result_payload
 
                 # Queue flush request for sync context (unless result type should skip flush)
                 with operation_depth_mgr:
@@ -1196,6 +1213,9 @@ class EventManager(EngineScoped):
                 context=result_context,
             )
         finally:
+            # Runs after _handle_request_core so the result's altered_workflow_state has been
+            # squelch-adjusted. A None result means the callback raised.
+            undo_manager.end_request_dispatch(undo_capture, request, dispatched_result)
             _active_request_type.reset(token)
 
     def _invoke_handler_from_sync(self, callback: Callable, request: RequestPayload) -> ResultPayload:

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -1362,7 +1362,7 @@ class EventManager(EngineScoped):
             async def _broadcast_async() -> None:
                 async with asyncio.TaskGroup() as tg:
                     for listener_callback in listener_set:
-                        tg.create_task(call_function(listener_callback, app_event))
+                        tg.create_task(self._call_app_event_listener(listener_callback, app_event))
 
             if _running_loop() is not None:
                 with ThreadRunner() as runner:
@@ -1382,7 +1382,31 @@ class EventManager(EngineScoped):
 
             async with asyncio.TaskGroup() as tg:
                 for listener_callback in listener_set:
-                    tg.create_task(call_function(listener_callback, app_event))
+                    tg.create_task(self._call_app_event_listener(listener_callback, app_event))
+
+    async def _call_app_event_listener(
+        self, listener_callback: Callable[[AP], None] | Callable[[AP], Awaitable[None]], app_event: AP
+    ) -> None:
+        """Run one app event listener, keeping its failure to itself.
+
+        Listeners are independent subsystems reacting to the same event, and they run as
+        siblings in a TaskGroup. A listener that raises would cancel every sibling that
+        had not finished yet, so one broken subsystem would silently skip the rest of the
+        app's reaction to the event. Broad by design: a listener is an arbitrary callback,
+        so there is no narrower type to catch here.
+
+        Args:
+            listener_callback: The listener to invoke.
+            app_event: The app event to pass to the listener.
+        """
+        try:
+            await call_function(listener_callback, app_event)
+        except Exception:
+            logging.getLogger("griptape_nodes").exception(
+                "App event listener '%s' failed handling '%s'. The remaining listeners still ran.",
+                getattr(listener_callback, "__qualname__", listener_callback),
+                type(app_event).__name__,
+            )
 
     def _flush_tracked_parameter_changes(self) -> None:
         obj_manager = self.engine.object_manager

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -4797,7 +4797,18 @@ class FlowManager(EngineScoped):
         # We are now going to have different behavior depending on how the node is behaving.
         if self.check_for_existing_running_flow():
             # Now we know something is running, it's ParallelResolutionMachine, and that we are in single_node_resolution.
-            self._global_dag_builder.add_node_with_dependencies(node, node.name)
+            # Nothing below awaits before inject_node: that is what lets the running driver
+            # see this as one atomic change, rather than catching it half-applied or tearing
+            # the DAG down between the check above and the mutation.
+            machine = self._global_control_flow_machine
+            if machine is None:
+                msg = f"Attempted to run '{node.name}' as part of the workflow already in progress, but that workflow could not be found. Wait for it to finish and try again."
+                raise RuntimeError(msg)
+            # The cold path below unresolves the node before queueing it, and so must this
+            # one: otherwise an already-resolved node is treated as a duplicate completion
+            # and never re-runs, and the editor keeps showing it as resolved.
+            node.prepare_to_run_again()
+            machine.resolution_machine.inject_node(node)
             # Emit involved nodes update after adding node to DAG
             involved_nodes = list(self._global_dag_builder.node_to_reference.keys())
             self.engine.event_manager.put_event(

--- a/src/griptape_nodes/retained_mode/managers/flow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/flow_manager.py
@@ -183,6 +183,7 @@ if TYPE_CHECKING:
     from griptape_nodes.retained_mode.engine import Engine
     from griptape_nodes.retained_mode.events.base_events import ResultPayload
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
+    from griptape_nodes.retained_mode.managers.undo import UndoManager
     from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowShapeNodes
     from griptape_nodes.retained_mode.variable_types import FlowVariable
 
@@ -359,6 +360,29 @@ class FlowManager(EngineScoped):
         self._global_single_node_resolution = False
         self._global_dag_builder = DagBuilder(self.engine)
         self._node_executor = NodeExecutor(self.engine)
+
+    def register_undo_policy(self, undo_manager: UndoManager) -> None:
+        """Declare the flow domain's undo policy: which of its requests a snapshot can capture.
+
+        Declaring is opt-in because the snapshot strategy models only flow contents; an undeclared
+        request is never a snapshot point, so it costs no capture and cannot commit a batch that
+        would revert nothing. Execution requests are therefore omitted deliberately: they alter
+        workflow state but undo is about editing, not running.
+        ``tests/unit/retained_mode/managers/test_undo_policy.py`` guards this list. Called from
+        GriptapeNodes wiring after construction; isolated unit tests that build a FlowManager
+        directly simply skip it.
+        """
+        undo_manager.register_undoable(
+            {
+                CreateFlowRequest: "Create flow",
+                DeleteFlowRequest: "Delete flow",
+                SetFlowMetadataRequest: "Change flow properties",
+                AutoLayoutFlowRequest: "Auto-layout",
+                CreateConnectionRequest: "Connect",
+                DeleteConnectionRequest: "Disconnect",
+                DeserializeFlowFromCommandsRequest: "Paste flow",
+            }
+        )
 
     @property
     def global_single_node_resolution(self) -> bool:

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from griptape_nodes.node_library.library_registry import LibrarySchema
     from griptape_nodes.retained_mode.engine import Engine
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
+    from griptape_nodes.retained_mode.managers.undo import UndoManager
     from griptape_nodes.retained_mode.managers.worker_manager import WorkerManager
     from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
 from griptape_nodes.exe_types.base_iterative_nodes import (
@@ -409,6 +410,39 @@ class NodeManager(EngineScoped):
         )
         event_manager.assign_manager_to_request_type(ExecuteNodeRequest, self.on_execute_node_request)
         event_manager.assign_manager_to_request_type(CancelExecuteNodeRequest, self.on_cancel_execute_node_request)
+
+    def register_undo_policy(self, undo_manager: UndoManager) -> None:
+        """Declare the node domain's undo policy: which of its requests a snapshot can capture.
+
+        Declaring is opt-in because the snapshot strategy models only flow contents (nodes,
+        connections, parameter values, metadata, locks); an undeclared request is never a snapshot
+        point, so it costs no capture and cannot commit a batch that would revert nothing.
+        Execution/runtime requests are therefore omitted deliberately: running or unresolving a node
+        is not a workflow edit. So are moves between flows (including into and out of node groups):
+        a snapshot records only the top-level flow's direct contents, so undoing one would recreate
+        the moved node alongside the original rather than move it back. So are parameter *structure*
+        edits (adding, removing, renaming, reordering, or altering a parameter or group): restore
+        reconciles a survivor node's values, metadata, lock, and connections, not the set of
+        parameters it carries, so declaring them would report a successful undo that changed nothing.
+        ``tests/unit/retained_mode/managers/test_undo_policy.py`` guards this list. Called from
+        GriptapeNodes wiring after construction; isolated unit tests that build a NodeManager
+        directly simply skip it.
+        """
+        undo_manager.register_undoable(
+            {
+                CreateNodeRequest: "Create node",
+                DeleteNodeRequest: "Delete node",
+                SetParameterValueRequest: "Change value",
+                # Node metadata is dominated by position, so these name the gesture that produces
+                # it. A style or annotation change goes through the same request and reads as a move.
+                SetNodeMetadataRequest: "Move node",
+                BatchSetNodeMetadataRequest: "Move nodes",
+                ResetNodeToDefaultsRequest: "Reset node",
+                DuplicateSelectedNodesRequest: "Duplicate nodes",
+                DeserializeNodeFromCommandsRequest: "Paste node",
+                DeserializeSelectedNodesFromCommandsRequest: "Paste nodes",
+            }
+        )
 
     def handle_node_rename(self, old_name: str, new_name: str) -> None:
         # Get the node itself

--- a/src/griptape_nodes/retained_mode/managers/object_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/object_manager.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import logging
 import re
 from re import Pattern
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from griptape_nodes.exe_types.core_types import (
     BaseNodeElement,
@@ -28,7 +30,10 @@ from griptape_nodes.retained_mode.events.object_events import (
 from griptape_nodes.retained_mode.events.parameter_events import (
     RemoveParameterFromNodeRequest,
 )
-from griptape_nodes.retained_mode.managers.event_manager import EventManager
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.managers.event_manager import EventManager
+    from griptape_nodes.retained_mode.managers.undo import UndoManager
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -45,6 +50,17 @@ class ObjectManager(EngineScoped):
         _event_manager.assign_manager_to_request_type(
             request_type=ClearAllObjectStateRequest, callback=self.on_clear_all_object_state_request
         )
+
+    def register_undo_policy(self, undo_manager: UndoManager) -> None:
+        """Declare the object domain's undo policy: which of its requests a snapshot can capture.
+
+        Renaming reaches the flow's contents (a node's name is part of the snapshot), so it is a
+        snapshot point. Clearing all object state is not: it replaces the whole object graph, which
+        the undo system treats as a history-invalidating lifecycle event instead of an edit.
+        Called from GriptapeNodes wiring after construction; isolated unit tests that build an
+        ObjectManager directly simply skip it.
+        """
+        undo_manager.register_undoable({RenameObjectRequest: "Rename"})
 
     def on_rename_object_request(self, request: RenameObjectRequest) -> ResultPayload:
         # Does the source object exist?

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -4669,7 +4669,7 @@ class ProjectManager(EngineScoped):
                 conflicts.add(var_name)
         return _BuiltinResolutionResult(conflicts=conflicts, unavailable=unavailable)
 
-    def _get_builtin_variable_value(self, var_name: str, project_info: ProjectInfo) -> str:  # noqa: C901
+    def _get_builtin_variable_value(self, var_name: str, project_info: ProjectInfo) -> str:
         """Get the value of a single builtin variable.
 
         Args:
@@ -4702,37 +4702,7 @@ class ProjectManager(EngineScoped):
                 return context_manager.get_current_workflow_name()
 
             case "workflow_dir":
-                context_manager = self.engine.context_manager
-                if not context_manager.has_current_workflow():
-                    msg = "No current workflow"
-                    raise RuntimeError(msg)
-                # Prefer the path the context was entered WITH. The registry key below is
-                # derived against the workspace that was active at push time, so a project
-                # switch -- which re-registers every workflow under the new workspace -- leaves
-                # the name pointing at a key that no longer exists. The lookup then raises,
-                # `{workflow_dir?:/}` swallows it as an optional reference, and `{outputs}`
-                # silently degrades from the workflow's own folder to a workspace-relative
-                # path, so saved media resolves somewhere it was never written.
-                context_file_path = context_manager.get_current_workflow_file_path()
-                if context_file_path is not None:
-                    return str(Path(context_file_path).parent)
-                workflow_name = context_manager.get_current_workflow_name()
-                try:
-                    workflow = WorkflowRegistry.get_workflow_by_name(workflow_name)
-                except KeyError as e:
-                    # NOT the same as unsaved: the file may be on disk and saved, but keyed
-                    # under a different workspace. Say so, rather than reporting a state the
-                    # user cannot act on.
-                    msg = (
-                        f"Workflow '{workflow_name}' is not registered on this engine "
-                        f"(it may be registered under a different workspace)"
-                    )
-                    raise RuntimeError(msg) from e
-                if workflow.file_path is None:
-                    msg = f"Workflow '{workflow_name}' has not been saved yet"
-                    raise RuntimeError(msg)
-                workflow_file_path = Path(WorkflowRegistry.get_complete_file_path(workflow.file_path))
-                return str(workflow_file_path.parent)
+                return self._resolve_workflow_dir()
 
             case "static_files_dir":
                 return self._config_manager.get_config_value("static_files_directory", default="staticfiles")
@@ -4740,6 +4710,66 @@ class ProjectManager(EngineScoped):
             case _:
                 msg = f"Unknown builtin variable: {var_name}"
                 raise ValueError(msg)
+
+        # Unreachable at runtime — `case _:` above catches everything. Present so
+        # static analyzers (CodeQL) can prove the function never implicitly returns None.
+        msg = f"Unknown builtin variable: {var_name}"
+        raise ValueError(msg)
+
+    def _resolve_workflow_dir(self) -> str:
+        """Resolve the `workflow_dir` builtin: the folder the current workflow belongs to.
+
+        Three sources, in descending order of authority:
+
+        1. The file path retained on the context. The registry key is derived against the
+           workspace that was active at push time, so a project switch -- which re-registers
+           every workflow under the new workspace -- leaves the name pointing at a key that no
+           longer exists. The lookup then raises, `{workflow_dir?:/}` swallows it as an
+           optional reference, and `{outputs}` silently degrades from the workflow's own folder
+           to a workspace-relative path, so saved media resolves somewhere it was never written.
+        2. The registry entry for the context's name.
+        3. The folder the workflow was created in, for a workflow that has never been saved and
+           so has no file to answer from. Last because a saved workflow's own location always
+           beats the folder it was created in -- the two differ as soon as the user saves
+           somewhere else.
+
+        Raises:
+            RuntimeError: If no workflow is in context, or the workflow has neither a file nor
+                a folder to answer with.
+        """
+        context_manager = self.engine.context_manager
+        if not context_manager.has_current_workflow():
+            msg = "No current workflow"
+            raise RuntimeError(msg)
+
+        context_file_path = context_manager.get_current_workflow_file_path()
+        if context_file_path is not None:
+            return str(Path(context_file_path).parent)
+
+        workflow_name = context_manager.get_current_workflow_name()
+        working_directory = context_manager.get_current_workflow_working_directory()
+        try:
+            workflow = WorkflowRegistry.get_workflow_by_name(workflow_name)
+        except KeyError as e:
+            if working_directory is not None:
+                return working_directory
+            # NOT the same as unsaved: the file may be on disk and saved, but keyed
+            # under a different workspace. Say so, rather than reporting a state the
+            # user cannot act on.
+            msg = (
+                f"Workflow '{workflow_name}' is not registered on this engine "
+                f"(it may be registered under a different workspace)"
+            )
+            raise RuntimeError(msg) from e
+
+        if workflow.file_path is None:
+            if working_directory is not None:
+                return working_directory
+            msg = f"Workflow '{workflow_name}' has not been saved yet"
+            raise RuntimeError(msg)
+
+        workflow_file_path = Path(WorkflowRegistry.get_complete_file_path(workflow.file_path))
+        return str(workflow_file_path.parent)
 
     def _absolute_path_to_macro_path(self, absolute_path: Path, project_info: ProjectInfo) -> str | None:
         """Convert an absolute path to macro form using longest prefix matching.

--- a/src/griptape_nodes/retained_mode/managers/undo/__init__.py
+++ b/src/griptape_nodes/retained_mode/managers/undo/__init__.py
@@ -1,0 +1,9 @@
+"""Undo/redo subsystem.
+
+Public surface: `UndoEntryReplayError`, the failure a reversal raises when it cannot complete and the
+undo history can no longer be trusted.
+"""
+
+from griptape_nodes.retained_mode.managers.undo.core import UndoEntryReplayError
+
+__all__ = ["UndoEntryReplayError"]

--- a/src/griptape_nodes/retained_mode/managers/undo/__init__.py
+++ b/src/griptape_nodes/retained_mode/managers/undo/__init__.py
@@ -1,9 +1,27 @@
 """Undo/redo subsystem.
 
-Public surface: `UndoEntryReplayError`, the failure a reversal raises when it cannot complete and the
-undo history can no longer be trusted.
+Public surface:
+    - `UndoManager`: the mechanism (undo/redo stacks, replay, request handlers, recording API).
+    - The vocabulary domains use to describe reversals: `UndoEntry`, `UndoBatch`,
+      `UndoEntryReplayError`, and the `RecordingStrategy` contract a recording strategy implements.
+
+The concrete recording strategy (currently the whole-flow `SnapshotRecordingSession`) lives in its
+own module and is selected by `UndoManager`. `RecordingStrategy` is the extension seam for layering
+in finer-grained strategies later.
 """
 
-from griptape_nodes.retained_mode.managers.undo.core import UndoEntryReplayError
+from griptape_nodes.retained_mode.managers.undo.core import (
+    RecordingStrategy,
+    UndoBatch,
+    UndoEntry,
+    UndoEntryReplayError,
+)
+from griptape_nodes.retained_mode.managers.undo.manager import UndoManager
 
-__all__ = ["UndoEntryReplayError"]
+__all__ = [
+    "RecordingStrategy",
+    "UndoBatch",
+    "UndoEntry",
+    "UndoEntryReplayError",
+    "UndoManager",
+]

--- a/src/griptape_nodes/retained_mode/managers/undo/core.py
+++ b/src/griptape_nodes/retained_mode/managers/undo/core.py
@@ -1,0 +1,12 @@
+"""The vocabulary domains use to describe reversible operations.
+
+This module is domain-agnostic: it defines the failure mode a reversal reports when it can no longer
+be trusted. The concrete reversal mechanism (currently whole-flow snapshots, in `flow_snapshot`)
+builds on these types.
+"""
+
+from __future__ import annotations
+
+
+class UndoEntryReplayError(RuntimeError):
+    """Raised when replaying an undo/redo entry fails and the undo history can no longer be trusted."""

--- a/src/griptape_nodes/retained_mode/managers/undo/core.py
+++ b/src/griptape_nodes/retained_mode/managers/undo/core.py
@@ -1,12 +1,155 @@
 """The vocabulary domains use to describe reversible operations.
 
-This module is domain-agnostic: it defines the failure mode a reversal reports when it can no longer
-be trusted. The concrete reversal mechanism (currently whole-flow snapshots, in `flow_snapshot`)
-builds on these types.
+This module is domain-agnostic: it defines what an undo entry and an undo batch are, the shared
+lifecycle triage every recording strategy applies, and the `RecordingStrategy` contract a strategy
+implements. `UndoManager` (the mechanism) and the concrete strategies (currently the whole-flow
+`SnapshotRecordingSession`) both build on these types.
+
+The `RecordingStrategy` protocol is the extension seam: a future finer-grained strategy (e.g. one
+that captures per-touched-entity state deltas instead of whole-flow snapshots) implements this same
+contract and drops in behind `UndoManager` without changing the dispatch path or the lifecycle
+policy.
 """
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import TYPE_CHECKING, Any, Protocol
+
+from griptape_nodes.retained_mode.events.context_events import SetWorkflowContextRequest
+from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
+from griptape_nodes.retained_mode.events.undo_events import (
+    ClearUndoStateRequest,
+    GetUndoStateRequest,
+    RedoRequest,
+    UndoRequest,
+)
+from griptape_nodes.retained_mode.events.workflow_events import (
+    ImportWorkflowRequest,
+    RunWorkflowFromRegistryRequest,
+    RunWorkflowFromScratchRequest,
+    RunWorkflowWithCurrentStateRequest,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from contextlib import AbstractContextManager
+
+    from griptape_nodes.retained_mode.events.base_events import RequestPayload, ResultPayload
+
+
+# Request types that invalidate all undo history whenever they are dispatched, regardless of origin,
+# because they replace or restructure the whole object graph. This is global lifecycle policy shared
+# by every recording strategy, so it lives here rather than being duplicated in each session.
+CLEAR_HISTORY_REQUEST_TYPES: tuple[type[RequestPayload], ...] = (
+    ClearAllObjectStateRequest,
+    SetWorkflowContextRequest,
+    RunWorkflowFromScratchRequest,
+    RunWorkflowFromRegistryRequest,
+    RunWorkflowWithCurrentStateRequest,
+    ImportWorkflowRequest,
+)
+
+# The undo manager's own request types. They alter workflow state by design (undo/redo) or not at all
+# (state/clear) and must never be recorded or clear history.
+OWN_EVENT_TYPES: tuple[type[RequestPayload], ...] = (
+    UndoRequest,
+    RedoRequest,
+    GetUndoStateRequest,
+    ClearUndoStateRequest,
+)
+
+
+class DispatchTriage(Enum):
+    """The shared lifecycle verdict for a dispatch, applied before any strategy-specific framing.
+
+    IGNORE: the undo system does not track this dispatch at all (its own events, or a replay in
+        progress). CLEAR_HISTORY: a lifecycle request that replaces or restructures the whole object
+        graph; the strategy clears history and flags any open frame. PROCEED: an ordinary dispatch
+        the strategy frames per its own logic.
+    """
+
+    IGNORE = auto()
+    CLEAR_HISTORY = auto()
+    PROCEED = auto()
+
+
+def triage_dispatch(request: RequestPayload, *, is_replaying: bool) -> DispatchTriage:
+    """Classify a dispatch by the shared lifecycle policy, before any strategy-specific framing.
+
+    Replay is isolated before the history-clearing check: a mutation dispatched during undo/redo
+    must never clear history, even if it is (or cascades into) a history-clearing lifecycle type.
+    Every recording strategy calls this so the policy sequence lives in one place and cannot drift.
+    """
+    if type(request) in OWN_EVENT_TYPES:
+        return DispatchTriage.IGNORE
+    if is_replaying:
+        return DispatchTriage.IGNORE
+    if isinstance(request, CLEAR_HISTORY_REQUEST_TYPES):
+        return DispatchTriage.CLEAR_HISTORY
+    return DispatchTriage.PROCEED
+
 
 class UndoEntryReplayError(RuntimeError):
     """Raised when replaying an undo/redo entry fails and the undo history can no longer be trusted."""
+
+
+class UndoEntry(ABC):
+    """A single reversible operation within an undo batch.
+
+    Implementations issue ordinary engine requests to revert (undo) or re-apply (redo)
+    the operation, raising UndoEntryReplayError when replay fails.
+    """
+
+    @abstractmethod
+    def undo(self) -> None:
+        """Revert the recorded operation. Raises UndoEntryReplayError on failure."""
+
+    @abstractmethod
+    def redo(self) -> None:
+        """Re-apply the recorded operation. Raises UndoEntryReplayError on failure."""
+
+
+@dataclass
+class UndoBatch:
+    """One undoable user action, made up of one or more entries replayed together.
+
+    Attributes:
+        label: Human-readable description of the action (e.g. "Create node 'Agent_1'").
+        entries: Entries recorded in application order. Undo replays them in reverse.
+    """
+
+    label: str
+    entries: list[UndoEntry]
+
+
+class RecordingStrategy(Protocol):
+    """The surface UndoManager and the EventManager dispatch path drive, independent of strategy.
+
+    One implementation exists today (the whole-flow SnapshotRecordingSession); this protocol is the
+    seam a future finer-grained strategy plugs into. UndoManager holds a strategy without knowing
+    which, so strategies can diverge in mechanism but not in the surface (or the shared lifecycle
+    policy) they honor.
+    """
+
+    def register_undoable(self, labels: Mapping[type[RequestPayload], str]) -> None:
+        """Declare request types this strategy can capture, each with the semantic name of its operation.
+
+        The name describes the operation, not the request, so it reads the same however the operation
+        was triggered (editor gesture, paste, MCP call, template). It becomes the undo entry's label.
+        """
+        ...
+
+    def transaction(self, label: str) -> AbstractContextManager[None]:
+        """Group every recordable mutation issued within the block into a single undo batch."""
+        ...
+
+    def begin_request_dispatch(self, request: RequestPayload, request_id: str | None) -> Any:
+        """Observe a request before its handler runs; return an opaque capture for end_request_dispatch."""
+        ...
+
+    def end_request_dispatch(self, capture: Any, request: RequestPayload, result: ResultPayload | None) -> None:
+        """Finish observing a dispatch: contribute to the active frame and finalize if it opened one."""
+        ...

--- a/src/griptape_nodes/retained_mode/managers/undo/flow_snapshot.py
+++ b/src/griptape_nodes/retained_mode/managers/undo/flow_snapshot.py
@@ -1,0 +1,506 @@
+"""A point-in-time image of one top-level flow, and the reconciling restore that puts it back.
+
+Capture serializes the flow's contents; restore diffs the live flow against that image and applies
+only the difference. This is state-centric -- it reasons about *what changed* (which
+nodes/connections/values exist now vs. then), not about which request produced the change -- so
+every way of producing an effect (create a node directly, duplicate, paste, import) reverts
+identically.
+
+Deliberately simple over efficient: it is the coarse baseline the undo system's snapshot recording
+strategy is built on.
+
+Scope and known limitations:
+
+- Single top-level flow (the common editor case). Multiple top-level flows or subflow-only state
+  are not handled.
+- A snapshot models nodes, connections, parameter values, node metadata, and lock state. State
+  outside the flow (variables, libraries, MCP servers, the workflow registry) is invisible to it, so
+  callers must not expect changes to that state to be reverted.
+- Restore reconciles the live flow against the snapshot: it deletes only removed nodes, creates only
+  added ones, and updates only changed values/positions/locks/connections on survivors. Nodes that
+  did not change are left untouched, so the canvas updates surgically (no teardown/rebuild blink) and
+  selection/viewport/execution state on unchanged nodes is preserved. Cost is O(changed) to apply,
+  though capture is O(workflow size).
+- Nodes are matched by name, so reverting a *rename* is the one case that does teardown/rebuild: the
+  new-named node is deleted and the old-named one recreated. Non-serializable transient state on that
+  node is lost, exactly as it would be for a freshly created node. Renaming the top-level *flow* is
+  not reverted: restore resolves that flow by its top-level status, so a snapshot captured before the
+  rename still replays, and only the new flow name stays in place.
+- Nodes living in a subflow (including a node group's private subflow) are outside the snapshot, so
+  moves between flows are not reverted.
+- Survivor parameter *structure* changes (a dynamic parameter added or removed) are not reconciled;
+  values, positions, locks, connections, and whole-node add/delete are.
+- The top-level flow's own metadata is captured and restored, but `SetFlowMetadataRequest` merges
+  keys rather than replacing the dict, so a key added since capture stays (the same caveat applies to
+  per-node metadata).
+- Serialization mints fresh UUIDs per capture, so two captures of identical state do not compare
+  equal. Callers must not use snapshot equality to detect whether anything changed.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from griptape_nodes.exe_types.flow import ControlFlow
+from griptape_nodes.exe_types.node_types import BaseNode
+from griptape_nodes.retained_mode.events.connection_events import (
+    CreateConnectionRequest,
+    DeleteConnectionRequest,
+    ListConnectionsForNodeRequest,
+    ListConnectionsForNodeResultSuccess,
+)
+from griptape_nodes.retained_mode.events.flow_events import (
+    GetFlowMetadataRequest,
+    GetFlowMetadataResultSuccess,
+    GetTopLevelFlowRequest,
+    GetTopLevelFlowResultSuccess,
+    ListNodesInFlowRequest,
+    ListNodesInFlowResultSuccess,
+    SerializeFlowToCommandsRequest,
+    SerializeFlowToCommandsResultSuccess,
+    SetFlowMetadataRequest,
+)
+from griptape_nodes.retained_mode.events.node_events import (
+    DeleteNodeRequest,
+    DeserializeNodeFromCommandsRequest,
+    SetLockNodeStateRequest,
+    SetNodeMetadataRequest,
+)
+from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
+from griptape_nodes.retained_mode.managers.undo.core import UndoEntryReplayError
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
+    from griptape_nodes.retained_mode.events.base_events import RequestPayload, ResultPayload
+    from griptape_nodes.retained_mode.events.flow_events import SerializedFlowCommands
+    from griptape_nodes.retained_mode.events.node_events import SerializedNodeCommands
+
+logger = logging.getLogger("griptape_nodes")
+
+
+@dataclass
+class FlowSnapshot:
+    """A serialized point-in-time image of one top-level flow's contents.
+
+    ``serialized_flow_commands`` is captured with ``include_create_flow_command=False`` so it
+    deserializes into the existing flow rather than creating a new one, keeping the flow's identity
+    (and name) stable across undo/redo.
+
+    ``explicit_value_keys`` records, per node name, the set of parameter names that had an explicit
+    value at capture time (``node.parameter_values`` keys). Serialization drops values that are
+    non-serializable or ``None``, so "absent from the serialized commands" does not mean "was unset";
+    the reconcile clear-path uses this set instead, so it only clears values genuinely added since
+    capture and never wipes a live non-serializable value on an unrelated undo.
+
+    ``flow_name`` is the top-level flow's name at capture time, kept for error messages only. Restore
+    resolves the top-level flow afresh, because a rename between capture and restore changes the name
+    but not which flow the snapshot describes.
+
+    ``flow_metadata`` is the flow's own metadata (canvas-level properties), which the serialized
+    commands omit: they are captured with no create-flow command, and that command is what carries it.
+    """
+
+    flow_name: str
+    serialized_flow_commands: SerializedFlowCommands
+    explicit_value_keys: dict[str, set[str]]
+    flow_metadata: dict[str, Any]
+
+
+def capture_workflow_snapshot(engine: Engine) -> FlowSnapshot | None:
+    """Serialize the current top-level flow, or None when there is nothing to snapshot.
+
+    Never raises: capture runs inside begin_request_dispatch, which the EventManager calls before the
+    user's handler. A serialization failure must degrade to "this action is not undoable" (return
+    None) rather than propagate and break the edit the undo system is only meant to observe.
+    """
+    try:
+        top_level_result = engine.handle_request(GetTopLevelFlowRequest())
+        if not isinstance(top_level_result, GetTopLevelFlowResultSuccess) or top_level_result.flow_name is None:
+            return None
+        flow_name = top_level_result.flow_name
+
+        serialize_result = engine.handle_request(
+            SerializeFlowToCommandsRequest(flow_name=flow_name, include_create_flow_command=False)
+        )
+        if not isinstance(serialize_result, SerializeFlowToCommandsResultSuccess):
+            logger.warning("Snapshot undo: failed to serialize flow '%s'; not snapshotting.", flow_name)
+            return None
+        explicit_value_keys = _capture_explicit_value_keys(engine, flow_name)
+        if explicit_value_keys is None:
+            # Could not enumerate every node's explicit values: proceeding with a partial map would
+            # let the reconcile clear-path wipe values on nodes missing from it. Treat as "not
+            # undoable" instead.
+            logger.warning("Snapshot undo: incomplete value-key capture for flow '%s'; not snapshotting.", flow_name)
+            return None
+        flow_metadata = _capture_flow_metadata(engine, flow_name)
+        if flow_metadata is None:
+            logger.warning("Snapshot undo: could not read metadata for flow '%s'; not snapshotting.", flow_name)
+            return None
+        return FlowSnapshot(
+            flow_name=flow_name,
+            serialized_flow_commands=serialize_result.serialized_flow_commands,
+            explicit_value_keys=explicit_value_keys,
+            flow_metadata=flow_metadata,
+        )
+    except Exception:
+        logger.exception("Snapshot undo: capturing the workflow snapshot raised; this action will not be undoable.")
+        return None
+
+
+def _capture_explicit_value_keys(engine: Engine, flow_name: str) -> dict[str, set[str]] | None:
+    """Record, per node, the parameter names that hold an explicit value right now.
+
+    Returns None if the node set cannot be fully enumerated, so the caller can decline to snapshot
+    rather than proceed with a partial map (a missing node would default to "no explicit values" and
+    have all its live values wiped by the reconcile clear-path). Used so the clear-path can tell
+    "unset at capture" from "set but not serialized" (non-serializable or None values).
+    """
+    list_result = engine.handle_request(ListNodesInFlowRequest(flow_name=flow_name))
+    if not isinstance(list_result, ListNodesInFlowResultSuccess):
+        return None
+    keys: dict[str, set[str]] = {}
+    for node_name in list_result.node_names:
+        node = engine.object_manager.attempt_get_object_by_name_as_type(node_name, BaseNode)
+        if node is None:
+            return None
+        keys[node_name] = set(node.parameter_values.keys())
+    return keys
+
+
+def _capture_flow_metadata(engine: Engine, flow_name: str) -> dict[str, Any] | None:
+    """The flow's own metadata, or None when it cannot be read (the caller then declines to snapshot)."""
+    result = engine.handle_request(GetFlowMetadataRequest(flow_name=flow_name))
+    if not isinstance(result, GetFlowMetadataResultSuccess):
+        return None
+    return copy.deepcopy(result.metadata)
+
+
+def restore_workflow_snapshot(engine: Engine, snapshot: FlowSnapshot) -> None:
+    """Reconcile the live flow to match the snapshot, emitting only the minimal set of mutations.
+
+    Nodes are matched by name (stable and unique). Removed nodes are deleted, added nodes are
+    created, and survivors have only their changed values/position/lock/connections updated. Nodes
+    that did not change are never touched, so the editor updates surgically instead of blinking
+    through a full teardown/rebuild. Raises UndoEntryReplayError on any failure so the manager can
+    clear history and surface a typed failure rather than leaving the workflow half-restored.
+    """
+    # Resolve by top-level status, not by the captured name: renaming the flow between capture and
+    # restore changes its name but not which flow this snapshot describes, and looking up the stale
+    # name would fail the replay and take the whole undo history down with it.
+    top_level_result = engine.handle_request(GetTopLevelFlowRequest())
+    if not isinstance(top_level_result, GetTopLevelFlowResultSuccess) or top_level_result.flow_name is None:
+        msg = f"snapshot restore could not find the flow it captured (named '{snapshot.flow_name}' at the time)"
+        raise UndoEntryReplayError(msg)
+    flow_name = top_level_result.flow_name
+
+    flow = engine.object_manager.attempt_get_object_by_name_as_type(flow_name, ControlFlow)
+    if flow is None:
+        msg = f"snapshot restore could not find flow '{flow_name}'"
+        raise UndoEntryReplayError(msg)
+
+    commands = snapshot.serialized_flow_commands
+
+    # Match nodes by name (the create command carries the node's stable name).
+    uuid_to_name: dict[str, str] = {}
+    name_to_node_commands: dict[str, SerializedNodeCommands] = {}
+    for node_commands in commands.serialized_node_commands:
+        node_name = node_commands.create_node_command.node_name
+        if node_name is None:
+            continue
+        uuid_to_name[node_commands.node_uuid] = node_name
+        name_to_node_commands[node_name] = node_commands
+
+    list_result = engine.handle_request(ListNodesInFlowRequest(flow_name=flow_name))
+    if not isinstance(list_result, ListNodesInFlowResultSuccess):
+        msg = f"snapshot restore could not list nodes in flow '{flow_name}'"
+        raise UndoEntryReplayError(msg)
+
+    current_names = set(list_result.node_names)
+    target_names = set(name_to_node_commands)
+    to_delete = current_names - target_names
+    to_create = target_names - current_names
+
+    # 1. Delete removed nodes (each cascades its own connections away).
+    for node_name in to_delete:
+        if not engine.object_manager.has_object_with_name(node_name):
+            continue
+        _require_success(
+            engine,
+            DeleteNodeRequest(node_name=node_name),
+            f"snapshot restore failed deleting node '{node_name}'",
+        )
+
+    # 2. Create added nodes (create command + element modifications, including position metadata).
+    with engine.context_manager.flow(flow):
+        for node_name in to_create:
+            _require_success(
+                engine,
+                DeserializeNodeFromCommandsRequest(serialized_node_commands=name_to_node_commands[node_name]),
+                f"snapshot restore failed creating node '{node_name}'",
+            )
+
+    # 3. Reconcile connections now that every endpoint exists.
+    _reconcile_connections(engine, commands, uuid_to_name, target_names)
+
+    # 4. Reconcile per-node values / position / lock. Created nodes are forced (nothing to compare
+    #    against); survivors are diffed so unchanged state emits no events.
+    for node_name in target_names:
+        _reconcile_node_state(
+            engine,
+            node_name=node_name,
+            node_commands=name_to_node_commands[node_name],
+            commands=commands,
+            explicit_value_keys=snapshot.explicit_value_keys.get(node_name),
+            force=node_name in to_create,
+        )
+
+    # 5. Reconcile the flow's own metadata.
+    _reconcile_flow_metadata(engine, flow=flow, target_metadata=snapshot.flow_metadata)
+
+
+def _reconcile_connections(
+    engine: Engine,
+    commands: SerializedFlowCommands,
+    uuid_to_name: dict[str, str],
+    target_names: set[str],
+) -> None:
+    """Delete connections not in the snapshot and create those missing, touching only what differs."""
+    target_connections: set[tuple[str, str, str, str]] = set()
+    for connection in commands.serialized_connections:
+        source_name = uuid_to_name.get(connection.source_node_uuid)
+        target_name = uuid_to_name.get(connection.target_node_uuid)
+        if source_name is None or target_name is None:
+            continue
+        target_connections.add(
+            (source_name, connection.source_parameter_name, target_name, connection.target_parameter_name)
+        )
+
+    # Enumerate current connections once, via each node's outgoing edges (source side is unique).
+    current_connections: set[tuple[str, str, str, str]] = set()
+    for node_name in target_names:
+        list_result = engine.handle_request(ListConnectionsForNodeRequest(node_name=node_name))
+        if not isinstance(list_result, ListConnectionsForNodeResultSuccess):
+            continue
+        for outgoing in list_result.outgoing_connections:
+            current_connections.add(
+                (node_name, outgoing.source_parameter_name, outgoing.target_node_name, outgoing.target_parameter_name)
+            )
+
+    for source_name, source_param, target_name, target_param in current_connections - target_connections:
+        _require_success(
+            engine,
+            DeleteConnectionRequest(
+                source_node_name=source_name,
+                source_parameter_name=source_param,
+                target_node_name=target_name,
+                target_parameter_name=target_param,
+            ),
+            f"snapshot restore failed removing connection '{source_name}.{source_param}' -> '{target_name}.{target_param}'",
+        )
+    for source_name, source_param, target_name, target_param in target_connections - current_connections:
+        _require_success(
+            engine,
+            CreateConnectionRequest(
+                source_node_name=source_name,
+                source_parameter_name=source_param,
+                target_node_name=target_name,
+                target_parameter_name=target_param,
+            ),
+            f"snapshot restore failed creating connection '{source_name}.{source_param}' -> '{target_name}.{target_param}'",
+        )
+
+
+def _reconcile_node_state(  # noqa: PLR0913
+    engine: Engine,
+    *,
+    node_name: str,
+    node_commands: SerializedNodeCommands,
+    commands: SerializedFlowCommands,
+    explicit_value_keys: set[str] | None,
+    force: bool,
+) -> None:
+    """Restore a node's position, parameter values, and lock, setting only what differs (unless forced)."""
+    node = engine.object_manager.attempt_get_object_by_name_as_type(node_name, BaseNode)
+    if node is None:
+        msg = f"snapshot restore could not find node '{node_name}' to reconcile"
+        raise UndoEntryReplayError(msg)
+
+    # Position / metadata. Created nodes already got it from their create command. SetNodeMetadata
+    # merges keys (it cannot remove one), so a metadata key present live but absent from the snapshot
+    # is not cleared; in practice the keys that change (e.g. position) are always present in both.
+    target_metadata = node_commands.create_node_command.metadata
+    if not force and target_metadata is not None and node.metadata != target_metadata:
+        logger.debug(
+            "Snapshot undo: reverting metadata on '%s'; keys that differ: %s.",
+            node_name,
+            sorted(_differing_keys(node.metadata, target_metadata)),
+        )
+        _try_reconcile(
+            engine,
+            SetNodeMetadataRequest(node_name=node_name, metadata=copy.deepcopy(target_metadata)),
+            f"setting metadata on node '{node_name}'",
+        )
+
+    # Parameter values. This may lazily unlock the node (a locked node rejects value sets); the lock
+    # step below then restores the target lock state, so this must run before it.
+    _reconcile_node_values(
+        engine,
+        node=node,
+        node_commands=node_commands,
+        commands=commands,
+        explicit_value_keys=explicit_value_keys,
+        force=force,
+    )
+
+    # Lock state (last: after any value restore that required temporarily unlocking the node).
+    lock_command = commands.set_lock_commands_per_node.get(node_commands.node_uuid)
+    target_lock = lock_command.lock if lock_command is not None else False
+    if node.lock != target_lock:
+        _try_reconcile(
+            engine,
+            SetLockNodeStateRequest(node_name=node_name, lock=target_lock),
+            f"setting lock on node '{node_name}'",
+        )
+
+
+def _reconcile_node_values(  # noqa: PLR0913
+    engine: Engine,
+    *,
+    node: BaseNode,
+    node_commands: SerializedNodeCommands,
+    commands: SerializedFlowCommands,
+    explicit_value_keys: set[str] | None,
+    force: bool,
+) -> None:
+    """Restore a node's parameter values to the snapshot, setting only what differs (unless forced)."""
+    node_name = node.name
+    for indirect_command in commands.set_parameter_value_commands.get(node_commands.node_uuid, []):
+        set_command = indirect_command.set_parameter_value_command
+        # Output values live in parameter_output_values and are execution state, not editor state;
+        # replaying them as internal sets would clobber the real input value, so skip them.
+        if set_command.is_output:
+            continue
+        parameter_name = set_command.parameter_name
+        if indirect_command.unique_value_uuid not in commands.unique_parameter_uuid_to_values:
+            continue
+        target_value = commands.unique_parameter_uuid_to_values[indirect_command.unique_value_uuid]
+        if not force and _values_equal(node.get_parameter_value(parameter_name), target_value):
+            continue
+        _ensure_node_unlocked(engine, node)
+        # Fresh request (do not mutate the snapshot's command; snapshots are reused across undo/redo).
+        # initial_setup bypasses the input+property connection guard and avoids unresolving the node,
+        # preserving execution state on nodes the restore did not otherwise change.
+        _try_reconcile(
+            engine,
+            SetParameterValueRequest(
+                node_name=node_name,
+                parameter_name=parameter_name,
+                value=copy.deepcopy(target_value),
+                initial_setup=True,
+            ),
+            f"setting value '{node_name}.{parameter_name}'",
+        )
+
+    # A None key set (node missing from the capture map) means the snapshot cannot vouch for this
+    # node, so nothing is cleared. Created nodes (force) start clean and need no clearing.
+    if not force and explicit_value_keys is not None:
+        _clear_added_node_values(engine, node, explicit_value_keys)
+
+
+def _clear_added_node_values(engine: Engine, node: BaseNode, explicit_value_keys: set[str]) -> None:
+    """Reset parameters that hold an explicit value now but did not at capture time to their default.
+
+    Uses the captured explicit-value key set (not the serialized commands) so a live value the
+    snapshot could not record (non-serializable, or None) is left intact rather than wiped.
+    """
+    node_name = node.name
+    for parameter_name in list(node.parameter_values.keys()):
+        if parameter_name in explicit_value_keys:
+            continue
+        parameter = node.get_parameter_by_name(parameter_name)
+        if parameter is None:
+            continue
+        _ensure_node_unlocked(engine, node)
+        _try_reconcile(
+            engine,
+            SetParameterValueRequest(
+                node_name=node_name,
+                parameter_name=parameter_name,
+                value=copy.deepcopy(parameter.default_value),
+                initial_setup=True,
+            ),
+            f"clearing value '{node_name}.{parameter_name}'",
+        )
+
+
+def _ensure_node_unlocked(engine: Engine, node: BaseNode) -> None:
+    """Unlock a node so its values can be restored; idempotent (no-op if already unlocked).
+
+    A locked node rejects value sets regardless of initial_setup. The caller restores the target
+    lock state afterward, so unlocking here is only a transient step during reconcile.
+    """
+    if node.lock:
+        _try_reconcile(
+            engine,
+            SetLockNodeStateRequest(node_name=node.name, lock=False),
+            f"unlocking node '{node.name}' to restore its values",
+        )
+
+
+def _reconcile_flow_metadata(engine: Engine, *, flow: ControlFlow, target_metadata: dict[str, Any]) -> None:
+    """Restore the flow's own metadata, setting it only when it differs from the snapshot.
+
+    SetFlowMetadata merges keys (it cannot remove one), so a key added since capture stays, exactly as
+    for per-node metadata.
+    """
+    if flow.metadata == target_metadata:
+        return
+    _try_reconcile(
+        engine,
+        SetFlowMetadataRequest(flow_name=flow.name, metadata=copy.deepcopy(target_metadata)),
+        f"setting metadata on flow '{flow.name}'",
+    )
+
+
+def _differing_keys(current: dict[str, Any], target: dict[str, Any]) -> set[str]:
+    """Keys whose values differ between two metadata dicts, including keys present in only one.
+
+    Diagnostics only: names which part of a node's metadata an undo is about to change, so a
+    seemingly inert undo step ("nothing moved") can be traced to the key that actually differed.
+    """
+    return {key for key in current.keys() | target.keys() if not _values_equal(current.get(key), target.get(key))}
+
+
+def _values_equal(current: Any, target: Any) -> bool:
+    """Best-effort value equality; treats an unorderable/ambiguous comparison as 'changed'."""
+    try:
+        return bool(current == target)
+    except Exception:
+        return False
+
+
+def _require_success(engine: Engine, request: RequestPayload, failure_message: str) -> ResultPayload:
+    result = engine.handle_request(request)
+    if result.failed():
+        msg = f"{failure_message}: {result.result_details}"
+        raise UndoEntryReplayError(msg)
+    return result
+
+
+def _try_reconcile(engine: Engine, request: RequestPayload, description: str) -> None:
+    """Apply a best-effort per-node reconcile step, logging (not raising) on failure.
+
+    Per-parameter/metadata/lock restores are best-effort: a single un-settable parameter (a rejecting
+    before_value_set hook, a default that is not a valid value, a type not accepted as input) must
+    not abort the whole replay, which would clear the entire undo history. Structural steps (node
+    create/delete, connections) stay fatal via _require_success because a wrong graph shape cannot be
+    trusted.
+    """
+    result = engine.handle_request(request)
+    if result.failed():
+        logger.warning(
+            "Snapshot undo: reconcile step (%s) failed; leaving as-is. %s", description, result.result_details
+        )

--- a/src/griptape_nodes/retained_mode/managers/undo/manager.py
+++ b/src/griptape_nodes/retained_mode/managers/undo/manager.py
@@ -1,0 +1,198 @@
+"""The undo/redo mechanism entry point.
+
+`UndoManager` owns the undo/redo stacks and the replay guard, wires the Undo/Redo/GetState/Clear
+request handlers, and exposes the recording API. Recording itself is delegated to a
+`RecordingStrategy` (currently the whole-flow `SnapshotRecordingSession`); domains declare which of
+their requests the strategy can capture, and what each one's operation is called, via
+`register_undoable`.
+
+`RecordingStrategy` is the extension seam: a finer-grained strategy (e.g. per-touched-entity state
+deltas) can be layered in later by implementing the same contract, without changing the manager or
+the dispatch path.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import deque
+from typing import TYPE_CHECKING
+
+from griptape_nodes.retained_mode.engine import EngineScoped
+from griptape_nodes.retained_mode.events.undo_events import (
+    ClearUndoStateRequest,
+    ClearUndoStateResultSuccess,
+    GetUndoStateRequest,
+    GetUndoStateResultSuccess,
+    RedoRequest,
+    RedoResultFailure,
+    RedoResultSuccess,
+    UndoRequest,
+    UndoResultFailure,
+    UndoResultSuccess,
+)
+from griptape_nodes.retained_mode.managers.undo.core import UndoBatch, UndoEntryReplayError
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from contextlib import AbstractContextManager
+
+    from griptape_nodes.retained_mode.engine import Engine
+    from griptape_nodes.retained_mode.events.base_events import RequestPayload, ResultPayload
+    from griptape_nodes.retained_mode.managers.event_manager import EventManager
+    from griptape_nodes.retained_mode.managers.undo.core import RecordingStrategy
+
+logger = logging.getLogger("griptape_nodes")
+
+# Maximum number of undoable user actions retained. Oldest entries are dropped first.
+MAX_UNDO_BATCHES = 100
+
+
+class UndoManager(EngineScoped):
+    """Owns the undo/redo stacks and replay; delegates recording to a RecordingStrategy."""
+
+    def __init__(self, event_manager: EventManager, *, engine: Engine | None = None) -> None:
+        super().__init__(engine)
+        # Local import: the snapshot strategy pulls in flow/serialization events and the engine
+        # singleton, which would create an import cycle if imported at module load.
+        from griptape_nodes.retained_mode.managers.undo.snapshot import SnapshotRecordingSession
+
+        self._undo_stack: deque[UndoBatch] = deque(maxlen=MAX_UNDO_BATCHES)
+        self._redo_stack: list[UndoBatch] = []
+        self._is_replaying = False
+        self._recording: RecordingStrategy = SnapshotRecordingSession(
+            engine=self.engine,
+            is_replaying=lambda: self._is_replaying,
+            commit_batch=self._commit_batch,
+            invalidate_history=self.clear_history,
+        )
+
+        event_manager.assign_manager_to_request_type(UndoRequest, self.on_undo_request)
+        event_manager.assign_manager_to_request_type(RedoRequest, self.on_redo_request)
+        event_manager.assign_manager_to_request_type(GetUndoStateRequest, self.on_get_undo_state_request)
+        event_manager.assign_manager_to_request_type(ClearUndoStateRequest, self.on_clear_undo_state_request)
+
+    def register_undoable(self, labels: Mapping[type[RequestPayload], str]) -> None:
+        """Declare request types the active strategy can capture, each with its operation's name."""
+        self._recording.register_undoable(labels)
+
+    def transaction(self, label: str) -> AbstractContextManager[None]:
+        """Group every recordable mutation issued within the block into a single undo batch."""
+        return self._recording.transaction(label)
+
+    def begin_request_dispatch(self, request: RequestPayload, request_id: str | None) -> object | None:
+        """Observe a request before its handler runs; returns an opaque capture for end_request_dispatch.
+
+        The capture is produced and consumed by the active recording session; callers treat it as
+        opaque (the inverse and snapshot strategies use different capture shapes).
+        """
+        return self._recording.begin_request_dispatch(request, request_id)
+
+    def end_request_dispatch(
+        self, capture: object | None, request: RequestPayload, result: ResultPayload | None
+    ) -> None:
+        """Finish observing a dispatch: contribute to the active frame and finalize if it was opened."""
+        self._recording.end_request_dispatch(capture, request, result)
+
+    def clear_history(self) -> None:
+        """Drop all undo and redo history."""
+        if self._undo_stack or self._redo_stack:
+            logger.debug("Cleared undo history (%d undo, %d redo).", len(self._undo_stack), len(self._redo_stack))
+        self._undo_stack.clear()
+        self._redo_stack.clear()
+
+    def on_undo_request(self, request: UndoRequest) -> ResultPayload:  # noqa: ARG002
+        if self._is_replaying:
+            details = "Attempted to undo. Failed because an undo or redo is already in progress."
+            return UndoResultFailure(result_details=details)
+        if self.engine.flow_manager.check_for_existing_running_flow():
+            details = "Attempted to undo. Failed because a flow is currently running."
+            return UndoResultFailure(result_details=details)
+        if not self._undo_stack:
+            details = "Attempted to undo. Failed because there is nothing to undo."
+            return UndoResultFailure(result_details=details)
+
+        batch = self._undo_stack.pop()
+        error_details = self._replay_batch(batch, undo=True)
+        if error_details is not None:
+            return UndoResultFailure(result_details=error_details)
+
+        self._redo_stack.append(batch)
+        return UndoResultSuccess(undone_label=batch.label, result_details=f"Undid '{batch.label}'.")
+
+    def on_redo_request(self, request: RedoRequest) -> ResultPayload:  # noqa: ARG002
+        if self._is_replaying:
+            details = "Attempted to redo. Failed because an undo or redo is already in progress."
+            return RedoResultFailure(result_details=details)
+        if self.engine.flow_manager.check_for_existing_running_flow():
+            details = "Attempted to redo. Failed because a flow is currently running."
+            return RedoResultFailure(result_details=details)
+        if not self._redo_stack:
+            details = "Attempted to redo. Failed because there is nothing to redo."
+            return RedoResultFailure(result_details=details)
+
+        batch = self._redo_stack.pop()
+        error_details = self._replay_batch(batch, undo=False)
+        if error_details is not None:
+            return RedoResultFailure(result_details=error_details)
+
+        self._undo_stack.append(batch)
+        return RedoResultSuccess(redone_label=batch.label, result_details=f"Redid '{batch.label}'.")
+
+    def on_get_undo_state_request(self, request: GetUndoStateRequest) -> ResultPayload:  # noqa: ARG002
+        undo_labels = [batch.label for batch in self._undo_stack]
+        redo_labels = [batch.label for batch in self._redo_stack]
+        return GetUndoStateResultSuccess(
+            undo_labels=undo_labels,
+            redo_labels=redo_labels,
+            result_details=f"Undo state retrieved ({len(undo_labels)} undo, {len(redo_labels)} redo).",
+        )
+
+    def on_clear_undo_state_request(self, request: ClearUndoStateRequest) -> ResultPayload:  # noqa: ARG002
+        self.clear_history()
+        return ClearUndoStateResultSuccess(result_details="Undo history cleared.")
+
+    def _commit_batch(self, batch: UndoBatch) -> None:
+        """Push a completed batch onto the undo stack, invalidating the redo stack."""
+        self._undo_stack.append(batch)
+        self._redo_stack.clear()
+
+    def _replay_batch(self, batch: UndoBatch, *, undo: bool) -> str | None:
+        """Replay one batch under the replay guard; return a failure detail string, or None on success.
+
+        Undo replays the batch's entries in reverse via entry.undo(); redo replays them in order via
+        entry.redo(). Any replay failure leaves the workflow partially reverted or re-applied, so the
+        whole history can no longer be trusted: it is cleared and a detail string is returned for the
+        caller to wrap in its typed failure.
+        """
+        if undo:
+            action_noun = "undo"
+            entries = list(reversed(batch.entries))
+        else:
+            action_noun = "redo"
+            entries = list(batch.entries)
+
+        self._is_replaying = True
+        try:
+            for entry in entries:
+                if undo:
+                    entry.undo()
+                else:
+                    entry.redo()
+        except UndoEntryReplayError as err:
+            self.clear_history()
+            return f"Attempted to {action_noun} '{batch.label}'. Failed because {err}. Undo history has been cleared."
+        except Exception as err:
+            # An entry raised something other than UndoEntryReplayError (e.g. an un-deep-copyable
+            # request). The workflow is now partially changed, so history can no longer be trusted;
+            # clear it and surface a typed failure rather than leaking the raw exception.
+            logger.exception(
+                "Unexpected error while replaying %s of '%s'; clearing undo history.", action_noun, batch.label
+            )
+            self.clear_history()
+            return (
+                f"Attempted to {action_noun} '{batch.label}'. Failed with unexpected error: {err}. "
+                "Undo history has been cleared."
+            )
+        finally:
+            self._is_replaying = False
+        return None

--- a/src/griptape_nodes/retained_mode/managers/undo/snapshot.py
+++ b/src/griptape_nodes/retained_mode/managers/undo/snapshot.py
@@ -1,0 +1,281 @@
+"""The whole-flow snapshot recording strategy for undo/redo.
+
+Frames each user action: capture the top-level flow before the action, capture it again after, and
+commit the pair as one undo batch. Reversal is delegated to `flow_snapshot`, which reconciles the
+live flow against the captured image, so this module owns only the framing question -- when does an
+action start, when does it end, and did it change anything worth recording.
+
+Because reversal is state-centric, every way of producing an effect (create a node directly,
+duplicate, paste, import) undoes identically. `RecordingStrategy` (in `undo.core`) is the seam for
+layering in a finer-grained strategy later (e.g. one that captures per-touched-entity deltas instead
+of the whole flow) without changing the manager or the dispatch path.
+
+Framing notes:
+
+- Only what a flow snapshot models is undoable. Requests that mutate state outside the flow are
+  never snapshot points -- domains opt in explicitly via `register_undoable`. See `flow_snapshot`
+  for what the snapshot covers.
+- A batch commits on the dispatch reporting that it altered workflow state, not on a snapshot diff:
+  capture mints fresh UUIDs, so two captures of identical state do not compare equal. A request that
+  reports an edit without changing anything -- setting a parameter to the value it already holds --
+  therefore still consumes an undo slot and replays as a no-op.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from griptape_nodes.retained_mode.managers.undo.core import (
+    DispatchTriage,
+    UndoBatch,
+    UndoEntry,
+    triage_dispatch,
+)
+from griptape_nodes.retained_mode.managers.undo.flow_snapshot import (
+    capture_workflow_snapshot,
+    restore_workflow_snapshot,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator, Mapping
+
+    from griptape_nodes.retained_mode.engine import Engine
+    from griptape_nodes.retained_mode.events.base_events import RequestPayload, ResultPayload
+    from griptape_nodes.retained_mode.managers.undo.flow_snapshot import FlowSnapshot
+
+logger = logging.getLogger("griptape_nodes")
+
+
+@dataclass
+class FlowSnapshotEntry(UndoEntry):
+    """Reverses a user action by restoring the whole-flow snapshot taken before it (undo) or after it (redo)."""
+
+    engine: Engine
+    before: FlowSnapshot
+    after: FlowSnapshot
+
+    def undo(self) -> None:
+        restore_workflow_snapshot(self.engine, self.before)
+
+    def redo(self) -> None:
+        restore_workflow_snapshot(self.engine, self.after)
+
+
+@dataclass
+class _SnapshotDispatch:
+    """Marker returned by begin_request_dispatch so end_request_dispatch knows whether it opened the frame."""
+
+    opened: bool
+
+
+class SnapshotRecordingSession:
+    """Implements RecordingStrategy by recording whole-flow snapshots around each user action.
+
+    Only the requests a domain declares via register_undoable are snapshot points, and the shared
+    lifecycle policy (CLEAR_HISTORY_REQUEST_TYPES, OWN_EVENT_TYPES) applies via triage_dispatch.
+    Declaring is opt-in because a flow snapshot models only flow contents: an undeclared request
+    that mutates something outside the flow would otherwise commit a batch whose before and after
+    are identical, so undoing it would consume a stack slot and revert nothing. It needs no
+    per-request reversal knowledge beyond that: a snapshot captures whole-flow state, so it is
+    agnostic to which declared request produced a change.
+
+    Frame invariant: the open-frame state below (`_before`, `_label`, `_depth`, `_altered`,
+    `_invalidated`) describes one frame at a time and assumes begin/end pairs nest as a single call
+    stack -- an outer dispatch driving inner ones. Overlapping gestures are detected rather than
+    folded together: an externally-initiated request carries a request_id, which a nested dispatch
+    never does, so one arriving while a frame is open means two independent gestures are in flight
+    at once (an async handler yielded and the next request ran as its own task). Both the frame and
+    the history are dropped in that case, costing undoability rather than recording one gesture's
+    edit as part of another's. `_close_frame` fails the same way if begin/end accounting ever goes
+    out of sync.
+    """
+
+    def __init__(
+        self,
+        *,
+        engine: Engine,
+        is_replaying: Callable[[], bool],
+        commit_batch: Callable[[UndoBatch], None],
+        invalidate_history: Callable[[], None],
+    ) -> None:
+        self._engine = engine
+        self._is_replaying = is_replaying
+        self._commit_batch = commit_batch
+        self._invalidate_history = invalidate_history
+        self._undoable_labels: dict[type[RequestPayload], str] = {}
+        self._before: FlowSnapshot | None = None
+        self._label: str | None = None
+        self._depth = 0
+        # Set when a dispatch inside the open frame reported that it altered workflow state. The
+        # frame commits on this union rather than on the framing request's own result, so a handler
+        # that under-reports its own alteration while cascading into mutating requests still yields
+        # an undoable batch instead of a silently unrecorded edit.
+        self._altered = False
+        # Set when a history-clearing lifecycle request is seen while a frame is open, so the frame
+        # finalizes without committing a batch onto the just-cleared stacks.
+        self._invalidated = False
+
+    def register_undoable(self, labels: Mapping[type[RequestPayload], str]) -> None:
+        """Declare request types a flow snapshot can capture, each with the name of its operation.
+
+        The name is keyed by request type rather than by call path, so the same operation reads the
+        same in the undo stack however it was triggered.
+        """
+        self._undoable_labels.update(labels)
+
+    @contextmanager
+    def transaction(self, label: str) -> Iterator[None]:
+        """Group every mutation in the block into one snapshot pair.
+
+        Commits only if some declared-undoable dispatch inside the block reported that it altered
+        workflow state, mirroring the per-dispatch gate. A block that takes a no-op or early-exit path
+        therefore pushes no undo entry, rather than one the user would watch do nothing.
+
+        A raise inside the block still commits: the after-snapshot is taken from live state, so it
+        records whatever the block managed to change, and undoing it backs that partial edit out.
+        """
+        if self._is_replaying() or self._depth > 0:
+            yield
+            return
+        # Unlike begin_request_dispatch, the frame opens even when the capture failed: it suppresses
+        # framing by nested dispatches, and _finalize declines to commit without a before-snapshot.
+        self._before = capture_workflow_snapshot(self._engine)
+        self._label = label
+        self._depth += 1
+        try:
+            yield
+        except Exception:
+            self._close_and_finalize()
+            raise
+        self._close_and_finalize()
+
+    def begin_request_dispatch(self, request: RequestPayload, request_id: str | None) -> _SnapshotDispatch | None:
+        request_type = type(request)
+        triage = triage_dispatch(request, is_replaying=self._is_replaying())
+        if triage is DispatchTriage.IGNORE:
+            return None
+        if triage is DispatchTriage.CLEAR_HISTORY:
+            self._invalidate_history()
+            # If a frame is open, make it finalize without committing onto the just-cleared stacks.
+            if self._depth > 0:
+                self._invalidated = True
+            return None
+
+        if self._depth > 0:
+            return self._join_open_frame(request_type, request_id)
+
+        # Only a user-initiated request (has request_id) whose effects a snapshot can capture opens a
+        # frame. Everything else is inert: it is never snapshotted, so it costs nothing and cannot
+        # commit a batch that would revert nothing.
+        if request_id is None or request_type not in self._undoable_labels:
+            return None
+
+        before = capture_workflow_snapshot(self._engine)
+        if before is None:
+            # Could not snapshot (nothing to capture, or serialization failed): do not open a frame,
+            # so this action is simply not undoable rather than committing an unusable batch.
+            return None
+        self._before = before
+        self._label = self._undoable_labels[request_type]
+        self._depth += 1
+        logger.debug("Snapshot undo: opened frame '%s' (%s).", self._label, request_type.__name__)
+        return _SnapshotDispatch(opened=True)
+
+    def end_request_dispatch(
+        self,
+        capture: _SnapshotDispatch | None,
+        request: RequestPayload,
+        result: ResultPayload | None,
+    ) -> None:
+        if capture is None:
+            return
+        if not self._close_frame():
+            return
+
+        altered = result is not None and result.succeeded() and result.altered_workflow_state
+        # Only declared-undoable types contribute: a snapshot cannot represent anything else, so an
+        # undeclared mutation inside the frame must not make it look like a capturable edit.
+        if altered and type(request) in self._undoable_labels:
+            self._altered = True
+
+        if not capture.opened:
+            return
+        self._finalize(committed=self._altered)
+
+    def _join_open_frame(self, request_type: type[RequestPayload], request_id: str | None) -> _SnapshotDispatch | None:
+        """Fold an inner dispatch into the open frame, or fail closed on an overlapping gesture.
+
+        An externally-initiated request carries a request_id, which an inner dispatch never does, so
+        one arriving mid-frame is a separate gesture in flight at the same time (see the frame
+        invariant on the class). Folding it in would record its edit as part of the open action, so
+        the frame and the history are dropped instead.
+        """
+        if request_id is not None:
+            logger.warning(
+                "Snapshot undo: %s arrived while '%s' was still in progress; clearing undo history to "
+                "avoid recording one edit as part of another.",
+                request_type.__name__,
+                self._label,
+            )
+            self._invalidate_history()
+            self._invalidated = True
+            return None
+        self._depth += 1
+        return _SnapshotDispatch(opened=False)
+
+    def _close_and_finalize(self) -> None:
+        """Close the frame this call opened and commit it if anything inside it altered the flow."""
+        if not self._close_frame():
+            return
+        self._finalize(committed=self._altered)
+
+    def _close_frame(self) -> bool:
+        """Close one nesting level of the open frame; False when frame accounting was out of sync.
+
+        A frame closing that was never open means begin/end pairs did not nest as a single call stack
+        (see the frame invariant on the class). Any batch built from there would be attributed to the
+        wrong action, so the frame and the history are dropped instead.
+        """
+        if self._depth <= 0:
+            logger.warning(
+                "Snapshot undo: dispatch frame tracking went out of sync; clearing undo history to "
+                "avoid recording a misattributed edit."
+            )
+            self._reset()
+            self._invalidate_history()
+            return False
+        self._depth -= 1
+        return True
+
+    def _finalize(self, *, committed: bool) -> None:
+        before = self._before
+        label = self._label or "Edit"
+        invalidated = self._invalidated
+        self._reset()
+        if invalidated or not committed or before is None:
+            logger.debug(
+                "Snapshot undo: discarded frame '%s' (invalidated=%s, altered=%s, captured=%s).",
+                label,
+                invalidated,
+                committed,
+                before is not None,
+            )
+            return
+        after = capture_workflow_snapshot(self._engine)
+        if after is None:
+            logger.debug("Snapshot undo: discarded frame '%s'; could not capture the after state.", label)
+            return
+        logger.debug("Snapshot undo: committed '%s'.", label)
+        self._commit_batch(
+            UndoBatch(label=label, entries=[FlowSnapshotEntry(engine=self._engine, before=before, after=after)])
+        )
+
+    def _reset(self) -> None:
+        self._before = None
+        self._label = None
+        self._depth = 0
+        self._altered = False
+        self._invalidated = False

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -1105,6 +1105,10 @@ class WorkflowManager(EngineScoped):
             if isinstance(request.metadata, dict):
                 request.metadata = WorkflowMetadata(**request.metadata)
 
+            request.metadata.name = self._repair_path_shaped_display_name(
+                display_name=request.metadata.name, registry_key=registry_key
+            )
+
             WorkflowRegistry.generate_new_workflow(
                 registry_key=registry_key, metadata=request.metadata, file_path=request.file_name
             )
@@ -1118,6 +1122,39 @@ class WorkflowManager(EngineScoped):
                 level=logging.DEBUG,
             ),
         )
+
+    def _repair_path_shaped_display_name(self, *, display_name: str, registry_key: str) -> str:
+        """Repair a display name that an older branch/merge/reset wrote as a registry key.
+
+        Those three sites used to write the path-derived registry key straight into ``metadata.name``,
+        so a branch of "Shot 010 Comp" living under ``shots/sh010/`` loaded as
+        "shots/sh010/comp_branch_1" everywhere the editor shows a workflow title. Files written by
+        those versions are still on disk, and they carry the *current* schema version -- the bug was
+        never a schema change -- so there is no version to gate on. We key on the damage itself.
+
+        Exact equality with the registry key is the fingerprint: a title someone actually typed does
+        not coincide with its own file path. Everything else is left alone, including a name that
+        merely happens to contain a separator, which may well be deliberate.
+
+        In-memory only. Rewriting headers during load would touch a pile of user files, churning
+        mtimes and git diffs for a cosmetic label; the repaired name persists on its own the next
+        time the workflow is saved for any other reason.
+        """
+        if display_name != registry_key:
+            return display_name
+        if "/" not in registry_key:
+            # A workspace-root workflow whose title matches its file stem. Nothing path-shaped here,
+            # and nothing the three sites broke -- they only read badly with directories in the key.
+            return display_name
+
+        repaired_name = PurePosixPath(registry_key).name
+        logger.debug(
+            "Workflow '%s' carries its registry key as its display name (written by a pre-fix branch, "
+            "merge, or reset). Showing it as '%s'; the file keeps the old name until its next save.",
+            registry_key,
+            repaired_name,
+        )
+        return repaired_name
 
     async def on_import_workflow_request(self, request: ImportWorkflowRequest) -> ResultPayload:
         # First, attempt to load metadata from the file
@@ -6094,15 +6131,20 @@ class WorkflowManager(EngineScoped):
             )
             return BranchWorkflowResultFailure(result_details=details)
 
-        # Generate branch name if not provided
-        branch_name = request.branched_workflow_name
-        if branch_name is None:
-            base_name = request.workflow_name
-            counter = 1
-            branch_name = f"{base_name}_branch_{counter}"
-            while WorkflowRegistry.has_workflow_with_name(branch_name):
-                counter += 1
-                branch_name = f"{base_name}_branch_{counter}"
+        # A caller-supplied display name has to actually say something; a blank label would leave the
+        # branch looking nameless everywhere the editor shows a workflow title.
+        requested_display_name = request.branched_workflow_display_name
+        if requested_display_name is not None and not requested_display_name.strip():
+            details = (
+                f"Attempted to branch workflow '{request.workflow_name}' with an empty display name. "
+                "Provide a display name with at least one non-whitespace character, or leave it unset "
+                "to name the branch after the workflow it came from."
+            )
+            return BranchWorkflowResultFailure(result_details=details)
+
+        branch_naming = self._resolve_branch_naming(request=request, source_workflow=source_workflow)
+        branch_name = branch_naming.registry_key
+        branch_display_name = branch_naming.display_name
 
         # Check if branch name already exists
         if WorkflowRegistry.has_workflow_with_name(branch_name):
@@ -6112,7 +6154,8 @@ class WorkflowManager(EngineScoped):
         try:
             # Create branch metadata by copying source metadata
             branch_metadata = WorkflowMetadata(
-                name=branch_name,
+                # The display name, not the registry key: `branch_name` is a file path.
+                name=branch_display_name,
                 schema_version=source_workflow.metadata.schema_version,
                 engine_version_created_with=source_workflow.metadata.engine_version_created_with,
                 node_libraries_referenced=source_workflow.metadata.node_libraries_referenced.copy(),
@@ -6170,6 +6213,81 @@ class WorkflowManager(EngineScoped):
 
             traceback.print_exc()
             return BranchWorkflowResultFailure(result_details=details)
+
+    class _BranchNaming(NamedTuple):
+        """The two distinct names a new branch needs.
+
+        `registry_key` is the workspace-relative file path minus its extension, used to key the
+        registry. `display_name` is the human-readable title stored as `metadata.name`. Conflating
+        them is what made branches show up in the editor as file paths.
+        """
+
+        registry_key: str
+        display_name: str
+
+    def _resolve_branch_naming(self, *, request: BranchWorkflowRequest, source_workflow: Workflow) -> _BranchNaming:
+        """Pick the registry key and display name for a new branch of ``source_workflow``.
+
+        The two are resolved together because the label depends on how the key was chosen: an
+        auto-generated key contributes its ``_branch_<n>`` counter to the label, while a
+        caller-supplied key does not. ``request.branched_workflow_display_name``, when given, wins
+        over either derivation; ``on_branch_workflow_request`` has already rejected a blank one.
+        """
+        branch_counter = None
+        branch_registry_key = request.branched_workflow_name
+        if branch_registry_key is None:
+            branch_counter = 1
+            branch_registry_key = f"{request.workflow_name}_branch_{branch_counter}"
+            while WorkflowRegistry.has_workflow_with_name(branch_registry_key):
+                branch_counter += 1
+                branch_registry_key = f"{request.workflow_name}_branch_{branch_counter}"
+
+        requested_display_name = request.branched_workflow_display_name
+        if requested_display_name is not None:
+            return self._BranchNaming(registry_key=branch_registry_key, display_name=requested_display_name.strip())
+
+        derived_display_name = self._derive_branch_display_name(
+            source_display_name=source_workflow.metadata.name,
+            source_registry_key=request.workflow_name,
+            branch_registry_key=branch_registry_key,
+            branch_counter=branch_counter,
+        )
+        return self._BranchNaming(registry_key=branch_registry_key, display_name=derived_display_name)
+
+    def _derive_branch_display_name(
+        self,
+        *,
+        source_display_name: str | None,
+        source_registry_key: str,
+        branch_registry_key: str,
+        branch_counter: int | None,
+    ) -> str:
+        """Compute the human-readable label (``metadata.name``) for a new branch.
+
+        A registry key is a file path; ``metadata.name`` is a title. Using the key as the label makes
+        a branch of "Shot 010 Comp" read as "shots/sh010/comp_branch_1" everywhere the editor shows a
+        workflow name, and the deeper the folder structure the worse it reads.
+
+        * ``branch_counter`` is set when the caller auto-generated the branch key as
+          ``<source key>_branch_<counter>``. The label mirrors that counter so it stays in step with
+          the key: "Shot 010 Comp (branch 1)".
+        * ``branch_counter`` is None when the caller supplied ``branched_workflow_name`` themselves.
+          They chose the key, so its final path segment is the most faithful label available.
+        """
+        if branch_counter is None:
+            return PurePosixPath(branch_registry_key).name
+
+        source_label = (source_display_name or "").strip()
+        if source_label:
+            # Keep only the final segment. A path-shaped source label is exactly the bug this
+            # derivation exists to fix -- branches created before it carry their full registry key as
+            # their name -- so deriving from one verbatim would carry the path forward.
+            source_label = PurePosixPath(source_label).name.strip()
+        if not source_label:
+            # A blank (or purely separator) display name means the source's own metadata is corrupt.
+            # A label off the file path beats propagating emptiness onto the branch.
+            source_label = PurePosixPath(source_registry_key).name
+        return f"{source_label} (branch {branch_counter})"
 
     def on_create_workflow_from_template_request(self, request: CreateWorkflowFromTemplateRequest) -> ResultPayload:
         """Create a new workflow file from a template (Griptape-provided or user-provided)."""
@@ -6287,7 +6405,11 @@ class WorkflowManager(EngineScoped):
         try:
             # Create updated metadata for source workflow - update timestamp
             merged_metadata = WorkflowMetadata(
-                name=source_workflow_name,
+                # Carry the source's existing display name across. `source_workflow_name` came from
+                # the branch's `branched_from`, which holds a registry key (a file path), so using it
+                # here would overwrite the source's correct title with a path and persist that to disk.
+                # A merge changes the source's contents, never what it is called.
+                name=source_workflow.metadata.name,
                 schema_version=source_workflow.metadata.schema_version,
                 engine_version_created_with=source_workflow.metadata.engine_version_created_with,
                 node_libraries_referenced=source_workflow.metadata.node_libraries_referenced.copy(),
@@ -6388,7 +6510,11 @@ class WorkflowManager(EngineScoped):
 
             # Create updated metadata for branch workflow - preserve branch relationship and source timestamp
             reset_metadata = WorkflowMetadata(
-                name=request.workflow_name,
+                # Keep the branch's own display name. A reset discards the branch's *content* changes;
+                # its identity fields below (creation_date, branched_from, is_template) are likewise
+                # kept from the branch, and its title belongs with them. `request.workflow_name` is a
+                # registry key, so using it would overwrite the branch's title with a path on disk.
+                name=branch_workflow.metadata.name,
                 schema_version=source_workflow.metadata.schema_version,
                 engine_version_created_with=source_workflow.metadata.engine_version_created_with,
                 node_libraries_referenced=source_workflow.metadata.node_libraries_referenced.copy(),

--- a/tests/unit/machines/conftest.py
+++ b/tests/unit/machines/conftest.py
@@ -1,0 +1,35 @@
+"""Fixtures for the scheduler tests. Shared non-fixture scaffolding lives in scheduler_stubs.py."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
+
+import pytest
+
+from griptape_nodes.machines.parallel_resolution import ExecuteDagState
+
+if TYPE_CHECKING:
+    from griptape_nodes.machines.dag_builder import DagNode
+
+
+@pytest.fixture
+def held_node_execution(monkeypatch: pytest.MonkeyPatch) -> asyncio.Event:
+    """These reach into the full engine (events, connections, library registry).
+
+    Stub them so these stay focused scheduler tests: they care about when a node is
+    dispatched, not what executing it does. `execute_node` blocks on the returned event
+    so a dispatched node stays PROCESSING long enough to assert on, instead of
+    completing in the same scheduler pass that started it.
+    """
+    monkeypatch.setattr(ExecuteDagState, "handle_done_nodes", AsyncMock())
+    monkeypatch.setattr(ExecuteDagState, "collect_values_from_upstream_nodes", AsyncMock())
+
+    hold = asyncio.Event()
+
+    async def _hold_until_released(_engine: object, _dag_node: DagNode) -> None:
+        await hold.wait()
+
+    monkeypatch.setattr(ExecuteDagState, "execute_node", _hold_until_released)
+    return hold

--- a/tests/unit/machines/scheduler_stubs.py
+++ b/tests/unit/machines/scheduler_stubs.py
@@ -1,0 +1,105 @@
+"""Shared scaffolding for the parallel-resolution scheduler tests.
+
+These build a machine that is already mid-run - one node PROCESSING, its task still
+pending - because that is the state every interesting scheduler question is about: what
+happens to a live DAG when something changes underneath the parked driver.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import NamedTuple
+from unittest.mock import AsyncMock, MagicMock
+
+from griptape_nodes.common.directed_graph import DirectedGraph
+from griptape_nodes.exe_types.node_types import BaseNode, NodeResolutionState
+from griptape_nodes.machines.dag_builder import DagBuilder, DagNode, NodeState
+from griptape_nodes.machines.parallel_resolution import ExecuteDagState, ParallelResolutionMachine
+
+
+class RunningMachine(NamedTuple):
+    machine: ParallelResolutionMachine
+    release: asyncio.Event
+    dag_builder: DagBuilder
+
+
+def node_stub(name: str) -> BaseNode:
+    """A node that is inert enough to be scheduled but never really executed."""
+    node = MagicMock(spec=BaseNode)
+    node.name = name
+    node.lock = False
+    node.state = NodeResolutionState.UNRESOLVED
+    node.parameters = []
+    # Instance attributes, so spec=BaseNode does not supply them. on_update touches both
+    # on the way to dispatching a node; validate must report no problems or we land in
+    # ErrorState instead of executing.
+    node.parameter_output_values = MagicMock()
+    node.validate_before_node_run = MagicMock(return_value=None)
+    return node
+
+
+def machine_running_one_node(max_nodes_in_parallel: int) -> RunningMachine:
+    """A machine with one PROCESSING node whose task is still pending.
+
+    Driving it parks it in `ExecuteDagState.on_update`'s `asyncio.wait`, which is
+    exactly the window an injection has to be able to interrupt.
+    """
+    running_node = node_stub("running")
+    running_node.state = NodeResolutionState.RESOLVING
+
+    graph = DirectedGraph()
+    graph.add_node("running")
+
+    # A stub engine keeps EngineScoped.engine from falling back to current_engine(),
+    # which would stand up the process-root engine here.
+    engine = MagicMock()
+    # Dispatching a node awaits this; a bare MagicMock is not awaitable.
+    engine.event_manager.aput_event = AsyncMock()
+    dag_builder = DagBuilder(engine)
+    dag_builder.graphs["running"] = graph
+    dag_builder.graph_to_nodes["running"] = {"running"}
+    dag_builder.node_to_reference["running"] = DagNode(node_reference=running_node, node_state=NodeState.PROCESSING)
+
+    machine = ParallelResolutionMachine(
+        "flow", max_nodes_in_parallel=max_nodes_in_parallel, dag_builder=dag_builder, engine=engine
+    )
+
+    release = asyncio.Event()
+    node_task = asyncio.ensure_future(release.wait())
+    machine.context.task_to_node[node_task] = dag_builder.node_to_reference["running"]
+    dag_builder.node_to_reference["running"].task_reference = node_task
+    machine.context.running_tasks_count = 1
+
+    return RunningMachine(machine=machine, release=release, dag_builder=dag_builder)
+
+
+def add_waiting_node(dag_builder: DagBuilder, name: str, graph_name: str) -> DagNode:
+    """Add a WAITING node to a graph, creating the graph if this is its first node."""
+    node = node_stub(name)
+    graph = dag_builder.graphs.setdefault(graph_name, DirectedGraph())
+    graph.add_node(name)
+    dag_builder.graph_to_nodes.setdefault(graph_name, set()).add(name)
+    dag_node = DagNode(node_reference=node, node_state=NodeState.WAITING)
+    dag_builder.node_to_reference[name] = dag_node
+    return dag_node
+
+
+def add_dependency(dag_builder: DagBuilder, graph_name: str, upstream: str, downstream: str) -> None:
+    """Make `downstream` depend on `upstream`, so it cannot be queued until `upstream` leaves."""
+    dag_builder.graphs[graph_name].add_edge(upstream, downstream)
+
+
+def queue_node(machine: ParallelResolutionMachine, name: str) -> None:
+    """Route a WAITING node through the real queueing funnel."""
+    ExecuteDagState._try_queue_waiting_node(machine.context, name)
+
+
+async def let_the_run_finish(driver: asyncio.Task, release: asyncio.Event, hold: asyncio.Event) -> None:
+    """Release both the pre-seeded node task and any dispatched node, then join.
+
+    The timeout is what turns "the driver never woke up" into a failure rather than a
+    hung test run.
+    """
+    release.set()
+    hold.set()
+    await asyncio.wait_for(driver, timeout=1)

--- a/tests/unit/machines/test_parallel_resolution_injection.py
+++ b/tests/unit/machines/test_parallel_resolution_injection.py
@@ -1,0 +1,205 @@
+"""A node added to a live run must start as soon as there is room for it.
+
+Running a single node while another single node is already resolving used to add the
+new node to the DAG and then leave it there: nothing queued it, and the driver was
+parked in `asyncio.wait`, whose awaitable set is snapshotted at call time. The node
+only started once some unrelated in-flight node happened to finish, so injection
+latency was "however long the shortest running node takes".
+
+These cover the two halves of the fix - queueing at injection time, and a wakeup that
+can actually break the driver's wait - plus the properties that make the wakeup safe
+to add to a loop that is also reaping node tasks.
+"""
+
+import asyncio
+
+import pytest
+
+from griptape_nodes.machines.dag_builder import NodeState
+from tests.unit.machines.scheduler_stubs import (
+    let_the_run_finish,
+    machine_running_one_node,
+    node_stub,
+)
+
+
+class TestInjectedNodeStartsImmediately:
+    @pytest.mark.asyncio
+    async def test_injected_node_runs_without_waiting_for_the_running_node(
+        self, held_node_execution: asyncio.Event
+    ) -> None:
+        machine, release, dag_builder = machine_running_one_node(max_nodes_in_parallel=2)
+
+        driver = asyncio.create_task(machine.resolve_node())
+        await asyncio.sleep(0)
+        assert machine.is_advancing, "driver should be parked on the running node"
+
+        injected = node_stub("injected")
+        machine.inject_node(injected)
+
+        # No release of the running node: the whole point is that the injected node
+        # does not have to wait for it.
+        for _ in range(20):
+            if dag_builder.node_to_reference["injected"].node_state is NodeState.PROCESSING:
+                break
+            await asyncio.sleep(0)
+
+        assert dag_builder.node_to_reference["injected"].node_state is NodeState.PROCESSING, (
+            "injected node should have been dispatched while the other node is still running"
+        )
+        expected_running = 2  # the pre-seeded node plus the injected one
+        assert machine.context.running_tasks_count == expected_running
+
+        await let_the_run_finish(driver, release, held_node_execution)
+
+    @pytest.mark.asyncio
+    async def test_injection_queues_the_node_even_with_no_driver_running(self) -> None:
+        machine, _release, dag_builder = machine_running_one_node(max_nodes_in_parallel=2)
+
+        injected = node_stub("injected")
+        added = machine.inject_node(injected)
+
+        assert injected in added
+        assert dag_builder.node_to_reference["injected"].node_state is NodeState.QUEUED
+        assert machine.context.new_work_event.is_set()
+
+
+class TestInjectionRespectsTheConcurrencyCap:
+    @pytest.mark.asyncio
+    async def test_injected_node_waits_for_a_free_slot(self, held_node_execution: asyncio.Event) -> None:
+        machine, release, dag_builder = machine_running_one_node(max_nodes_in_parallel=1)
+
+        driver = asyncio.create_task(machine.resolve_node())
+        await asyncio.sleep(0)
+
+        injected = node_stub("injected")
+        machine.inject_node(injected)
+
+        # Give the woken driver every chance to overshoot the cap.
+        for _ in range(20):
+            await asyncio.sleep(0)
+
+        assert dag_builder.node_to_reference["injected"].node_state is NodeState.QUEUED, (
+            "the pool is full, so the injected node must stay queued"
+        )
+        assert machine.context.running_tasks_count == 1, "must not oversubscribe max_nodes_in_parallel"
+
+        await let_the_run_finish(driver, release, held_node_execution)
+
+
+class TestTheWakeupIsSafeToAddToTheReapLoop:
+    @pytest.mark.asyncio
+    async def test_a_wakeup_does_not_reap_the_still_running_node(self, held_node_execution: asyncio.Event) -> None:
+        """The waiter is not a node task, so it must not be popped from task_to_node."""
+        machine, release, _dag_builder = machine_running_one_node(max_nodes_in_parallel=2)
+
+        driver = asyncio.create_task(machine.resolve_node())
+        await asyncio.sleep(0)
+
+        machine.inject_node(node_stub("injected"))
+        for _ in range(20):
+            await asyncio.sleep(0)
+
+        node_names = {dag_node.node_reference.name for dag_node in machine.context.task_to_node.values()}
+        assert "running" in node_names, "waking for an injection must not retire the running node"
+        assert machine.context.running_tasks_count == len(machine.context.task_to_node)
+
+        await let_the_run_finish(driver, release, held_node_execution)
+
+    @pytest.mark.asyncio
+    async def test_wakeup_waiter_does_not_leak(self, held_node_execution: asyncio.Event) -> None:
+        machine, release, _dag_builder = machine_running_one_node(max_nodes_in_parallel=2)
+        before = asyncio.all_tasks()
+
+        driver = asyncio.create_task(machine.resolve_node())
+        await asyncio.sleep(0)
+        machine.inject_node(node_stub("injected"))
+        await let_the_run_finish(driver, release, held_node_execution)
+        # Let the cancelled waiters actually finish unwinding.
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+        leaked = {task for task in asyncio.all_tasks() if task not in before and task is not driver}
+        leaked = {task for task in leaked if not task.done()}
+        assert not leaked, f"scheduling waiters should not outlive the drive: {leaked}"
+
+    @pytest.mark.asyncio
+    async def test_driver_does_not_spin_when_nothing_can_be_dispatched(
+        self, held_node_execution: asyncio.Event
+    ) -> None:
+        """A set flag with nothing dispatchable must suspend, not busy-loop.
+
+        The flag is consumed at the top of every dispatch pass, so a node the queue
+        refuses cannot leave the driver re-entering on_update forever at 100% CPU.
+        """
+        machine, release, _dag_builder = machine_running_one_node(max_nodes_in_parallel=2)
+
+        driver = asyncio.create_task(machine.resolve_node())
+        await asyncio.sleep(0)
+
+        # Signal work that does not exist: nothing was added to the queue.
+        machine.context.signal_new_work()
+        for _ in range(50):
+            await asyncio.sleep(0)
+
+        assert not driver.done(), "driver should still be parked on the running node"
+        assert not machine.context.new_work_event.is_set(), "the spurious signal was consumed, not left to spin"
+
+        await let_the_run_finish(driver, release, held_node_execution)
+
+
+class TestInjectionIntoAPausedRun:
+    @pytest.mark.asyncio
+    async def test_paused_run_queues_the_node_but_does_not_start_it(self, held_node_execution: asyncio.Event) -> None:
+        machine, release, dag_builder = machine_running_one_node(max_nodes_in_parallel=2)
+
+        driver = asyncio.create_task(machine.resolve_node())
+        await asyncio.sleep(0)
+        machine.change_debug_mode(debug_mode=True)
+
+        machine.inject_node(node_stub("injected"))
+        for _ in range(20):
+            await asyncio.sleep(0)
+
+        assert dag_builder.node_to_reference["injected"].node_state is NodeState.QUEUED, (
+            "a paused run must not start the injected node"
+        )
+
+        release.set()
+        held_node_execution.set()
+        await asyncio.wait_for(driver, timeout=1)
+        assert not machine.is_advancing
+
+        # Continuing the run picks the queued node up. Hold the DagNode itself: finishing
+        # the run clears node_to_reference, so it cannot be looked up by name afterwards.
+        injected_dag_node = dag_builder.node_to_reference["injected"]
+        machine.change_debug_mode(debug_mode=False)
+        await machine.update()
+        assert injected_dag_node.node_state is NodeState.DONE, "continuing the run must run the queued node"
+
+
+class TestTeardownWhileParkedOnTheWakeup:
+    @pytest.mark.asyncio
+    async def test_reset_unparks_the_driver_without_waiting_for_the_running_node(self) -> None:
+        """reset() must release the FSM's single-driver claim promptly.
+
+        It clears task_to_node but cannot itself break the driver's wait, so before the
+        wakeup existed the driver held the claim until some *old* node task finished,
+        and any resolve_node in that window died on the single-driver guard.
+        """
+        machine, release, _dag_builder = machine_running_one_node(max_nodes_in_parallel=2)
+
+        driver = asyncio.create_task(machine.resolve_node())
+        await asyncio.sleep(0)
+        assert machine.is_advancing
+
+        machine.reset_machine()
+
+        # The running node is deliberately never released.
+        await asyncio.wait_for(driver, timeout=1)
+
+        assert not machine.is_advancing, "the abandoned driver released the machine"
+        assert machine.current_state is None, "teardown left the machine reset, not resurrected"
+        assert not machine.context.task_to_node
+
+        release.set()

--- a/tests/unit/retained_mode/managers/test_context_manager.py
+++ b/tests/unit/retained_mode/managers/test_context_manager.py
@@ -1,6 +1,7 @@
 """Tests for ContextManager.push_workflow."""
 
 import ast
+import logging
 import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
@@ -8,8 +9,18 @@ from unittest.mock import patch
 
 import pytest
 
+from griptape_nodes.common.macro_parser import ParsedMacro
 from griptape_nodes.node_library.workflow_registry import WorkflowMetadata, WorkflowRegistry
 from griptape_nodes.retained_mode.engine import Engine
+from griptape_nodes.retained_mode.events.context_events import (
+    SetWorkflowContextFailure,
+    SetWorkflowContextRequest,
+    SetWorkflowContextSuccess,
+)
+from griptape_nodes.retained_mode.events.project_events import (
+    GetPathForMacroRequest,
+    GetPathForMacroResultSuccess,
+)
 
 
 class TestPushWorkflow:
@@ -194,6 +205,232 @@ class TestPushWorkflow:
         assert "." not in result
 
         context_manager.pop_workflow()
+
+
+class TestWorkflowWorkingDirectory:
+    """Tests for the folder an unsaved workflow belongs to.
+
+    A workflow that has never been saved has no file, so `{workflow_dir}` -- and every project
+    directory built on it -- has nothing to anchor to and degrades to a workspace-relative
+    path. Files generated before the first save land at the workspace root rather than in the
+    folder the user created the workflow in. `working_directory` is what the caller passes so
+    the engine can answer with the intended folder in the meantime.
+    """
+
+    def _resolve_outputs(self, griptape_nodes: Engine) -> Path:
+        """Resolve `{workflow_dir?:/}outputs/img.png` the way a saving node would."""
+        result = griptape_nodes.handle_request(
+            GetPathForMacroRequest(parsed_macro=ParsedMacro("{workflow_dir?:/}outputs/img.png"), variables={})
+        )
+        assert isinstance(result, GetPathForMacroResultSuccess)
+        return result.absolute_path
+
+    def test_unsaved_workflow_outputs_land_in_the_supplied_folder(self, griptape_nodes: Engine) -> None:
+        """The whole point: an unsaved workflow's outputs resolve under the folder it was created in."""
+        context_manager = griptape_nodes.ContextManager()
+        config_manager = griptape_nodes.ConfigManager()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            workspace = Path(tmp_dir).resolve()
+            browsed = workspace / "shots" / "sh010"
+            browsed.mkdir(parents=True)
+            original = config_manager.workspace_path
+            config_manager.workspace_path = workspace
+            try:
+                result = griptape_nodes.handle_request(
+                    SetWorkflowContextRequest(display_name="Untitled", working_directory=str(browsed))
+                )
+                assert isinstance(result, SetWorkflowContextSuccess)
+                # The folder is NOT the registry key: the workflow is still unsaved.
+                assert result.workflow_name.startswith(WorkflowRegistry.UNSAVED_KEY_PREFIX)
+                assert context_manager.get_current_workflow_file_path() is None
+
+                assert self._resolve_outputs(griptape_nodes) == browsed / "outputs" / "img.png"
+            finally:
+                config_manager.workspace_path = original
+                while context_manager.has_current_workflow():
+                    context_manager.pop_workflow()
+
+    def test_omitting_the_folder_keeps_the_workspace_root_fallback(self, griptape_nodes: Engine) -> None:
+        """The field is optional, so the pre-existing behavior has to survive untouched.
+
+        Only one of the places the editor creates a workflow has a folder to offer; the others
+        pass a display name and nothing else.
+        """
+        context_manager = griptape_nodes.ContextManager()
+        config_manager = griptape_nodes.ConfigManager()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            workspace = Path(tmp_dir).resolve()
+            original = config_manager.workspace_path
+            config_manager.workspace_path = workspace
+            try:
+                result = griptape_nodes.handle_request(SetWorkflowContextRequest(display_name="Untitled"))
+                assert isinstance(result, SetWorkflowContextSuccess)
+                assert context_manager.get_current_workflow_working_directory() is None
+
+                assert self._resolve_outputs(griptape_nodes) == workspace / "outputs" / "img.png"
+            finally:
+                config_manager.workspace_path = original
+                while context_manager.has_current_workflow():
+                    context_manager.pop_workflow()
+
+    def test_relative_folder_is_anchored_to_the_workspace(self, griptape_nodes: Engine) -> None:
+        """A relative folder resolves against the workspace, not the process working directory.
+
+        The path a caller holds is often built from the project base directory, which sits a
+        level above the workspace that macro resolution is relative to, so the value is
+        normalized on the way in rather than being trusted as-is.
+        """
+        context_manager = griptape_nodes.ContextManager()
+        config_manager = griptape_nodes.ConfigManager()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            workspace = Path(tmp_dir).resolve()
+            original = config_manager.workspace_path
+            config_manager.workspace_path = workspace
+            try:
+                result = griptape_nodes.handle_request(
+                    SetWorkflowContextRequest(display_name="Untitled", working_directory="shots/sh020")
+                )
+                assert isinstance(result, SetWorkflowContextSuccess)
+
+                expected = workspace / "shots" / "sh020"
+                assert context_manager.get_current_workflow_working_directory() == str(expected)
+                assert self._resolve_outputs(griptape_nodes) == expected / "outputs" / "img.png"
+            finally:
+                config_manager.workspace_path = original
+                while context_manager.has_current_workflow():
+                    context_manager.pop_workflow()
+
+    def test_saved_location_wins_over_the_supplied_folder(self, griptape_nodes: Engine) -> None:
+        """Saving elsewhere repoints `{workflow_dir}`; the creation folder does not linger.
+
+        The folder is only an answer for a workflow with no file of its own. Once there is a
+        file -- and the user may well have saved it somewhere other than where they started --
+        that file's own directory is the better answer.
+        """
+        context_manager = griptape_nodes.ContextManager()
+        config_manager = griptape_nodes.ConfigManager()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            workspace = Path(tmp_dir).resolve()
+            browsed = workspace / "shots" / "sh010"
+            browsed.mkdir(parents=True)
+            original = config_manager.workspace_path
+            config_manager.workspace_path = workspace
+            try:
+                result = griptape_nodes.handle_request(
+                    SetWorkflowContextRequest(display_name="Untitled", working_directory=str(browsed))
+                )
+                assert isinstance(result, SetWorkflowContextSuccess)
+                assert self._resolve_outputs(griptape_nodes) == browsed / "outputs" / "img.png"
+
+                # What the save path does once the workflow gets a file.
+                saved_to = workspace / "elsewhere" / "my_flow.py"
+                context_manager.set_current_workflow_file_path(str(saved_to))
+
+                assert self._resolve_outputs(griptape_nodes) == saved_to.parent / "outputs" / "img.png"
+            finally:
+                config_manager.workspace_path = original
+                while context_manager.has_current_workflow():
+                    context_manager.pop_workflow()
+
+    def test_supplying_a_file_as_the_folder_is_refused(self, griptape_nodes: Engine) -> None:
+        """A file where a folder was meant fails loudly rather than writing beside the file.
+
+        The value becomes the parent of everything the workflow writes, so accepting a file
+        would silently put outputs next to it -- a plausible location, which is exactly what
+        makes it hard to notice.
+        """
+        context_manager = griptape_nodes.ContextManager()
+        config_manager = griptape_nodes.ConfigManager()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            workspace = Path(tmp_dir)
+            not_a_folder = workspace / "notes.txt"
+            not_a_folder.write_text("not a folder")
+            original = config_manager.workspace_path
+            config_manager.workspace_path = workspace
+            try:
+                result = griptape_nodes.handle_request(
+                    SetWorkflowContextRequest(display_name="Untitled", working_directory=str(not_a_folder))
+                )
+
+                assert isinstance(result, SetWorkflowContextFailure)
+                # Rejected before the context was pushed, so there is nothing to unwind.
+                assert not context_manager.has_current_workflow()
+            finally:
+                config_manager.workspace_path = original
+                while context_manager.has_current_workflow():
+                    context_manager.pop_workflow()
+
+    def test_folder_need_not_exist_yet(self, griptape_nodes: Engine) -> None:
+        """A folder that has not been created yet is accepted.
+
+        Project directories are created on demand at write time, so requiring the folder to
+        exist up front would reject the ordinary case of creating a workflow in a new folder.
+        """
+        context_manager = griptape_nodes.ContextManager()
+        config_manager = griptape_nodes.ConfigManager()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            workspace = Path(tmp_dir).resolve()
+            not_yet = workspace / "shots" / "sh030"
+            original = config_manager.workspace_path
+            config_manager.workspace_path = workspace
+            try:
+                result = griptape_nodes.handle_request(
+                    SetWorkflowContextRequest(display_name="Untitled", working_directory=str(not_yet))
+                )
+
+                assert isinstance(result, SetWorkflowContextSuccess)
+                assert self._resolve_outputs(griptape_nodes) == not_yet / "outputs" / "img.png"
+            finally:
+                config_manager.workspace_path = original
+                while context_manager.has_current_workflow():
+                    context_manager.pop_workflow()
+
+    def test_folder_silences_the_unresolved_workflow_dir_warning(
+        self, griptape_nodes: Engine, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """With a folder to answer with, `{workflow_dir?:/}` no longer degrades.
+
+        The degradation is warned about precisely because the result is a plausible path rather
+        than an obvious error, so the absence of the warning is the signal that nothing was
+        dropped.
+        """
+        context_manager = griptape_nodes.ContextManager()
+        config_manager = griptape_nodes.ConfigManager()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            workspace = Path(tmp_dir)
+            browsed = workspace / "shots" / "sh010"
+            browsed.mkdir(parents=True)
+            original = config_manager.workspace_path
+            config_manager.workspace_path = workspace
+            try:
+                result = griptape_nodes.handle_request(
+                    SetWorkflowContextRequest(display_name="Untitled", working_directory=str(browsed))
+                )
+                assert isinstance(result, SetWorkflowContextSuccess)
+
+                with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+                    self._resolve_outputs(griptape_nodes)
+
+                warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+                assert not warnings, f"Expected no degradation warnings but got: {[r.getMessage() for r in warnings]}"
+            finally:
+                config_manager.workspace_path = original
+                while context_manager.has_current_workflow():
+                    context_manager.pop_workflow()
+
+    def test_get_working_directory_requires_a_workflow(self, griptape_nodes: Engine) -> None:
+        """Asking outside a workflow context is an error, matching the other context accessors."""
+        context_manager = griptape_nodes.ContextManager()
+
+        with pytest.raises(context_manager.NoActiveWorkflowError):
+            context_manager.get_current_workflow_working_directory()
 
 
 class TestGeneratedWorkflowCode:

--- a/tests/unit/retained_mode/managers/test_event_manager.py
+++ b/tests/unit/retained_mode/managers/test_event_manager.py
@@ -106,8 +106,8 @@ class TestEventManagerBroadcasting:
         event_manager.broadcast_app_event(event)
 
     @pytest.mark.asyncio
-    async def test_abroadcast_app_event_handles_listener_exceptions(self) -> None:
-        """Test that abroadcast_app_event raises ExceptionGroup when a listener raises an exception."""
+    async def test_abroadcast_app_event_contains_listener_exceptions(self) -> None:
+        """Test that abroadcast_app_event contains a listener failure instead of propagating it."""
         event_manager = EventManager()
 
         # Create listeners where one raises an exception
@@ -119,9 +119,12 @@ class TestEventManagerBroadcasting:
 
         event = ConfigChanged(key="test_key", old_value="old", new_value="new")
 
-        # TaskGroup raises ExceptionGroup when a task fails
-        with pytest.raises(ExceptionGroup):
-            await event_manager.abroadcast_app_event(event)
+        # The failure is logged per listener, so the broadcast completes and the
+        # surviving listener still sees the event.
+        await event_manager.abroadcast_app_event(event)
+
+        listener1.assert_awaited_once_with(event)
+        listener2.assert_awaited_once_with(event)
 
     @pytest.mark.asyncio
     async def test_abroadcast_app_event_with_mixed_listener_types(self) -> None:
@@ -364,6 +367,72 @@ class TestBroadcastAppEventLoopSafety:
 
         assert "listener_loop" in captured
         assert captured["listener_loop"] is not caller_loop
+
+
+class TestBroadcastAppEventListenerIsolation:
+    """One failing listener must not cancel the siblings sharing its TaskGroup."""
+
+    @pytest.mark.asyncio
+    async def test_async_broadcast_runs_siblings_after_a_listener_raises(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A failing listener must not abort the broadcast.
+
+        Regression guard: a PermissionError in ModelManager's AppInitializationComplete
+        listener aborted the whole broadcast, so every other subsystem silently skipped
+        its startup work.
+        """
+        event_manager = EventManager()
+        completed: list[str] = []
+        failed = asyncio.Event()
+
+        async def failing_listener(_event: ConfigChanged) -> None:
+            failed.set()
+            msg = "listener blew up"
+            raise PermissionError(msg)
+
+        async def surviving_listener(_event: ConfigChanged) -> None:
+            # Resumes only after the sibling raised, so it completes only if that failure
+            # did not cancel the TaskGroup. Listeners are stored in a set, so this cannot
+            # rely on creation order.
+            await failed.wait()
+            completed.append("survivor")
+
+        def sync_listener(_event: ConfigChanged) -> None:
+            completed.append("sync")
+
+        event_manager.add_listener_to_app_event(ConfigChanged, failing_listener)
+        event_manager.add_listener_to_app_event(ConfigChanged, surviving_listener)
+        event_manager.add_listener_to_app_event(ConfigChanged, sync_listener)
+
+        with caplog.at_level(logging.ERROR, logger="griptape_nodes"):
+            await event_manager.abroadcast_app_event(ConfigChanged(key="k", old_value="a", new_value="b"))
+
+        assert sorted(completed) == ["survivor", "sync"]
+        assert "failing_listener" in caplog.text
+        assert "ConfigChanged" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_sync_broadcast_runs_siblings_after_a_listener_raises(self) -> None:
+        event_manager = EventManager()
+        completed: list[str] = []
+        failed = asyncio.Event()
+
+        async def failing_listener(_event: ConfigChanged) -> None:
+            failed.set()
+            msg = "listener blew up"
+            raise PermissionError(msg)
+
+        async def surviving_listener(_event: ConfigChanged) -> None:
+            await failed.wait()
+            completed.append("survivor")
+
+        event_manager.add_listener_to_app_event(ConfigChanged, failing_listener)
+        event_manager.add_listener_to_app_event(ConfigChanged, surviving_listener)
+
+        event_manager.broadcast_app_event(ConfigChanged(key="k", old_value="a", new_value="b"))
+
+        assert completed == ["survivor"]
 
 
 class TestLogResultDetailsSkipsStrictModeViolations:

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -340,6 +340,7 @@ class TestProjectManagerMacroHandlers:
         mock_context_manager.has_current_workflow.return_value = True
         mock_context_manager.get_current_workflow_name.return_value = "My Cool Workflow"
         mock_context_manager.get_current_workflow_file_path.return_value = None
+        mock_context_manager.get_current_workflow_working_directory.return_value = None
         project_manager._engine = MagicMock()
         project_manager._engine.context_manager = mock_context_manager
 
@@ -651,6 +652,7 @@ class TestProjectManagerBuiltinVariables:
         mock_context_manager.has_current_workflow.return_value = True
         mock_context_manager.get_current_workflow_name.return_value = "my_workflow"
         mock_context_manager.get_current_workflow_file_path.return_value = None
+        mock_context_manager.get_current_workflow_working_directory.return_value = None
         project_manager_with_template._engine = MagicMock()
         project_manager_with_template._engine.context_manager = mock_context_manager
 
@@ -717,6 +719,7 @@ class TestProjectManagerBuiltinVariables:
         mock_context_manager.has_current_workflow.return_value = True
         mock_context_manager.get_current_workflow_name.return_value = "my_workflow"
         mock_context_manager.get_current_workflow_file_path.return_value = None
+        mock_context_manager.get_current_workflow_working_directory.return_value = None
         project_manager_with_template._engine = MagicMock()
         project_manager_with_template._engine.context_manager = mock_context_manager
 
@@ -788,6 +791,7 @@ class TestProjectManagerBuiltinVariables:
         mock_context_manager.has_current_workflow.return_value = True
         mock_context_manager.get_current_workflow_name.return_value = "workflow_5"
         mock_context_manager.get_current_workflow_file_path.return_value = None
+        mock_context_manager.get_current_workflow_working_directory.return_value = None
         project_manager_with_template._engine = MagicMock()
         project_manager_with_template._engine.context_manager = mock_context_manager
 
@@ -820,6 +824,7 @@ class TestProjectManagerBuiltinVariables:
         mock_context_manager.has_current_workflow.return_value = True
         mock_context_manager.get_current_workflow_name.return_value = "workflow_5"
         mock_context_manager.get_current_workflow_file_path.return_value = None
+        mock_context_manager.get_current_workflow_working_directory.return_value = None
         project_manager_with_template._engine = MagicMock()
         project_manager_with_template._engine.context_manager = mock_context_manager
 
@@ -6723,6 +6728,7 @@ class TestProjectEnvironmentVariableRecursion:
             mock_context.has_current_workflow.return_value = True
             mock_context.get_current_workflow_name.return_value = "my_workflow"
             mock_context.get_current_workflow_file_path.return_value = None
+            mock_context.get_current_workflow_working_directory.return_value = None
             mock_engine.context_manager = mock_context
 
             mock_workflow = Mock()

--- a/tests/unit/retained_mode/managers/test_undo_flow_snapshot.py
+++ b/tests/unit/retained_mode/managers/test_undo_flow_snapshot.py
@@ -1,0 +1,514 @@
+"""Tests for `flow_snapshot`: the pure capture/restore layer, exercised directly.
+
+These call `capture_workflow_snapshot` and `restore_workflow_snapshot` themselves rather than going
+through `UndoRequest`/`RedoRequest` or the recording session, so nothing here depends on any request
+type being declared undoable, on undo stacks, or on dispatch framing. What is covered is the
+reconcile itself: given a snapshot and a live flow that has since diverged from it, restore emits
+only the minimal set of mutations needed to bring the live flow back in line.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, ParameterTypeBuiltin
+from griptape_nodes.exe_types.node_types import BaseNode
+from griptape_nodes.retained_mode.engine import current_engine
+from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest, DeleteConnectionRequest
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    CreateFlowResultSuccess,
+    SerializeFlowToCommandsRequest,
+    SerializeFlowToCommandsResultFailure,
+    SetFlowMetadataRequest,
+)
+from griptape_nodes.retained_mode.events.node_events import (
+    CreateNodeRequest,
+    CreateNodeResultSuccess,
+    DeleteNodeRequest,
+    DeleteNodeResultFailure,
+    SetLockNodeStateRequest,
+    SetNodeMetadataRequest,
+)
+from griptape_nodes.retained_mode.events.object_events import RenameObjectRequest
+from griptape_nodes.retained_mode.events.parameter_events import (
+    GetParameterValueRequest,
+    GetParameterValueResultSuccess,
+    SetParameterValueRequest,
+)
+from griptape_nodes.retained_mode.managers.undo import UndoEntryReplayError
+from griptape_nodes.retained_mode.managers.undo.flow_snapshot import (
+    _differing_keys,
+    capture_workflow_snapshot,
+    restore_workflow_snapshot,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    from griptape_nodes.retained_mode.engine import Engine
+    from griptape_nodes.retained_mode.events.base_events import RequestPayload, ResultPayload
+
+
+class _ProbeNode(BaseNode):
+    """Concrete `BaseNode` with a single settable string parameter."""
+
+    def __init__(self, name: str, metadata=None) -> None:  # noqa: ANN001
+        super().__init__(name=name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="text",
+                tooltip="probe text",
+                type=ParameterTypeBuiltin.STR.value,
+                allowed_modes={ParameterMode.PROPERTY, ParameterMode.INPUT, ParameterMode.OUTPUT},
+                default_value="",
+            )
+        )
+        # A parameter whose default is None and which starts unset, so serialization records no
+        # value command for it until it is explicitly set (exercises the reconcile clear path).
+        self.add_parameter(
+            Parameter(
+                name="opt",
+                tooltip="optional value",
+                type=ParameterTypeBuiltin.STR.value,
+                allowed_modes={ParameterMode.PROPERTY, ParameterMode.INPUT, ParameterMode.OUTPUT},
+                default_value=None,
+            )
+        )
+
+    def process(self) -> None:
+        return None
+
+
+class TestFlowSnapshot:
+    """Direct capture/restore round trips: given a diverged live flow, restore reconciles it back."""
+
+    _LIBRARY_NAME = "flow-snapshot-test-library"
+    _NODE_TYPE = "_ProbeNode"
+
+    @pytest.fixture
+    def flow_engine(self) -> Iterator[Engine]:
+        """A fresh engine with the flow-snapshot test library registered.
+
+        No undo machinery (recording strategy, stacks, request framing) is involved: capture and
+        restore are called directly against this engine.
+        """
+        from griptape_nodes.node_library.library_registry import LibraryRegistry
+
+        LibraryRegistry._clear()
+        engine = current_engine()
+        self._register_library()
+        yield engine
+        LibraryRegistry._clear()
+
+    def _register_library(self) -> None:
+        from griptape_nodes.node_library.library_registry import (
+            LibraryMetadata,
+            LibraryRegistry,
+            LibrarySchema,
+            NodeMetadata,
+        )
+
+        schema = LibrarySchema(
+            name=self._LIBRARY_NAME,
+            library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+            metadata=LibraryMetadata(
+                author="t", description="d", library_version="1.0.0", engine_version="1.0.0", tags=[]
+            ),
+            categories=[],
+            nodes=[],
+        )
+        library = LibraryRegistry.generate_new_library(library_data=schema)
+        library.register_new_node_type(_ProbeNode, NodeMetadata(category="t", description="d", display_name="Probe"))
+
+    def _make_flow(self, engine: Engine) -> str:
+        from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
+        from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowMetadata
+
+        context_manager = engine.context_manager
+        if not context_manager.has_current_workflow():
+            workflow_key = "unsaved:flow-snapshot-test"
+            if workflow_key not in WorkflowRegistry._workflows:
+                metadata = WorkflowMetadata(
+                    name="Untitled",
+                    schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+                    engine_version_created_with="",
+                    node_libraries_referenced=[],
+                    creation_date=datetime.now(UTC),
+                )
+                WorkflowRegistry.generate_new_workflow(registry_key=workflow_key, metadata=metadata, file_path=None)
+            context_manager.push_workflow(workflow_name=workflow_key)
+        create_result = engine.handle_request(CreateFlowRequest(parent_flow_name=None))
+        assert isinstance(create_result, CreateFlowResultSuccess)
+        return create_result.flow_name
+
+    def _create_node(self, engine: Engine, flow_name: str, node_name: str | None = None) -> str:
+        result = engine.handle_request(
+            CreateNodeRequest(
+                node_type=self._NODE_TYPE,
+                specific_library_name=self._LIBRARY_NAME,
+                node_name=node_name,
+                override_parent_flow_name=flow_name,
+            )
+        )
+        assert isinstance(result, CreateNodeResultSuccess)
+        return result.node_name
+
+    @staticmethod
+    def _patch_handler(
+        monkeypatch: pytest.MonkeyPatch,
+        request_type: type[RequestPayload],
+        handler: Callable[[RequestPayload], ResultPayload],
+    ) -> None:
+        """Replace the EventManager's dispatch-table entry for request_type with a stand-in handler.
+
+        FlowManager/NodeManager hand `assign_manager_to_request_type` their already-bound method at
+        construction time, so monkeypatching the manager's method attribute afterward is a no-op: the
+        dispatch table holds a fixed reference to that original bound method, not a live attribute
+        lookup. The dispatch-table entry itself is looked up fresh per dispatch, so replacing it here
+        is the only way to observe a stand-in handler.
+        """
+        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+        monkeypatch.setitem(GriptapeNodes.EventManager()._request_type_to_manager, request_type, handler)
+
+    # ---------- Capture/restore round trips ----------
+
+    def test_restore_recreates_a_node_deleted_after_capture(self, flow_engine: Engine) -> None:
+        """A node present in the snapshot but missing live is synthesized back from its captured commands."""
+        flow_name = self._make_flow(flow_engine)
+        self._create_node(flow_engine, flow_name, node_name="ProbeA")
+        snapshot = capture_workflow_snapshot(flow_engine)
+        assert snapshot is not None
+
+        assert flow_engine.handle_request(DeleteNodeRequest(node_name="ProbeA")).succeeded()
+        assert not flow_engine.object_manager.has_object_with_name("ProbeA")
+
+        restore_workflow_snapshot(flow_engine, snapshot)
+        assert flow_engine.object_manager.has_object_with_name("ProbeA")
+
+    def test_restore_deletes_a_node_created_after_capture(self, flow_engine: Engine) -> None:
+        """A node absent from the snapshot but present live is deleted to match the captured state."""
+        flow_name = self._make_flow(flow_engine)
+        self._create_node(flow_engine, flow_name, node_name="ProbeA")
+        snapshot = capture_workflow_snapshot(flow_engine)
+        assert snapshot is not None
+
+        self._create_node(flow_engine, flow_name, node_name="ProbeB")
+        assert flow_engine.object_manager.has_object_with_name("ProbeB")
+
+        restore_workflow_snapshot(flow_engine, snapshot)
+        assert not flow_engine.object_manager.has_object_with_name("ProbeB")
+        assert flow_engine.object_manager.has_object_with_name("ProbeA")
+
+    def test_restore_puts_back_a_changed_parameter_value(self, flow_engine: Engine) -> None:
+        """A survivor's parameter value reverts to what the snapshot captured, via the value-reconcile path."""
+        flow_name = self._make_flow(flow_engine)
+        self._create_node(flow_engine, flow_name, node_name="ProbeA")
+        snapshot = capture_workflow_snapshot(flow_engine)
+        assert snapshot is not None
+
+        assert flow_engine.handle_request(
+            SetParameterValueRequest(node_name="ProbeA", parameter_name="text", value="hello")
+        ).succeeded()
+
+        restore_workflow_snapshot(flow_engine, snapshot)
+        value_result = flow_engine.handle_request(GetParameterValueRequest(node_name="ProbeA", parameter_name="text"))
+        assert isinstance(value_result, GetParameterValueResultSuccess)
+        assert value_result.value == ""
+
+    def test_restore_clears_a_value_first_set_after_capture(self, flow_engine: Engine) -> None:
+        """A parameter with no explicit value at capture time is cleared back to unset, not to a stale command.
+
+        `opt` defaults to None and starts unset, so serialization records no value command for it.
+        The reconcile clear path, not a replayed set command, is what has to reset it.
+        """
+        flow_name = self._make_flow(flow_engine)
+        self._create_node(flow_engine, flow_name, node_name="ProbeA")
+        snapshot = capture_workflow_snapshot(flow_engine)
+        assert snapshot is not None
+
+        assert flow_engine.handle_request(
+            SetParameterValueRequest(node_name="ProbeA", parameter_name="opt", value="set-once")
+        ).succeeded()
+
+        restore_workflow_snapshot(flow_engine, snapshot)
+        value_result = flow_engine.handle_request(GetParameterValueRequest(node_name="ProbeA", parameter_name="opt"))
+        assert isinstance(value_result, GetParameterValueResultSuccess)
+        assert value_result.value is None
+
+    def test_restore_recreates_a_connection_deleted_after_capture(self, flow_engine: Engine) -> None:
+        """A connection present in the snapshot but missing live is recreated, after every endpoint exists."""
+        flow_name = self._make_flow(flow_engine)
+        self._create_node(flow_engine, flow_name, node_name="Source")
+        self._create_node(flow_engine, flow_name, node_name="Target")
+        assert flow_engine.handle_request(
+            CreateConnectionRequest(
+                source_node_name="Source",
+                source_parameter_name="text",
+                target_node_name="Target",
+                target_parameter_name="text",
+            )
+        ).succeeded()
+        snapshot = capture_workflow_snapshot(flow_engine)
+        assert snapshot is not None
+
+        def connected() -> bool:
+            incoming = flow_engine.flow_manager.get_connections().incoming_index.get("Target", {})
+            return "text" in incoming
+
+        assert flow_engine.handle_request(
+            DeleteConnectionRequest(
+                source_node_name="Source",
+                source_parameter_name="text",
+                target_node_name="Target",
+                target_parameter_name="text",
+            )
+        ).succeeded()
+        assert not connected()
+
+        restore_workflow_snapshot(flow_engine, snapshot)
+        assert connected()
+
+    def test_restore_removes_a_connection_created_after_capture(self, flow_engine: Engine) -> None:
+        """A connection absent from the snapshot but present live is deleted to match the captured state."""
+        flow_name = self._make_flow(flow_engine)
+        self._create_node(flow_engine, flow_name, node_name="Source")
+        self._create_node(flow_engine, flow_name, node_name="Target")
+        snapshot = capture_workflow_snapshot(flow_engine)
+        assert snapshot is not None
+
+        assert flow_engine.handle_request(
+            CreateConnectionRequest(
+                source_node_name="Source",
+                source_parameter_name="text",
+                target_node_name="Target",
+                target_parameter_name="text",
+            )
+        ).succeeded()
+
+        def connected() -> bool:
+            incoming = flow_engine.flow_manager.get_connections().incoming_index.get("Target", {})
+            return "text" in incoming
+
+        assert connected()
+        restore_workflow_snapshot(flow_engine, snapshot)
+        assert not connected()
+
+    def test_restore_puts_back_changed_node_metadata(self, flow_engine: Engine) -> None:
+        """A survivor's position reverts to the snapshot, via the metadata-reconcile path.
+
+        A move only changes node metadata, so it is easy to mistake for something restore can skip;
+        this pins the metadata-reconcile branch as its own case, independent of any value change.
+        """
+        flow_name = self._make_flow(flow_engine)
+        create_result = flow_engine.handle_request(
+            CreateNodeRequest(
+                node_type=self._NODE_TYPE,
+                specific_library_name=self._LIBRARY_NAME,
+                node_name="ProbeA",
+                override_parent_flow_name=flow_name,
+                metadata={"position": {"x": 10, "y": 20}},
+            )
+        )
+        assert isinstance(create_result, CreateNodeResultSuccess)
+        snapshot = capture_workflow_snapshot(flow_engine)
+        assert snapshot is not None
+
+        node = flow_engine.object_manager.attempt_get_object_by_name_as_type("ProbeA", BaseNode)
+        assert node is not None
+        moved_metadata = {**node.metadata, "position": {"x": 500, "y": 600}}
+        assert flow_engine.handle_request(
+            SetNodeMetadataRequest(node_name="ProbeA", metadata=moved_metadata)
+        ).succeeded()
+        assert node.metadata.get("position") == {"x": 500, "y": 600}
+
+        restore_workflow_snapshot(flow_engine, snapshot)
+        assert node.metadata.get("position") == {"x": 10, "y": 20}
+
+    def test_restore_reverts_a_node_rename(self, flow_engine: Engine) -> None:
+        """A rename undoes via delete+recreate, since nodes are matched by name (the only teardown/rebuild case)."""
+        flow_name = self._make_flow(flow_engine)
+        self._create_node(flow_engine, flow_name, node_name="ProbeA")
+        assert flow_engine.handle_request(
+            SetParameterValueRequest(node_name="ProbeA", parameter_name="text", value="kept")
+        ).succeeded()
+        snapshot = capture_workflow_snapshot(flow_engine)
+        assert snapshot is not None
+
+        assert flow_engine.handle_request(
+            RenameObjectRequest(object_name="ProbeA", requested_name="Renamed")
+        ).succeeded()
+        assert flow_engine.object_manager.has_object_with_name("Renamed")
+        assert not flow_engine.object_manager.has_object_with_name("ProbeA")
+
+        restore_workflow_snapshot(flow_engine, snapshot)
+        assert flow_engine.object_manager.has_object_with_name("ProbeA")
+        assert not flow_engine.object_manager.has_object_with_name("Renamed")
+        value_result = flow_engine.handle_request(GetParameterValueRequest(node_name="ProbeA", parameter_name="text"))
+        assert isinstance(value_result, GetParameterValueResultSuccess)
+        assert value_result.value == "kept"
+
+    def test_restore_puts_back_changed_flow_metadata(self, flow_engine: Engine) -> None:
+        """The top-level flow's own metadata reverts to the snapshot.
+
+        The serialized node/connection commands omit it (captured without a create-flow command,
+        which is what carries it), so the flow's metadata has to be captured and restored separately.
+        """
+        flow_name = self._make_flow(flow_engine)
+        assert flow_engine.handle_request(
+            SetFlowMetadataRequest(flow_name=flow_name, metadata={"note": "before"})
+        ).succeeded()
+        snapshot = capture_workflow_snapshot(flow_engine)
+        assert snapshot is not None
+
+        assert flow_engine.handle_request(
+            SetFlowMetadataRequest(flow_name=flow_name, metadata={"note": "after"})
+        ).succeeded()
+        flow = flow_engine.flow_manager.get_flow_by_name(flow_name)
+        assert flow.metadata["note"] == "after"
+
+        restore_workflow_snapshot(flow_engine, snapshot)
+        assert flow.metadata["note"] == "before"
+
+    def test_restore_reconciles_survivors_in_place(self, flow_engine: Engine) -> None:
+        """An untouched node keeps its exact instance identity across a restore.
+
+        Only the changed node's values/position/lock/connections are updated; survivors are never
+        deleted and recreated, so the editor updates surgically instead of blinking through a
+        teardown/rebuild.
+        """
+        flow_name = self._make_flow(flow_engine)
+        self._create_node(flow_engine, flow_name, node_name="ProbeA")
+        self._create_node(flow_engine, flow_name, node_name="ProbeB")
+        snapshot = capture_workflow_snapshot(flow_engine)
+        assert snapshot is not None
+
+        obj = flow_engine.object_manager
+        node_a_before = obj.attempt_get_object_by_name_as_type("ProbeA", BaseNode)
+        node_b_before = obj.attempt_get_object_by_name_as_type("ProbeB", BaseNode)
+
+        assert flow_engine.handle_request(
+            SetParameterValueRequest(node_name="ProbeB", parameter_name="text", value="hello")
+        ).succeeded()
+
+        restore_workflow_snapshot(flow_engine, snapshot)
+        assert obj.attempt_get_object_by_name_as_type("ProbeA", BaseNode) is node_a_before
+        assert obj.attempt_get_object_by_name_as_type("ProbeB", BaseNode) is node_b_before
+
+    def test_restore_reaches_a_value_on_a_node_locked_at_restore_time(self, flow_engine: Engine) -> None:
+        """A value restore reaches a node that is locked when restore runs; the lock is lifted and reapplied.
+
+        A locked node rejects value sets, so the reconcile has to unlock it before setting the value
+        and then restore the lock state afterward, rather than leaving the stale post-capture value
+        stuck behind the lock.
+        """
+        flow_name = self._make_flow(flow_engine)
+        self._create_node(flow_engine, flow_name, node_name="ProbeA")
+        snapshot = capture_workflow_snapshot(flow_engine)
+        assert snapshot is not None
+
+        assert flow_engine.handle_request(
+            SetParameterValueRequest(node_name="ProbeA", parameter_name="text", value="hello")
+        ).succeeded()
+        assert flow_engine.handle_request(SetLockNodeStateRequest(node_name="ProbeA", lock=True)).succeeded()
+
+        node = flow_engine.object_manager.attempt_get_object_by_name_as_type("ProbeA", BaseNode)
+        assert node is not None
+        assert node.lock is True
+
+        restore_workflow_snapshot(flow_engine, snapshot)
+        assert node.lock is False
+        value_result = flow_engine.handle_request(GetParameterValueRequest(node_name="ProbeA", parameter_name="text"))
+        assert isinstance(value_result, GetParameterValueResultSuccess)
+        assert value_result.value == ""
+
+    def test_restore_raises_on_a_fatal_structural_failure(
+        self, flow_engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A structural step (node delete) failing raises UndoEntryReplayError rather than leaving a half restore.
+
+        Structural steps stay fatal (unlike the best-effort per-node value/metadata/lock steps)
+        because a wrong graph shape cannot be trusted; the caller decides how to react to the raise.
+        """
+        flow_name = self._make_flow(flow_engine)
+        self._create_node(flow_engine, flow_name, node_name="ProbeA")
+        snapshot = capture_workflow_snapshot(flow_engine)
+        assert snapshot is not None
+
+        self._create_node(flow_engine, flow_name, node_name="ProbeB")
+        self._patch_handler(
+            monkeypatch,
+            DeleteNodeRequest,
+            lambda _request: DeleteNodeResultFailure(result_details="forced failure"),
+        )
+
+        with pytest.raises(UndoEntryReplayError):
+            restore_workflow_snapshot(flow_engine, snapshot)
+
+    # ---------- Fail-closed capture ----------
+
+    def test_capture_returns_none_when_serialization_fails(
+        self, flow_engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """capture_workflow_snapshot must return None (not a partial snapshot) when serialization fails."""
+        self._make_flow(flow_engine)
+        self._patch_handler(
+            monkeypatch,
+            SerializeFlowToCommandsRequest,
+            lambda _request: SerializeFlowToCommandsResultFailure(result_details="forced failure"),
+        )
+        assert capture_workflow_snapshot(flow_engine) is None
+
+    def test_capture_returns_none_when_serialization_raises(
+        self, flow_engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """capture_workflow_snapshot's broad except must swallow a raising handler rather than propagate."""
+        self._make_flow(flow_engine)
+
+        def _raise(_request: RequestPayload) -> ResultPayload:
+            msg = "boom"
+            raise RuntimeError(msg)
+
+        self._patch_handler(monkeypatch, SerializeFlowToCommandsRequest, _raise)
+        assert capture_workflow_snapshot(flow_engine) is None
+
+    def test_capture_returns_none_on_partial_value_key_capture(
+        self, flow_engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_capture_explicit_value_keys must refuse a partial map rather than let capture proceed with one."""
+        flow_name = self._make_flow(flow_engine)
+        self._create_node(flow_engine, flow_name, node_name="ProbeA")
+        self._create_node(flow_engine, flow_name, node_name="ProbeB")
+
+        object_manager = flow_engine.object_manager
+        original = object_manager.attempt_get_object_by_name_as_type
+
+        def _partial(name: str, cast_type: type[object]) -> object | None:
+            if name == "ProbeB":
+                return None
+            return original(name, cast_type)
+
+        monkeypatch.setattr(object_manager, "attempt_get_object_by_name_as_type", _partial)
+        assert capture_workflow_snapshot(flow_engine) is None
+
+
+class TestDifferingKeys:
+    """Covers the metadata diff used to report which part of a node an undo is about to change."""
+
+    def test_reports_only_keys_whose_values_changed(self) -> None:
+        current = {"position": {"x": 1, "y": 2}, "size": {"width": 260}}
+        target = {"position": {"x": 1, "y": 2}, "size": {"width": 200}}
+        assert _differing_keys(current, target) == {"size"}
+
+    def test_reports_keys_present_on_only_one_side(self) -> None:
+        """A key added or dropped since capture differs, so it must not be silently equal."""
+        assert _differing_keys({"tempId": "t1"}, {}) == {"tempId"}
+        assert _differing_keys({}, {"tempId": "t1"}) == {"tempId"}
+
+    def test_reports_nothing_when_metadata_matches(self) -> None:
+        metadata = {"position": {"x": 1, "y": 2}, "size": {"width": 200}}
+        assert _differing_keys(dict(metadata), dict(metadata)) == set()

--- a/tests/unit/retained_mode/managers/test_undo_manager.py
+++ b/tests/unit/retained_mode/managers/test_undo_manager.py
@@ -1,0 +1,277 @@
+"""Unit tests for `UndoManager`: the strategy-agnostic mechanism (stacks, guards, replay, lifecycle).
+
+These exercise the manager itself -- undo/redo stacks, the replay guard, the flow-running guard,
+history invalidation, and the shared lifecycle policy -- independently of which recording strategy
+is installed. Snapshot-specific behavior (capture/reconcile) lives in ``test_undo_snapshot.py``.
+
+User-initiated requests are simulated by dispatching through the EventManager with a ``request_id``
+in the result context, which is what marks a request as originating from an external caller.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, ParameterTypeBuiltin
+from griptape_nodes.exe_types.node_types import BaseNode
+from griptape_nodes.retained_mode.engine import current_engine
+from griptape_nodes.retained_mode.events.context_events import SetWorkflowContextRequest
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
+from griptape_nodes.retained_mode.events.undo_events import (
+    ClearUndoStateRequest,
+    ClearUndoStateResultSuccess,
+    GetUndoStateRequest,
+    GetUndoStateResultSuccess,
+    RedoRequest,
+    RedoResultFailure,
+    UndoRequest,
+    UndoResultFailure,
+    UndoResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.undo import UndoBatch, UndoEntry, UndoEntryReplayError
+from griptape_nodes.retained_mode.managers.undo.manager import MAX_UNDO_BATCHES
+from griptape_nodes.retained_mode.managers.undo.snapshot import SnapshotRecordingSession
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from griptape_nodes.retained_mode.engine import Engine
+    from griptape_nodes.retained_mode.events.base_events import RequestPayload, ResultPayload
+
+
+class _ProbeNode(BaseNode):
+    """Concrete `BaseNode` with a single settable string parameter."""
+
+    def __init__(self, name: str, metadata=None) -> None:  # noqa: ANN001
+        super().__init__(name=name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="text",
+                tooltip="probe text",
+                type=ParameterTypeBuiltin.STR.value,
+                allowed_modes={ParameterMode.PROPERTY, ParameterMode.INPUT, ParameterMode.OUTPUT},
+                default_value="",
+            )
+        )
+
+    def process(self) -> None:
+        return None
+
+
+class _NoopUndoEntry(UndoEntry):
+    """Entry that does nothing; used to populate the stacks in mechanism tests."""
+
+    def undo(self) -> None:
+        return None
+
+    def redo(self) -> None:
+        return None
+
+
+class _RaisingUndoEntry(UndoEntry):
+    """Entry that raises a given error on replay; used to drive the replay-failure paths."""
+
+    def __init__(self, error: Exception) -> None:
+        self._error = error
+
+    def undo(self) -> None:
+        raise self._error
+
+    def redo(self) -> None:
+        raise self._error
+
+
+class TestUndoManager:
+    _LIBRARY_NAME = "undo-manager-test-library"
+    _NODE_TYPE = "_ProbeNode"
+
+    @pytest.fixture
+    def engine(self) -> Iterator[Engine]:
+        """A fresh engine with the undo-manager test library and a test-local undo policy.
+
+        Confirms the UndoManager wires the (default) snapshot recording strategy, then declares
+        CreateNodeRequest undoable here rather than relying on what the node domain declares in
+        production. These tests are about the mechanism (stacks, replay, guards, lifecycle), so they
+        must not start failing because a domain revised its own policy or the label it uses.
+        """
+        from griptape_nodes.node_library.library_registry import LibraryRegistry
+
+        LibraryRegistry._clear()
+        engine = current_engine()
+        assert isinstance(engine.undo_manager._recording, SnapshotRecordingSession)
+        engine.undo_manager.register_undoable({CreateNodeRequest: "Create node"})
+        self._register_library()
+        yield engine
+        LibraryRegistry._clear()
+
+    def _register_library(self) -> None:
+        from griptape_nodes.node_library.library_registry import (
+            LibraryMetadata,
+            LibraryRegistry,
+            LibrarySchema,
+            NodeMetadata,
+        )
+
+        schema = LibrarySchema(
+            name=self._LIBRARY_NAME,
+            library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+            metadata=LibraryMetadata(
+                author="t", description="d", library_version="1.0.0", engine_version="1.0.0", tags=[]
+            ),
+            categories=[],
+            nodes=[],
+        )
+        library = LibraryRegistry.generate_new_library(library_data=schema)
+        library.register_new_node_type(_ProbeNode, NodeMetadata(category="t", description="d", display_name="Probe"))
+
+    def _make_flow(self, griptape_nodes: GriptapeNodes) -> str:
+        from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
+        from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowMetadata
+
+        context_manager = griptape_nodes.ContextManager()
+        if not context_manager.has_current_workflow():
+            workflow_key = "unsaved:undo-manager-test"
+            if workflow_key not in WorkflowRegistry._workflows:
+                metadata = WorkflowMetadata(
+                    name="Untitled",
+                    schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+                    engine_version_created_with="",
+                    node_libraries_referenced=[],
+                    creation_date=datetime.now(UTC),
+                )
+                WorkflowRegistry.generate_new_workflow(registry_key=workflow_key, metadata=metadata, file_path=None)
+            context_manager.push_workflow(workflow_name=workflow_key)
+        create_result = griptape_nodes.handle_request(CreateFlowRequest(parent_flow_name=None))
+        assert isinstance(create_result, CreateFlowResultSuccess)
+        return create_result.flow_name
+
+    @staticmethod
+    def _user_request(request: RequestPayload, request_id: str = "test-request") -> ResultPayload:
+        event_manager = GriptapeNodes.EventManager()
+        return event_manager.handle_request(request, result_context={"request_id": request_id}).result
+
+    def _create_node(self, flow_name: str, node_name: str | None = None) -> str:
+        result = self._user_request(
+            CreateNodeRequest(
+                node_type=self._NODE_TYPE,
+                specific_library_name=self._LIBRARY_NAME,
+                node_name=node_name,
+                override_parent_flow_name=flow_name,
+            )
+        )
+        assert isinstance(result, CreateNodeResultSuccess)
+        return result.node_name
+
+    # ---------- Empty stacks / state reporting ----------
+
+    def test_undo_empty_stack_fails(self, engine: GriptapeNodes) -> None:  # noqa: ARG002
+        assert isinstance(GriptapeNodes.handle_request(UndoRequest()), UndoResultFailure)
+
+    def test_redo_empty_stack_fails(self, engine: GriptapeNodes) -> None:  # noqa: ARG002
+        assert isinstance(GriptapeNodes.handle_request(RedoRequest()), RedoResultFailure)
+
+    def test_get_undo_state_reports_labels(self, engine: GriptapeNodes) -> None:
+        flow_name = self._make_flow(engine)
+        self._create_node(flow_name, node_name="ProbeA")
+
+        state = GriptapeNodes.handle_request(GetUndoStateRequest())
+        assert isinstance(state, GetUndoStateResultSuccess)
+        assert len(state.undo_labels) == 1
+        assert state.redo_labels == []
+
+    def test_clear_undo_state(self, engine: GriptapeNodes) -> None:
+        flow_name = self._make_flow(engine)
+        self._create_node(flow_name, node_name="ProbeA")
+
+        assert isinstance(GriptapeNodes.handle_request(ClearUndoStateRequest()), ClearUndoStateResultSuccess)
+        state = GriptapeNodes.handle_request(GetUndoStateRequest())
+        assert isinstance(state, GetUndoStateResultSuccess)
+        assert state.undo_labels == []
+        assert state.redo_labels == []
+
+    def test_new_recorded_action_clears_redo_stack(self, engine: GriptapeNodes) -> None:
+        flow_name = self._make_flow(engine)
+        self._create_node(flow_name, node_name="ProbeA")
+        assert isinstance(GriptapeNodes.handle_request(UndoRequest()), UndoResultSuccess)
+
+        state = GriptapeNodes.handle_request(GetUndoStateRequest())
+        assert isinstance(state, GetUndoStateResultSuccess)
+        assert state.redo_labels  # a redo is available
+
+        self._create_node(flow_name, node_name="ProbeB")
+        state = GriptapeNodes.handle_request(GetUndoStateRequest())
+        assert isinstance(state, GetUndoStateResultSuccess)
+        assert state.redo_labels == []
+
+    # ---------- Stack bound ----------
+
+    def test_undo_stack_respects_max_batches(self, engine: GriptapeNodes) -> None:  # noqa: ARG002
+        undo_manager = GriptapeNodes.UndoManager()
+        for index in range(MAX_UNDO_BATCHES + 5):
+            undo_manager._commit_batch(UndoBatch(label=f"batch-{index}", entries=[_NoopUndoEntry()]))
+        assert len(undo_manager._undo_stack) == MAX_UNDO_BATCHES
+
+    # ---------- Guards ----------
+
+    def test_undo_blocked_while_replay_in_progress(self, engine: GriptapeNodes) -> None:  # noqa: ARG002
+        undo_manager = GriptapeNodes.UndoManager()
+        undo_manager._undo_stack.append(UndoBatch(label="x", entries=[_NoopUndoEntry()]))
+        undo_manager._is_replaying = True
+        try:
+            assert isinstance(GriptapeNodes.handle_request(UndoRequest()), UndoResultFailure)
+        finally:
+            undo_manager._is_replaying = False
+
+    def test_redo_blocked_while_replay_in_progress(self, engine: GriptapeNodes) -> None:  # noqa: ARG002
+        undo_manager = GriptapeNodes.UndoManager()
+        undo_manager._redo_stack.append(UndoBatch(label="x", entries=[_NoopUndoEntry()]))
+        undo_manager._is_replaying = True
+        try:
+            assert isinstance(GriptapeNodes.handle_request(RedoRequest()), RedoResultFailure)
+        finally:
+            undo_manager._is_replaying = False
+
+    def test_undo_fails_while_flow_running(self, engine: GriptapeNodes, monkeypatch: pytest.MonkeyPatch) -> None:  # noqa: ARG002
+        undo_manager = GriptapeNodes.UndoManager()
+        undo_manager._undo_stack.append(UndoBatch(label="x", entries=[_NoopUndoEntry()]))
+        monkeypatch.setattr(GriptapeNodes.FlowManager(), "check_for_existing_running_flow", lambda: True)
+        assert isinstance(GriptapeNodes.handle_request(UndoRequest()), UndoResultFailure)
+
+    def test_redo_fails_while_flow_running(self, engine: GriptapeNodes, monkeypatch: pytest.MonkeyPatch) -> None:  # noqa: ARG002
+        undo_manager = GriptapeNodes.UndoManager()
+        undo_manager._redo_stack.append(UndoBatch(label="x", entries=[_NoopUndoEntry()]))
+        monkeypatch.setattr(GriptapeNodes.FlowManager(), "check_for_existing_running_flow", lambda: True)
+        assert isinstance(GriptapeNodes.handle_request(RedoRequest()), RedoResultFailure)
+
+    # ---------- Replay failure clears history ----------
+
+    def test_replay_error_clears_history(self, engine: GriptapeNodes) -> None:  # noqa: ARG002
+        undo_manager = GriptapeNodes.UndoManager()
+        undo_manager._undo_stack.append(UndoBatch(label="x", entries=[_RaisingUndoEntry(UndoEntryReplayError("boom"))]))
+        assert isinstance(GriptapeNodes.handle_request(UndoRequest()), UndoResultFailure)
+        assert not undo_manager._undo_stack
+        assert not undo_manager._redo_stack
+
+    def test_unexpected_replay_error_clears_history(self, engine: GriptapeNodes) -> None:  # noqa: ARG002
+        undo_manager = GriptapeNodes.UndoManager()
+        undo_manager._undo_stack.append(UndoBatch(label="x", entries=[_RaisingUndoEntry(ValueError("boom"))]))
+        assert isinstance(GriptapeNodes.handle_request(UndoRequest()), UndoResultFailure)
+        assert not undo_manager._undo_stack
+        assert not undo_manager._redo_stack
+
+    # ---------- Lifecycle policy ----------
+
+    def test_set_workflow_context_clears_history(self, engine: GriptapeNodes) -> None:
+        flow_name = self._make_flow(engine)
+        self._create_node(flow_name, node_name="ProbeA")
+
+        # A whole-graph lifecycle request invalidates all undo history.
+        self._user_request(SetWorkflowContextRequest(workflow_name=None))
+        state = GriptapeNodes.handle_request(GetUndoStateRequest())
+        assert isinstance(state, GetUndoStateResultSuccess)
+        assert state.undo_labels == []

--- a/tests/unit/retained_mode/managers/test_undo_policy.py
+++ b/tests/unit/retained_mode/managers/test_undo_policy.py
@@ -1,0 +1,289 @@
+"""Completeness guard for the undo policy the domain managers declare to UndoManager.
+
+Undo recording is opt-in: only request types a domain declares via ``register_undoable`` become
+snapshot points. That default matters because a flow snapshot models only flow contents (nodes,
+connections, parameter values, metadata, locks). A request that mutates state outside the flow --
+variables, libraries, MCP servers, the workflow registry -- produces identical before and after
+snapshots, so recording it would push an undo entry that consumes a stack slot, clears the redo
+stack, and reverts nothing.
+
+Asserting against a hand-copied expected list would only catch drift between two copies. So these
+tests derive from the engine itself: they introspect the EventManager's routing table to find which
+manager owns each declared type, and resolve each request's ``<Name>ResultSuccess`` to check whether
+it actually reports ``altered_workflow_state``. What they enforce:
+
+- every declared type can actually commit (its success result alters workflow state),
+- every declared type belongs to a domain the snapshot models,
+- no altering request outside those domains is declared,
+- every altering request inside those domains is either declared or explicitly acknowledged as
+  intentionally not undoable.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.retained_mode.engine import current_engine
+from griptape_nodes.retained_mode.events.base_events import WorkflowAlteredMixin
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, DeleteNodeRequest
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.undo import snapshot as snapshot_module
+from griptape_nodes.retained_mode.managers.undo.snapshot import SnapshotRecordingSession
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from griptape_nodes.retained_mode.events.base_events import RequestPayload
+
+# The domains whose state a flow snapshot models, and which therefore declare undoable requests.
+_SNAPSHOT_DOMAIN_MANAGERS = ("FlowManager", "NodeManager", "ObjectManager")
+
+# Altering requests inside the snapshot domains that are deliberately NOT undoable: execution and
+# runtime triggers. They alter workflow state, but undo is about editing, not running. Listing them
+# here is the acknowledgment that they were considered; an altering request in those domains that is
+# neither declared undoable nor named here fails test_snapshot_domain_altering_requests_are_triaged.
+_ACKNOWLEDGED_NOT_UNDOABLE: frozenset[str] = frozenset(
+    {
+        # Flow execution triggers.
+        "StartFlowRequest",
+        "StartFlowFromNodeRequest",
+        "StartLocalSubflowRequest",
+        "SingleNodeStepRequest",
+        "SingleExecutionStepRequest",
+        "ContinueExecutionStepRequest",
+        "CancelFlowRequest",
+        "UnresolveFlowRequest",
+        # Node execution / runtime state.
+        "ResolveNodeRequest",
+        "UnresolveNodeRequest",
+        # Moves between flows: a snapshot records only the top-level flow's direct contents, so
+        # undoing a move into or out of a subflow (node groups use one) would recreate the node
+        # alongside the original instead of moving it back.
+        "MoveNodeToNewFlowRequest",
+        "AddNodesToNodeGroupRequest",
+        "RemoveNodeFromNodeGroupRequest",
+        # Parameter structure: restore reconciles a survivor node's values, metadata, lock, and
+        # connections, not the set of parameters it carries, so undoing one would report success and
+        # leave the parameter as it is.
+        "AddParameterToNodeRequest",
+        "RemoveParameterFromNodeRequest",
+        "RenameParameterRequest",
+        "AlterParameterDetailsRequest",
+        "MigrateParameterRequest",
+        "ReorderParameterListItemRequest",
+        "AddParameterGroupToNodeRequest",
+        "AlterParameterGroupDetailsRequest",
+        # Replaces the whole object graph; handled as a history-clearing lifecycle event instead.
+        "ClearAllObjectStateRequest",
+    }
+)
+
+# Stands in for a captured snapshot in the mechanism test, which only cares whether a frame opened.
+_STUB_SNAPSHOT = object()
+
+
+def _owning_manager_name(request_type: type[RequestPayload]) -> str | None:
+    """Name of the manager class the EventManager dispatches this request type to."""
+    handler = GriptapeNodes.EventManager()._request_type_to_manager.get(request_type)
+    owner = getattr(handler, "__self__", None)
+    if owner is None:
+        return None
+    return type(owner).__name__
+
+
+def _routed_request_types(manager_name: str) -> list[type[RequestPayload]]:
+    """Every request type the EventManager dispatches to a bound method of the named manager."""
+    routing = GriptapeNodes.EventManager()._request_type_to_manager
+    return [request_type for request_type in routing if _owning_manager_name(request_type) == manager_name]
+
+
+def _alters_workflow_state(request_type: type[RequestPayload]) -> bool:
+    """Whether this request's success result forces ``altered_workflow_state``, i.e. can commit a batch.
+
+    The success type is resolved by the engine-wide ``<Name>Request`` -> ``<Name>ResultSuccess``
+    naming convention within the request's own module. An unresolvable one is reported by
+    test_result_success_types_are_resolvable rather than skipped silently, so this derivation cannot
+    quietly degrade into a vacuous one.
+    """
+    result_type = _result_success_type(request_type)
+    if result_type is None:
+        return False
+    return issubclass(result_type, WorkflowAlteredMixin)
+
+
+def _result_success_type(request_type: type[RequestPayload]) -> type | None:
+    module = sys.modules[request_type.__module__]
+    success_name = request_type.__name__.removesuffix("Request") + "ResultSuccess"
+    return getattr(module, success_name, None)
+
+
+class TestUndoPolicy:
+    @pytest.fixture
+    def recording_session(self) -> Iterator[SnapshotRecordingSession]:
+        """Rebuild the singleton and return the SnapshotRecordingSession the UndoManager wired up.
+
+        No library registration is needed: these tests inspect the declared policy and never create
+        a node.
+        """
+        from griptape_nodes.node_library.library_registry import LibraryRegistry
+        from griptape_nodes.utils.metaclasses import SingletonMeta
+
+        SingletonMeta._instances.clear()
+        LibraryRegistry._clear()
+        griptape_nodes = GriptapeNodes()
+        recording = griptape_nodes.UndoManager()._recording
+        assert isinstance(recording, SnapshotRecordingSession)
+        yield recording
+        SingletonMeta._instances.clear()
+        LibraryRegistry._clear()
+
+    # ---------- What is declared undoable ----------
+
+    def test_declared_undoable_requests_can_actually_commit(self, recording_session: SnapshotRecordingSession) -> None:
+        """A declared type whose result never alters workflow state can never commit, so declaring it lies.
+
+        Such a declaration silently does nothing: the frame opens, pays for a whole-flow capture, and
+        finalizes without committing. Either the request should report its alteration or it should not
+        be declared.
+        """
+        declared = recording_session._undoable_labels
+        assert declared, "no undoable requests declared at all; the wiring is broken"
+
+        inert = sorted(request_type.__name__ for request_type in declared if not _alters_workflow_state(request_type))
+        assert inert == []
+
+    def test_declared_operations_have_a_human_name(self, recording_session: SnapshotRecordingSession) -> None:
+        """Every declared type carries the name of its operation, which becomes the undo entry's label.
+
+        The name is what the editor shows for "undo X", so a blank or placeholder one leaves the user
+        unable to tell what a stack entry will revert.
+        """
+        unnamed = sorted(
+            request_type.__name__
+            for request_type, label in recording_session._undoable_labels.items()
+            if not label.strip() or label == "Edit"
+        )
+        assert unnamed == []
+
+    def test_declared_undoable_requests_belong_to_snapshot_domains(
+        self, recording_session: SnapshotRecordingSession
+    ) -> None:
+        """Only domains a flow snapshot models may declare undoable requests.
+
+        Declaring a request from any other domain records an entry whose before and after snapshots
+        are identical, so undoing it would burn a stack slot and revert nothing.
+        """
+        out_of_scope = sorted(
+            f"{request_type.__name__} ({_owning_manager_name(request_type)})"
+            for request_type in recording_session._undoable_labels
+            if _owning_manager_name(request_type) not in _SNAPSHOT_DOMAIN_MANAGERS
+        )
+        assert out_of_scope == []
+
+    def test_altering_requests_outside_snapshot_domains_are_not_undoable(
+        self, recording_session: SnapshotRecordingSession
+    ) -> None:
+        """No altering request from a non-snapshot domain may be undoable, however it got declared.
+
+        The inverse of the test above, stated over the engine's whole routing table rather than over
+        the declared set, so a request reachable through some other wiring path is caught too.
+        """
+        routing = GriptapeNodes.EventManager()._request_type_to_manager
+        leaked = sorted(
+            f"{request_type.__name__} ({_owning_manager_name(request_type)})"
+            for request_type in routing
+            if _owning_manager_name(request_type) not in _SNAPSHOT_DOMAIN_MANAGERS
+            and _alters_workflow_state(request_type)
+            and request_type in recording_session._undoable_labels
+        )
+        assert leaked == []
+
+    # ---------- Completeness within the snapshot domains ----------
+
+    def test_snapshot_domain_altering_requests_are_triaged(self, recording_session: SnapshotRecordingSession) -> None:
+        """Every altering request in a snapshot domain must be declared undoable or acknowledged as not.
+
+        A request that is neither is an edit nobody decided on: it silently will not be undoable, and
+        the omission is invisible without this check.
+        """
+        candidates = [
+            request_type
+            for manager_name in _SNAPSHOT_DOMAIN_MANAGERS
+            for request_type in _routed_request_types(manager_name)
+            if _alters_workflow_state(request_type)
+        ]
+        assert candidates, "derivation found no altering requests at all; the introspection is broken"
+
+        untriaged = sorted(
+            request_type.__name__
+            for request_type in candidates
+            if request_type not in recording_session._undoable_labels
+            and request_type.__name__ not in _ACKNOWLEDGED_NOT_UNDOABLE
+        )
+        assert untriaged == []
+
+    def test_declared_and_acknowledged_sets_are_disjoint(self, recording_session: SnapshotRecordingSession) -> None:
+        """A type cannot be both declared undoable and acknowledged as intentionally not undoable.
+
+        Without this, re-declaring an acknowledged type (undoing a deliberate exclusion) leaves every
+        other policy test passing: the type is no longer "untriaged", and its stale acknowledgment
+        entry is simply never consulted.
+        """
+        declared_names = {request_type.__name__ for request_type in recording_session._undoable_labels}
+        assert sorted(declared_names & _ACKNOWLEDGED_NOT_UNDOABLE) == []
+
+    def test_acknowledged_not_undoable_types_are_not_stale(self, recording_session: SnapshotRecordingSession) -> None:  # noqa: ARG002
+        """The acknowledgment set must not name types that no longer alter state in a snapshot domain.
+
+        Without this, a request that stops altering (or is renamed, or moves domains) leaves a stale
+        entry that would mask a genuinely untriaged type sharing its name later.
+        """
+        derived_names = {
+            request_type.__name__
+            for manager_name in _SNAPSHOT_DOMAIN_MANAGERS
+            for request_type in _routed_request_types(manager_name)
+            if _alters_workflow_state(request_type)
+        }
+        assert sorted(_ACKNOWLEDGED_NOT_UNDOABLE - derived_names) == []
+
+    def test_result_success_types_are_resolvable(self, recording_session: SnapshotRecordingSession) -> None:  # noqa: ARG002
+        """Every snapshot-domain request must expose a resolvable success type, or the derivation goes blind.
+
+        A request whose ``<Name>ResultSuccess`` cannot be found looks non-altering to the checks
+        above, so it is surfaced here instead of being silently dropped.
+        """
+        unresolvable = sorted(
+            request_type.__name__
+            for manager_name in _SNAPSHOT_DOMAIN_MANAGERS
+            for request_type in _routed_request_types(manager_name)
+            if _result_success_type(request_type) is None
+        )
+        assert unresolvable == []
+
+    # ---------- Mechanism: register_undoable gates frame opening ----------
+
+    def test_only_registered_undoable_types_open_a_frame(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """register_undoable is the mechanism the declared policy feeds into.
+
+        A registered type must open a frame; an unregistered one must not, even though both are
+        user-initiated and both alter workflow state. Built against a scratch session with stub
+        callables and a stubbed capture, so this does not depend on a live flow.
+        """
+        monkeypatch.setattr(snapshot_module, "capture_workflow_snapshot", lambda _engine: _STUB_SNAPSHOT)
+        session = SnapshotRecordingSession(
+            engine=current_engine(),
+            is_replaying=lambda: False,
+            commit_batch=lambda _batch: None,
+            invalidate_history=lambda: None,
+        )
+        session.register_undoable({CreateNodeRequest: "Create node"})
+
+        opened = session.begin_request_dispatch(CreateNodeRequest(node_type="Probe"), "some-request-id")
+        assert opened is not None
+        assert opened.opened
+        session.end_request_dispatch(opened, CreateNodeRequest(node_type="Probe"), None)
+
+        assert session.begin_request_dispatch(DeleteNodeRequest(), "some-request-id") is None

--- a/tests/unit/retained_mode/managers/test_undo_snapshot.py
+++ b/tests/unit/retained_mode/managers/test_undo_snapshot.py
@@ -1,0 +1,785 @@
+"""Tests for the whole-flow snapshot recording strategy: framing, dispatch, and stack behavior.
+
+These build a fresh engine so the UndoManager wires the SnapshotRecordingSession
+(the default and only strategy), then drive user-request flows through UndoRequest/RedoRequest and
+verify the recorded round trip: undo reconciles the flow back to the previous whole-flow state; redo
+re-applies it. Direct capture/restore behavior (the reconcile mechanics themselves, independent of
+framing) lives in ``test_undo_flow_snapshot.py``.
+"""
+
+from __future__ import annotations
+
+import copy
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, ParameterTypeBuiltin
+from griptape_nodes.exe_types.node_types import BaseNode
+from griptape_nodes.retained_mode.engine import current_engine
+from griptape_nodes.retained_mode.events.connection_events import (
+    CreateConnectionRequest,
+    CreateConnectionResultSuccess,
+    DeleteConnectionRequest,
+)
+from griptape_nodes.retained_mode.events.context_events import SetWorkflowContextRequest
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    CreateFlowResultSuccess,
+    SerializeFlowToCommandsRequest,
+    SerializeFlowToCommandsResultFailure,
+    SetFlowMetadataRequest,
+)
+from griptape_nodes.retained_mode.events.node_events import (
+    CreateNodeRequest,
+    CreateNodeResultSuccess,
+    DeleteNodeRequest,
+    DeleteNodeResultFailure,
+    SetLockNodeStateRequest,
+    SetNodeMetadataRequest,
+    SetNodeMetadataResultSuccess,
+)
+from griptape_nodes.retained_mode.events.object_events import RenameObjectRequest
+from griptape_nodes.retained_mode.events.parameter_events import (
+    GetParameterValueRequest,
+    GetParameterValueResultSuccess,
+    SetParameterValueRequest,
+)
+from griptape_nodes.retained_mode.events.undo_events import (
+    GetUndoStateRequest,
+    GetUndoStateResultSuccess,
+    RedoRequest,
+    RedoResultSuccess,
+    UndoRequest,
+    UndoResultFailure,
+    UndoResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.managers.undo.snapshot import SnapshotRecordingSession
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    from griptape_nodes.retained_mode.engine import Engine
+    from griptape_nodes.retained_mode.events.base_events import RequestPayload, ResultPayload
+
+
+class _ProbeNode(BaseNode):
+    """Concrete `BaseNode` with a single settable string parameter."""
+
+    def __init__(self, name: str, metadata=None) -> None:  # noqa: ANN001
+        super().__init__(name=name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="text",
+                tooltip="probe text",
+                type=ParameterTypeBuiltin.STR.value,
+                allowed_modes={ParameterMode.PROPERTY, ParameterMode.INPUT, ParameterMode.OUTPUT},
+                default_value="",
+            )
+        )
+        # A parameter whose default is None and which starts unset, so serialization records no
+        # value command for it until it is explicitly set (exercises the reconcile clear path).
+        self.add_parameter(
+            Parameter(
+                name="opt",
+                tooltip="optional value",
+                type=ParameterTypeBuiltin.STR.value,
+                allowed_modes={ParameterMode.PROPERTY, ParameterMode.INPUT, ParameterMode.OUTPUT},
+                default_value=None,
+            )
+        )
+
+    def process(self) -> None:
+        return None
+
+
+class TestSnapshotStrategy:
+    _LIBRARY_NAME = "undo-snapshot-test-library"
+    _NODE_TYPE = "_ProbeNode"
+
+    @pytest.fixture
+    def snapshot_engine(self) -> Iterator[Engine]:
+        """A fresh engine with the undo-snapshot test library registered.
+
+        Confirms the UndoManager wires the (default) snapshot session.
+        """
+        from griptape_nodes.node_library.library_registry import LibraryRegistry
+
+        LibraryRegistry._clear()
+        engine = current_engine()
+        assert isinstance(engine.undo_manager._recording, SnapshotRecordingSession)
+        self._register_library()
+        yield engine
+        LibraryRegistry._clear()
+
+    def _register_library(self) -> None:
+        from griptape_nodes.node_library.library_registry import (
+            LibraryMetadata,
+            LibraryRegistry,
+            LibrarySchema,
+            NodeMetadata,
+        )
+
+        schema = LibrarySchema(
+            name=self._LIBRARY_NAME,
+            library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+            metadata=LibraryMetadata(
+                author="t", description="d", library_version="1.0.0", engine_version="1.0.0", tags=[]
+            ),
+            categories=[],
+            nodes=[],
+        )
+        library = LibraryRegistry.generate_new_library(library_data=schema)
+        library.register_new_node_type(_ProbeNode, NodeMetadata(category="t", description="d", display_name="Probe"))
+
+    def _make_flow(self, griptape_nodes: Engine) -> str:
+        from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
+        from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowMetadata
+
+        context_manager = griptape_nodes.ContextManager()
+        if not context_manager.has_current_workflow():
+            workflow_key = "unsaved:undo-snapshot-test"
+            if workflow_key not in WorkflowRegistry._workflows:
+                metadata = WorkflowMetadata(
+                    name="Untitled",
+                    schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+                    engine_version_created_with="",
+                    node_libraries_referenced=[],
+                    creation_date=datetime.now(UTC),
+                )
+                WorkflowRegistry.generate_new_workflow(registry_key=workflow_key, metadata=metadata, file_path=None)
+            context_manager.push_workflow(workflow_name=workflow_key)
+        create_result = griptape_nodes.handle_request(CreateFlowRequest(parent_flow_name=None))
+        assert isinstance(create_result, CreateFlowResultSuccess)
+        return create_result.flow_name
+
+    @staticmethod
+    def _user_request(request: RequestPayload, request_id: str = "test-request") -> ResultPayload:
+        event_manager = GriptapeNodes.EventManager()
+        return event_manager.handle_request(request, result_context={"request_id": request_id}).result
+
+    def _create_node(self, flow_name: str, node_name: str | None = None) -> str:
+        result = self._user_request(
+            CreateNodeRequest(
+                node_type=self._NODE_TYPE,
+                specific_library_name=self._LIBRARY_NAME,
+                node_name=node_name,
+                override_parent_flow_name=flow_name,
+            )
+        )
+        assert isinstance(result, CreateNodeResultSuccess)
+        return result.node_name
+
+    @staticmethod
+    def _patch_handler(
+        monkeypatch: pytest.MonkeyPatch,
+        request_type: type[RequestPayload],
+        handler: Callable[[RequestPayload], ResultPayload],
+    ) -> None:
+        """Replace the EventManager's dispatch-table entry for request_type with a stand-in handler.
+
+        FlowManager/NodeManager hand `assign_manager_to_request_type` their already-bound method at
+        construction time, so monkeypatching the manager's method attribute afterward is a no-op: the
+        dispatch table holds a fixed reference to that original bound method, not a live attribute
+        lookup. The dispatch-table entry itself is looked up fresh per dispatch, so replacing it here
+        is the only way to observe a stand-in handler.
+        """
+        monkeypatch.setitem(GriptapeNodes.EventManager()._request_type_to_manager, request_type, handler)
+
+    # ---------- End-to-end via the snapshot session ----------
+
+    def test_undo_restores_prior_whole_flow_state(self, snapshot_engine: Engine) -> None:
+        flow_name = self._make_flow(snapshot_engine)
+        self._create_node(flow_name, node_name="ProbeA")
+        self._create_node(flow_name, node_name="ProbeB")
+
+        # Undo the second creation: the flow is restored to the snapshot taken before it.
+        undo_result = GriptapeNodes.handle_request(UndoRequest())
+        assert isinstance(undo_result, UndoResultSuccess)
+        assert GriptapeNodes.ObjectManager().has_object_with_name("ProbeA")
+        assert not GriptapeNodes.ObjectManager().has_object_with_name("ProbeB")
+
+        # Redo re-applies the after-snapshot.
+        redo_result = GriptapeNodes.handle_request(RedoRequest())
+        assert isinstance(redo_result, RedoResultSuccess)
+        assert GriptapeNodes.ObjectManager().has_object_with_name("ProbeA")
+        assert GriptapeNodes.ObjectManager().has_object_with_name("ProbeB")
+
+    def test_undo_restores_parameter_value(self, snapshot_engine: Engine) -> None:
+        flow_name = self._make_flow(snapshot_engine)
+        self._create_node(flow_name, node_name="ProbeA")
+        assert self._user_request(
+            SetParameterValueRequest(node_name="ProbeA", parameter_name="text", value="hello")
+        ).succeeded()
+
+        assert isinstance(GriptapeNodes.handle_request(UndoRequest()), UndoResultSuccess)
+        value_result = GriptapeNodes.handle_request(GetParameterValueRequest(node_name="ProbeA", parameter_name="text"))
+        assert isinstance(value_result, GetParameterValueResultSuccess)
+        assert value_result.value == ""
+
+    def test_undo_restores_connection(self, snapshot_engine: Engine) -> None:
+        flow_name = self._make_flow(snapshot_engine)
+        self._create_node(flow_name, node_name="Source")
+        self._create_node(flow_name, node_name="Target")
+        assert isinstance(
+            self._user_request(
+                CreateConnectionRequest(
+                    source_node_name="Source",
+                    source_parameter_name="text",
+                    target_node_name="Target",
+                    target_parameter_name="text",
+                )
+            ),
+            CreateConnectionResultSuccess,
+        )
+
+        def connected() -> bool:
+            incoming = GriptapeNodes.FlowManager().get_connections().incoming_index.get("Target", {})
+            return "text" in incoming
+
+        assert connected()
+        assert isinstance(GriptapeNodes.handle_request(UndoRequest()), UndoResultSuccess)
+        assert not connected()
+
+    def test_transaction_groups_into_one_snapshot(self, snapshot_engine: Engine) -> None:
+        flow_name = self._make_flow(snapshot_engine)
+        undo_manager = GriptapeNodes.UndoManager()
+
+        with undo_manager.transaction("Add pair"):
+            snapshot_engine.handle_request(
+                CreateNodeRequest(
+                    node_type=self._NODE_TYPE,
+                    specific_library_name=self._LIBRARY_NAME,
+                    node_name="Pair1",
+                    override_parent_flow_name=flow_name,
+                )
+            )
+            snapshot_engine.handle_request(
+                CreateNodeRequest(
+                    node_type=self._NODE_TYPE,
+                    specific_library_name=self._LIBRARY_NAME,
+                    node_name="Pair2",
+                    override_parent_flow_name=flow_name,
+                )
+            )
+
+        state = GriptapeNodes.handle_request(GetUndoStateRequest())
+        assert isinstance(state, GetUndoStateResultSuccess)
+        assert state.undo_labels == ["Add pair"]
+
+        assert isinstance(GriptapeNodes.handle_request(UndoRequest()), UndoResultSuccess)
+        assert not GriptapeNodes.ObjectManager().has_object_with_name("Pair1")
+        assert not GriptapeNodes.ObjectManager().has_object_with_name("Pair2")
+
+    # ---------- Reconcile (surgical restore, not teardown/rebuild) ----------
+
+    def test_undo_value_edit_reconciles_survivors_in_place(self, snapshot_engine: Engine) -> None:
+        """Undoing a value edit updates only the changed node; survivors keep their instance identity."""
+        flow_name = self._make_flow(snapshot_engine)
+        self._create_node(flow_name, node_name="ProbeA")
+        self._create_node(flow_name, node_name="ProbeB")
+        assert self._user_request(
+            SetParameterValueRequest(node_name="ProbeB", parameter_name="text", value="hello")
+        ).succeeded()
+
+        obj = GriptapeNodes.ObjectManager()
+        node_a_before = obj.attempt_get_object_by_name_as_type("ProbeA", BaseNode)
+        node_b_before = obj.attempt_get_object_by_name_as_type("ProbeB", BaseNode)
+
+        assert isinstance(GriptapeNodes.handle_request(UndoRequest()), UndoResultSuccess)
+
+        # Neither node was deleted/recreated: the restore reconciled in place (no teardown blink).
+        assert obj.attempt_get_object_by_name_as_type("ProbeA", BaseNode) is node_a_before
+        assert obj.attempt_get_object_by_name_as_type("ProbeB", BaseNode) is node_b_before
+        value_result = GriptapeNodes.handle_request(GetParameterValueRequest(node_name="ProbeB", parameter_name="text"))
+        assert isinstance(value_result, GetParameterValueResultSuccess)
+        assert value_result.value == ""
+
+    def test_undo_delete_recreates_only_changed_node(self, snapshot_engine: Engine) -> None:
+        """Undoing a delete recreates the removed node while leaving untouched survivors intact."""
+        flow_name = self._make_flow(snapshot_engine)
+        self._create_node(flow_name, node_name="ProbeA")
+        self._create_node(flow_name, node_name="ProbeB")
+
+        obj = GriptapeNodes.ObjectManager()
+        node_a_before = obj.attempt_get_object_by_name_as_type("ProbeA", BaseNode)
+
+        assert self._user_request(DeleteNodeRequest(node_name="ProbeB")).succeeded()
+        assert isinstance(GriptapeNodes.handle_request(UndoRequest()), UndoResultSuccess)
+
+        # A was never touched (same instance); only B was recreated.
+        assert obj.attempt_get_object_by_name_as_type("ProbeA", BaseNode) is node_a_before
+        assert obj.attempt_get_object_by_name_as_type("ProbeB", BaseNode) is not None
+
+    # ---------- Editor mutations that a snapshot captures as their own steps ----------
+
+    def test_node_move_is_its_own_undo_step(self, snapshot_engine: Engine) -> None:
+        """A node move is captured as its own snapshot step and is undoable.
+
+        A move only changes node metadata, so it is easy to mistake for something the undo system can
+        skip. Skipping it means moves cannot be undone, and an unrelated undo silently discards them.
+        """
+        flow_name = self._make_flow(snapshot_engine)
+        create_result = self._user_request(
+            CreateNodeRequest(
+                node_type=self._NODE_TYPE,
+                specific_library_name=self._LIBRARY_NAME,
+                node_name="ProbeA",
+                override_parent_flow_name=flow_name,
+                metadata={"position": {"x": 10, "y": 20}},
+            )
+        )
+        assert isinstance(create_result, CreateNodeResultSuccess)
+        obj = GriptapeNodes.ObjectManager()
+        node = obj.attempt_get_object_by_name_as_type("ProbeA", BaseNode)
+        assert node is not None
+        original_position = copy.deepcopy(node.metadata.get("position"))
+
+        moved_metadata = {**copy.deepcopy(node.metadata), "position": {"x": 500, "y": 600}}
+        assert self._user_request(SetNodeMetadataRequest(node_name="ProbeA", metadata=moved_metadata)).succeeded()
+        assert node.metadata.get("position") == {"x": 500, "y": 600}
+
+        state = GriptapeNodes.handle_request(GetUndoStateRequest())
+        assert isinstance(state, GetUndoStateResultSuccess)
+        assert len(state.undo_labels) == 2  # create + move  # noqa: PLR2004
+
+        assert isinstance(GriptapeNodes.handle_request(UndoRequest()), UndoResultSuccess)
+        node_after = obj.attempt_get_object_by_name_as_type("ProbeA", BaseNode)
+        assert node_after is not None
+        assert node_after.metadata.get("position") == original_position
+
+    def test_undo_edit_preserves_an_earlier_move(self, snapshot_engine: Engine) -> None:
+        """Undoing a value edit reverts only the edit; an earlier move stays applied."""
+        flow_name = self._make_flow(snapshot_engine)
+        self._create_node(flow_name, node_name="ProbeA")
+        obj = GriptapeNodes.ObjectManager()
+        node = obj.attempt_get_object_by_name_as_type("ProbeA", BaseNode)
+        assert node is not None
+
+        moved_metadata = {**copy.deepcopy(node.metadata), "position": {"x": 500, "y": 600}}
+        assert self._user_request(SetNodeMetadataRequest(node_name="ProbeA", metadata=moved_metadata)).succeeded()
+        assert self._user_request(
+            SetParameterValueRequest(node_name="ProbeA", parameter_name="text", value="hello")
+        ).succeeded()
+
+        assert isinstance(GriptapeNodes.handle_request(UndoRequest()), UndoResultSuccess)
+        node_after = obj.attempt_get_object_by_name_as_type("ProbeA", BaseNode)
+        assert node_after is not None
+        assert node_after.metadata.get("position") == {"x": 500, "y": 600}
+        value_result = GriptapeNodes.handle_request(GetParameterValueRequest(node_name="ProbeA", parameter_name="text"))
+        assert isinstance(value_result, GetParameterValueResultSuccess)
+        assert value_result.value == ""
+
+    def test_undo_clears_first_time_value_on_none_default_param(self, snapshot_engine: Engine) -> None:
+        """Undoing the first set of a None-default parameter clears it (it had no snapshot command)."""
+        flow_name = self._make_flow(snapshot_engine)
+        self._create_node(flow_name, node_name="ProbeA")
+        assert self._user_request(
+            SetParameterValueRequest(node_name="ProbeA", parameter_name="opt", value="set-once")
+        ).succeeded()
+
+        assert isinstance(GriptapeNodes.handle_request(UndoRequest()), UndoResultSuccess)
+        value_result = GriptapeNodes.handle_request(GetParameterValueRequest(node_name="ProbeA", parameter_name="opt"))
+        assert isinstance(value_result, GetParameterValueResultSuccess)
+        assert value_result.value is None
+
+    def test_unrelated_undo_preserves_other_node_value(self, snapshot_engine: Engine) -> None:
+        """Undoing one node's move must not clear a value set on a different, untouched node.
+
+        Guards the reconcile clear-path: it runs over every survivor, and must only clear values
+        added since the snapshot, never a value that was already present.
+        """
+        flow_name = self._make_flow(snapshot_engine)
+        self._create_node(flow_name, node_name="ProbeA")
+        self._create_node(flow_name, node_name="ProbeB")
+        assert self._user_request(
+            SetParameterValueRequest(node_name="ProbeB", parameter_name="text", value="keepB")
+        ).succeeded()
+
+        obj = GriptapeNodes.ObjectManager()
+        node_a = obj.attempt_get_object_by_name_as_type("ProbeA", BaseNode)
+        assert node_a is not None
+        moved_metadata = {**copy.deepcopy(node_a.metadata), "position": {"x": 500, "y": 600}}
+        assert self._user_request(SetNodeMetadataRequest(node_name="ProbeA", metadata=moved_metadata)).succeeded()
+
+        # Undo the move on A; B's value is unrelated and must survive the reconcile over B.
+        assert isinstance(GriptapeNodes.handle_request(UndoRequest()), UndoResultSuccess)
+        value_result = GriptapeNodes.handle_request(GetParameterValueRequest(node_name="ProbeB", parameter_name="text"))
+        assert isinstance(value_result, GetParameterValueResultSuccess)
+        assert value_result.value == "keepB"
+
+    def test_undo_restores_value_on_a_node_that_ends_locked(self, snapshot_engine: Engine) -> None:
+        """Undo restores a value even when the batch also locked the node (unlock happens first).
+
+        Order matters in the reconcile: a locked node rejects value sets, so applying values before
+        restoring lock state leaves stale post-edit values behind after an undo.
+        """
+        flow_name = self._make_flow(snapshot_engine)
+        self._create_node(flow_name, node_name="ProbeA")
+        undo_manager = GriptapeNodes.UndoManager()
+
+        # One undoable batch that both sets a value and locks the node.
+        with undo_manager.transaction("Edit and lock"):
+            snapshot_engine.handle_request(
+                SetParameterValueRequest(node_name="ProbeA", parameter_name="text", value="hello")
+            )
+            snapshot_engine.handle_request(SetLockNodeStateRequest(node_name="ProbeA", lock=True))
+
+        obj = GriptapeNodes.ObjectManager()
+        node = obj.attempt_get_object_by_name_as_type("ProbeA", BaseNode)
+        assert node is not None
+        assert node.lock is True
+
+        assert isinstance(GriptapeNodes.handle_request(UndoRequest()), UndoResultSuccess)
+        # The node must be unlocked again and its value reverted (the reconcile unlocks before setting).
+        assert node.lock is False
+        value_result = GriptapeNodes.handle_request(GetParameterValueRequest(node_name="ProbeA", parameter_name="text"))
+        assert isinstance(value_result, GetParameterValueResultSuccess)
+        assert value_result.value == ""
+
+        # Redo re-applies the after-snapshot against the now unlocked+empty node, exercising the
+        # unlock-during-restore-then-relock branch: the value is set while unlocked, then relocked.
+        assert isinstance(GriptapeNodes.handle_request(RedoRequest()), RedoResultSuccess)
+        assert node.lock is True
+        redo_value = GriptapeNodes.handle_request(GetParameterValueRequest(node_name="ProbeA", parameter_name="text"))
+        assert isinstance(redo_value, GetParameterValueResultSuccess)
+        assert redo_value.value == "hello"
+
+    def test_undo_restores_a_renamed_node(self, snapshot_engine: Engine) -> None:
+        """Undoing a rename brings the old name back, via delete+recreate since nodes are matched by name."""
+        flow_name = self._make_flow(snapshot_engine)
+        self._create_node(flow_name, node_name="ProbeA")
+        assert self._user_request(
+            SetParameterValueRequest(node_name="ProbeA", parameter_name="text", value="kept")
+        ).succeeded()
+        assert self._user_request(RenameObjectRequest(object_name="ProbeA", requested_name="Renamed")).succeeded()
+
+        obj = GriptapeNodes.ObjectManager()
+        assert obj.has_object_with_name("Renamed")
+        assert not obj.has_object_with_name("ProbeA")
+
+        assert isinstance(GriptapeNodes.handle_request(UndoRequest()), UndoResultSuccess)
+        assert obj.has_object_with_name("ProbeA")
+        assert not obj.has_object_with_name("Renamed")
+        value = GriptapeNodes.handle_request(GetParameterValueRequest(node_name="ProbeA", parameter_name="text"))
+        assert isinstance(value, GetParameterValueResultSuccess)
+        assert value.value == "kept"
+
+    def test_undo_restores_flow_metadata(self, snapshot_engine: Engine) -> None:
+        """Changing the flow's own properties is undoable: the snapshot carries the flow's metadata.
+
+        The serialized commands omit it (they are captured without a create-flow command, which is
+        what carries it), so the flow's metadata is captured alongside them.
+        """
+        flow_name = self._make_flow(snapshot_engine)
+        assert self._user_request(SetFlowMetadataRequest(flow_name=flow_name, metadata={"note": "before"})).succeeded()
+        assert self._user_request(SetFlowMetadataRequest(flow_name=flow_name, metadata={"note": "after"})).succeeded()
+
+        flow = GriptapeNodes.FlowManager().get_flow_by_name(flow_name)
+        assert flow.metadata["note"] == "after"
+
+        assert isinstance(GriptapeNodes.handle_request(UndoRequest()), UndoResultSuccess)
+        assert flow.metadata["note"] == "before"
+
+        assert isinstance(GriptapeNodes.handle_request(RedoRequest()), RedoResultSuccess)
+        assert flow.metadata["note"] == "after"
+
+    def test_undo_survives_a_top_level_flow_rename(self, snapshot_engine: Engine) -> None:
+        """An edit recorded before the top-level flow was renamed is still undoable afterward.
+
+        Restore resolves the top-level flow by its status rather than by the name the snapshot
+        captured, so a rename in between does not fail the replay and take the whole undo history
+        down with it. Drains the stack instead of assuming a batch count, since whether the rename
+        itself is recorded depends on capture succeeding after it.
+        """
+        flow_name = self._make_flow(snapshot_engine)
+        self._create_node(flow_name, node_name="ProbeA")
+        assert self._user_request(RenameObjectRequest(object_name=flow_name, requested_name="RenamedFlow")).succeeded()
+
+        while True:
+            state = GriptapeNodes.handle_request(GetUndoStateRequest())
+            assert isinstance(state, GetUndoStateResultSuccess)
+            if not state.undo_labels:
+                break
+            assert isinstance(GriptapeNodes.handle_request(UndoRequest()), UndoResultSuccess)
+
+        assert not GriptapeNodes.ObjectManager().has_object_with_name("ProbeA")
+
+    def test_undo_entries_are_labeled_by_their_operation(self, snapshot_engine: Engine) -> None:
+        """Each entry is named for the operation that opened it, so the stack says what it will revert.
+
+        This is what makes a multi-request gesture legible: a client that creates a node and then
+        writes its metadata produces two entries, and the labels show that the first undo reverts the
+        move rather than the creation.
+        """
+        flow_name = self._make_flow(snapshot_engine)
+        self._create_node(flow_name, node_name="ProbeA")
+        assert self._user_request(
+            SetNodeMetadataRequest(node_name="ProbeA", metadata={"position": {"x": 120, "y": 40}})
+        ).succeeded()
+
+        state = GriptapeNodes.handle_request(GetUndoStateRequest())
+        assert isinstance(state, GetUndoStateResultSuccess)
+        assert state.undo_labels == ["Create node", "Move node"]
+
+        undo_result = GriptapeNodes.handle_request(UndoRequest())
+        assert isinstance(undo_result, UndoResultSuccess)
+        assert undo_result.undone_label == "Move node"
+        # The node survives the first undo: only its position was reverted.
+        assert GriptapeNodes.ObjectManager().has_object_with_name("ProbeA")
+
+        undo_result = GriptapeNodes.handle_request(UndoRequest())
+        assert isinstance(undo_result, UndoResultSuccess)
+        assert undo_result.undone_label == "Create node"
+        assert not GriptapeNodes.ObjectManager().has_object_with_name("ProbeA")
+
+    # ---------- Fail-closed capture ----------
+
+    def test_capture_failure_makes_the_action_not_undoable(
+        self, snapshot_engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A capture failure degrades the edit to not-undoable; it must never fail the edit itself."""
+        flow_name = self._make_flow(snapshot_engine)
+        self._patch_handler(
+            monkeypatch,
+            SerializeFlowToCommandsRequest,
+            lambda _request: SerializeFlowToCommandsResultFailure(result_details="forced failure"),
+        )
+        self._create_node(flow_name, node_name="ProbeA")
+
+        assert self._user_request(
+            SetParameterValueRequest(node_name="ProbeA", parameter_name="text", value="hello")
+        ).succeeded()
+
+        state = GriptapeNodes.handle_request(GetUndoStateRequest())
+        assert isinstance(state, GetUndoStateResultSuccess)
+        assert state.undo_labels == []
+
+    # ---------- Fail-closed framing / replay ----------
+
+    def test_handler_raising_mid_frame_records_no_batch(
+        self, snapshot_engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A frame whose handler raised without changing anything must commit nothing.
+
+        The complement of test_dispatch_raising_after_a_nested_mutation_commits_the_partial_edit:
+        nothing altered state before the raise, so there is no partial edit to keep.
+        """
+        flow_name = self._make_flow(snapshot_engine)
+        # Dispatched without a request_id, so this setup step is itself not recorded, leaving the
+        # undo stack empty going into the raising dispatch below.
+        snapshot_engine.handle_request(
+            CreateNodeRequest(
+                node_type=self._NODE_TYPE,
+                specific_library_name=self._LIBRARY_NAME,
+                node_name="ProbeA",
+                override_parent_flow_name=flow_name,
+            )
+        )
+
+        def _raise(_request: RequestPayload) -> ResultPayload:
+            msg = "boom"
+            raise RuntimeError(msg)
+
+        self._patch_handler(monkeypatch, SetNodeMetadataRequest, _raise)
+
+        with pytest.raises(RuntimeError):
+            self._user_request(SetNodeMetadataRequest(node_name="ProbeA", metadata={"position": {"x": 1, "y": 2}}))
+
+        state = GriptapeNodes.handle_request(GetUndoStateRequest())
+        assert isinstance(state, GetUndoStateResultSuccess)
+        assert state.undo_labels == []
+
+    def test_transaction_exception_still_commits_the_partial_edit(self, snapshot_engine: Engine) -> None:
+        """A raise inside a transaction commits what the block managed to change, so undo can back it out.
+
+        The after-snapshot is taken from live state, so it records the partial mutation faithfully;
+        discarding it instead would leave the half-applied edit stuck.
+        """
+        flow_name = self._make_flow(snapshot_engine)
+        self._create_node(flow_name, node_name="ProbeA")
+
+        undo_manager = GriptapeNodes.UndoManager()
+
+        def _mutate_then_raise() -> None:
+            with undo_manager.transaction("Boom"):
+                snapshot_engine.handle_request(
+                    CreateNodeRequest(
+                        node_type=self._NODE_TYPE,
+                        specific_library_name=self._LIBRARY_NAME,
+                        node_name="ProbeC",
+                        override_parent_flow_name=flow_name,
+                    )
+                )
+                msg = "boom"
+                raise RuntimeError(msg)
+
+        with pytest.raises(RuntimeError):
+            _mutate_then_raise()
+
+        assert GriptapeNodes.ObjectManager().has_object_with_name("ProbeC")
+        state = GriptapeNodes.handle_request(GetUndoStateRequest())
+        assert isinstance(state, GetUndoStateResultSuccess)
+        assert state.undo_labels[-1] == "Boom"
+
+        assert isinstance(GriptapeNodes.handle_request(UndoRequest()), UndoResultSuccess)
+        assert not GriptapeNodes.ObjectManager().has_object_with_name("ProbeC")
+
+    def test_dispatch_raising_after_a_nested_mutation_commits_the_partial_edit(
+        self, snapshot_engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The per-dispatch path treats a raise the same way transaction() does: the partial edit stays undoable."""
+        flow_name = self._make_flow(snapshot_engine)
+        self._create_node(flow_name, node_name="ProbeA")
+
+        def _mutate_then_raise(_request: RequestPayload) -> ResultPayload:
+            GriptapeNodes.handle_request(
+                SetParameterValueRequest(node_name="ProbeA", parameter_name="text", value="partial")
+            )
+            msg = "boom"
+            raise RuntimeError(msg)
+
+        self._patch_handler(monkeypatch, SetNodeMetadataRequest, _mutate_then_raise)
+
+        with pytest.raises(RuntimeError):
+            self._user_request(SetNodeMetadataRequest(node_name="ProbeA", metadata={"position": {"x": 1, "y": 2}}))
+
+        partial = GriptapeNodes.handle_request(GetParameterValueRequest(node_name="ProbeA", parameter_name="text"))
+        assert isinstance(partial, GetParameterValueResultSuccess)
+        assert partial.value == "partial"
+
+        assert isinstance(GriptapeNodes.handle_request(UndoRequest()), UndoResultSuccess)
+        reverted = GriptapeNodes.handle_request(GetParameterValueRequest(node_name="ProbeA", parameter_name="text"))
+        assert isinstance(reverted, GetParameterValueResultSuccess)
+        assert reverted.value == ""
+
+    def test_transaction_without_mutation_records_nothing(self, snapshot_engine: Engine) -> None:
+        """Transaction commits only if something inside it altered workflow state; an empty block pushes nothing."""
+        self._make_flow(snapshot_engine)
+        undo_manager = GriptapeNodes.UndoManager()
+
+        with undo_manager.transaction("No-op"):
+            pass
+
+        state = GriptapeNodes.handle_request(GetUndoStateRequest())
+        assert isinstance(state, GetUndoStateResultSuccess)
+        assert state.undo_labels == []
+
+    def test_clear_history_request_inside_open_frame_records_no_batch(self, snapshot_engine: Engine) -> None:
+        """A history-clearing lifecycle request seen mid-frame makes the frame finalize without committing."""
+        flow_name = self._make_flow(snapshot_engine)
+        self._create_node(flow_name, node_name="ProbeA")
+
+        state = GriptapeNodes.handle_request(GetUndoStateRequest())
+        assert isinstance(state, GetUndoStateResultSuccess)
+        assert state.undo_labels  # sanity: something to lose
+
+        undo_manager = GriptapeNodes.UndoManager()
+        with undo_manager.transaction("Mixed"):
+            snapshot_engine.handle_request(
+                CreateNodeRequest(
+                    node_type=self._NODE_TYPE,
+                    specific_library_name=self._LIBRARY_NAME,
+                    node_name="ProbeB",
+                    override_parent_flow_name=flow_name,
+                )
+            )
+            self._user_request(SetWorkflowContextRequest(workflow_name=None))
+
+        state = GriptapeNodes.handle_request(GetUndoStateRequest())
+        assert isinstance(state, GetUndoStateResultSuccess)
+        assert state.undo_labels == []
+        assert state.redo_labels == []
+
+    def test_overlapping_user_request_inside_open_frame_clears_history(
+        self, snapshot_engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A second externally-initiated request seen mid-frame drops both the frame and the history.
+
+        Only a nested dispatch can belong to an open frame, and a nested dispatch carries no
+        request_id. One that does is a separate gesture running at the same time, so folding it in
+        would record its edit as part of the open action.
+        """
+        flow_name = self._make_flow(snapshot_engine)
+        self._create_node(flow_name, node_name="ProbeA")
+
+        state = GriptapeNodes.handle_request(GetUndoStateRequest())
+        assert isinstance(state, GetUndoStateResultSuccess)
+        assert state.undo_labels  # sanity: something to lose
+
+        def _overlapping_gesture(_request: RequestPayload) -> ResultPayload:
+            self._user_request(
+                SetParameterValueRequest(node_name="ProbeA", parameter_name="text", value="other-gesture"),
+                request_id="other-request",
+            )
+            return SetNodeMetadataResultSuccess(result_details="stand-in metadata handler")
+
+        self._patch_handler(monkeypatch, SetNodeMetadataRequest, _overlapping_gesture)
+        assert self._user_request(
+            SetNodeMetadataRequest(node_name="ProbeA", metadata={"position": {"x": 1, "y": 2}})
+        ).succeeded()
+
+        state = GriptapeNodes.handle_request(GetUndoStateRequest())
+        assert isinstance(state, GetUndoStateResultSuccess)
+        assert state.undo_labels == []
+        assert state.redo_labels == []
+
+    def test_structural_restore_failure_clears_history_and_reports_failure(
+        self, snapshot_engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A structural replay failure (_require_success) surfaces as UndoResultFailure and clears all history."""
+        flow_name = self._make_flow(snapshot_engine)
+        self._create_node(flow_name, node_name="ProbeA")
+        self._create_node(flow_name, node_name="ProbeB")  # undoing this must DELETE it
+
+        self._patch_handler(
+            monkeypatch,
+            DeleteNodeRequest,
+            lambda _request: DeleteNodeResultFailure(result_details="forced failure"),
+        )
+
+        result = GriptapeNodes.handle_request(UndoRequest())
+        assert isinstance(result, UndoResultFailure)
+        assert "history has been cleared" in str(result.result_details).lower()
+
+        state = GriptapeNodes.handle_request(GetUndoStateRequest())
+        assert isinstance(state, GetUndoStateResultSuccess)
+        assert state.undo_labels == []
+        assert state.redo_labels == []
+
+    def test_undo_restores_a_deleted_connection(self, snapshot_engine: Engine) -> None:
+        """Undo recreates a deleted connection: the mirror of the removal branch other tests cover."""
+        flow_name = self._make_flow(snapshot_engine)
+        self._create_node(flow_name, node_name="Source")
+        self._create_node(flow_name, node_name="Target")
+        assert isinstance(
+            self._user_request(
+                CreateConnectionRequest(
+                    source_node_name="Source",
+                    source_parameter_name="text",
+                    target_node_name="Target",
+                    target_parameter_name="text",
+                )
+            ),
+            CreateConnectionResultSuccess,
+        )
+
+        def connected() -> bool:
+            incoming = GriptapeNodes.FlowManager().get_connections().incoming_index.get("Target", {})
+            return "text" in incoming
+
+        assert connected()
+        assert self._user_request(
+            DeleteConnectionRequest(
+                source_node_name="Source",
+                source_parameter_name="text",
+                target_node_name="Target",
+                target_parameter_name="text",
+            )
+        ).succeeded()
+        assert not connected()
+
+        assert isinstance(GriptapeNodes.handle_request(UndoRequest()), UndoResultSuccess)
+        assert connected()

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -18,11 +18,20 @@ if TYPE_CHECKING:
 
 from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.exe_types.node_types import NodeDependencies
-from griptape_nodes.node_library.workflow_registry import Workflow, WorkflowMetadata, WorkflowRegistry, WorkflowShape
+from griptape_nodes.node_library.workflow_registry import (
+    Workflow,
+    WorkflowMetadata,
+    WorkflowRegistry,
+    WorkflowShape,
+    read_workflow_metadata,
+)
 from griptape_nodes.retained_mode.engine import Engine
 from griptape_nodes.retained_mode.events.base_events import ResultDetails
 from griptape_nodes.retained_mode.events.flow_events import SerializedFlowCommands
 from griptape_nodes.retained_mode.events.workflow_events import (
+    BranchWorkflowRequest,
+    BranchWorkflowResultFailure,
+    BranchWorkflowResultSuccess,
     CreateWorkflowFromTemplateRequest,
     CreateWorkflowFromTemplateResultFailure,
     CreateWorkflowFromTemplateResultSuccess,
@@ -45,11 +54,16 @@ from griptape_nodes.retained_mode.events.workflow_events import (
     LoadWorkflowMetadata,
     LoadWorkflowMetadataResultFailure,
     LoadWorkflowMetadataResultSuccess,
+    MergeWorkflowBranchRequest,
+    MergeWorkflowBranchResultSuccess,
     MoveWorkflowRequest,
     MoveWorkflowResultFailure,
     MoveWorkflowResultSuccess,
+    RegisterWorkflowRequest,
     RegisterWorkflowResultFailure,
     RegisterWorkflowResultSuccess,
+    ResetWorkflowBranchRequest,
+    ResetWorkflowBranchResultSuccess,
     SetWorkflowMetadataRequest,
     SetWorkflowMetadataResultSuccess,
     WorkflowDependencyInfo,
@@ -4508,3 +4522,348 @@ class TestSaveWorkflowOverwriteProtection:
 
             assert isinstance(result, SaveWorkflowResultSuccess)
             assert victim_path.read_text() != "# theirs"
+
+
+class TestWorkflowBranchDisplayNames:
+    """Regression coverage: a branch's ``metadata.name`` must be a title, not a registry key.
+
+    A registry key is a file path (``shots/sh010/comp``); ``metadata.name`` is the human-readable
+    label the editor shows. Three sites used to write the key into the label, so any branch of a
+    workflow living in a subdirectory read as a file path in the UI. Two of them overwrote a
+    previously-correct label and persisted it to disk, so each test asserts the registry entry *and*
+    the on-disk header.
+
+    Driven through ``GriptapeNodes.handle_request`` with real files in a real temp workspace, since
+    the persisted header is half the bug.
+    """
+
+    SOURCE_KEY = "shots/sh010/comp"
+    SOURCE_DISPLAY_NAME = "Shot 010 Comp"
+
+    @pytest.fixture
+    def temp_dir(self, tmp_path: Path) -> Path:
+        return tmp_path.resolve()
+
+    @pytest.fixture(autouse=True)
+    def workspace(self, temp_dir: Path, griptape_nodes: Engine) -> "Generator[None, None, None]":
+        """Point the workspace at a temp dir so registry keys resolve to real files."""
+        original_workspace = griptape_nodes.ConfigManager().workspace_path
+        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        with patch.dict(WorkflowRegistry._workflows, {}, clear=True):
+            yield
+        griptape_nodes.ConfigManager().workspace_path = original_workspace
+
+    @staticmethod
+    def _register_workflow(griptape_nodes: Engine, temp_dir: Path, *, registry_key: str, display_name: str) -> Path:
+        """Write a workflow file carrying a real metadata header and register it."""
+        metadata = WorkflowMetadata(
+            name=display_name,
+            schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+            engine_version_created_with="test",
+            node_libraries_referenced=[],
+            creation_date=datetime.now(UTC),
+        )
+        header = griptape_nodes.WorkflowManager()._generate_workflow_metadata_header(metadata)
+        assert header is not None
+
+        relative_file_path = f"{registry_key}.py"
+        file_path = temp_dir / relative_file_path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(f"{header}\n\nprint('body')\n", encoding="utf-8")
+
+        WorkflowRegistry.generate_new_workflow(
+            registry_key=registry_key, metadata=metadata, file_path=relative_file_path
+        )
+        return file_path
+
+    @staticmethod
+    def _persisted_display_name(temp_dir: Path, registry_key: str) -> str:
+        """Read ``metadata.name`` back out of the workflow file on disk."""
+        return read_workflow_metadata(temp_dir / f"{registry_key}.py").name
+
+    def _register_source(self, griptape_nodes: Engine, temp_dir: Path) -> Path:
+        return self._register_workflow(
+            griptape_nodes, temp_dir, registry_key=self.SOURCE_KEY, display_name=self.SOURCE_DISPLAY_NAME
+        )
+
+    def test_branch_of_nested_workflow_gets_readable_display_name(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+        """The reported bug: the branch's label was the full registry key path.
+
+        The key still carries the directories (it is a file path), but the label is derived from the
+        source's display name.
+        """
+        self._register_source(griptape_nodes, temp_dir)
+
+        result = GriptapeNodes.handle_request(BranchWorkflowRequest(workflow_name=self.SOURCE_KEY))
+
+        assert isinstance(result, BranchWorkflowResultSuccess)
+        branch_key = result.branched_workflow_name
+        assert branch_key == "shots/sh010/comp_branch_1"
+
+        branch = WorkflowRegistry.get_workflow_by_name(branch_key)
+        assert branch.metadata.name == "Shot 010 Comp (branch 1)"
+        assert self._persisted_display_name(temp_dir, branch_key) == "Shot 010 Comp (branch 1)"
+        # The branch relationship is keyed on the registry key, not the label.
+        assert branch.metadata.branched_from == self.SOURCE_KEY
+
+    def test_branch_leaves_source_display_name_alone(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+        """Branching must not touch the source's label."""
+        self._register_source(griptape_nodes, temp_dir)
+
+        result = GriptapeNodes.handle_request(BranchWorkflowRequest(workflow_name=self.SOURCE_KEY))
+
+        assert isinstance(result, BranchWorkflowResultSuccess)
+        source = WorkflowRegistry.get_workflow_by_name(self.SOURCE_KEY)
+        assert source.metadata.name == self.SOURCE_DISPLAY_NAME
+        assert self._persisted_display_name(temp_dir, self.SOURCE_KEY) == self.SOURCE_DISPLAY_NAME
+
+    def test_branch_counter_stays_in_step_with_registry_key(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+        """The label's counter tracks the key's counter, so branches stay distinguishable."""
+        self._register_source(griptape_nodes, temp_dir)
+
+        first = GriptapeNodes.handle_request(BranchWorkflowRequest(workflow_name=self.SOURCE_KEY))
+        second = GriptapeNodes.handle_request(BranchWorkflowRequest(workflow_name=self.SOURCE_KEY))
+
+        assert isinstance(first, BranchWorkflowResultSuccess)
+        assert isinstance(second, BranchWorkflowResultSuccess)
+        assert first.branched_workflow_name == "shots/sh010/comp_branch_1"
+        assert second.branched_workflow_name == "shots/sh010/comp_branch_2"
+        assert WorkflowRegistry.get_workflow_by_name(first.branched_workflow_name).metadata.name == (
+            "Shot 010 Comp (branch 1)"
+        )
+        assert WorkflowRegistry.get_workflow_by_name(second.branched_workflow_name).metadata.name == (
+            "Shot 010 Comp (branch 2)"
+        )
+
+    def test_branch_uses_explicit_display_name_when_provided(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+        """A caller-supplied label wins over the derivation, and is stripped."""
+        self._register_source(griptape_nodes, temp_dir)
+
+        result = GriptapeNodes.handle_request(
+            BranchWorkflowRequest(workflow_name=self.SOURCE_KEY, branched_workflow_display_name="  Lighting Test  ")
+        )
+
+        assert isinstance(result, BranchWorkflowResultSuccess)
+        branch_key = result.branched_workflow_name
+        assert WorkflowRegistry.get_workflow_by_name(branch_key).metadata.name == "Lighting Test"
+        assert self._persisted_display_name(temp_dir, branch_key) == "Lighting Test"
+
+    def test_branch_rejects_blank_display_name(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+        """A whitespace-only label would leave the branch looking nameless, so refuse it."""
+        self._register_source(griptape_nodes, temp_dir)
+
+        result = GriptapeNodes.handle_request(
+            BranchWorkflowRequest(workflow_name=self.SOURCE_KEY, branched_workflow_display_name="   ")
+        )
+
+        assert isinstance(result, BranchWorkflowResultFailure)
+        assert "empty display name" in str(result.result_details)
+        # Nothing was created.
+        assert WorkflowRegistry.get_branches_of_workflow(self.SOURCE_KEY) == []
+
+    def test_branch_with_caller_supplied_key_labels_from_final_segment(
+        self, griptape_nodes: Engine, temp_dir: Path
+    ) -> None:
+        """When the caller picks the key, its last segment is the label -- never the whole path."""
+        self._register_source(griptape_nodes, temp_dir)
+
+        result = GriptapeNodes.handle_request(
+            BranchWorkflowRequest(workflow_name=self.SOURCE_KEY, branched_workflow_name="shots/sh010/my_experiment")
+        )
+
+        assert isinstance(result, BranchWorkflowResultSuccess)
+        branch_key = result.branched_workflow_name
+        assert branch_key == "shots/sh010/my_experiment"
+        assert WorkflowRegistry.get_workflow_by_name(branch_key).metadata.name == "my_experiment"
+        assert self._persisted_display_name(temp_dir, branch_key) == "my_experiment"
+
+    def test_branch_of_path_shaped_label_does_not_propagate_the_path(
+        self, griptape_nodes: Engine, temp_dir: Path
+    ) -> None:
+        """Branches created before this fix carry their key as their label; don't carry it forward."""
+        self._register_workflow(
+            griptape_nodes,
+            temp_dir,
+            registry_key="shots/sh010/comp_branch_1",
+            display_name="shots/sh010/comp_branch_1",
+        )
+
+        result = GriptapeNodes.handle_request(BranchWorkflowRequest(workflow_name="shots/sh010/comp_branch_1"))
+
+        assert isinstance(result, BranchWorkflowResultSuccess)
+        branch_key = result.branched_workflow_name
+        assert WorkflowRegistry.get_workflow_by_name(branch_key).metadata.name == "comp_branch_1 (branch 1)"
+
+    def test_branch_falls_back_to_key_segment_when_source_label_blank(
+        self, griptape_nodes: Engine, temp_dir: Path
+    ) -> None:
+        """A corrupt (blank) source label falls back to the file name, not to emptiness."""
+        self._register_workflow(griptape_nodes, temp_dir, registry_key=self.SOURCE_KEY, display_name="   ")
+
+        result = GriptapeNodes.handle_request(BranchWorkflowRequest(workflow_name=self.SOURCE_KEY))
+
+        assert isinstance(result, BranchWorkflowResultSuccess)
+        branch_key = result.branched_workflow_name
+        assert WorkflowRegistry.get_workflow_by_name(branch_key).metadata.name == "comp (branch 1)"
+
+    def test_merge_preserves_source_display_name(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+        """Merging changes the source's contents, never its title.
+
+        This site read the branch's ``branched_from`` (a registry key) into the source's
+        ``metadata.name``, overwriting a correct label with a path and writing it to disk.
+        """
+        self._register_source(griptape_nodes, temp_dir)
+        branch_result = GriptapeNodes.handle_request(BranchWorkflowRequest(workflow_name=self.SOURCE_KEY))
+        assert isinstance(branch_result, BranchWorkflowResultSuccess)
+
+        merge_result = GriptapeNodes.handle_request(
+            MergeWorkflowBranchRequest(workflow_name=branch_result.branched_workflow_name)
+        )
+
+        assert isinstance(merge_result, MergeWorkflowBranchResultSuccess)
+        source = WorkflowRegistry.get_workflow_by_name(self.SOURCE_KEY)
+        assert source.metadata.name == self.SOURCE_DISPLAY_NAME
+        assert self._persisted_display_name(temp_dir, self.SOURCE_KEY) == self.SOURCE_DISPLAY_NAME
+
+    def test_reset_preserves_branch_display_name(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+        """Resetting discards the branch's content changes, not its title.
+
+        This site wrote the branch's own registry key into its ``metadata.name`` and persisted it,
+        so a reset silently renamed the branch to its file path.
+        """
+        self._register_source(griptape_nodes, temp_dir)
+        branch_result = GriptapeNodes.handle_request(
+            BranchWorkflowRequest(workflow_name=self.SOURCE_KEY, branched_workflow_display_name="Lighting Test")
+        )
+        assert isinstance(branch_result, BranchWorkflowResultSuccess)
+        branch_key = branch_result.branched_workflow_name
+
+        reset_result = GriptapeNodes.handle_request(ResetWorkflowBranchRequest(workflow_name=branch_key))
+
+        assert isinstance(reset_result, ResetWorkflowBranchResultSuccess)
+        assert WorkflowRegistry.get_workflow_by_name(branch_key).metadata.name == "Lighting Test"
+        assert self._persisted_display_name(temp_dir, branch_key) == "Lighting Test"
+
+
+class TestRepairPathShapedDisplayName:
+    """Workflows already on disk carry a registry key as their ``metadata.name``.
+
+    The pre-fix branch/merge/reset sites wrote the path-derived key into the display name and
+    persisted it, so those files are still out there. They carry the *current* schema version -- the
+    bug was never a schema change -- so registration keys on the damage itself: a display name that
+    exactly equals its own registry key.
+
+    Repair is in-memory. The file keeps the old header until its next save, so each test asserts the
+    registry entry shows the readable name while the file on disk is untouched.
+    """
+
+    @pytest.fixture
+    def temp_dir(self, tmp_path: Path) -> Path:
+        return tmp_path.resolve()
+
+    @pytest.fixture(autouse=True)
+    def workspace(self, temp_dir: Path, griptape_nodes: Engine) -> "Generator[None, None, None]":
+        original_workspace = griptape_nodes.ConfigManager().workspace_path
+        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        with patch.dict(WorkflowRegistry._workflows, {}, clear=True):
+            yield
+        griptape_nodes.ConfigManager().workspace_path = original_workspace
+
+    @staticmethod
+    def _write_and_register(
+        griptape_nodes: Engine, temp_dir: Path, *, relative_file_path: str, display_name: str
+    ) -> Path:
+        """Write a real workflow file with `display_name` in its header, then register it from disk."""
+        metadata = WorkflowMetadata(
+            name=display_name,
+            schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+            engine_version_created_with="test",
+            node_libraries_referenced=[],
+            creation_date=datetime.now(UTC),
+        )
+        header = griptape_nodes.WorkflowManager()._generate_workflow_metadata_header(metadata)
+        assert header is not None
+
+        file_path = temp_dir / relative_file_path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(f"{header}\n\nprint('body')\n", encoding="utf-8")
+
+        result = GriptapeNodes.handle_request(RegisterWorkflowRequest(metadata=metadata, file_name=relative_file_path))
+        assert isinstance(result, RegisterWorkflowResultSuccess)
+        return file_path
+
+    def test_legacy_branch_name_is_repaired_on_load(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+        """The reported symptom, loaded from a file a pre-fix build wrote."""
+        file_path = self._write_and_register(
+            griptape_nodes,
+            temp_dir,
+            relative_file_path="shots/sh010/comp_branch_1.py",
+            display_name="shots/sh010/comp_branch_1",
+        )
+
+        workflow = WorkflowRegistry.get_workflow_by_name("shots/sh010/comp_branch_1")
+        assert workflow.metadata.name == "comp_branch_1"
+        # In-memory only: the header on disk is deliberately left for the next save to rewrite.
+        assert read_workflow_metadata(file_path).name == "shots/sh010/comp_branch_1"
+
+    def test_legacy_merged_source_name_is_repaired_on_load(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+        """The merge site overwrote a *source* workflow's title with its key; same fingerprint."""
+        self._write_and_register(
+            griptape_nodes, temp_dir, relative_file_path="shots/sh010/comp.py", display_name="shots/sh010/comp"
+        )
+
+        assert WorkflowRegistry.get_workflow_by_name("shots/sh010/comp").metadata.name == "comp"
+
+    def test_deeper_nesting_keeps_only_the_final_segment(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+        """The deeper the folder structure the worse the old label read; only the file name survives."""
+        self._write_and_register(
+            griptape_nodes,
+            temp_dir,
+            relative_file_path="show/seq/shots/sh010/comp_branch_2.py",
+            display_name="show/seq/shots/sh010/comp_branch_2",
+        )
+
+        workflow = WorkflowRegistry.get_workflow_by_name("show/seq/shots/sh010/comp_branch_2")
+        assert workflow.metadata.name == "comp_branch_2"
+
+    def test_real_display_name_is_left_alone(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+        """A proper title never equals its own registry key, so it is never touched."""
+        self._write_and_register(
+            griptape_nodes,
+            temp_dir,
+            relative_file_path="shots/sh010/comp.py",
+            display_name="Shot 010 Comp",
+        )
+
+        assert WorkflowRegistry.get_workflow_by_name("shots/sh010/comp").metadata.name == "Shot 010 Comp"
+
+    def test_deliberate_separator_in_a_title_is_left_alone(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+        """Only exact key equality triggers repair -- a slash someone typed on purpose survives."""
+        self._write_and_register(
+            griptape_nodes,
+            temp_dir,
+            relative_file_path="shots/sh010/comp.py",
+            display_name="Lighting / Comp",
+        )
+
+        assert WorkflowRegistry.get_workflow_by_name("shots/sh010/comp").metadata.name == "Lighting / Comp"
+
+    def test_workspace_root_workflow_matching_its_stem_is_left_alone(
+        self, griptape_nodes: Engine, temp_dir: Path
+    ) -> None:
+        """Name == key with no directories is the normal unnamed-workflow case, not the bug."""
+        self._write_and_register(griptape_nodes, temp_dir, relative_file_path="my_flow.py", display_name="my_flow")
+
+        assert WorkflowRegistry.get_workflow_by_name("my_flow").metadata.name == "my_flow"
+
+    def test_repaired_workflow_branches_with_a_readable_label(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+        """The payoff: branching a legacy workflow no longer carries the path forward."""
+        self._write_and_register(
+            griptape_nodes, temp_dir, relative_file_path="shots/sh010/comp.py", display_name="shots/sh010/comp"
+        )
+
+        result = GriptapeNodes.handle_request(BranchWorkflowRequest(workflow_name="shots/sh010/comp"))
+
+        assert isinstance(result, BranchWorkflowResultSuccess)
+        branch = WorkflowRegistry.get_workflow_by_name(result.branched_workflow_name)
+        assert branch.metadata.name == "comp (branch 1)"


### PR DESCRIPTION
Turns undo on by declaring which node, flow, and object requests a snapshot can capture, and documents the feature for the editor shortcuts landing in griptape-vsl-gui. The policy guard test derives expectations from the engine's own routing table so an altering request cannot be silently left out.