### PR TITLE
Support metadata_only for static files

### DIFF
--- a/src/griptape_nodes/retained_mode/events/static_file_events.py
+++ b/src/griptape_nodes/retained_mode/events/static_file_events.py
@@ -146,6 +146,9 @@ class CreateStaticFileDownloadUrlFromPathRequest(RequestPayload):
             Ignored for non-macro paths.
         preview: If True, generates and returns preview(s) rather than the original file.
             Defaults to False.
+        metadata_only: If True, extracts and returns artifact_metadata for the original file
+            without generating a preview. The returned URL points to the original full-quality
+            file. Takes precedence over preview. Defaults to False.
 
     Results: CreateStaticFileDownloadUrlResultSuccess (with URL) | CreateStaticFileDownloadUrlResultFailure (URL creation error)
     """
@@ -153,6 +156,7 @@ class CreateStaticFileDownloadUrlFromPathRequest(RequestPayload):
     file_path: str
     macro_variables: MacroVariables = field(default_factory=dict)
     preview: bool = False
+    metadata_only: bool = False
 
 
 @dataclass
@@ -176,8 +180,9 @@ class CreateStaticFileDownloadUrlFromPathResultSuccess(CreateStaticFileDownloadU
 
     Args:
         artifact_metadata: Original properties extracted from the source file header.
-            Only populated when preview=True and the file is a local image.
-            Contains: width, height, format, channels, color_space, file_size.
+            Populated when preview=True or metadata_only=True and the file format has
+            a registered provider. Contains a subset of: width, height, format, channels,
+            color_space, file_size, duration_seconds, codec, frame_rate.
     """
 
     artifact_metadata: dict | None = None

--- a/src/griptape_nodes/retained_mode/managers/artifact_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_manager.py
@@ -345,6 +345,31 @@ class ArtifactManager(EngineScoped):
             return None
         return provider.check_read_permission(source_path)
 
+    async def extract_artifact_metadata(self, source_path: str) -> dict | None:
+        """Extract source-file metadata via the format's provider, off the event loop.
+
+        Resolves the provider through ``_provider_for_format`` so the
+        multi-provider-per-format policy stays centralized. Returns None when no
+        provider claims the extension or the provider cannot extract metadata
+        (built-in providers return None rather than raise on unreadable files).
+        Exceptions from third-party providers propagate; callers own their
+        failure policy.
+
+        Args:
+            source_path: Absolute path to the source file.
+
+        Returns:
+            The provider's metadata as a dict, or None.
+        """
+        extension = Path(source_path).suffix.lstrip(".").lower()
+        if not extension:
+            return None
+        provider = self._provider_for_format(extension)
+        if provider is None:
+            return None
+        metadata = await to_thread(provider.get_artifact_metadata, source_path)
+        return metadata.model_dump() if metadata else None
+
     def _provider_for_format(self, fmt: str) -> BaseArtifactProvider | None:
         """Resolve the registered provider that handles ``fmt`` (empty → None).
 

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -5,6 +5,7 @@ import threading
 from pathlib import Path
 from typing import NamedTuple
 
+import anyio
 from xdg_base_dirs import xdg_config_home
 
 from griptape_nodes.common.macro_parser import MacroSyntaxError, ParsedMacro
@@ -52,6 +53,7 @@ from griptape_nodes.retained_mode.managers.event_manager import EventManager
 from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
 from griptape_nodes.servers import bind_free_socket
 from griptape_nodes.servers.static import STATIC_SERVER_HOST, STATIC_SERVER_PORT, STATIC_SERVER_URL, start_static_server
+from griptape_nodes.utils.async_utils import to_thread
 from griptape_nodes.utils.url_utils import uri_to_path
 
 logger = logging.getLogger("griptape_nodes")
@@ -328,16 +330,58 @@ class StaticFilesManager(EngineScoped):
             static_files_directory=static_files_directory,
         )
 
-    async def _resolve_preview_path(self, file_path: Path, *, preview: bool) -> tuple[Path, dict | None]:
+    async def _extract_metadata_only(self, file_path: Path) -> dict | None:
+        """Extract artifact metadata for a file without generating a preview.
+
+        Returns None if no provider supports the format or extraction fails --
+        serving the download URL must not fail because metadata could not be read.
+
+        Args:
+            file_path: Path to the original file.
+
+        Returns:
+            Extracted metadata dict or None.
+        """
+        extension = file_path.suffix.lstrip(".").lower()
+        if not extension:
+            return None
+
+        # Cloud URLs arrive here as Path("https:/...") -- providers can only probe local files.
+        if not await anyio.Path(file_path).is_file():
+            logger.debug("Skipping metadata extraction for non-local file: %s", file_path)
+            return None
+
+        registry = self.engine.artifact_manager._registry
+        provider_classes = registry.get_provider_classes_by_format(extension)
+        if not provider_classes:
+            logger.debug("Skipping metadata extraction for unsupported file format: %s", file_path)
+            return None
+
+        provider_class = provider_classes[0]
+        metadata = await to_thread(provider_class.get_artifact_metadata, str(file_path))
+        return metadata.model_dump() if metadata else None
+
+    async def _resolve_preview_path(
+        self, file_path: Path, *, preview: bool, metadata_only: bool = False
+    ) -> tuple[Path, dict | None]:
         """Return the path to serve and any source metadata, generating a preview when requested.
 
         Args:
             file_path: Path to the original file.
             preview: Whether to generate and serve a preview.
