### PR TITLE
fix: contain app event listener failures

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -1362,7 +1362,7 @@ class EventManager(EngineScoped):
             async def _broadcast_async() -> None:
                 async with asyncio.TaskGroup() as tg:
                     for listener_callback in listener_set:
-                        tg.create_task(call_function(listener_callback, app_event))
+                        tg.create_task(self._call_app_event_listener(listener_callback, app_event))
 
             if _running_loop() is not None:
                 with ThreadRunner() as runner:
@@ -1382,7 +1382,31 @@ class EventManager(EngineScoped):
 
             async with asyncio.TaskGroup() as tg:
                 for listener_callback in listener_set:
-                    tg.create_task(call_function(listener_callback, app_event))
+                    tg.create_task(self._call_app_event_listener(listener_callback, app_event))
+
+    async def _call_app_event_listener(
+        self, listener_callback: Callable[[AP], None] | Callable[[AP], Awaitable[None]], app_event: AP
+    ) -> None:
+        """Run one app event listener, keeping its failure to itself.
+
+        Listeners are independent subsystems reacting to the same event, and they run as
+        siblings in a TaskGroup. A listener that raises would cancel every sibling that
+        had not finished yet, so one broken subsystem would silently skip the rest of the
+        app's reaction to the event. Broad by design: a listener is an arbitrary callback,
+        so there is no narrower type to catch here.
+
+        Args:
+            listener_callback: The listener to invoke.
+            app_event: The app event to pass to the listener.
+        """
+        try:
+            await call_function(listener_callback, app_event)
+        except Exception:
+            logging.getLogger("griptape_nodes").exception(
+                "App event listener '%s' failed handling '%s'. The remaining listeners still ran.",
+                getattr(listener_callback, "__qualname__", listener_callback),
+                type(app_event).__name__,
+            )
 
     def _flush_tracked_parameter_changes(self) -> None:
         obj_manager = self.engine.object_manager

