### PR TITLE
fix: skip startup model downloads on library workers

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -903,12 +903,27 @@ class ModelManager(EngineScoped):
             query_info=query_info,
         )
 
-    async def on_app_initialization_complete(self, _payload: AppInitializationComplete) -> None:
+    async def on_app_initialization_complete(self, payload: AppInitializationComplete) -> None:
         """Handle app initialization complete event by downloading configured models and resuming unfinished downloads.
+
+        No-op on a worker. Workers share the orchestrator's config and model status
+        directory, so a worker that downloaded too would duplicate every transfer and
+        write the same status files the orchestrator is writing. Downloads land in the
+        shared cache either way, so a worker still finds the models it needs. Explicit
+        DownloadModelRequest handling is unaffected.
+
+        Worker identity comes from the payload rather than LibraryManager.is_worker
+        because both managers listen for this event and their tasks run concurrently:
+        LibraryManager assigns its flag partway through its own handler, so reading it
+        here would see the default False.
 
         Args:
             payload: The app initialization complete payload
         """
+        if payload.is_worker:
+            logger.debug("Worker process; the orchestrator owns startup model downloads")
+            return
+
         # Get models to download from configuration
         config_manager = self.engine.config_manager
         models_to_download = config_manager.get_config_value(MODELS_TO_DOWNLOAD_KEY, default=[])

--- a/tests/unit/retained_mode/managers/test_model_manager.py
+++ b/tests/unit/retained_mode/managers/test_model_manager.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from griptape_nodes.exe_types.node_types import BaseNode
+from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
 from griptape_nodes.retained_mode.events.base_events import RequestPayload
 from griptape_nodes.retained_mode.events.model_events import (
     DeclareModelInvocationRequest,
@@ -537,3 +538,40 @@ class TestDownloadModelTaskSubprocess:
 
         assert captured_cmd[3] == "download"
         assert "org/model" in captured_cmd
+
+
+class TestAppInitializationCompleteWorkerGuard:
+    """Startup model downloads belong to the orchestrator alone."""
+
+    @pytest.mark.asyncio
+    async def test_worker_skips_startup_downloads(self, model_manager: ModelManager) -> None:
+        """A worker must not scan or resume downloads.
+
+        Every worker shares the orchestrator's status directory. When workers resumed
+        too, they read those files while the orchestrator was writing them, which on
+        Windows surfaces as PermissionError from the writer's exclusive lock and took
+        down the whole AppInitializationComplete broadcast.
+        """
+        with (
+            patch.object(model_manager, "_find_unfinished_downloads") as find_unfinished,
+            patch.object(model_manager, "on_handle_download_model_request") as handle_download,
+        ):
+            await model_manager.on_app_initialization_complete(AppInitializationComplete(is_worker=True))
+
+        find_unfinished.assert_not_called()
+        handle_download.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_orchestrator_resumes_unfinished_downloads(self, model_manager: ModelManager) -> None:
+        """The orchestrator still resumes, so the guard cannot be read as "never resume"."""
+        engine = SimpleNamespace(config_manager=SimpleNamespace(get_config_value=lambda *_args, **_kwargs: []))
+
+        with (
+            patch.object(type(model_manager), "engine", property(lambda _self: engine)),
+            patch.object(model_manager, "_find_unfinished_downloads", return_value=["org/model"]) as find_unfinished,
+            patch.object(model_manager, "on_handle_download_model_request", new_callable=AsyncMock) as handle_download,
+        ):
+            await model_manager.on_app_initialization_complete(AppInitializationComplete(is_worker=False))
+
+        find_unfinished.assert_called_once()
+        assert handle_download.await_args_list[0].args[0].model_id == "org/model"


### PR DESCRIPTION
A library worker shares the orchestrator's config and model status directory, so every worker resumed the same downloads and read status files while the orchestrator was writing them. On Windows the writer's `portalocker` exclusive lock turns those concurrent reads into `PermissionError`, which aborted the entire `AppInitializationComplete` broadcast in that process.

Observed in a Windows session log (app v0.85.4, engine v0.98.0). Condensed from the rich-formatted traceback, with line numbers as they appear in the v0.98.0 bundle:

```
ERROR  Worker-966d6296 Background task failed

  griptape_nodes_app/app/app.py:917 in _process_app_event
    await griptape_nodes.abroadcast_app_event(...)
  griptape_nodes/retained_mode/engine.py:512 in abroadcast_app_event
  griptape_nodes/retained_mode/managers/event_manager.py:1020 in abroadcast_app_event
    async with asyncio.TaskGroup() as tg:
  asyncio/taskgroups.py:164 in _aexit

ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)

  Sub-exception #1:
    griptape_nodes/utils/async_utils.py:30 in call_function
    griptape_nodes/retained_mode/managers/model_manager.py:917 in on_app_initialization_complete
      unfinished_models = await asyncio.to_thread(self._find_unfinished_downloads)
    asyncio/threads.py:25 in to_thread
    griptape_nodes/retained_mode/managers/model_manager.py:1068 in _find_unfinished_downloads
      data = json.load(f)
    json/__init__.py:293 in load
      return loads(fp.read(), ...)

  PermissionError: [Errno 13] Permission denied
```

The read failed on `ByteDance-Seed--SeedVR2-7B.json`, the only status file present, which the orchestrator had been writing at up to 1 Hz since it began resuming that same model 4 minutes earlier. The failure surfaces at `fp.read()` rather than `open()` because Windows byte-range locks are mandatory, so the reader opens the file and then fails on the locked range.