+            metadata_only: When True, extract metadata without generating a preview. The
+                returned path is always the original file. Takes precedence over preview.
 
         Returns:
             Tuple of (path to serve, artifact metadata or None).
         """
+        if metadata_only:
+            try:
+                artifact_metadata = await self._extract_metadata_only(file_path)
+            except Exception as e:
+                logger.warning("Metadata extraction failed for %s: %s", file_path, e)
+                artifact_metadata = None
+            return file_path, artifact_metadata
         if not preview:
             logger.debug("Serving full image for %s", file_path)
             return file_path, None
@@ -363,7 +407,12 @@ class StaticFilesManager(EngineScoped):
             Result with download URL or failure message.
         """
         file_path = request.file_path
-        logger.debug("CreateStaticFileDownloadUrlFromPath: file_path=%s, preview=%s", file_path, request.preview)
+        logger.debug(
+            "CreateStaticFileDownloadUrlFromPath: file_path=%s, preview=%s, metadata_only=%s",
+            file_path,
+            request.preview,
+            request.metadata_only,
+        )
 
         # Resolve macro paths (e.g. "{outputs}/file.png") before further processing
         try:
@@ -398,9 +447,10 @@ class StaticFilesManager(EngineScoped):
             # For local paths, convert URI to path
             file_path_for_driver = Path(uri_to_path(file_path))
 
-        # If preview requested, generate preview and get preview path + artifact metadata
+        # If preview requested, generate preview and get preview path + artifact metadata.
+        # If metadata_only requested, extract metadata without generating a preview.
         file_path_to_use, artifact_metadata = await self._resolve_preview_path(
-            file_path_for_driver, preview=request.preview
+            file_path_for_driver, preview=request.preview, metadata_only=request.metadata_only
         )
 
         try:

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -14,7 +14,7 @@ from griptape_nodes.drivers.cloud_credentials import MISSING_CREDENTIAL_MESSAGE,
 from griptape_nodes.drivers.storage import StorageBackend
 from griptape_nodes.drivers.storage.griptape_cloud_storage_driver import GriptapeCloudStorageDriver
 from griptape_nodes.drivers.storage.local_storage_driver import LocalStorageDriver
