### PR TITLE
feat: add loading_label to GetPublishOptionsResultSuccess

### DIFF
--- a/src/griptape_nodes/retained_mode/events/workflow_events.py
+++ b/src/griptape_nodes/retained_mode/events/workflow_events.py
@@ -547,11 +547,14 @@ class GetPublishOptionsResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSucce
         fields: Ordered list of fields to render in the publish dialog
         title: Optional dialog title (e.g. "Update Published Gizmo"). None uses the frontend default.
         button_label: Optional publish button label (e.g. "Update"). None uses the frontend default.
+        loading_label: Optional label shown while publishing is in progress (e.g. "Updating"). None
+            lets the frontend derive it from button_label automatically.
     """
 
     fields: list[PublishOptionField]
     title: str | None = None
     button_label: str | None = None
+    loading_label: str | None = None
 
 
 @dataclass


### PR DESCRIPTION
## Summary

- Adds `loading_label: str | None = None` to `GetPublishOptionsResultSuccess` in `workflow_events.py`
- Publishers can now supply an explicit in-progress label (e.g. `"Updating"`) instead of relying on the frontend to derive it from `button_label`
- Fully optional and backwards-compatible — engines that don't send it return `None`, triggering the frontend's auto-derive fallback

Closes https://github.com/griptape-ai/griptape-nodes-engine/issues/5371

## Test plan

- [ ] Verify `GetPublishOptionsResultSuccess` serializes `loading_label` correctly when set
- [ ] Verify `loading_label=None` (default) leaves frontend fallback behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)