--- a/tests/unit/retained_mode/managers/test_event_manager.py
+++ b/tests/unit/retained_mode/managers/test_event_manager.py
@@ -384,29 +384,31 @@ class TestBroadcastAppEventListenerIsolation:
         """
         event_manager = EventManager()
         completed: list[str] = []
+        failed = asyncio.Event()
 
         async def failing_listener(_event: ConfigChanged) -> None:
+            failed.set()
             msg = "listener blew up"
             raise PermissionError(msg)
 
-        async def slow_listener(_event: ConfigChanged) -> None:
-            # Yields after the sibling has already raised, so it only completes if the
-            # failure did not cancel the TaskGroup.
-            await asyncio.sleep(0)
-            await asyncio.sleep(0)
-            completed.append("slow")
+        async def surviving_listener(_event: ConfigChanged) -> None:
+            # Resumes only after the sibling raised, so it completes only if that failure
+            # did not cancel the TaskGroup. Listeners are stored in a set, so this cannot
+            # rely on creation order.
+            await failed.wait()
+            completed.append("survivor")
 
         def sync_listener(_event: ConfigChanged) -> None:
             completed.append("sync")
 
         event_manager.add_listener_to_app_event(ConfigChanged, failing_listener)
-        event_manager.add_listener_to_app_event(ConfigChanged, slow_listener)
+        event_manager.add_listener_to_app_event(ConfigChanged, surviving_listener)
         event_manager.add_listener_to_app_event(ConfigChanged, sync_listener)
 
         with caplog.at_level(logging.ERROR, logger="griptape_nodes"):
             await event_manager.abroadcast_app_event(ConfigChanged(key="k", old_value="a", new_value="b"))
 
-        assert sorted(completed) == ["slow", "sync"]
+        assert sorted(completed) == ["survivor", "sync"]
         assert "failing_listener" in caplog.text
         assert "ConfigChanged" in caplog.text
 
@@ -414,13 +416,15 @@ class TestBroadcastAppEventListenerIsolation:
     async def test_sync_broadcast_runs_siblings_after_a_listener_raises(self) -> None:
         event_manager = EventManager()
         completed: list[str] = []
+        failed = asyncio.Event()
 
         async def failing_listener(_event: ConfigChanged) -> None:
+            failed.set()
             msg = "listener blew up"
             raise PermissionError(msg)
 
         async def surviving_listener(_event: ConfigChanged) -> None:
-            await asyncio.sleep(0)
+            await failed.wait()
             completed.append("survivor")
 
         event_manager.add_listener_to_app_event(ConfigChanged, failing_listener)

--- a/tests/unit/retained_mode/managers/test_event_manager.py
+++ b/tests/unit/retained_mode/managers/test_event_manager.py
@@ -106,8 +106,8 @@ class TestEventManagerBroadcasting:
         event_manager.broadcast_app_event(event)
 
     @pytest.mark.asyncio
-    async def test_abroadcast_app_event_handles_listener_exceptions(self) -> None:
-        """Test that abroadcast_app_event raises ExceptionGroup when a listener raises an exception."""
+    async def test_abroadcast_app_event_contains_listener_exceptions(self) -> None:
+        """Test that abroadcast_app_event contains a listener failure instead of propagating it."""
         event_manager = EventManager()
 
         # Create listeners where one raises an exception
@@ -119,9 +119,12 @@ class TestEventManagerBroadcasting:
 
         event = ConfigChanged(key="test_key", old_value="old", new_value="new")
 
-        # TaskGroup raises ExceptionGroup when a task fails
-        with pytest.raises(ExceptionGroup):
-            await event_manager.abroadcast_app_event(event)
+        # The failure is logged per listener, so the broadcast completes and the
+        # surviving listener still sees the event.
+        await event_manager.abroadcast_app_event(event)
+
+        listener1.assert_awaited_once_with(event)
+        listener2.assert_awaited_once_with(event)
 
     @pytest.mark.asyncio
     async def test_abroadcast_app_event_with_mixed_listener_types(self) -> None:
@@ -364,6 +367,68 @@ class TestBroadcastAppEventLoopSafety:
 
         assert "listener_loop" in captured
         assert captured["listener_loop"] is not caller_loop
+
+
+class TestBroadcastAppEventListenerIsolation:
+    """One failing listener must not cancel the siblings sharing its TaskGroup."""
+
+    @pytest.mark.asyncio
+    async def test_async_broadcast_runs_siblings_after_a_listener_raises(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A failing listener must not abort the broadcast.
+
+        Regression guard: a PermissionError in ModelManager's AppInitializationComplete
+        listener aborted the whole broadcast, so every other subsystem silently skipped
+        its startup work.
+        """
+        event_manager = EventManager()
+        completed: list[str] = []
+
+        async def failing_listener(_event: ConfigChanged) -> None:
+            msg = "listener blew up"
+            raise PermissionError(msg)
+
+        async def slow_listener(_event: ConfigChanged) -> None:
+            # Yields after the sibling has already raised, so it only completes if the
+            # failure did not cancel the TaskGroup.
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            completed.append("slow")
+
+        def sync_listener(_event: ConfigChanged) -> None:
+            completed.append("sync")
+
+        event_manager.add_listener_to_app_event(ConfigChanged, failing_listener)
+        event_manager.add_listener_to_app_event(ConfigChanged, slow_listener)
+        event_manager.add_listener_to_app_event(ConfigChanged, sync_listener)
+
+        with caplog.at_level(logging.ERROR, logger="griptape_nodes"):
+            await event_manager.abroadcast_app_event(ConfigChanged(key="k", old_value="a", new_value="b"))
+
+        assert sorted(completed) == ["slow", "sync"]
+        assert "failing_listener" in caplog.text
+        assert "ConfigChanged" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_sync_broadcast_runs_siblings_after_a_listener_raises(self) -> None:
+        event_manager = EventManager()
+        completed: list[str] = []
+
+        async def failing_listener(_event: ConfigChanged) -> None:
+            msg = "listener blew up"
+            raise PermissionError(msg)
+
+        async def surviving_listener(_event: ConfigChanged) -> None:
+            await asyncio.sleep(0)
+            completed.append("survivor")
+
+        event_manager.add_listener_to_app_event(ConfigChanged, failing_listener)
+        event_manager.add_listener_to_app_event(ConfigChanged, surviving_listener)
+
+        event_manager.broadcast_app_event(ConfigChanged(key="k", old_value="a", new_value="b"))
+
+        assert completed == ["survivor"]
 
 
 class TestLogResultDetailsSkipsStrictModeViolations:


### PR DESCRIPTION
App event listeners share a single `asyncio.TaskGroup`, so the first listener to raise cancels every sibling that has not finished and the process silently skips the rest of its reaction to the event. This contains each failure to its own listener and logs it, so one broken subsystem no longer decides whether the others run.

Observed in a Windows session log (app v0.85.4, engine v0.98.0), where a `PermissionError` in one listener aborted the whole `AppInitializationComplete` broadcast and the worker went on to register itself milliseconds later, half initialized:

```
01:16:14.902  ERROR  Worker-966d6296 Background task failed

  griptape_nodes/retained_mode/managers/event_manager.py:1020 in abroadcast_app_event
    async with asyncio.TaskGroup() as tg:

ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)

  Sub-exception #1:
    griptape_nodes/retained_mode/managers/model_manager.py:1068 in _find_unfinished_downloads
      data = json.load(f)

  PermissionError: [Errno 13] Permission denied

01:16:15.038  INFO   Worker registered: 966d6296-70ad-4b61-ab57-ec70f00a2cd3 to library 'Griptape Nodes SeedVR Library'
```

That specific listener failure is fixed independently in #5373; this PR keeps any future one from taking its siblings down. Reviewer note: this reverses the contract asserted by `test_abroadcast_app_event_handles_listener_exceptions`, which expected the `ExceptionGroup` to propagate, so that test is rewritten here.