-from griptape_nodes.files.path_utils import FilenameParts
+from griptape_nodes.files.path_utils import FilenameParts, resolve_workspace_path
 from griptape_nodes.retained_mode.engine import Engine, EngineScoped
 from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
 from griptape_nodes.retained_mode.events.artifact_events import (
@@ -53,7 +53,6 @@ from griptape_nodes.retained_mode.managers.event_manager import EventManager
 from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
 from griptape_nodes.servers import bind_free_socket
 from griptape_nodes.servers.static import STATIC_SERVER_HOST, STATIC_SERVER_PORT, STATIC_SERVER_URL, start_static_server
-from griptape_nodes.utils.async_utils import to_thread
 from griptape_nodes.utils.url_utils import uri_to_path
 
 logger = logging.getLogger("griptape_nodes")
@@ -333,33 +332,32 @@ class StaticFilesManager(EngineScoped):
     async def _extract_metadata_only(self, file_path: Path) -> dict | None:
         """Extract artifact metadata for a file without generating a preview.
 
-        Returns None if no provider supports the format or extraction fails --
-        serving the download URL must not fail because metadata could not be read.
+        Returns None if the file is not a local file, no provider supports the
+        format, or extraction fails -- serving the download URL must never fail
+        because metadata could not be read.
 
         Args:
-            file_path: Path to the original file.
+            file_path: Path to the original file, as handed to the storage driver.
 
         Returns:
             Extracted metadata dict or None.
         """
-        extension = file_path.suffix.lstrip(".").lower()
-        if not extension:
+        # Probe the same file the local driver will serve: workspace-relative paths are a
+        # documented request shape, and the raw path would resolve against the process
+        # CWD instead. Cloud URLs arrive here as Path("https:/...") and fail the
+        # is_file check -- providers can only probe local files. Under the GTC storage
+        # backend the probe reads the local workspace copy, mirroring how preview
+        # generation already behaves there.
+        probe_path = resolve_workspace_path(file_path, self.config_manager.workspace_path)
+        if not await anyio.Path(probe_path).is_file():
+            logger.debug("Skipping metadata extraction for non-local file: %s", probe_path)
             return None
 
-        # Cloud URLs arrive here as Path("https:/...") -- providers can only probe local files.
-        if not await anyio.Path(file_path).is_file():
-            logger.debug("Skipping metadata extraction for non-local file: %s", file_path)
+        try:
+            return await self.engine.artifact_manager.extract_artifact_metadata(str(probe_path))
+        except Exception as e:
+            logger.warning("Metadata extraction failed for %s: %s", probe_path, e)
             return None
-
-        registry = self.engine.artifact_manager._registry
-        provider_classes = registry.get_provider_classes_by_format(extension)
-        if not provider_classes:
-            logger.debug("Skipping metadata extraction for unsupported file format: %s", file_path)
-            return None
-
-        provider_class = provider_classes[0]
-        metadata = await to_thread(provider_class.get_artifact_metadata, str(file_path))
-        return metadata.model_dump() if metadata else None
 
     async def _resolve_preview_path(
         self, file_path: Path, *, preview: bool, metadata_only: bool = False
@@ -376,11 +374,7 @@ class StaticFilesManager(EngineScoped):
             Tuple of (path to serve, artifact metadata or None).
         """
         if metadata_only:
-            try:
-                artifact_metadata = await self._extract_metadata_only(file_path)
-            except Exception as e:
-                logger.warning("Metadata extraction failed for %s: %s", file_path, e)
-                artifact_metadata = None
+            artifact_metadata = await self._extract_metadata_only(file_path)
             return file_path, artifact_metadata
         if not preview:
             logger.debug("Serving full image for %s", file_path)

--- a/tests/unit/retained_mode/managers/test_artifact_manager.py
+++ b/tests/unit/retained_mode/managers/test_artifact_manager.py
@@ -554,6 +554,77 @@ class TestPermissionDispatch:
         assert manager.check_read_permission("/some/file_without_ext") is None
 
 
+class TestExtractArtifactMetadata:
+    """extract_artifact_metadata resolves the provider by extension and returns its metadata as a dict."""
+
+    _PROBE_FORMAT = "probe"
+
+    def _make_probe_provider_class(self, metadata=None):  # noqa: ANN001, ANN202
+        from griptape_nodes.retained_mode.managers.artifact_providers.base_artifact_provider import (
+            BaseArtifactMetadata,
+            BaseArtifactProvider,
+        )
+
+        probe_format = self._PROBE_FORMAT
+
+        class _ProbeProvider(BaseArtifactProvider):
+            @classmethod
+            def get_friendly_name(cls) -> str:
+                return "Probe"
+
+            @classmethod
+            def get_supported_formats(cls) -> set[str]:
+                return {probe_format}
+
+            @classmethod
+            def get_artifact_metadata(cls, source_path: str) -> BaseArtifactMetadata | None:  # noqa: ARG003
+                return metadata
+
+        return _ProbeProvider
+
+    def _register(self, manager: ArtifactManager, provider_class: type) -> None:
+        result = manager.on_handle_register_artifact_provider_request(
+            RegisterArtifactProviderRequest(provider_class=provider_class)
+        )
+        assert isinstance(result, RegisterArtifactProviderResultSuccess)
+
+    @pytest.mark.asyncio
+    async def test_returns_provider_metadata_as_dict(self) -> None:
+        from griptape_nodes.retained_mode.managers.artifact_providers.base_artifact_provider import (
+            BaseArtifactMetadata,
+        )
+
+        class _ProbeMetadata(BaseArtifactMetadata):
+            codec: str = "prores"
+            width: int = 1920
+
+        probe_cls = self._make_probe_provider_class(metadata=_ProbeMetadata())
+        manager = ArtifactManager()
+        self._register(manager, probe_cls)
+
+        result = await manager.extract_artifact_metadata(f"/some/clip.{self._PROBE_FORMAT}")
+
+        assert result == {"codec": "prores", "width": 1920}
+
+    @pytest.mark.asyncio
+    async def test_unknown_extension_returns_none(self) -> None:
+        manager = ArtifactManager()
+        assert await manager.extract_artifact_metadata("/some/clip.unregistered") is None
+
+    @pytest.mark.asyncio
+    async def test_no_extension_returns_none(self) -> None:
+        manager = ArtifactManager()
+        assert await manager.extract_artifact_metadata("/some/file_without_ext") is None
+
+    @pytest.mark.asyncio
+    async def test_provider_returning_none_metadata_returns_none(self) -> None:
+        probe_cls = self._make_probe_provider_class(metadata=None)
+        manager = ArtifactManager()
+        self._register(manager, probe_cls)
+
+        assert await manager.extract_artifact_metadata(f"/some/clip.{self._PROBE_FORMAT}") is None
+
+
 class TestCheckArtifactReadPermissionHandler:
     """The request-based read-permission check.
 

--- a/tests/unit/retained_mode/managers/test_static_files_manager.py
+++ b/tests/unit/retained_mode/managers/test_static_files_manager.py
@@ -626,6 +626,68 @@ class TestStaticFilesManagerCreateDownloadUrlFromPath:
         assert isinstance(result, CreateStaticFileDownloadUrlResultFailure)
         assert "invalid macro syntax" in result.error
 
+    @pytest.mark.asyncio
+    async def test_create_download_url_from_path_metadata_only(
+        self, mock_static_files_manager: StaticFilesManager, tmp_path: Path
+    ) -> None:
+        """Test metadata_only extracts provider metadata, serves the original file, and skips preview generation."""
+        from griptape_nodes.retained_mode.events.static_file_events import (
+            CreateStaticFileDownloadUrlFromPathRequest,
+            CreateStaticFileDownloadUrlFromPathResultSuccess,
+        )
+
+        source_file = tmp_path / "clip.mov"
+        source_file.write_bytes(b"not a real video")
+
+        mock_metadata = Mock()
+        mock_metadata.model_dump.return_value = {"width": 1920, "height": 1080, "codec": "prores"}
+        mock_provider_class = Mock()
+        mock_provider_class.get_artifact_metadata.return_value = mock_metadata
+        registry = mock_static_files_manager.engine.artifact_manager._registry
+        registry.get_provider_classes_by_format.return_value = [mock_provider_class]
+
+        mock_static_files_manager.storage_driver.create_signed_download_url.return_value = "http://signed-url.com"
+        mock_static_files_manager.storage_driver.get_asset_url.return_value = "http://asset-url.com"
+
+        # preview=True alongside metadata_only proves metadata_only takes precedence
+        request = CreateStaticFileDownloadUrlFromPathRequest(
+            file_path=str(source_file), preview=True, metadata_only=True
+        )
+
+        with patch.object(mock_static_files_manager, "_generate_preview_if_needed") as mock_generate_preview:
+            result = await mock_static_files_manager.on_handle_create_static_file_download_url_from_path_request(
+                request
+            )
+
+        assert isinstance(result, CreateStaticFileDownloadUrlFromPathResultSuccess)
+        assert result.artifact_metadata == {"width": 1920, "height": 1080, "codec": "prores"}
+        mock_provider_class.get_artifact_metadata.assert_called_once_with(str(source_file))
+        mock_generate_preview.assert_not_called()
+        # The original file is served, not a preview
+        mock_static_files_manager.storage_driver.create_signed_download_url.assert_called_once_with(source_file)
+
+    @pytest.mark.asyncio
+    async def test_create_download_url_from_path_metadata_only_missing_file(
+        self, mock_static_files_manager: StaticFilesManager
+    ) -> None:
+        """Test metadata_only on a non-local path still succeeds with no metadata and no provider probe."""
+        from griptape_nodes.retained_mode.events.static_file_events import (
+            CreateStaticFileDownloadUrlFromPathRequest,
+            CreateStaticFileDownloadUrlFromPathResultSuccess,
+        )
+
+        registry = mock_static_files_manager.engine.artifact_manager._registry
+        mock_static_files_manager.storage_driver.create_signed_download_url.return_value = "http://signed-url.com"
+        mock_static_files_manager.storage_driver.get_asset_url.return_value = "http://asset-url.com"
+
+        request = CreateStaticFileDownloadUrlFromPathRequest(file_path="/does/not/exist/clip.mov", metadata_only=True)
+
+        result = await mock_static_files_manager.on_handle_create_static_file_download_url_from_path_request(request)
+
+        assert isinstance(result, CreateStaticFileDownloadUrlFromPathResultSuccess)
+        assert result.artifact_metadata is None
+        registry.get_provider_classes_by_format.assert_not_called()
+
 
 class TestStaticFilesManagerResolveStaticFilePath:
     """Test StaticFilesManager._resolve_static_file_path() method."""

--- a/tests/unit/retained_mode/managers/test_static_files_manager.py
+++ b/tests/unit/retained_mode/managers/test_static_files_manager.py
@@ -1,7 +1,7 @@
 import tempfile
 from collections.abc import Generator
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -639,12 +639,8 @@ class TestStaticFilesManagerCreateDownloadUrlFromPath:
         source_file = tmp_path / "clip.mov"
         source_file.write_bytes(b"not a real video")
 
-        mock_metadata = Mock()
-        mock_metadata.model_dump.return_value = {"width": 1920, "height": 1080, "codec": "prores"}
-        mock_provider_class = Mock()
-        mock_provider_class.get_artifact_metadata.return_value = mock_metadata
-        registry = mock_static_files_manager.engine.artifact_manager._registry
-        registry.get_provider_classes_by_format.return_value = [mock_provider_class]
+        extract_metadata = AsyncMock(return_value={"width": 1920, "height": 1080, "codec": "prores"})
+        mock_static_files_manager.engine.artifact_manager.extract_artifact_metadata = extract_metadata
 
         mock_static_files_manager.storage_driver.create_signed_download_url.return_value = "http://signed-url.com"
         mock_static_files_manager.storage_driver.get_asset_url.return_value = "http://asset-url.com"
@@ -661,10 +657,66 @@ class TestStaticFilesManagerCreateDownloadUrlFromPath:
 
         assert isinstance(result, CreateStaticFileDownloadUrlFromPathResultSuccess)
         assert result.artifact_metadata == {"width": 1920, "height": 1080, "codec": "prores"}
-        mock_provider_class.get_artifact_metadata.assert_called_once_with(str(source_file))
+        extract_metadata.assert_awaited_once_with(str(source_file))
         mock_generate_preview.assert_not_called()
         # The original file is served, not a preview
         mock_static_files_manager.storage_driver.create_signed_download_url.assert_called_once_with(source_file)
+
+    @pytest.mark.asyncio
+    async def test_create_download_url_from_path_metadata_only_workspace_relative(
+        self, mock_static_files_manager: StaticFilesManager, tmp_path: Path
+    ) -> None:
+        """Test metadata_only resolves workspace-relative paths to the file the driver serves."""
+        from griptape_nodes.retained_mode.events.static_file_events import (
+            CreateStaticFileDownloadUrlFromPathRequest,
+            CreateStaticFileDownloadUrlFromPathResultSuccess,
+        )
+
+        source_file = tmp_path / "outputs" / "clip.mov"
+        source_file.parent.mkdir()
+        source_file.write_bytes(b"not a real video")
+        mock_static_files_manager.config_manager.workspace_path = tmp_path
+
+        extract_metadata = AsyncMock(return_value={"codec": "prores"})
+        mock_static_files_manager.engine.artifact_manager.extract_artifact_metadata = extract_metadata
+
+        mock_static_files_manager.storage_driver.create_signed_download_url.return_value = "http://signed-url.com"
+        mock_static_files_manager.storage_driver.get_asset_url.return_value = "http://asset-url.com"
+
+        request = CreateStaticFileDownloadUrlFromPathRequest(file_path="outputs/clip.mov", metadata_only=True)
+
+        result = await mock_static_files_manager.on_handle_create_static_file_download_url_from_path_request(request)
+
+        assert isinstance(result, CreateStaticFileDownloadUrlFromPathResultSuccess)
+        assert result.artifact_metadata == {"codec": "prores"}
+        # The probe targets the workspace-resolved path, not the CWD-relative one
+        extract_metadata.assert_awaited_once_with(str(source_file))
+
+    @pytest.mark.asyncio
+    async def test_create_download_url_from_path_metadata_only_extraction_error_still_succeeds(
+        self, mock_static_files_manager: StaticFilesManager, tmp_path: Path
+    ) -> None:
+        """Test the never-fail policy: a raising provider must not break URL creation."""
+        from griptape_nodes.retained_mode.events.static_file_events import (
+            CreateStaticFileDownloadUrlFromPathRequest,
+            CreateStaticFileDownloadUrlFromPathResultSuccess,
+        )
+
+        source_file = tmp_path / "clip.mov"
+        source_file.write_bytes(b"not a real video")
+
+        extract_metadata = AsyncMock(side_effect=RuntimeError("third-party provider exploded"))
+        mock_static_files_manager.engine.artifact_manager.extract_artifact_metadata = extract_metadata
+        mock_static_files_manager.storage_driver.create_signed_download_url.return_value = "http://signed-url.com"
+        mock_static_files_manager.storage_driver.get_asset_url.return_value = "http://asset-url.com"
+
+        request = CreateStaticFileDownloadUrlFromPathRequest(file_path=str(source_file), metadata_only=True)
+
+        result = await mock_static_files_manager.on_handle_create_static_file_download_url_from_path_request(request)
+
+        assert isinstance(result, CreateStaticFileDownloadUrlFromPathResultSuccess)
+        assert result.artifact_metadata is None
+        assert result.url == "http://signed-url.com"
 
     @pytest.mark.asyncio
     async def test_create_download_url_from_path_metadata_only_missing_file(
@@ -676,7 +728,8 @@ class TestStaticFilesManagerCreateDownloadUrlFromPath:
             CreateStaticFileDownloadUrlFromPathResultSuccess,
         )
 
-        registry = mock_static_files_manager.engine.artifact_manager._registry
+        extract_metadata = AsyncMock()
+        mock_static_files_manager.engine.artifact_manager.extract_artifact_metadata = extract_metadata
         mock_static_files_manager.storage_driver.create_signed_download_url.return_value = "http://signed-url.com"
         mock_static_files_manager.storage_driver.get_asset_url.return_value = "http://asset-url.com"
 
@@ -686,7 +739,7 @@ class TestStaticFilesManagerCreateDownloadUrlFromPath:
 
         assert isinstance(result, CreateStaticFileDownloadUrlFromPathResultSuccess)
         assert result.artifact_metadata is None
-        registry.get_provider_classes_by_format.assert_not_called()
+        extract_metadata.assert_not_awaited()
 
 
 class TestStaticFilesManagerResolveStaticFilePath:


### PR DESCRIPTION
Adds a `metadata_only` flag to `CreateStaticFileDownloadUrlFromPathRequest` so callers (the editor's video players) can get source-file metadata without forcing a downscaled preview transcode. Pairs with griptape-ai/griptape-vsl-gui#2871 to fix the ProRes no-preview/no-metadata regression.

## What it does

- `CreateStaticFileDownloadUrlFromPathRequest` gains `metadata_only: bool = False`. When true, the engine extracts artifact metadata via the format's registered provider and returns the **original** file's download URL plus `artifact_metadata`. Takes precedence over `preview`. The result's `artifact_metadata` now documents the full field union (subset of: `width`, `height`, `format`, `channels`, `color_space`, `file_size`, `duration_seconds`, `codec`, `frame_rate`).
- New public `ArtifactManager.extract_artifact_metadata(source_path)` owns provider selection (via the centralized `_provider_for_format`, keeping the multi-provider-per-format policy in one place — #4027), the thread-offloaded probe, and the model-to-dict conversion. Provider exceptions propagate; callers own their failure policy.
- `StaticFilesManager._extract_metadata_only` resolves workspace-relative paths through `resolve_workspace_path` before probing, so it probes the same file the local storage driver serves (a raw relative path would resolve against the process CWD). Non-local paths (cloud URLs arrive as `Path("https:/...")`) skip extraction quietly. This manager owns the never-fail policy: metadata extraction failure logs a warning and returns no metadata rather than failing URL creation. Under the GTC storage backend the probe reads the local workspace copy, mirroring how preview generation already behaves there.

## Compatibility

Engines before this change deserialize requests with cattrs, which drops unknown fields — older engines silently ignore `metadata_only` and behave as `preview=false`. The GUI gates sending the flag on engine >= 0.99.0.

## Tests

- `metadata_only` returns provider metadata, serves the original file, and takes precedence over `preview=True`.
- Workspace-relative paths probe the workspace-resolved file, not CWD-relative.
- Missing/non-local files still succeed with `artifact_metadata=None` and no provider probe.
- A raising provider still succeeds with `artifact_metadata=None` (never-fail policy).
- `ArtifactManager.extract_artifact_metadata`: provider dispatch by extension, dict conversion, None for unknown/missing extensions and None-returning providers.
