### PR TITLE
feat(libraries): report per-node-type port summaries for connection ranking

### DIFF
--- a/docs/development/custom_nodes/parameters.md
+++ b/docs/development/custom_nodes/parameters.md
@@ -867,10 +867,10 @@ What this asks of your node:
 - **Keep `__init__` cheap and offline.** Summaries are computed for every node type in a
     library in one pass. A node whose `__init__` raises is omitted from the summary — it stays
     creatable, but the editor cannot rank it, so it sinks to the bottom of the menu. One that
-    blocks past a 10-second timeout is omitted the same way, and once a handful of node types in
-    one library have timed out the engine stops probing that library for the rest of the pass, so
-    a few blocking nodes can cost their neighbors their ranking too. This is the same constraint
-    the worker-mode schema probe imposes — see
+    blocks past a 10-second timeout is omitted the same way, and it costs more than itself: a
+    blocked probe holds a thread the engine cannot reclaim, so after a handful of them the engine
+    stops probing that library at all and its remaining node types go unranked until it reloads.
+    This is the same constraint the worker-mode schema probe imposes — see
     [`__init__` runs during library load](node_isolation_with_workers.md#__init__-runs-during-library-load).
 - **Expect dynamic ports to be missing.** Only ports that exist right after construction are
     reported. Ports added later — a
@@ -880,9 +880,12 @@ What this asks of your node:
     matters for discoverability, declare a port for it up front.
 
 Summaries are cached per library and recomputed after that library changes — a reload, an unload,
-or a new sandbox node — so the probe pass happens once, not per menu open. A node type whose
-`__init__` blocked past the timeout is the one exception: it gets a second attempt on the next
-request, alone, and is then left out until the library reloads.
+or a new sandbox node — so the probe pass happens once, not per menu open. Blocking nodes are the
+one exception. A node type whose `__init__` blocked past the timeout gets a second attempt on the
+next request, alone, and is then left out until the library reloads. Because each of those timeouts
+costs the engine a thread for good, one request will only wait out a few of them; libraries it did
+not reach are probed on a later request instead, and a library that has spent the whole allowance is
+left as-is until it reloads.
 
 ### Two-Image Processing Node Pattern
 

--- a/docs/development/custom_nodes/parameters.md
+++ b/docs/development/custom_nodes/parameters.md
@@ -850,10 +850,11 @@ the element type its children take. A `ParameterList(input_types=["str"])` repor
 just dragging a whole list.
 
 The two type lists hold raw declared type names, and the engine's matching rules are not plain
-string equality: matching is case-insensitive, a target of `any` accepts anything (but a source
-of `any` is not accepted by a specific target), and `list[str]` matches a `list` target on the
-base type. `ParameterType.are_types_compatible` implements those three. One more rule lives
-outside it — a source of `all` matches anything, applied by
+string equality: matching is case-insensitive; a target of `any` accepts anything (but a source
+of `any` is not accepted by a specific target); `none` on either side matches nothing, `any`
+target included; and `list[str]` matches a `list` or `list[any]` target on the base type, though a
+bare `list` source does not match `list[str]`. `ParameterType.are_types_compatible` implements
+those. One more rule lives outside it — a source of `all` matches anything, applied by
 `Parameter.is_incoming_type_allowed` before it delegates — so a client that calls
 `are_types_compatible` alone will not rank `all`-typed outputs against anything.
 
@@ -866,8 +867,10 @@ What this asks of your node:
 - **Keep `__init__` cheap and offline.** Summaries are computed for every node type in a
     library in one pass. A node whose `__init__` raises is omitted from the summary — it stays
     creatable, but the editor cannot rank it, so it sinks to the bottom of the menu. One that
-    blocks past a 10-second timeout is omitted the same way. This is the same constraint the
-    worker-mode schema probe imposes — see
+    blocks past a 10-second timeout is omitted the same way, and once a handful of node types in
+    one library have timed out the engine stops probing that library for the rest of the pass, so
+    a few blocking nodes can cost their neighbors their ranking too. This is the same constraint
+    the worker-mode schema probe imposes — see
     [`__init__` runs during library load](node_isolation_with_workers.md#__init__-runs-during-library-load).
 - **Expect dynamic ports to be missing.** Only ports that exist right after construction are
     reported. Ports added later — a

--- a/docs/development/custom_nodes/parameters.md
+++ b/docs/development/custom_nodes/parameters.md
@@ -838,6 +838,17 @@ dragged connection", not that a specific port will. The real connection is still
 against the created node's actual parameters, which is where `allow_incoming_connection` /
 `allow_outgoing_connection` get their say.
 
+A `ParameterList` or `ParameterDictionary` contributes both the container type and, for lists,
+the element type its children take. A `ParameterList(input_types=["str"])` reports
+`list[str]`, `list`, *and* `str`, so dragging a single string finds your expander node — not
+just dragging a whole list.
+
+The two type lists hold raw declared type names, and the engine's matching rules are not plain
+string equality: matching is case-insensitive, a target of `any` accepts anything (but a source
+of `any` is not accepted by a specific target), a source of `all` matches anything, and
+`list[str]` matches a `list` target on the base type. `ParameterType.are_types_compatible` is
+the authority.
+
 What this asks of your node:
 
 - **Declare `input_types` / `output_type` honestly in `__init__`.** They are what the editor
@@ -851,14 +862,14 @@ What this asks of your node:
     worker-mode schema probe imposes — see
     [`__init__` runs during library load](node_isolation_with_workers.md#__init__-runs-during-library-load).
 - **Expect dynamic ports to be missing.** Only ports that exist right after construction are
-    reported. Ports added later — container children, a
+    reported. Ports added later — a
     [`ParameterTransitionComponent`](#dynamic-parameter-schemas-with-parametertransitioncomponent)
-    swapping in a schema after a dropdown changes — are absent, so your node will not be
-    offered for those types until it is on the canvas. If a type matters for discoverability,
-    declare a port for it up front.
+    swapping in a schema after a dropdown changes, or ports you add from `after_value_set` — are
+    absent, so your node will not be offered for those types until it is on the canvas. If a type
+    matters for discoverability, declare a port for it up front.
 
-Summaries are cached per library for the life of the process and recomputed after that library
-is reloaded, so the probe pass happens once, not per menu open.
+Summaries are cached per library and recomputed after that library changes — a reload, an unload,
+or a new sandbox node — so the probe pass happens once, not per menu open.
 
 ### Two-Image Processing Node Pattern
 

--- a/docs/development/custom_nodes/parameters.md
+++ b/docs/development/custom_nodes/parameters.md
@@ -849,6 +849,12 @@ the element type its children take. A `ParameterList(input_types=["str"])` repor
 `list[str]`, `list`, *and* `str`, so dragging a single string finds your expander node — not
 just dragging a whole list.
 
+One exception: a library
+[hosted in a worker](node_isolation_with_workers.md) reports its parameters to the orchestrator as
+flat descriptions, so its lists are summarized as `list[str]` and `list` without the element type.
+Dragging a single `str` will not float a worker-hosted expander node the way it floats the same node
+in an in-process library. Everything else in this section applies to both.
+
 The two type lists hold raw declared type names, and the engine's matching rules are not plain
 string equality: matching is case-insensitive; a target of `any` accepts anything (but a source
 of `any` is not accepted by a specific target); `none` on either side matches nothing, `any`
@@ -892,7 +898,9 @@ left as-is until it reloads.
 The pass normally runs in the background, right after libraries finish loading and again after a
 reload, so the menu is ready before anyone opens it. Worth knowing while authoring: **your
 `__init__` runs shortly after startup whether or not anyone creates your node**, so anything it does
-eagerly — an auth check, a model download, a directory it creates — happens then too. That is
+eagerly — an auth check, a model download, a directory it creates — happens then too. (In a
+worker-hosted library that already happens when the worker loads your library and serializes its
+schemas; the orchestrator summarizes what the worker reported and never constructs your node.) That is
 another reason to keep it cheap and offline. Setting `library.warm_port_summaries` to `false` in
 your config turns the background pass off; the summaries are then computed by the first request that
 needs them, which moves the cost back into the artist's first drag rather than removing it.

--- a/docs/development/custom_nodes/parameters.md
+++ b/docs/development/custom_nodes/parameters.md
@@ -851,9 +851,11 @@ just dragging a whole list.
 
 The two type lists hold raw declared type names, and the engine's matching rules are not plain
 string equality: matching is case-insensitive, a target of `any` accepts anything (but a source
-of `any` is not accepted by a specific target), a source of `all` matches anything, and
-`list[str]` matches a `list` target on the base type. `ParameterType.are_types_compatible` is
-the authority.
+of `any` is not accepted by a specific target), and `list[str]` matches a `list` target on the
+base type. `ParameterType.are_types_compatible` implements those three. One more rule lives
+outside it — a source of `all` matches anything, applied by
+`Parameter.is_incoming_type_allowed` before it delegates — so a client that calls
+`are_types_compatible` alone will not rank `all`-typed outputs against anything.
 
 What this asks of your node:
 
@@ -875,7 +877,9 @@ What this asks of your node:
     matters for discoverability, declare a port for it up front.
 
 Summaries are cached per library and recomputed after that library changes — a reload, an unload,
-or a new sandbox node — so the probe pass happens once, not per menu open.
+or a new sandbox node — so the probe pass happens once, not per menu open. A node type whose
+`__init__` blocked past the timeout is the one exception: it gets a second attempt on the next
+request, alone, and is then left out until the library reloads.
 
 ### Two-Image Processing Node Pattern
 

--- a/docs/development/custom_nodes/parameters.md
+++ b/docs/development/custom_nodes/parameters.md
@@ -828,10 +828,16 @@ The engine answers that with a **port summary** per node type, served by
 
 There is nothing to declare and nothing to keep in sync — the engine derives all four by
 constructing one throwaway instance of your node and reading the parameters your `__init__`
-added. `input_types` and `output_type` are read straight off each `Parameter` (each falling
-back to `type` when not set), `allowed_modes` decides which side a parameter lands on, and
-`private=True` parameters are skipped. Control ports are reported only as the two booleans and
-never appear in the type lists, because control and data connections never interconnect.
+added. `input_types` and `output_type` are read straight off each `Parameter`, `allowed_modes`
+decides which side a parameter lands on, and `private=True` parameters are skipped. Control ports
+are reported only as the two booleans and never appear in the type lists, because control and
+data connections never interconnect.
+
+Two defaults surprise people here. A parameter with the default `allowed_modes` is both an input
+and an output, so it lands on *both* sides. And the unset direction inherits from the set one:
+`input_types` falls back to `type`, then `output_type`, then `"str"`; `output_type` falls back to
+`type`, then the first entry of `input_types`, then `"str"`. So a parameter declaring only
+`input_types=["ImageArtifact"]` is reported as emitting `ImageArtifact` too.
 
 Because it is a union, a match means "this node type has *some* port that could accept the
 dragged connection", not that a specific port will. The real connection is still resolved

--- a/docs/development/custom_nodes/parameters.md
+++ b/docs/development/custom_nodes/parameters.md
@@ -810,6 +810,56 @@ class ColorMatch(SuccessFailureNode):
 
 **Trade-off**: You lose helper methods from specialized base classes, but gain complete control over the node's UI structure.
 
+### How the editor previews your ports before a node exists
+
+Some editor features need to know what a node type can connect to *before* one is on the
+canvas. Dragging a connection off a port and dropping it on empty canvas is the main one: the
+Add Node menu that opens floats node types with a compatible port to the top.
+
+The engine answers that with a **port summary** per node type, served by
+`GetPortSummariesForAllLibrariesRequest`. Each summary is four fields:
+
+| Field                | Meaning                                                        |
+| -------------------- | -------------------------------------------------------------- |
+| `input_types`        | Every type accepted, unioned across all ports allowing `INPUT` |
+| `output_types`       | Every type emitted, unioned across all ports allowing `OUTPUT` |
+| `has_control_input`  | Whether the node declares an incoming control (execution) port |
+| `has_control_output` | Whether the node declares an outgoing control (execution) port |
+
+There is nothing to declare and nothing to keep in sync — the engine derives all four by
+constructing one throwaway instance of your node and reading the parameters your `__init__`
+added. `input_types` and `output_type` are read straight off each `Parameter` (each falling
+back to `type` when not set), `allowed_modes` decides which side a parameter lands on, and
+`private=True` parameters are skipped. Control ports are reported only as the two booleans and
+never appear in the type lists, because control and data connections never interconnect.
+
+Because it is a union, a match means "this node type has *some* port that could accept the
+dragged connection", not that a specific port will. The real connection is still resolved
+against the created node's actual parameters, which is where `allow_incoming_connection` /
+`allow_outgoing_connection` get their say.
+
+What this asks of your node:
+
+- **Declare `input_types` / `output_type` honestly in `__init__`.** They are what the editor
+    ranks on. A parameter left at the default `type` is fine; a parameter whose declared types
+    are wider than what `process()` really handles will get your node offered for connections
+    it cannot use.
+- **Keep `__init__` cheap and offline.** Summaries are computed for every node type in a
+    library in one pass. A node whose `__init__` raises is omitted from the summary — it stays
+    creatable, but the editor cannot rank it, so it sinks to the bottom of the menu. One that
+    blocks past a 10-second timeout is omitted the same way. This is the same constraint the
+    worker-mode schema probe imposes — see
+    [`__init__` runs during library load](node_isolation_with_workers.md#__init__-runs-during-library-load).
+- **Expect dynamic ports to be missing.** Only ports that exist right after construction are
+    reported. Ports added later — container children, a
+    [`ParameterTransitionComponent`](#dynamic-parameter-schemas-with-parametertransitioncomponent)
+    swapping in a schema after a dropdown changes — are absent, so your node will not be
+    offered for those types until it is on the canvas. If a type matters for discoverability,
+    declare a port for it up front.
+
+Summaries are cached per library for the life of the process and recomputed after that library
+is reloaded, so the probe pass happens once, not per menu open.
+
 ### Two-Image Processing Node Pattern
 
 For nodes that process two images together (blending, color matching, compositing), use this pattern:

--- a/docs/development/custom_nodes/parameters.md
+++ b/docs/development/custom_nodes/parameters.md
@@ -870,6 +870,8 @@ What this asks of your node:
     blocks past a 10-second timeout is omitted the same way, and it costs more than itself: a
     blocked probe holds a thread the engine cannot reclaim, so after a handful of them the engine
     stops probing that library at all and its remaining node types go unranked until it reloads.
+    Enough of them across every library and it stops probing for the rest of the session, because
+    at that point the leaked threads are a bigger problem than an unranked menu.
     This is the same constraint the worker-mode schema probe imposes — see
     [`__init__` runs during library load](node_isolation_with_workers.md#__init__-runs-during-library-load).
 - **Expect dynamic ports to be missing.** Only ports that exist right after construction are
@@ -886,6 +888,14 @@ next request, alone, and is then left out until the library reloads. Because eac
 costs the engine a thread for good, one request will only wait out a few of them; libraries it did
 not reach are probed on a later request instead, and a library that has spent the whole allowance is
 left as-is until it reloads.
+
+The pass normally runs in the background, right after libraries finish loading and again after a
+reload, so the menu is ready before anyone opens it. Worth knowing while authoring: **your
+`__init__` runs shortly after startup whether or not anyone creates your node**, so anything it does
+eagerly — an auth check, a model download, a directory it creates — happens then too. That is
+another reason to keep it cheap and offline. Setting `library.warm_port_summaries` to `false` in
+your config turns the background pass off; the summaries are then computed by the first request that
+needs them, which moves the cost back into the artist's first drag rather than removing it.
 
 ### Two-Image Processing Node Pattern
 

--- a/src/griptape_nodes/bootstrap/workflow_executors/local_session_workflow_executor.py
+++ b/src/griptape_nodes/bootstrap/workflow_executors/local_session_workflow_executor.py
@@ -60,7 +60,9 @@ class LocalSessionWorkflowExecutor(LocalWorkflowExecutor, SubprocessWebSocketSen
     async def __aenter__(self) -> Self:
         """Async context manager entry: initialize queue and broadcast app initialization."""
         GriptapeNodes.EventManager().initialize_queue()
-        await GriptapeNodes.EventManager().abroadcast_app_event(AppInitializationComplete())
+        # warm_port_summaries=False: a subprocess executing one workflow. The port summaries only
+        # answer "what can this connect to?" for an editor, and there is none here.
+        await GriptapeNodes.EventManager().abroadcast_app_event(AppInitializationComplete(warm_port_summaries=False))
 
         logger.info("Setting up session %s", self._session_id)
         GriptapeNodes.SessionManager().save_session(self._session_id)

--- a/src/griptape_nodes/bootstrap/workflow_executors/local_workflow_executor.py
+++ b/src/griptape_nodes/bootstrap/workflow_executors/local_workflow_executor.py
@@ -83,9 +83,14 @@ class LocalWorkflowExecutor(WorkflowExecutor):
         if self._project_file_path is not None:
             await self._load_project(self._project_file_path)
 
+        # warm_port_summaries=False: this process runs one already-built workflow and exits. Nobody
+        # here drags a connection, so probing every node type for its ports would only compete with
+        # the run for CPU.
         await GriptapeNodes.EventManager().abroadcast_app_event(
             AppInitializationComplete(
-                skip_library_loading=self._skip_library_loading, workflows_to_register=self._workflows_to_register
+                skip_library_loading=self._skip_library_loading,
+                workflows_to_register=self._workflows_to_register,
+                warm_port_summaries=False,
             )
         )
         return self

--- a/src/griptape_nodes/bootstrap/workflow_publishers/local_session_workflow_publisher.py
+++ b/src/griptape_nodes/bootstrap/workflow_publishers/local_session_workflow_publisher.py
@@ -50,7 +50,9 @@ class LocalSessionWorkflowPublisher(LocalWorkflowPublisher, SubprocessWebSocketS
     async def __aenter__(self) -> Self:
         """Async context manager entry: initialize queue and start WebSocket connection."""
         GriptapeNodes.EventManager().initialize_queue()
-        await GriptapeNodes.EventManager().abroadcast_app_event(AppInitializationComplete())
+        # warm_port_summaries=False: a subprocess that packages a workflow for publishing. It never
+        # displays an Add Node menu, so nothing will read the summaries the warm pass would build.
+        await GriptapeNodes.EventManager().abroadcast_app_event(AppInitializationComplete(warm_port_summaries=False))
 
         logger.info("Setting up publishing session %s", self._session_id)
         GriptapeNodes.SessionManager().save_session(self._session_id)

--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -2469,6 +2469,28 @@ class ParameterContainer(Parameter, ABC):
         """
         return True
 
+    def get_element_input_types(self) -> list[str]:
+        """Types a single child port of this container accepts, without the container wrapper.
+
+        A container's own `input_types` describe connecting a whole collection to it
+        (`list[str]`, `list`), which is not what one of its child ports accepts (`str`). Callers
+        reasoning about connectivity before any child exists -- ranking node types for the Add
+        Node menu, for instance -- need both, because a list container is exactly how a node
+        advertises "I take many of these".
+
+        Empty by default: a container whose children are not plain scalar ports (a dictionary's
+        key-value pairs) has no element type worth connecting to.
+        """
+        return []
+
+    def get_element_output_type(self) -> str | None:
+        """Type a single child port of this container emits, without the container wrapper.
+
+        The output-side counterpart to `get_element_input_types`. None when the container has no
+        scalar element type.
+        """
+        return None
+
     @abstractmethod
     def add_child_parameter(self) -> Parameter:
         pass
@@ -2690,6 +2712,17 @@ class ParameterList(ParameterContainer):
         base_type = super()._custom_getter_for_property_output_type()
         result = f"list[{base_type}]"
         return result
+
+    def get_element_input_types(self) -> list[str]:
+        # Bypassing this class's wrapping getter lands on Parameter's, which applies the same
+        # declared-else-`type` fallback the children get: add_child_parameter hands a new child the
+        # raw `_input_types` / `_type` / `_output_type`, so the child's resolved `input_types` are
+        # exactly these.
+        return super()._custom_getter_for_property_input_types()
+
+    def get_element_output_type(self) -> str | None:
+        # Same reasoning as get_element_input_types, for the output side.
+        return super()._custom_getter_for_property_output_type()
 
     def __len__(self) -> int:
         # Returns the number of child Parameters. Just do the top level.

--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -2717,8 +2717,9 @@ class ParameterList(ParameterContainer):
         # Bypassing this class's wrapping getter lands on Parameter's, which applies the same
         # declared-else-`type` fallback the children get: add_child_parameter hands a new child the
         # raw `_input_types` / `_type` / `_output_type`, so the child's resolved `input_types` are
-        # exactly these.
-        return super()._custom_getter_for_property_input_types()
+        # exactly these. Copied because Parameter's getter can return `self._input_types` itself,
+        # and a caller mutating what it got back would rewrite this container's declared types.
+        return list(super()._custom_getter_for_property_input_types())
 
     def get_element_output_type(self) -> str | None:
         # Same reasoning as get_element_input_types, for the output side.

--- a/src/griptape_nodes/retained_mode/events/app_events.py
+++ b/src/griptape_nodes/retained_mode/events/app_events.py
@@ -125,6 +125,14 @@ class AppInitializationComplete(AppPayload):
     # then serves the workspace itself, which is the path that goes away once every shipped
     # host provides a server (see the fallback in StaticFilesManager).
     static_server_base_url: str | None = None
+    # Whether anything in this process will ask what ports node types have. True for a host with an
+    # editor attached, which needs port summaries to rank node types mid-drag; False for a headless
+    # run (a CLI execution, a published workflow), which runs a fixed graph and never asks. The
+    # engine warms that cache in the background after libraries load, and warming means
+    # constructing every node type in every library -- worth doing ahead of an artist, wasted work
+    # competing with a workflow that is already running. Defaults to True so a host that says
+    # nothing keeps the interactive behavior.
+    warm_port_summaries: bool = True
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/library_events.py
+++ b/src/griptape_nodes/retained_mode/events/library_events.py
@@ -274,7 +274,7 @@ class ParameterDescription:
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class NodePortSummary:
     """Connectivity-only view of a node type's ports, derived from the parameters it declares.
 
@@ -289,17 +289,24 @@ class NodePortSummary:
     `input_types` / `output_types` because control and data connections never interconnect.
 
     The type strings are raw declared type names, so matching them is NOT set membership. Use the
-    engine's own rules, which `ParameterType.are_types_compatible(source, target)` implements:
+    engine's own rules. `ParameterType.are_types_compatible(source, target)` implements most of
+    them:
 
     - Matching is case-insensitive (`"Image"` matches `"image"`).
     - It is directional and asymmetric. A target of `"any"` accepts every source type, but a
       source of `"any"` is not accepted by a specific target.
-    - A source of `"all"` matches every target (`Parameter.is_incoming_type_allowed`
-      short-circuits on it).
     - Parameterized types match on their base, so `"list[str]"` matches a `"list"` target.
+
+    One rule lives outside that function and a client has to apply it too: a source of `"all"`
+    matches every target. `Parameter.is_incoming_type_allowed` short-circuits on it before
+    delegating, so calling `are_types_compatible` alone leaves every `"all"`-typed output ranked
+    against nothing -- the wildcard case ranking most needs to get right.
 
     A client that treats these as opaque strings and intersects two sets will get the wrong
     answer for every one of those cases.
+
+    Immutable, and the type fields are tuples, so a cached summary can be handed to a caller
+    without copying it.
 
     Args:
         input_types: Accepted types unioned over every port allowing the INPUT mode
@@ -308,8 +315,8 @@ class NodePortSummary:
         has_control_output: Whether the node declares an outgoing control (execution) port
     """
 
-    input_types: list[str]
-    output_types: list[str]
+    input_types: tuple[str, ...]
+    output_types: tuple[str, ...]
     has_control_input: bool
     has_control_output: bool
 
@@ -347,8 +354,8 @@ class NodePortSummary:
                     output_types.append(emitted_type)
 
         return cls(
-            input_types=input_types,
-            output_types=output_types,
+            input_types=tuple(input_types),
+            output_types=tuple(output_types),
             has_control_input=has_control_input,
             has_control_output=has_control_output,
         )
@@ -934,7 +941,10 @@ class GetPortSummariesForAllLibrariesRequest(RequestPayload):
     (`library.lazy_node_loading`), so folding this into the catalog would import and instantiate
     every node type in every library on every editor connect. Here the cost is paid once, on
     demand, by the callers that need ranking. Results are cached per library for the process
-    lifetime and recomputed after the library is reloaded.
+    lifetime and recomputed after the library is reloaded. A node type whose probe timed out is
+    the one thing retried, and only on the next request; after that its gap is treated as
+    permanent until the library reloads, because re-probing a node whose `__init__` blocks costs
+    a thread that cannot be reclaimed.
 
     Known limitation: only ports present right after construction are reported. Ports created
     dynamically later (config-driven ports, transition components swapping in a schema) are

--- a/src/griptape_nodes/retained_mode/events/library_events.py
+++ b/src/griptape_nodes/retained_mode/events/library_events.py
@@ -962,11 +962,12 @@ class GetPortSummariesForAllLibrariesRequest(RequestPayload):
     node's actual parameters. Container parameters are covered despite their children not
     existing yet, because a container knows its element type up front.
 
-    Always succeeds, so there is no failure result to handle. Every way a probe can fail is a
-    property of one node type -- an unimportable module, a raising `__init__`, one that blocks past
-    the timeout -- and the answer is to omit that node type, not to fail the request for every
-    other one. A caller that gets fewer node types than it expected reads that as "leave these
-    unranked".
+    Declares no failure result, because every way a probe can fail is a property of one node type --
+    an unimportable module, a raising `__init__`, one that blocks past the timeout -- and the answer
+    is to omit that node type, not to fail the request for every other one. A caller that gets fewer
+    node types than it expected reads that as "leave these unranked". A caller must still handle a
+    failure it did not ask for: as with any request, an unhandled exception inside the engine comes
+    back as `GenericResultFailure`.
 
     Results: GetPortSummariesForAllLibrariesResultSuccess
     """

--- a/src/griptape_nodes/retained_mode/events/library_events.py
+++ b/src/griptape_nodes/retained_mode/events/library_events.py
@@ -945,9 +945,13 @@ class GetPortSummariesForAllLibrariesRequest(RequestPayload):
     Deliberately a separate request rather than a field on the library catalog. A node type's
     ports are only knowable by constructing it, and node modules are imported lazily by default
     (`library.lazy_node_loading`), so folding this into the catalog would import and instantiate
-    every node type in every library on every editor connect. Here the cost is paid once, on
-    demand, by the callers that need ranking. Results are cached per library for the process
-    lifetime and recomputed after the library is reloaded. A node type whose probe timed out is
+    every node type in every library on every editor connect. Here the cost is paid once per
+    library per load, and by default off the critical path: the engine warms the cache in the
+    background once libraries finish loading, and again after a reload, so a caller normally hits
+    a warm cache (`library.warm_port_summaries` disables that, which only changes *when* the cost
+    is paid -- the first request then computes it, as it did before warming existed). Results are
+    cached per library for the process lifetime and recomputed after the library is reloaded. A
+    node type whose probe timed out is
     the one thing retried, and only on the next request; after that its gap is treated as
     permanent until the library reloads, because re-probing a node whose `__init__` blocks costs
     a thread that cannot be reclaimed.

--- a/src/griptape_nodes/retained_mode/events/library_events.py
+++ b/src/griptape_nodes/retained_mode/events/library_events.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, NamedTuple
 
-from griptape_nodes.exe_types.core_types import ParameterMode, ParameterTypeBuiltin
+from griptape_nodes.exe_types.core_types import ParameterContainer, ParameterMode, ParameterTypeBuiltin
 from griptape_nodes.node_library.library_registry import (
     LibraryMetadata,
     LibrarySchema,
@@ -288,6 +288,19 @@ class NodePortSummary:
     Control flow is carried solely by the two booleans. Control ports are excluded from
     `input_types` / `output_types` because control and data connections never interconnect.
 
+    The type strings are raw declared type names, so matching them is NOT set membership. Use the
+    engine's own rules, which `ParameterType.are_types_compatible(source, target)` implements:
+
+    - Matching is case-insensitive (`"Image"` matches `"image"`).
+    - It is directional and asymmetric. A target of `"any"` accepts every source type, but a
+      source of `"any"` is not accepted by a specific target.
+    - A source of `"all"` matches every target (`Parameter.is_incoming_type_allowed`
+      short-circuits on it).
+    - Parameterized types match on their base, so `"list[str]"` matches a `"list"` target.
+
+    A client that treats these as opaque strings and intersects two sets will get the wrong
+    answer for every one of those cases.
+
     Args:
         input_types: Accepted types unioned over every port allowing the INPUT mode
         output_types: Emitted types unioned over every port allowing the OUTPUT mode
@@ -305,8 +318,10 @@ class NodePortSummary:
         """Derive the summary from the parameters a probed node declares.
 
         Only sees parameters that exist right after construction. Ports added dynamically at
-        runtime (container children, config-driven ports) are absent by design -- see
-        GetPortSummariesForAllLibrariesRequest.
+        runtime (config-driven ports, transition components) are absent by design -- see
+        GetPortSummariesForAllLibrariesRequest. Container parameters are the exception: their
+        children do not exist yet either, but a container knows the element type its children will
+        have, so both the container type and the element type are reported.
         """
         control_type = ParameterTypeBuiltin.CONTROL_TYPE.value
         input_types: list[str] = []
@@ -319,17 +334,13 @@ class NodePortSummary:
             if parameter.private:
                 continue
 
-            if ParameterMode.INPUT in parameter.allowed_modes:
-                # `Parameter.input_types` already falls back to the parameter's single `type`.
-                for accepted_type in parameter.input_types:
-                    if accepted_type == control_type:
-                        has_control_input = True
-                    elif accepted_type not in input_types:
-                        input_types.append(accepted_type)
+            for accepted_type in cls._accepted_types_for(parameter):
+                if accepted_type == control_type:
+                    has_control_input = True
+                elif accepted_type not in input_types:
+                    input_types.append(accepted_type)
 
-            if ParameterMode.OUTPUT in parameter.allowed_modes:
-                # Likewise, `Parameter.output_type` falls back to `type`.
-                emitted_type = parameter.output_type
+            for emitted_type in cls._emitted_types_for(parameter):
                 if emitted_type == control_type:
                     has_control_output = True
                 elif emitted_type not in output_types:
@@ -341,6 +352,42 @@ class NodePortSummary:
             has_control_input=has_control_input,
             has_control_output=has_control_output,
         )
+
+    @staticmethod
+    def _accepted_types_for(parameter: Parameter) -> list[str]:
+        """Every type a single parameter can accept, before deduplication.
+
+        A container advertises the collection type on itself (`list[str]`, `list`) while its
+        children take the element type (`str`). Both are reported: an expander node is precisely
+        how a node type says "I accept many of these", so omitting the element type would hide the
+        nodes a single-value drag most wants to find. Children inherit the container's
+        `allowed_modes`, so the same INPUT gating covers them.
+        """
+        if ParameterMode.INPUT not in parameter.allowed_modes:
+            return []
+
+        # `Parameter.input_types` already falls back to the parameter's single `type`.
+        accepted_types = list(parameter.input_types)
+        if isinstance(parameter, ParameterContainer):
+            accepted_types.extend(parameter.get_element_input_types())
+        return accepted_types
+
+    @staticmethod
+    def _emitted_types_for(parameter: Parameter) -> list[str]:
+        """Every type a single parameter can emit, before deduplication.
+
+        The output-side counterpart to `_accepted_types_for`, with the same container reasoning.
+        """
+        if ParameterMode.OUTPUT not in parameter.allowed_modes:
+            return []
+
+        # Likewise, `Parameter.output_type` falls back to `type`.
+        emitted_types = [parameter.output_type]
+        if isinstance(parameter, ParameterContainer):
+            element_output_type = parameter.get_element_output_type()
+            if element_output_type is not None:
+                emitted_types.append(element_output_type)
+        return emitted_types
 
 
 @dataclass
@@ -890,8 +937,10 @@ class GetPortSummariesForAllLibrariesRequest(RequestPayload):
     lifetime and recomputed after the library is reloaded.
 
     Known limitation: only ports present right after construction are reported. Ports created
-    dynamically later (container children, config-driven ports) are absent, which is fine for
-    ranking -- the real connection is resolved against the created node's actual parameters.
+    dynamically later (config-driven ports, transition components swapping in a schema) are
+    absent, which is fine for ranking -- the real connection is resolved against the created
+    node's actual parameters. Container parameters are covered despite their children not
+    existing yet, because a container knows its element type up front.
 
     Results: GetPortSummariesForAllLibrariesResultSuccess | GetPortSummariesForAllLibrariesResultFailure
     """

--- a/src/griptape_nodes/retained_mode/events/library_events.py
+++ b/src/griptape_nodes/retained_mode/events/library_events.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any, NamedTuple
 
+from griptape_nodes.exe_types.core_types import ParameterMode, ParameterTypeBuiltin
 from griptape_nodes.node_library.library_registry import (
     LibraryMetadata,
     LibrarySchema,
@@ -270,6 +271,75 @@ class ParameterDescription:
             settable=param_dict["settable"],
             ui_options=param_dict["ui_options"],
             parent_container_name=param_dict["parent_container_name"],
+        )
+
+
+@dataclass
+class NodePortSummary:
+    """Connectivity-only view of a node type's ports, derived from the parameters it declares.
+
+    Purpose-built for ranking node types before any node exists -- e.g. the editor dragging a
+    connection onto empty canvas, where the Add Node menu wants to float compatible node types
+    to the top. The type lists are unions across every port, so a match means "this node type
+    has some port that could accept the dragged connection", not that a specific port will:
+    the actual connection is still resolved against the created node's real parameters, which
+    is also where a node gets to veto via `allow_incoming_connection` / `allow_outgoing_connection`.
+
+    Control flow is carried solely by the two booleans. Control ports are excluded from
+    `input_types` / `output_types` because control and data connections never interconnect.
+
+    Args:
+        input_types: Accepted types unioned over every port allowing the INPUT mode
+        output_types: Emitted types unioned over every port allowing the OUTPUT mode
+        has_control_input: Whether the node declares an incoming control (execution) port
+        has_control_output: Whether the node declares an outgoing control (execution) port
+    """
+
+    input_types: list[str]
+    output_types: list[str]
+    has_control_input: bool
+    has_control_output: bool
+
+    @classmethod
+    def from_parameters(cls, parameters: list[Parameter]) -> NodePortSummary:
+        """Derive the summary from the parameters a probed node declares.
+
+        Only sees parameters that exist right after construction. Ports added dynamically at
+        runtime (container children, config-driven ports) are absent by design -- see
+        GetPortSummariesForAllLibrariesRequest.
+        """
+        control_type = ParameterTypeBuiltin.CONTROL_TYPE.value
+        input_types: list[str] = []
+        output_types: list[str] = []
+        has_control_input = False
+        has_control_output = False
+
+        for parameter in parameters:
+            # Private parameters are engine bookkeeping and are never offered as ports.
+            if parameter.private:
+                continue
+
+            if ParameterMode.INPUT in parameter.allowed_modes:
+                # `Parameter.input_types` already falls back to the parameter's single `type`.
+                for accepted_type in parameter.input_types:
+                    if accepted_type == control_type:
+                        has_control_input = True
+                    elif accepted_type not in input_types:
+                        input_types.append(accepted_type)
+
+            if ParameterMode.OUTPUT in parameter.allowed_modes:
+                # Likewise, `Parameter.output_type` falls back to `type`.
+                emitted_type = parameter.output_type
+                if emitted_type == control_type:
+                    has_control_output = True
+                elif emitted_type not in output_types:
+                    output_types.append(emitted_type)
+
+        return cls(
+            input_types=input_types,
+            output_types=output_types,
+            has_control_input=has_control_input,
+            has_control_output=has_control_output,
         )
 
 
@@ -800,6 +870,51 @@ class GetAllInfoForAllLibrariesResultSuccess(WorkflowNotAlteredMixin, ResultPayl
 @PayloadRegistry.register
 class GetAllInfoForAllLibrariesResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     """Comprehensive information retrieval for all libraries failed. Common causes: registry not initialized, system error."""
+
+
+@dataclass
+@PayloadRegistry.register
+class GetPortSummariesForAllLibrariesRequest(RequestPayload):
+    """Get a compact port summary for every node type in every registered library.
+
+    Use when: ranking node types by what they can connect to before any node exists -- the
+    editor's drag-a-connection-onto-empty-canvas flow, or any other "which node types accept
+    this type?" question. `GetAllInfoForLibraryRequest` deliberately carries only display
+    metadata, which cannot answer it.
+
+    Deliberately a separate request rather than a field on the library catalog. A node type's
+    ports are only knowable by constructing it, and node modules are imported lazily by default
+    (`library.lazy_node_loading`), so folding this into the catalog would import and instantiate
+    every node type in every library on every editor connect. Here the cost is paid once, on
+    demand, by the callers that need ranking. Results are cached per library for the process
+    lifetime and recomputed after the library is reloaded.
+
+    Known limitation: only ports present right after construction are reported. Ports created
+    dynamically later (container children, config-driven ports) are absent, which is fine for
+    ranking -- the real connection is resolved against the created node's actual parameters.
+
+    Results: GetPortSummariesForAllLibrariesResultSuccess | GetPortSummariesForAllLibrariesResultFailure
+    """
+
+
+@dataclass
+@PayloadRegistry.register
+class GetPortSummariesForAllLibrariesResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """Port summaries retrieved successfully.
+
+    Args:
+        library_name_to_port_summaries: Per library, a map of node type name to its port summary.
+            Node types the engine could not construct are omitted rather than reported as
+            portless, so callers can leave them unranked instead of ranking them wrongly.
+    """
+
+    library_name_to_port_summaries: dict[str, dict[str, NodePortSummary]]
+
+
+@dataclass
+@PayloadRegistry.register
+class GetPortSummariesForAllLibrariesResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """Port summary retrieval failed. Common causes: registry not initialized, system error."""
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/library_events.py
+++ b/src/griptape_nodes/retained_mode/events/library_events.py
@@ -962,7 +962,13 @@ class GetPortSummariesForAllLibrariesRequest(RequestPayload):
     node's actual parameters. Container parameters are covered despite their children not
     existing yet, because a container knows its element type up front.
 
-    Results: GetPortSummariesForAllLibrariesResultSuccess | GetPortSummariesForAllLibrariesResultFailure
+    Always succeeds, so there is no failure result to handle. Every way a probe can fail is a
+    property of one node type -- an unimportable module, a raising `__init__`, one that blocks past
+    the timeout -- and the answer is to omit that node type, not to fail the request for every
+    other one. A caller that gets fewer node types than it expected reads that as "leave these
+    unranked".
+
+    Results: GetPortSummariesForAllLibrariesResultSuccess
     """
 
 
@@ -978,12 +984,6 @@ class GetPortSummariesForAllLibrariesResultSuccess(WorkflowNotAlteredMixin, Resu
     """
 
     library_name_to_port_summaries: dict[str, dict[str, NodePortSummary]]
-
-
-@dataclass
-@PayloadRegistry.register
-class GetPortSummariesForAllLibrariesResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
-    """Port summary retrieval failed. Common causes: registry not initialized, system error."""
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/library_events.py
+++ b/src/griptape_nodes/retained_mode/events/library_events.py
@@ -295,7 +295,11 @@ class NodePortSummary:
     - Matching is case-insensitive (`"Image"` matches `"image"`).
     - It is directional and asymmetric. A target of `"any"` accepts every source type, but a
       source of `"any"` is not accepted by a specific target.
-    - Parameterized types match on their base, so `"list[str]"` matches a `"list"` target.
+    - `"none"` on either side never matches, ahead of every rule below it -- including the
+      `"any"` target, which does not rescue it.
+    - Parameterized types match on their base, but only toward a less specific target:
+      `"list[str]"` matches a `"list"` or `"list[any]"` target, while a bare `"list"` source does
+      not match a `"list[str]"` one.
 
     One rule lives outside that function and a client has to apply it too: a source of `"all"`
     matches every target. `Parameter.is_incoming_type_allowed` short-circuits on it before
@@ -326,9 +330,11 @@ class NodePortSummary:
 
         Only sees parameters that exist right after construction. Ports added dynamically at
         runtime (config-driven ports, transition components) are absent by design -- see
-        GetPortSummariesForAllLibrariesRequest. Container parameters are the exception: their
-        children do not exist yet either, but a container knows the element type its children will
-        have, so both the container type and the element type are reported.
+        GetPortSummariesForAllLibrariesRequest. List containers are the exception: their children do
+        not exist yet either, but the container knows the element type its children will have, so
+        both the container type and the element type are reported. A dictionary container reports
+        only its own type, because its children are key-value pairs rather than scalar ports and
+        there is no single element type to advertise.
         """
         control_type = ParameterTypeBuiltin.CONTROL_TYPE.value
         input_types: list[str] = []

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -83,6 +83,33 @@ _active_post_dispatch_hooks: ContextVar[tuple[tuple[type[RequestPayload], Any], 
 # for a hook that runs slower than requests arrive.
 POST_DISPATCH_HOOK_INFLIGHT_WARNING_THRESHOLD = 100
 
+_event_publication_suppressed: ContextVar[bool] = ContextVar(
+    "_event_manager_event_publication_suppressed", default=False
+)
+
+
+@contextmanager
+def suppress_event_publication() -> Iterator[None]:
+    """Drop every event published from the calling task or thread for the duration of the block.
+
+    For work that constructs a real object purely to inspect it. `LibraryManager`'s throwaway
+    probe node is the case this exists for: its `__init__` runs the same `add_parameter` calls a
+    canvas node's would, so it publishes parameter events naming a node the editor has never
+    heard of and never will.
+
+    Deliberately not `EventSuppressionContext`, which reference-counts event types on the manager
+    and is consulted at the send boundary. That is the wrong tool twice over here: probe
+    construction runs in a worker thread, where mutating manager state races the loop, and
+    suppressing a type outright would also silence that event for real nodes changing at the same
+    moment. A ContextVar is scoped to the block that set it, and `asyncio.to_thread` carries it
+    into the worker via `copy_context()`.
+    """
+    token = _event_publication_suppressed.set(True)
+    try:
+        yield
+    finally:
+        _event_publication_suppressed.reset(token)
+
 
 def _is_async_callable(callback: Any) -> bool:
     """Whether calling `callback` returns a coroutine.
@@ -322,6 +349,8 @@ class EventManager(EngineScoped):
         Args:
             event: The event to publish to the queue
         """
+        if _event_publication_suppressed.get():
+            return
         if self._event_queue is None:
             return
 
@@ -346,6 +375,8 @@ class EventManager(EngineScoped):
         Args:
             event: The event to publish to the queue
         """
+        if _event_publication_suppressed.get():
+            return
         if self._event_queue is None:
             return
 

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -97,11 +97,16 @@ def suppress_event_publication() -> Iterator[None]:
     canvas node's would, so it publishes parameter events naming a node the editor has never
     heard of and never will.
 
-    Blunt on purpose, and worth knowing how blunt: this drops *every* event the block publishes,
-    including the fan-out to registered execution-event listeners, and it covers anything the block
-    transitively causes -- a request the inspected object's `__init__` issues has its result
-    dropped too. It follows the context rather than the call stack, so a thread the block spawns
-    itself starts from a fresh copy and does publish.
+    Blunt on purpose, and worth knowing exactly how blunt. It drops everything routed through
+    `put_event` / `aput_event`, which includes the fan-out to registered execution-event listeners,
+    and it covers whatever the block transitively causes -- a request the inspected object's
+    `__init__` issues has its result dropped too. App events are the exception: `broadcast_app_event`
+    dispatches to `_app_event_listeners` directly and is unaffected.
+
+    Scope follows the context, not the call stack, which cuts both ways. A `threading.Thread` the
+    block starts gets a fresh context and does publish. But `asyncio.create_task`, `loop.call_soon`,
+    and `run_coroutine_threadsafe` all *copy* the current context, so anything the block schedules
+    onto the loop stays suppressed for that callback's whole life, well after the block exits.
 
     Deliberately not `EventSuppressionContext`, which reference-counts event types on the manager
     and is consulted at the send boundary. That is the wrong tool twice over here: probe

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -83,9 +83,35 @@ _active_post_dispatch_hooks: ContextVar[tuple[tuple[type[RequestPayload], Any], 
 # for a hook that runs slower than requests arrive.
 POST_DISPATCH_HOOK_INFLIGHT_WARNING_THRESHOLD = 100
 
-_event_publication_suppressed: ContextVar[bool] = ContextVar(
-    "_event_manager_event_publication_suppressed", default=False
+
+class _EventSuppressionScope:
+    """One `suppress_event_publication` block, shared by every context copied out of it.
+
+    A plain `True` in the ContextVar cannot be taken back: `asyncio.create_task`, `loop.call_soon`,
+    and `run_coroutine_threadsafe` snapshot the context, and resetting the token afterwards only
+    touches the context the block ran in. Holding a mutable object instead means every copy points
+    at this one, so clearing `active` on the way out ends suppression in all of them at once and
+    scopes it to the block's actual duration.
+    """
+
+    __slots__ = ("active",)
+
+    def __init__(self) -> None:
+        self.active = True
+
+
+_event_publication_suppressed: ContextVar[_EventSuppressionScope | None] = ContextVar(
+    "_event_manager_event_publication_suppressed", default=None
 )
+
+
+def _is_event_publication_suppressed() -> bool:
+    """Whether the caller is running inside a live `suppress_event_publication` block."""
+    scope = _event_publication_suppressed.get()
+    if scope is None:
+        return False
+
+    return scope.active
 
 
 @contextmanager
@@ -104,9 +130,12 @@ def suppress_event_publication() -> Iterator[None]:
     dispatches to `_app_event_listeners` directly and is unaffected.
 
     Scope follows the context, not the call stack, which cuts both ways. A `threading.Thread` the
-    block starts gets a fresh context and does publish. But `asyncio.create_task`, `loop.call_soon`,
-    and `run_coroutine_threadsafe` all *copy* the current context, so anything the block schedules
-    onto the loop stays suppressed for that callback's whole life, well after the block exits.
+    block starts gets a fresh context and does publish. `asyncio.create_task`, `loop.call_soon`, and
+    `run_coroutine_threadsafe` all *copy* the current context, so a callback the block schedules is
+    suppressed too -- but only for as long as the block itself is running (see
+    `_EventSuppressionScope`). A callback that outlives the block publishes normally from the moment
+    the block returns, which is what stops an inspected object's stray `create_task` from silently
+    dropping the editor's events for the rest of the process.
 
     Deliberately not `EventSuppressionContext`, which reference-counts event types on the manager
     and is consulted at the send boundary. That is the wrong tool twice over here: probe
@@ -115,10 +144,15 @@ def suppress_event_publication() -> Iterator[None]:
     moment. A ContextVar is scoped to the block that set it, and `asyncio.to_thread` carries it
     into the worker via `copy_context()`.
     """
-    token = _event_publication_suppressed.set(True)
+    scope = _EventSuppressionScope()
+    token = _event_publication_suppressed.set(scope)
     try:
         yield
     finally:
+        # Both, and in this order. Clearing the flag ends suppression for every context copied out
+        # of this block, including ones this coroutine cannot reach; resetting the token restores
+        # whatever an enclosing block had set, so nesting still works.
+        scope.active = False
         _event_publication_suppressed.reset(token)
 
 
@@ -360,7 +394,7 @@ class EventManager(EngineScoped):
         Args:
             event: The event to publish to the queue
         """
-        if _event_publication_suppressed.get():
+        if _is_event_publication_suppressed():
             return
         if self._event_queue is None:
             return
@@ -386,7 +420,7 @@ class EventManager(EngineScoped):
         Args:
             event: The event to publish to the queue
         """
-        if _event_publication_suppressed.get():
+        if _is_event_publication_suppressed():
             return
         if self._event_queue is None:
             return

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -97,6 +97,12 @@ def suppress_event_publication() -> Iterator[None]:
     canvas node's would, so it publishes parameter events naming a node the editor has never
     heard of and never will.
 
+    Blunt on purpose, and worth knowing how blunt: this drops *every* event the block publishes,
+    including the fan-out to registered execution-event listeners, and it covers anything the block
+    transitively causes -- a request the inspected object's `__init__` issues has its result
+    dropped too. It follows the context rather than the call stack, so a thread the block spawns
+    itself starts from a fresh copy and does publish.
+
     Deliberately not `EventSuppressionContext`, which reference-counts event types on the manager
     and is consulted at the send boundary. That is the wrong tool twice over here: probe
     construction runs in a worker thread, where mutating manager state races the loop, and

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -470,6 +470,37 @@ class NodeTypePortProbeOutcome(NamedTuple):
     thread_lost: bool = False
 
 
+class ProbeThreadSignals(NamedTuple):
+    """What a probe's worker thread reports about itself, on the way in and on the way out.
+
+    The worker has to be the one to say, because nothing on the loop's side can. Cancelling either
+    the task or the executor future leaves a running worker running, so a construction that is still
+    holding a thread looks exactly like one that returned. And a work item cancelled out of the
+    executor's queue before any thread picked it up looks the same again, while holding nothing: a
+    `concurrent.futures.Future` still in PENDING cancels for real, and the callable never runs.
+
+    That last case is why "started" is recorded as well as "finished". Reading a clear `finished` as
+    "still holding a thread" charged the engine-wide ceiling for probes that never ran, and a busy
+    executor is exactly when it would happen -- so a burst of contention could permanently stop
+    probing on an engine holding no probe threads at all.
+    """
+
+    started: threading.Event
+    finished: threading.Event
+
+    @property
+    def thread_is_held(self) -> bool:
+        """Whether a worker is inside the node's `__init__` right now, holding an unreclaimable thread.
+
+        There is a window of a few instructions where a worker that has been handed the work item
+        has not yet set `started`, and this reads False for a thread that is in fact held. Erring
+        that way on purpose: the cost of undercounting is one probe's worth of slack in a ceiling
+        that only decides when to stop probing, while overcounting -- the case above -- permanently
+        disables connection ranking for the whole process.
+        """
+        return self.started.is_set() and not self.finished.is_set()
+
+
 class LibraryGitOperationContext(NamedTuple):
     """Context information for git operations on a library."""
 
@@ -753,8 +784,8 @@ class LibraryManager(EngineScoped):
         # This never decreases, and _PROBE_THREAD_LEAK_CEILING is the only bound expressed in terms
         # of the executor actually being drained.
         self._port_summary_timed_out_threads: int = 0
-        # The "worker finished" signal of every construction abandoned by a cancellation, kept until
-        # it fires. A timeout means the thread is gone for the life of the process, but a
+        # The "worker finished" signal of every started construction abandoned by a cancellation,
+        # kept until it fires. A timeout means the thread is gone for the life of the process, but a
         # cancellation usually catches a perfectly healthy __init__ a few milliseconds in, and that
         # thread is back in the pool almost immediately. Charging those permanently would walk the
         # ceiling up on every reload -- each one cancels the warm pass, often mid-probe -- and
@@ -2321,20 +2352,23 @@ class LibraryManager(EngineScoped):
         node_type: str,
         node_class: type[BaseNode],
         library_node_metadata: dict[str, Any],
-        finished: threading.Event,
+        signals: ProbeThreadSignals,
     ) -> NodeProbeResult:
-        """Construct a probe node and record, from inside the worker, that the thread is free again.
+        """Construct a probe node, reporting from inside the worker when it takes a thread and frees it.
 
-        Exists because a caller that gave up on this construction cannot otherwise tell whether the
-        thread it started is still held: neither `asyncio.wait_for`'s timeout nor a cancellation
-        reaches into the worker, and both leave the task looking finished while `__init__` runs on.
+        Exists because a caller that gave up on this construction cannot otherwise tell whether a
+        thread is held: neither `asyncio.wait_for`'s timeout nor a cancellation reaches into the
+        worker, and both leave the task looking finished whether `__init__` is running on, already
+        returned, or never started at all. See `ProbeThreadSignals`.
+
         `finished` is set even when construction fails, since a raising `__init__` returns its thread
         just as a successful one does.
         """
+        signals.started.set()
         try:
             return self._construct_probe_node(library_name, node_type, node_class, library_node_metadata)
         finally:
-            finished.set()
+            signals.finished.set()
 
     def list_categories_in_library_request(self, request: ListCategoriesInLibraryRequest) -> ResultPayload:
         # Does this library exist?
@@ -3608,26 +3642,34 @@ class LibraryManager(EngineScoped):
             return
 
         task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            # The expected outcome, and not this coroutine's own cancellation: `task` is not the
-            # caller's task, so awaiting it raises the cancellation we just requested.
-            pass
-        except Exception as err:
-            # The pass answered the cancellation by failing instead -- a broken `finally` on its way
-            # out, say. (A pass that had already failed cannot arrive here: the check above skips a
-            # task that is `done()`.) Callers use this to make an unload safe, not to find out how
-            # warming went, and letting it propagate would abort a reload over a background task that
-            # is already off the loop -- exactly what the reload would fix. DEBUG rather than WARNING
-            # because `_on_port_summary_warm_done` has already logged this same exception for the
-            # operator; two warnings for one failure only invite chasing it twice.
-            logger.debug(
-                "Port summary warming raised while being stopped: %s: %s. Summaries will be recomputed after this "
-                "reload.",
-                type(err).__name__,
-                err,
-            )
+        # Waited on through `asyncio.wait` rather than by awaiting the task, which would make it this
+        # coroutine's `_fut_waiter`: cancelling *this* coroutine then cancels `task` and raises here
+        # indistinguishably from the cancellation just requested, so swallowing that -- as this used
+        # to -- loses the caller's cancellation. That is the shutdown-during-reload case, and losing
+        # it means the reload carries on tearing the registry down for a caller that has gone away.
+        # `asyncio.wait` suspends on a future of its own, so it returns when the pass is off the loop
+        # and raises only when this coroutine is really being cancelled.
+        await asyncio.wait({task})
+
+        if task.cancelled():
+            return
+
+        error = task.exception()
+        if error is None:
+            return
+
+        # The pass answered the cancellation by failing instead -- a broken `finally` on its way out,
+        # say. (A pass that had already failed cannot arrive here: the check above skips a task that
+        # is `done()`.) Callers use this to make an unload safe, not to find out how warming went, and
+        # raising it would abort a reload over a background task that is already off the loop --
+        # exactly what the reload would fix. DEBUG rather than WARNING because
+        # `_on_port_summary_warm_done` has already logged this same exception for the operator; two
+        # warnings for one failure only invite chasing it twice.
+        logger.debug(
+            "Port summary warming raised while being stopped: %s: %s. Summaries will be recomputed after this reload.",
+            type(error).__name__,
+            error,
+        )
 
     async def _warm_port_summaries(self) -> None:
         """Probe every registered library's node types so the first real request is a cache hit.
@@ -4175,10 +4217,9 @@ class LibraryManager(EngineScoped):
             )
             return NodeTypePortProbeOutcome(summary=None, timed_out=False)
 
-        # Set by the worker itself, so it is the one signal that distinguishes "this construction is
-        # still holding a thread" from "it finished and the worker went back to the pool". Neither
-        # the task nor the future can say: cancelling either leaves the thread running.
-        probe_finished = threading.Event()
+        # The worker's own account of the thread it takes, which is the only account available: see
+        # `ProbeThreadSignals`.
+        signals = ProbeThreadSignals(started=threading.Event(), finished=threading.Event())
         try:
             probe_result = await asyncio.wait_for(
                 asyncio.to_thread(
@@ -4187,7 +4228,7 @@ class LibraryManager(EngineScoped):
                     node_type,
                     resolution.node_class,
                     library_node_metadata,
-                    probe_finished,
+                    signals,
                 ),
                 timeout=self._SCHEMA_PROBE_TIMEOUT_S,
             )
@@ -4200,8 +4241,8 @@ class LibraryManager(EngineScoped):
             # the usual abandoned construction is a healthy one that finishes moments later: see
             # `_leaked_probe_thread_count`. Not charged to the library or the pass either way, both
             # being about to be discarded.
-            if not probe_finished.is_set():
-                self._abandoned_probe_signals.append(probe_finished)
+            if signals.thread_is_held:
+                self._abandoned_probe_signals.append(signals.finished)
                 logger.warning(
                     "Port summary probing was stopped while constructing node type '%s' in library '%s'. Its thread "
                     "cannot be cancelled, so it is held until that construction returns (%d thread(s) held now); "
@@ -4213,9 +4254,7 @@ class LibraryManager(EngineScoped):
                 )
             raise
         except TimeoutError:
-            return self._timed_out_probe_outcome(
-                library_name=library_name, node_type=node_type, probe_finished=probe_finished
-            )
+            return self._timed_out_probe_outcome(library_name=library_name, node_type=node_type, signals=signals)
         except Exception:
             # _construct_probe_node already converts a raising __init__ into a result, so reaching
             # here means the failure was outside it -- the executor refusing work during interpreter
@@ -4256,32 +4295,49 @@ class LibraryManager(EngineScoped):
         return NodeTypePortProbeOutcome(summary=summary, timed_out=False)
 
     def _timed_out_probe_outcome(
-        self, *, library_name: str, node_type: str, probe_finished: threading.Event
+        self, *, library_name: str, node_type: str, signals: ProbeThreadSignals
     ) -> NodeTypePortProbeOutcome:
         """Report a construction that missed its deadline, saying whether its thread went with it.
 
-        `asyncio.to_thread` cannot be cancelled, so a timed-out construction usually holds a worker
-        of the loop's default executor until `__init__` returns, which for a genuinely stuck node
-        means for the life of the process. That is why the caller both bounds how many timeouts one
-        pass will spend and grants a node type one retry rather than one per request.
+        Three different things end up here, and only the first costs a thread.
 
-        Except when the construction landed in the window between its deadline passing and
-        `TimeoutError` being raised, in which case the worker is already back in the pool and only
-        the result was lost. Same question the cancellation branch asks, and the same answer: nothing
-        is charged to the engine-wide ceiling for a thread that is not held. Past the deadline the
-        engine has no basis to expect a *later* return, though, so a node that hands its thread back
-        at 10.5s is still charged -- conservative on purpose, and exactly the shape of node the
-        ceiling exists to stop paying for.
+        Usually the node's `__init__` is still running: `asyncio.to_thread` cannot be cancelled, so
+        it holds a worker of the loop's default executor until it returns, which for a genuinely
+        stuck node means for the life of the process. That is why the caller both bounds how many
+        timeouts one pass will spend and grants a node type one retry rather than one per request.
+
+        Or the construction landed in the window between its deadline passing and `TimeoutError`
+        being raised, so the worker is already back in the pool and only the result was lost. Past
+        the deadline the engine has no basis to expect a *later* return, so a node that hands its
+        thread back at 10.5s is still charged -- conservative on purpose, and exactly the shape of
+        node the ceiling exists to stop paying for.
+
+        Or the work item was never picked up at all, because every thread in the pool was busy for
+        the whole deadline. Nothing was learned about the node, and no thread is held.
+
+        The timeout itself is charged to the library and the pass in all three cases: the caller
+        really did wait out the deadline. Only the engine-wide ceiling distinguishes them, and it is
+        the one that has to, since it is the bound that never resets.
         """
-        thread_lost = not probe_finished.is_set()
+        thread_lost = signals.thread_is_held
         if thread_lost:
-            thread_note = " and leaking its probe thread, which cannot be cancelled"
+            thread_note = (
+                " and leaking its probe thread, which cannot be cancelled. The node's __init__ likely makes a "
+                "blocking call"
+            )
+        elif signals.started.is_set():
+            thread_note = (
+                ", though its probe thread finished in time to go back to the pool. The node's __init__ is close to "
+                "the time limit"
+            )
         else:
-            thread_note = ", though its probe thread finished in time to go back to the pool"
+            thread_note = (
+                ", though its construction never started: every thread in the engine's pool was busy for the whole "
+                "time limit, so this says nothing about the node itself"
+            )
 
         logger.warning(
-            "Port summary probe for node type '%s' in library '%s' timed out after %.1fs; skipping it%s. The node's "
-            "__init__ likely makes a blocking call.",
+            "Port summary probe for node type '%s' in library '%s' timed out after %.1fs; skipping it%s.",
             node_type,
             library_name,
             self._SCHEMA_PROBE_TIMEOUT_S,
@@ -6791,12 +6847,17 @@ class LibraryManager(EngineScoped):
         return new_downloads
 
     async def reload_libraries_request(self, request: ReloadAllLibrariesRequest) -> ResultPayload:
-        # Stop any background port summary warming before anything is torn down, and keep anything
-        # else from starting one until this is finished. The pass resolves node classes, so one left
+        # Keep anything else from starting a background port summary warm pass, then stop the one
+        # that is running, before anything is torn down. The pass resolves node classes, so one left
         # running -- or one begun in the several awaits it takes to tear the registry down -- would
         # import modules belonging to libraries this is about to unload, reviving exactly what the
         # reload exists to replace.
-        await self._cancel_port_summary_warm()
+        #
+        # In that order because the cancel suspends, and it clears the handle before it does: a
+        # notification handler landing in that window -- `_on_library_loaded_notification` runs as its
+        # own task and asks for a pass whenever a worker reports its node types -- would start one the
+        # cancel had already walked past, and the `finally` below would find it in flight and leave it
+        # running over the rebuild.
         self._port_summary_warm_suppressed += 1
 
         # Bracket the reload like on_app_initialization_complete so the heartbeat reports
@@ -6804,6 +6865,7 @@ class LibraryManager(EngineScoped):
         self._is_initializing = True
         restart_warming = True
         try:
+            await self._cancel_port_summary_warm()
             return await self._run_reload_libraries(request)
         except asyncio.CancelledError:
             # The reload itself was cancelled, which happens when the engine is shutting down or the
@@ -7717,10 +7779,12 @@ class LibraryManager(EngineScoped):
             On success: new_version (str, may be "unknown")
             On failure: ResultPayloadFailure instance
         """
-        await self._cancel_port_summary_warm()
+        # Raised before the cancel, which suspends after clearing the handle: see
+        # `reload_libraries_request`, which brackets itself the same way and for the same reason.
         self._port_summary_warm_suppressed += 1
         restart_warming = True
         try:
+            await self._cancel_port_summary_warm()
             return await self._run_reload_library_after_git_operation(
                 library_name=library_name,
                 library_file_path=library_file_path,

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -13,6 +13,7 @@ import shutil
 import subprocess
 import sys
 import sysconfig
+import threading
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -408,7 +409,7 @@ class PortSummaryComputation(NamedTuple):
 class PortSummaryCacheEntry(NamedTuple):
     """A library's cached port summaries plus the state deciding what a later pass still owes it.
 
-    Held as one value rather than parallel dicts because the four fields are only ever correct
+    Held as one value rather than parallel dicts because the five fields are only ever correct
     together: a summary map is complete exactly when nothing is pending, and `timeouts_spent` is
     what decides whether anything pending will actually be attempted.
     """
@@ -419,6 +420,12 @@ class PortSummaryCacheEntry(NamedTuple):
     retry_node_types: frozenset[str]
     # Node types no pass has attempted yet, carried until one does.
     unprobed_node_types: frozenset[str]
+    # Every node type whose one retry has been granted since this library loaded, whether or not the
+    # retry was ever taken. Accumulates for the life of the entry and is never treated as pending.
+    # Separate from `retry_node_types` because that set is what the *next* pass will retry, and a
+    # pass that stops early empties it without the retry having happened -- so using it alone as the
+    # record would hand the same node type a second and third retry.
+    retried_node_types: frozenset[str]
     # Probe timeouts this library has cost since it last loaded. Each one permanently holds a worker
     # of the loop's default executor, so this is the library's lifetime bill, not a per-pass count.
     timeouts_spent: int
@@ -897,8 +904,9 @@ class LibraryManager(EngineScoped):
             self._register_nodes_from_worker_schemas(notification.library_name, notification.node_schemas)
             # Registering those stubs dropped this library's cached summaries, and a worker can
             # report at any point -- including long after the startup warm pass finished. Without
-            # restarting the pass here, worker-hosted libraries would be the only ones left cold,
-            # so the artist pays the probe cost mid-drag for exactly those.
+            # this, worker-hosted libraries would be the only ones left cold, so the artist pays the
+            # probe cost mid-drag for exactly those. Ensures a pass exists rather than restarting
+            # one: several workers reporting in succession must not each cancel the last one's work.
             self._start_port_summary_warm()
         # Unblock any code awaiting this library's worker_ready event.
         if library_info.worker_ready is not None:
@@ -2285,6 +2293,27 @@ class LibraryManager(EngineScoped):
 
         return NodeProbeResult(node=probe_node, error_message="")
 
+    def _construct_probe_node_signalling_completion(
+        self,
+        library_name: str,
+        node_type: str,
+        node_class: type[BaseNode],
+        library_node_metadata: dict[str, Any],
+        finished: threading.Event,
+    ) -> NodeProbeResult:
+        """Construct a probe node and record, from inside the worker, that the thread is free again.
+
+        Exists because a caller that gave up on this construction cannot otherwise tell whether the
+        thread it started is still held: neither `asyncio.wait_for`'s timeout nor a cancellation
+        reaches into the worker, and both leave the task looking finished while `__init__` runs on.
+        `finished` is set even when construction fails, since a raising `__init__` returns its thread
+        just as a successful one does.
+        """
+        try:
+            return self._construct_probe_node(library_name, node_type, node_class, library_node_metadata)
+        finally:
+            finished.set()
+
     def list_categories_in_library_request(self, request: ListCategoriesInLibraryRequest) -> ResultPayload:
         # Does this library exist?
         try:
@@ -2805,21 +2834,32 @@ class LibraryManager(EngineScoped):
                         # in LibraryRegistry (for the editor and workflow loading); the worker
                         # process handles node loading and will report fitness via
                         # LibraryLoadedNotification once it finishes.
-                        if library_info.requires_worker and not self._is_worker:
-                            library_info.fitness = LibraryManager.LibraryFitness.NOT_EVALUATED
-                            library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.WORKER_PENDING
-                            self._library_file_path_to_info[file_path] = library_info
-                        else:
-                            # Attempt to load nodes from the library (modifies library_info in place).
-                            await asyncio.to_thread(
-                                self._attempt_load_nodes_from_library,
-                                library_data=library_data,
-                                library=library,
-                                base_dir=base_dir,
-                                library_info=library_info,
-                                lazy_loading=self._should_lazy_load_nodes(),
-                            )
-                            self._library_file_path_to_info[file_path] = library_info
+                        try:
+                            if library_info.requires_worker and not self._is_worker:
+                                library_info.fitness = LibraryManager.LibraryFitness.NOT_EVALUATED
+                                library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.WORKER_PENDING
+                                self._library_file_path_to_info[file_path] = library_info
+                            else:
+                                # Attempt to load nodes from the library (modifies library_info in place).
+                                await asyncio.to_thread(
+                                    self._attempt_load_nodes_from_library,
+                                    library_data=library_data,
+                                    library=library,
+                                    base_dir=base_dir,
+                                    library_info=library_info,
+                                    lazy_loading=self._should_lazy_load_nodes(),
+                                )
+                                self._library_file_path_to_info[file_path] = library_info
+                        finally:
+                            # Node types have just been registered into a library LibraryRegistry
+                            # published a few lines above, and the loading above awaited. A port
+                            # summary request landing in that window measured a library with no node
+                            # types (or only some of them), and nothing else invalidates afterwards,
+                            # so that empty result would be served for the rest of the process's
+                            # life. In `finally` because a load that raises partway leaves the
+                            # registry holding whichever node types it managed to add, which makes
+                            # the stale entry no less wrong.
+                            self._invalidate_port_summaries(library_data.name)
 
                         # On a worker process, broadcast the notification so app.py can relay it
                         # to the orchestrator over the transport layer. Include serialized node
@@ -2858,20 +2898,19 @@ class LibraryManager(EngineScoped):
                         )
 
                         # Discover real class names by importing files
-                        await self._attempt_generate_sandbox_library_from_schema(
-                            library_schema=metadata_result.library_schema,
-                            sandbox_directory=str(sandbox_directory),
-                            library_info=library_info,
-                        )
+                        try:
+                            await self._attempt_generate_sandbox_library_from_schema(
+                                library_schema=metadata_result.library_schema,
+                                sandbox_directory=str(sandbox_directory),
+                                library_info=library_info,
+                            )
+                        finally:
+                            # Same reason as the regular-library branch above: this both publishes
+                            # the library and registers its node types, with awaits in between, so
+                            # any port summaries cached during it describe a half-built library.
+                            self._invalidate_port_summaries(library_data.name)
                         # Function handles registration and updates library_info with problems
                         # lifecycle_state set to LOADED by _attempt_load_nodes_from_library
-
-                    # Node types have just been registered into a library that LibraryRegistry
-                    # published earlier in this method, and the loading above awaited. A port
-                    # summary request landing in that window measured a library with no node types
-                    # (or only some of them), and nothing invalidates afterwards, so that empty
-                    # result would be served for the rest of the process's life.
-                    self._invalidate_port_summaries(library_data.name)
 
                     # Exit loop after final phase
                     break
@@ -3400,7 +3439,7 @@ class LibraryManager(EngineScoped):
         """
         await self._libraries_loading_complete.wait()
 
-        allowance = ProbeTimeoutAllowance(remaining=self._PORT_SUMMARY_TIMEOUT_BUDGET)
+        allowance = ProbeTimeoutAllowance(remaining=self._PORT_SUMMARY_REQUEST_TIMEOUT_BUDGET)
         library_name_to_port_summaries: dict[str, dict[str, NodePortSummary]] = {}
         # Counted rather than flagged so concurrent requests do not un-register each other, and
         # decremented in `finally` so a cancelled request does not leave the warm pass unthrottled
@@ -3458,18 +3497,45 @@ class LibraryManager(EngineScoped):
             )
             return
 
-        # Replace a pass already in flight rather than running a second one alongside it. Two
-        # concurrent passes would still be correct -- the per-library lock and the generation
-        # counter see to that -- but only one handle is kept, and a pass nothing holds a handle to
-        # is a pass a reload cannot cancel, which is the one thing here that has to work.
-        # Restarting costs little: libraries the previous pass already finished are cache hits.
-        previous_task = self._port_summary_warm_task
-        if previous_task is not None and not previous_task.done():
-            previous_task.cancel()
+        # Leave a pass already in flight alone rather than replacing it. Only one handle is kept --
+        # a pass nothing holds a handle to is a pass a reload cannot cancel, which is the one thing
+        # here that has to work -- so this cannot start a second one, and it should not cancel the
+        # first either: the caller invalidating a library is usually a worker reporting its node
+        # schemas, and cancelling for that would throw away a large library's half-finished probing
+        # and leak the thread of whatever probe was in flight. The running pass re-sweeps the
+        # library list until nothing is cold, so it picks the invalidated library up by itself. A
+        # reload, which must stop the pass rather than let it keep resolving node classes, calls
+        # `_cancel_port_summary_warm` first and then reaches the line below.
+        if self._in_flight_port_summary_warm_task() is not None:
+            logger.debug("Port summary warming is already running; it will pick up any library that just changed.")
+            return
 
         task = asyncio.create_task(self._warm_port_summaries())
         self._port_summary_warm_task = task
         task.add_done_callback(self._on_port_summary_warm_done)
+
+    def _in_flight_port_summary_warm_task(self) -> asyncio.Task[None] | None:
+        """The warm pass running on *this* loop, if there is one, dropping a handle from a dead loop.
+
+        A manager outlives any one `asyncio.run()` call, and a task left over from a previous loop is
+        not a pass anything can wait for or cancel: `Task.cancel()` on one suspended in a closed loop
+        raises `RuntimeError` from the callback scheduling underneath it. `asyncio.run` cancels its
+        pending tasks on the way out, so such a handle is normally already `done()` -- but a host
+        driving the loop itself with `run_until_complete` and closing it has no such guarantee, which
+        is the same staleness `_port_summaries_lock_for` handles for its locks.
+        """
+        task = self._port_summary_warm_task
+        if task is None:
+            return None
+
+        if task.get_loop() is not asyncio.get_running_loop():
+            self._port_summary_warm_task = None
+            return None
+
+        if task.done():
+            return None
+
+        return task
 
     def _on_port_summary_warm_done(self, task: asyncio.Task[None]) -> None:
         """Clear the handle and surface anything the warm pass raised.
@@ -3499,17 +3565,15 @@ class LibraryManager(EngineScoped):
         Awaited rather than just cancelled because the caller is about to unload libraries, and a
         pass between awaits could still resolve a node class -- importing a module belonging to a
         library being dismantled. Returns promptly even when the pass is inside a probe: the
-        construction thread cannot be cancelled, but the coroutine awaiting it can, which is the
-        same leaked-thread trade the probe path already documents.
+        construction thread cannot be cancelled, but the coroutine awaiting it can. That abandons the
+        thread, so the probe path charges it to the engine-wide leak ceiling exactly as a timeout is
+        charged -- reloading repeatedly is not a free way past that bound.
 
         Clearing the handle before awaiting keeps a second caller from awaiting the same task.
         """
-        task = self._port_summary_warm_task
-        if task is None:
-            return
-
+        task = self._in_flight_port_summary_warm_task()
         self._port_summary_warm_task = None
-        if task.done():
+        if task is None:
             return
 
         task.cancel()
@@ -3542,23 +3606,61 @@ class LibraryManager(EngineScoped):
 
         Runs on its own timeout allowance, and throttled, both because it covers every library at
         once and because nothing is waiting on it.
+
+        Sweeps the library list repeatedly rather than once, because a library can be invalidated
+        after this pass has already walked past it -- a worker reporting its node schemas is the
+        everyday case. That is what lets those callers leave a running pass alone instead of
+        cancelling and restarting it. A sweep that finds every library warm ends the pass, so the
+        sweep cap only binds when something is invalidating in a loop.
         """
         await self._libraries_loading_complete.wait()
 
         allowance = ProbeTimeoutAllowance(remaining=self._PORT_SUMMARY_WARM_TIMEOUT_BUDGET)
-        library_names = LibraryRegistry.list_libraries()
-        node_type_count = 0
-        for library_name in library_names:
-            summaries = await self._get_port_summaries_for_library(
-                library_name, allowance, throttle_s=self._PORT_SUMMARY_WARM_THROTTLE_S
-            )
-            node_type_count += len(summaries)
+        for sweep in range(self._PORT_SUMMARY_WARM_MAX_SWEEPS):
+            cold_library_names = [
+                library_name
+                for library_name in LibraryRegistry.list_libraries()
+                if self._port_summaries_need_a_pass(library_name)
+            ]
+            if not cold_library_names:
+                warmed = self._library_to_port_summary_cache
+                node_type_count = sum(len(entry.summaries) for entry in warmed.values())
+                logger.info(
+                    "Warmed port summaries for %d node type(s) across %d librar(ies) in %d sweep(s); connection "
+                    "ranking is ready.",
+                    node_type_count,
+                    len(warmed),
+                    sweep,
+                )
+                return
 
+            for library_name in cold_library_names:
+                await self._get_port_summaries_for_library(
+                    library_name, allowance, throttle_s=self._PORT_SUMMARY_WARM_THROTTLE_S
+                )
+
+        # Only reachable while something keeps invalidating libraries as fast as this fills them in.
+        # Stopping is the right answer: the pass is not converging, and the on-demand path in
+        # `on_get_port_summaries_for_all_libraries_request` covers whatever is still cold.
         logger.info(
-            "Warmed port summaries for %d node type(s) across %d librar(ies); connection ranking is ready.",
-            node_type_count,
-            len(library_names),
+            "Stopped warming port summaries after %d sweep(s) because libraries kept changing. Anything still "
+            "uncomputed will be computed by the first request that needs it.",
+            self._PORT_SUMMARY_WARM_MAX_SWEEPS,
         )
+
+    def _port_summaries_need_a_pass(self, library_name: str) -> bool:
+        """Whether a probe pass over this library would do any work.
+
+        The same condition `_get_port_summaries_for_library` uses to decide a cache hit, so the warm
+        pass skips exactly the libraries a request would answer from cache. A library that has given
+        up on node types -- spent allowance, or the engine's leak ceiling -- has nothing pending and
+        counts as warm, which is what stops the warm sweep from retrying it forever.
+        """
+        entry = self._library_to_port_summary_cache.get(library_name)
+        if entry is None:
+            return True
+
+        return bool(entry.pending_node_types())
 
     async def _get_port_summaries_for_library(
         self, library_name: str, allowance: ProbeTimeoutAllowance, *, throttle_s: float
@@ -3577,8 +3679,8 @@ class LibraryManager(EngineScoped):
         pending until it gets one.
 
         Three bounds cap all of it, and `_probe_stop_reason` holds them alongside its reload check:
-        the caller's per-pass `allowance`, `_PORT_SUMMARY_TIMEOUT_BUDGET` per library per load, and
-        `_PROBE_THREAD_LEAK_CEILING` for the whole process. The last one is what actually protects
+        the caller's per-pass `allowance`, `_PORT_SUMMARY_LIBRARY_TIMEOUT_BUDGET` per library per
+        load, and `_PROBE_THREAD_LEAK_CEILING` for the whole process. The last one is what actually protects
         the engine: the first two reset (every request, and every reload), so neither bounds the
         running total. Each timeout burned a thread ``asyncio.to_thread`` cannot cancel, and
         continuing to pay would drain the loop's shared executor and eventually stall every other
@@ -3622,8 +3724,7 @@ class LibraryManager(EngineScoped):
                 )
                 summaries = {**entry.summaries, **computation.summaries}
                 timeouts_spent = entry.timeouts_spent + len(computation.timed_out_node_types)
-                # What this pass was retrying is exactly what has now had its one retry.
-                already_retried_node_types = entry.retry_node_types
+                already_retried_node_types = entry.retried_node_types
 
             # The pass above awaited, so the library may have been reloaded, unloaded, or had node
             # types registered into it in the meantime. Caching what we just measured would pin
@@ -3680,7 +3781,17 @@ class LibraryManager(EngineScoped):
 
         Separated from the pass itself because it is the whole termination argument in one place:
         each rule below is what stops some node type from being probed forever.
+
+        `already_retried_node_types` is every node type this library has already been granted its one
+        retry for, which is why it is carried on the entry rather than derived from the pass: the
+        grant and the retry can be separated by any number of passes that never reached the node
+        type.
         """
+        # Accumulated, not replaced. A node type's entitlement is spent the moment it is granted, so
+        # the record has to outlive the pass that granted it -- a pass that stops before reaching the
+        # node type would otherwise clear the grant and let the next timeout re-grant it.
+        retried_node_types = already_retried_node_types | computation.timed_out_node_types
+
         if self._port_summary_threads_leaked >= self._PROBE_THREAD_LEAK_CEILING:
             # No pass in this process will probe again, so carrying anything as pending would only
             # make every future request take the lock and run a pass that stops immediately.
@@ -3697,10 +3808,11 @@ class LibraryManager(EngineScoped):
                 summaries=summaries,
                 retry_node_types=frozenset(),
                 unprobed_node_types=frozenset(),
+                retried_node_types=retried_node_types,
                 timeouts_spent=timeouts_spent,
             )
 
-        if timeouts_spent >= self._PORT_SUMMARY_TIMEOUT_BUDGET:
+        if timeouts_spent >= self._PORT_SUMMARY_LIBRARY_TIMEOUT_BUDGET:
             # The library has spent its whole allowance of un-reclaimable threads. Everything still
             # pending is dropped -- including node types never attempted, which cannot be told apart
             # from the blocking ones without paying again.
@@ -3718,15 +3830,16 @@ class LibraryManager(EngineScoped):
                 summaries=summaries,
                 retry_node_types=frozenset(),
                 unprobed_node_types=frozenset(),
+                retried_node_types=retried_node_types,
                 timeouts_spent=timeouts_spent,
             )
 
         # One retry per node type per library load, granted the first time that node type's own probe
         # times out -- which is not the same as the first pass over the library. A pass that stopped
         # early leaves node types unreached, and the pass that finally reaches one is the pass where
-        # its first timeout can happen. Subtracting the set this pass was already retrying is what
-        # makes it exactly one: a node type that times out again while being retried is not
-        # re-recorded, so nothing cycles.
+        # its first timeout can happen. Subtracting everything already granted is what makes it
+        # exactly one: a node type that times out again, whether during its retry or on a pass long
+        # after, is not re-recorded, so nothing cycles.
         retry_node_types = computation.timed_out_node_types - already_retried_node_types
 
         # Node types never reached are always carried, and the two branches above are what stops
@@ -3740,6 +3853,7 @@ class LibraryManager(EngineScoped):
             summaries=summaries,
             retry_node_types=retry_node_types,
             unprobed_node_types=computation.unprobed_node_types,
+            retried_node_types=retried_node_types,
             timeouts_spent=timeouts_spent,
         )
 
@@ -3773,6 +3887,13 @@ class LibraryManager(EngineScoped):
         failed (see `PortSummaryComputation`). `timeouts_already_spent` is what this library has
         cost on earlier passes, and is required for the per-library bound to be enforced *during*
         a pass rather than only after it.
+
+        It also stops if the registry's `Library` for this name is replaced mid-pass, because every
+        probe resolves its node class *through* that object: holding the pre-replacement one would
+        import modules of a library that has just been unloaded, putting them back in `sys.modules`
+        after the unload cleared them. Whatever the pass measured is still returned -- the caller
+        compares generations and declines to cache it -- and the node types it had not reached stay
+        pending for a pass that will see the new object.
         """
         try:
             library = LibraryRegistry.get_library(library_name)
@@ -3820,6 +3941,16 @@ class LibraryManager(EngineScoped):
             # which is what actually leaves the loop usable while it works.
             await asyncio.sleep(self._effective_probe_throttle_s(throttle_s))
 
+            if not self._library_is_still_registered(library=library, library_name=library_name):
+                unprobed_node_types = node_types_to_probe[probe_index:]
+                logger.info(
+                    "Stopped probing library '%s' with %d node type(s) left: it was unloaded or replaced while this "
+                    "pass was running, so the node classes it would resolve are no longer the registered ones.",
+                    library_name,
+                    len(unprobed_node_types),
+                )
+                break
+
             outcome = await self._probe_node_type_port_summary(
                 library=library, library_name=library_name, node_type=node_type
             )
@@ -3848,6 +3979,21 @@ class LibraryManager(EngineScoped):
             timed_out_node_types=frozenset(timed_out_node_types),
             unprobed_node_types=frozenset(unprobed_node_types),
         )
+
+    def _library_is_still_registered(self, *, library: Library, library_name: str) -> bool:
+        """Whether the registry still holds this exact `Library` object under this name.
+
+        Identity, not just presence. A reload unregisters the name and registers a fresh `Library`
+        for it, so a name-only check passes while the object in hand is the pre-reload one -- and
+        resolving a node class through that object runs the old loader, importing the very modules
+        the reload exists to replace.
+        """
+        try:
+            registered_library = LibraryRegistry.get_library(library_name)
+        except KeyError:
+            return False
+
+        return registered_library is library
 
     def _effective_probe_throttle_s(self, throttle_s: float) -> float:
         """Drop a background pass's throttle for as long as an interactive request is waiting.
@@ -3889,8 +4035,11 @@ class LibraryManager(EngineScoped):
                 f"No further probing will be attempted in this process"
             )
 
-        if timeouts_spent >= self._PORT_SUMMARY_TIMEOUT_BUDGET:
-            return f"this library has spent its {self._PORT_SUMMARY_TIMEOUT_BUDGET}-timeout allowance for this load"
+        if timeouts_spent >= self._PORT_SUMMARY_LIBRARY_TIMEOUT_BUDGET:
+            return (
+                f"this library has spent its {self._PORT_SUMMARY_LIBRARY_TIMEOUT_BUDGET}-timeout allowance for this "
+                f"load"
+            )
 
         if allowance.remaining <= 0:
             return "this pass has spent its probe timeout allowance"
@@ -3949,17 +4098,41 @@ class LibraryManager(EngineScoped):
             )
             return NodeTypePortProbeOutcome(summary=None, timed_out=False)
 
+        # Set by the worker itself, so it is the one signal that distinguishes "this construction is
+        # still holding a thread" from "it finished and the worker went back to the pool". Neither
+        # the task nor the future can say: cancelling either leaves the thread running.
+        probe_finished = threading.Event()
         try:
             probe_result = await asyncio.wait_for(
                 asyncio.to_thread(
-                    self._construct_probe_node,
+                    self._construct_probe_node_signalling_completion,
                     library_name,
                     node_type,
                     resolution.node_class,
                     library_node_metadata,
+                    probe_finished,
                 ),
                 timeout=self._SCHEMA_PROBE_TIMEOUT_S,
             )
+        except asyncio.CancelledError:
+            # A reload stopping the warm pass mid-probe. The construction thread is not cancellable,
+            # so if it has not finished it is held exactly as a timeout would hold it, and the
+            # engine-wide ceiling has to hear about it: cancellation is not rare (every reload does
+            # it), and a ceiling that only counted timeouts would let repeated reloads drain the
+            # loop's executor without ever tripping. Not counted against the library or the pass --
+            # both are about to be discarded -- and not counted at all when the thread did finish,
+            # since charging a leak that did not happen would disable probing for the session.
+            if not probe_finished.is_set():
+                self._port_summary_threads_leaked += 1
+                logger.warning(
+                    "Port summary probing was stopped while constructing node type '%s' in library '%s'. Its thread "
+                    "cannot be cancelled, so it is leaked (%d so far); probing stops for this process after %d.",
+                    node_type,
+                    library_name,
+                    self._port_summary_threads_leaked,
+                    self._PROBE_THREAD_LEAK_CEILING,
+                )
+            raise
         except TimeoutError:
             # asyncio.to_thread cannot be cancelled, so the thread is not reclaimed: it holds a
             # worker of the loop's default executor until __init__ returns, which for a truly stuck
@@ -5926,23 +6099,33 @@ class LibraryManager(EngineScoped):
     # await init-time events (e.g. WorkflowManager._workflows_loading_complete),
     # so each probe runs in a worker thread with this ceiling.
     _SCHEMA_PROBE_TIMEOUT_S: float = 10.0
-    # How many probe timeouts the port summary machinery will pay for, counted two
-    # ways: per request across every library it touches, and per library across
-    # every request until that library reloads. Each timeout permanently costs a
-    # worker of the event loop's default executor -- asyncio.to_thread cannot
-    # cancel the thread it started -- so an unbounded count over a library of
-    # blocking nodes would starve every other to_thread caller in the engine.
-    # Leaving part of one library unranked until it reloads is the cheaper failure.
-    _PORT_SUMMARY_TIMEOUT_BUDGET: int = 4
-    # The same allowance for the background warm pass, which needs its own number because it
-    # covers every library rather than the one a caller asked about: given the interactive
-    # budget, a single library of blocking nodes would spend the whole thing and leave every
-    # other library cold, which is the one outcome that makes warming pointless.
+    # How many probe timeouts the port summary machinery will pay for. Each one permanently costs a
+    # worker of the event loop's default executor -- asyncio.to_thread cannot cancel the thread it
+    # started -- so an unbounded count over a library of blocking nodes would starve every other
+    # to_thread caller in the engine. Leaving part of one library unranked until it reloads is the
+    # cheaper failure. Three separate numbers because they bound three different things, and only
+    # keeping them apart lets a log line or a test say which one fired:
+    #
+    # Per interactive request, across every library it touches.
+    _PORT_SUMMARY_REQUEST_TIMEOUT_BUDGET: int = 4
+    # Per library, across every pass until that library reloads.
+    _PORT_SUMMARY_LIBRARY_TIMEOUT_BUDGET: int = 4
+    # Per background warm pass. Larger than the interactive budget because it covers every library
+    # rather than the one a caller asked about: at the interactive number, a single library of
+    # blocking nodes would spend the whole thing and leave every other library cold, which is the
+    # one outcome that makes warming pointless.
     _PORT_SUMMARY_WARM_TIMEOUT_BUDGET: int = 8
+    # How many times one warm pass will walk the library list looking for work. More than one
+    # because a library can be invalidated after the pass has already walked past it -- a worker
+    # reporting its node schemas is the everyday case -- and re-sweeping is what lets that caller
+    # leave the running pass alone instead of cancelling it and discarding a large library's
+    # half-finished probing. A sweep that finds nothing to do ends the pass, so this only caps a
+    # caller invalidating in a loop; anything still cold after it is computed on demand.
+    _PORT_SUMMARY_WARM_MAX_SWEEPS: int = 5
     # Hard engine-wide ceiling on leaked probe threads, and the only bound that is stated in
     # terms of the resource actually at stake. The two budgets above are per request and per
     # library-load, so neither bounds the total: three libraries of blocking nodes cost
-    # 3 * _PORT_SUMMARY_TIMEOUT_BUDGET threads, and a reload lets the bill start over. asyncio
+    # 3 * _PORT_SUMMARY_LIBRARY_TIMEOUT_BUDGET threads, and a reload lets the bill start over. asyncio
     # .to_thread hands work to the loop's *default* executor, which is
     # min(32, (os.cpu_count() or 1) + 4) wide -- 6 on a 2-core CI box -- and every other
     # to_thread caller in the engine (library loading, sandbox generation, worker schema
@@ -7408,7 +7591,15 @@ class LibraryManager(EngineScoped):
         *,
         failure_result_class: type[ResultPayloadFailure],
     ) -> str | ResultPayloadFailure:
-        """Reload library after git operation.
+        """Reload library after git operation, with the port summary warm pass held off.
+
+        Split from the reload itself for the same reason `reload_libraries_request` is: the pass
+        resolves node classes, so one still running while this unloads and re-registers the library
+        would import the pre-update modules back into `sys.modules` after the unload cleared them --
+        and it is the updated code the artist is waiting for. Unlike the full reload this does not
+        close `_libraries_loading_complete`, so an interactive request's pass can still be mid-flight
+        here; that one stops itself when it notices the registry no longer holds the `Library` it
+        started with (see `_compute_port_summaries_for_library`).
 
         Args:
             library_name: Name of the library to reload
@@ -7419,6 +7610,27 @@ class LibraryManager(EngineScoped):
             On success: new_version (str, may be "unknown")
             On failure: ResultPayloadFailure instance
         """
+        await self._cancel_port_summary_warm()
+        try:
+            return await self._run_reload_library_after_git_operation(
+                library_name=library_name,
+                library_file_path=library_file_path,
+                failure_result_class=failure_result_class,
+            )
+        finally:
+            # In `finally`, not on the success path: a reload that failed partway has still dropped
+            # this library's summaries, and leaving warming stopped would make every other library's
+            # first connection drag pay the probe cost too.
+            self._start_port_summary_warm()
+
+    async def _run_reload_library_after_git_operation(
+        self,
+        library_name: str,
+        library_file_path: str,
+        *,
+        failure_result_class: type[ResultPayloadFailure],
+    ) -> str | ResultPayloadFailure:
+        """Unload and re-register one library from disk. See the caller for the warming it brackets."""
         # Unload the library
         unload_result = self.engine.handle_request(UnloadLibraryFromRegistryRequest(library_name=library_name))
         if not unload_result.succeeded():

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -397,6 +397,22 @@ class PortSummaryComputation(NamedTuple):
     retry_node_types: frozenset[str]
 
 
+class NodeTypePortProbeOutcome(NamedTuple):
+    """Outcome of probing a single node type for its port summary.
+
+    `summary` is None for every node type the engine could not probe, which keeps it out of the
+    library's map entirely rather than recording it as portless: a caller ranking node types should
+    leave it unranked, not rank it as connecting to nothing.
+
+    `timed_out` separates the one gap worth another attempt from the ones that are stable until the
+    library reloads. It also tells the caller a thread was spent that cannot be reclaimed, which is
+    what the per-pass timeout budget counts.
+    """
+
+    summary: NodePortSummary | None
+    timed_out: bool
+
+
 class LibraryGitOperationContext(NamedTuple):
     """Context information for git operations on a library."""
 
@@ -663,10 +679,10 @@ class LibraryManager(EngineScoped):
         # Per-library node type -> port summary, computed on the first GetPortSummaries request
         # and dropped when the library is unloaded (which a reload goes through).
         self._library_to_port_summaries: dict[str, dict[str, NodePortSummary]] = {}
-        # Node types in a cached library whose probe timed out, owed exactly one more attempt on
-        # the next request. Emptied by that attempt whether or not it succeeds, so a node whose
-        # __init__ blocks forever costs at most two un-reclaimable threads rather than one per
-        # request.
+        # Node types in a cached library whose probe timed out, owed exactly one more attempt on the
+        # next request. Emptied by that attempt whether or not it succeeds, so a node whose __init__
+        # blocks forever costs two un-reclaimable threads per library generation -- one per pass --
+        # rather than one per request. Each reload of the library starts that allowance over.
         self._library_to_port_summary_retries: dict[str, frozenset[str]] = {}
         # Bumped by _invalidate_port_summaries. The compute pass awaits, so a library can be
         # mutated while its summaries are being computed; comparing the counter before and after
@@ -3369,7 +3385,8 @@ class LibraryManager(EngineScoped):
         stays on the event loop because ``NodeTypeEntry.resolve()`` is not thread-safe, and only
         construction goes to a thread, where the same timeout the worker-side schema pass uses
         bounds it: a node's ``__init__`` can block indefinitely, and one such node must not stall
-        the rest.
+        the rest. A pass gives up entirely after `_PORT_SUMMARY_TIMEOUT_BUDGET` timeouts, because
+        every one of those has cost a thread that cannot be handed back.
 
         Only a timeout is reported in `retry_node_types` -- see `PortSummaryComputation` for why
         every other gap is stable.
@@ -3377,9 +3394,11 @@ class LibraryManager(EngineScoped):
         try:
             library = LibraryRegistry.get_library(library_name)
         except KeyError:
-            # Reachable when a library is unloaded between LibraryRegistry.list_libraries() and
-            # this lookup. That path bumps the generation counter, so the caller already declines
-            # to cache what comes back; nothing here is worth retrying.
+            # Reachable when a library is unloaded between LibraryRegistry.list_libraries() and this
+            # lookup. The caller may well cache this empty result, since unloading only bumps the
+            # generation counter when it happens *during* a pass, not before one starts. That is
+            # harmless: the entry is for a library nothing can now ask about, and re-registering the
+            # name invalidates it. Nothing here is worth retrying.
             logger.warning("Cannot compute port summaries: library '%s' not found in registry.", library_name)
             return PortSummaryComputation(summaries={}, retry_node_types=frozenset())
 
@@ -3392,93 +3411,41 @@ class LibraryManager(EngineScoped):
         summaries: dict[str, NodePortSummary] = {}
         skipped_node_types: list[str] = []
         retry_node_types: set[str] = set()
-        for node_type in node_types_to_probe:
+        timed_out_count = 0
+        for probe_index, node_type in enumerate(node_types_to_probe):
             # Yield between node types so a large library's resolve calls, which run on the loop,
             # interleave with other work instead of monopolizing it for the whole pass.
             await asyncio.sleep(0)
 
-            try:
-                resolution = self._resolve_node_class_for_probe(library=library, node_type=node_type)
-            except Exception:
-                # Resolution converts import failures into a result, so reaching here means
-                # something else went wrong -- a LibraryRegistryError for a node type unregistered
-                # since get_registered_nodes() was read (the loop awaits, so that is reachable), or
-                # a NodeTypeEntry with neither class nor loader. Skip the one node type rather than
-                # failing summaries for every library in the response.
-                logger.debug(
-                    "Unexpected failure resolving node type '%s' in library '%s' for its port summary; skipping.",
-                    node_type,
-                    library_name,
-                    exc_info=True,
-                )
+            outcome = await self._probe_node_type_port_summary(
+                library=library, library_name=library_name, node_type=node_type
+            )
+            if outcome.summary is None:
                 skipped_node_types.append(node_type)
-                continue
+                if not outcome.timed_out:
+                    continue
 
-            if resolution.node_class is None:
-                logger.debug(
-                    "Could not probe node type '%s' in library '%s' for its port summary: %s",
-                    node_type,
-                    library_name,
-                    resolution.error_message,
-                )
-                skipped_node_types.append(node_type)
-                continue
-
-            # Built before the try because it reads the library's node-metadata dict, and a failure
-            # doing so is a defect in that data rather than anything a retry would fix.
-            library_node_metadata = self._library_node_metadata_for_probe(library=library, node_type=node_type)
-
-            try:
-                probe_result = await asyncio.wait_for(
-                    asyncio.to_thread(
-                        self._construct_probe_node,
-                        library_name,
-                        node_type,
-                        resolution.node_class,
-                        library_node_metadata,
-                    ),
-                    timeout=self._SCHEMA_PROBE_TIMEOUT_S,
-                )
-            except TimeoutError:
-                # asyncio.to_thread cannot be cancelled, so the thread is not reclaimed: it holds a
-                # worker of the loop's default executor until __init__ returns, which for a truly
-                # stuck node means for the life of the process. That is also why this node type
-                # gets one retry rather than one per request.
-                logger.warning(
-                    "Port summary probe for node type '%s' in library '%s' timed out after %.1fs; "
-                    "skipping it and leaking the probe thread, which cannot be cancelled. The "
-                    "node's __init__ likely makes a blocking call.",
-                    node_type,
-                    library_name,
-                    self._SCHEMA_PROBE_TIMEOUT_S,
-                )
-                skipped_node_types.append(node_type)
                 retry_node_types.add(node_type)
-                continue
-            except Exception:
-                # _construct_probe_node already converts a raising __init__ into a result, so
-                # reaching here means the failure was outside it -- the executor refusing work
-                # during interpreter shutdown, for instance, which a retry cannot help either.
-                logger.debug(
-                    "Unexpected failure probing node type '%s' in library '%s' for its port summary; skipping.",
-                    node_type,
-                    library_name,
-                    exc_info=True,
-                )
-                skipped_node_types.append(node_type)
-                continue
+                timed_out_count += 1
+                if timed_out_count < self._PORT_SUMMARY_TIMEOUT_BUDGET:
+                    continue
 
-            if probe_result.node is None:
-                logger.debug(
-                    "Could not probe node type '%s' in library '%s' for its port summary: %s",
-                    node_type,
+                abandoned_node_types = node_types_to_probe[probe_index + 1 :]
+                logger.warning(
+                    "Abandoning port summaries for the remaining %d node type(s) in library '%s' after %d probe "
+                    "timeout(s): %s. Each timeout costs a thread the engine cannot reclaim, so the rest of this "
+                    "library goes unranked until it is reloaded.",
+                    len(abandoned_node_types),
                     library_name,
-                    probe_result.error_message,
+                    timed_out_count,
+                    ", ".join(abandoned_node_types),
                 )
-                skipped_node_types.append(node_type)
-                continue
+                # Not added to retry_node_types: they were never probed, so a retry would walk
+                # straight back into the same timeouts that stopped this pass.
+                skipped_node_types.extend(abandoned_node_types)
+                break
 
-            summaries[node_type] = NodePortSummary.from_parameters(probe_result.node.parameters)
+            summaries[node_type] = outcome.summary
 
         if skipped_node_types:
             logger.info(
@@ -3489,6 +3456,116 @@ class LibraryManager(EngineScoped):
                 ", ".join(skipped_node_types),
             )
         return PortSummaryComputation(summaries=summaries, retry_node_types=frozenset(retry_node_types))
+
+    async def _probe_node_type_port_summary(  # noqa: PLR0911
+        self, *, library: Library, library_name: str, node_type: str
+    ) -> NodeTypePortProbeOutcome:
+        """Construct one node type's throwaway probe node and summarize the ports it declared.
+
+        Every failure is contained here and reported as a missing summary rather than raised. The
+        caller answers for every library in the engine at once, so a single library's malformed
+        metadata, unimportable module, or raising ``__init__`` must not blank the whole response.
+        """
+        try:
+            resolution = self._resolve_node_class_for_probe(library=library, node_type=node_type)
+        except Exception:
+            # Resolution converts import failures into a result, so reaching here means something
+            # else went wrong -- a LibraryRegistryError for a node type unregistered since
+            # get_registered_nodes() was read (the caller awaits, so that is reachable), or a
+            # NodeTypeEntry with neither class nor loader.
+            logger.debug(
+                "Unexpected failure resolving node type '%s' in library '%s' for its port summary; skipping.",
+                node_type,
+                library_name,
+                exc_info=True,
+            )
+            return NodeTypePortProbeOutcome(summary=None, timed_out=False)
+
+        if resolution.node_class is None:
+            logger.debug(
+                "Could not probe node type '%s' in library '%s' for its port summary: %s",
+                node_type,
+                library_name,
+                resolution.error_message,
+            )
+            return NodeTypePortProbeOutcome(summary=None, timed_out=False)
+
+        try:
+            library_node_metadata = self._library_node_metadata_for_probe(library=library, node_type=node_type)
+        except Exception:
+            # Reads and serializes the library author's node metadata, so a malformed entry raises
+            # here. Not worth retrying -- the metadata is as broken next request as it is now.
+            logger.debug(
+                "Unexpected failure reading metadata for node type '%s' in library '%s' for its port summary; "
+                "skipping.",
+                node_type,
+                library_name,
+                exc_info=True,
+            )
+            return NodeTypePortProbeOutcome(summary=None, timed_out=False)
+
+        try:
+            probe_result = await asyncio.wait_for(
+                asyncio.to_thread(
+                    self._construct_probe_node,
+                    library_name,
+                    node_type,
+                    resolution.node_class,
+                    library_node_metadata,
+                ),
+                timeout=self._SCHEMA_PROBE_TIMEOUT_S,
+            )
+        except TimeoutError:
+            # asyncio.to_thread cannot be cancelled, so the thread is not reclaimed: it holds a
+            # worker of the loop's default executor until __init__ returns, which for a truly stuck
+            # node means for the life of the process. That is why the caller both bounds how many
+            # timeouts one pass will spend and gives this node type one retry rather than one per
+            # request.
+            logger.warning(
+                "Port summary probe for node type '%s' in library '%s' timed out after %.1fs; skipping it and "
+                "leaking the probe thread, which cannot be cancelled. The node's __init__ likely makes a "
+                "blocking call.",
+                node_type,
+                library_name,
+                self._SCHEMA_PROBE_TIMEOUT_S,
+            )
+            return NodeTypePortProbeOutcome(summary=None, timed_out=True)
+        except Exception:
+            # _construct_probe_node already converts a raising __init__ into a result, so reaching
+            # here means the failure was outside it -- the executor refusing work during interpreter
+            # shutdown, for instance, which a retry cannot help either.
+            logger.debug(
+                "Unexpected failure probing node type '%s' in library '%s' for its port summary; skipping.",
+                node_type,
+                library_name,
+                exc_info=True,
+            )
+            return NodeTypePortProbeOutcome(summary=None, timed_out=False)
+
+        if probe_result.node is None:
+            logger.debug(
+                "Could not probe node type '%s' in library '%s' for its port summary: %s",
+                node_type,
+                library_name,
+                probe_result.error_message,
+            )
+            return NodeTypePortProbeOutcome(summary=None, timed_out=False)
+
+        try:
+            summary = NodePortSummary.from_parameters(probe_result.node.parameters)
+        except Exception:
+            # Reads each parameter's declared types, and a container's element types through
+            # `get_element_input_types` -- an override point construction never calls, so a
+            # library's subclass can raise here on a node that built perfectly well.
+            logger.debug(
+                "Unexpected failure summarizing the ports of node type '%s' in library '%s'; skipping.",
+                node_type,
+                library_name,
+                exc_info=True,
+            )
+            return NodeTypePortProbeOutcome(summary=None, timed_out=False)
+
+        return NodeTypePortProbeOutcome(summary=summary, timed_out=False)
 
     def _invalidate_port_summaries(self, library_name: str) -> None:
         """Drop a library's cached port summaries after its node types change.
@@ -5384,6 +5461,13 @@ class LibraryManager(EngineScoped):
     # await init-time events (e.g. WorkflowManager._workflows_loading_complete),
     # so each probe runs in a worker thread with this ceiling.
     _SCHEMA_PROBE_TIMEOUT_S: float = 10.0
+    # How many probe timeouts one port summary pass tolerates before abandoning
+    # the library's remaining node types. Each timeout permanently costs a worker
+    # of the event loop's default executor -- asyncio.to_thread cannot cancel the
+    # thread it started -- so an unbounded pass over a library of blocking nodes
+    # would starve every other to_thread caller in the engine. Leaving the tail
+    # of one library unranked until it reloads is the cheaper failure.
+    _PORT_SUMMARY_TIMEOUT_BUDGET: int = 4
     # Sentinel name passed to the throwaway node instance built for schema
     # discovery. The instance is discarded after its parameters are read.
     _SCHEMA_PROBE_NODE_NAME: str = "__schema_probe__"

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -209,6 +209,7 @@ from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
     CheckpointAttribute,
     CheckpointSubjectType,
 )
+from griptape_nodes.retained_mode.managers.event_manager import suppress_event_publication
 from griptape_nodes.retained_mode.managers.fitness_problems.libraries import (
     AdvancedLibraryLoadFailureProblem,
     AfterLibraryCallbackProblem,
@@ -382,16 +383,18 @@ class NodeProbeResult(NamedTuple):
 
 
 class PortSummaryComputation(NamedTuple):
-    """Outcome of probing a whole library for its per-node-type port summaries.
+    """Outcome of probing a library's node types for their port summaries.
 
-    `is_complete` is False when a node type was skipped for a reason that may not recur -- a probe
-    timeout, an unexpected error, or the library not being in the registry yet. Callers use it to
-    decide whether the result is worth caching; a node type whose module is simply broken does not
-    make the pass incomplete, because that gap is stable until the library reloads.
+    `retry_node_types` holds the node types whose gap might close on its own, which in practice
+    means only the ones whose probe timed out: `asyncio.to_thread` shares the loop's default
+    executor, so a saturated pool can time out a probe that would otherwise have succeeded. Every
+    other gap is stable until the library reloads -- a module that fails to import keeps failing,
+    an `__init__` that raises keeps raising -- so those node types are simply absent from
+    `summaries` and are not worth another pass.
     """
 
     summaries: dict[str, NodePortSummary]
-    is_complete: bool
+    retry_node_types: frozenset[str]
 
 
 class LibraryGitOperationContext(NamedTuple):
@@ -660,11 +663,18 @@ class LibraryManager(EngineScoped):
         # Per-library node type -> port summary, computed on the first GetPortSummaries request
         # and dropped when the library is unloaded (which a reload goes through).
         self._library_to_port_summaries: dict[str, dict[str, NodePortSummary]] = {}
+        # Node types in a cached library whose probe timed out, owed exactly one more attempt on
+        # the next request. Emptied by that attempt whether or not it succeeds, so a node whose
+        # __init__ blocks forever costs at most two un-reclaimable threads rather than one per
+        # request.
+        self._library_to_port_summary_retries: dict[str, frozenset[str]] = {}
         # Bumped by _invalidate_port_summaries. The compute pass awaits, so a library can be
         # mutated while its summaries are being computed; comparing the counter before and after
         # tells the pass whether its now-stale result is still safe to cache.
         self._library_to_port_summaries_generation: dict[str, int] = {}
-        self._port_summaries_lock = asyncio.Lock()
+        # One lock per library, so a request that only needs an already-computed library's
+        # summaries does not queue behind a different library's first probe pass.
+        self._library_to_port_summaries_lock: dict[str, asyncio.Lock] = {}
         self._libraries_loading_complete = asyncio.Event()
         self._libraries_loading_complete.set()  # Not loading initially; load_all_libraries_from_config will clear/set this
         # True for the duration of the engine's initialization sequence (library + workflow
@@ -2137,24 +2147,29 @@ class LibraryManager(EngineScoped):
         """Construct a probe instance of an already-resolved node class.
 
         Safe to hand to ``asyncio.to_thread``. Everything it reads from the library is passed in as
-        a plain value, so it touches no state the event loop mutates, and
-        ``LibraryRegistry.constructing_node()`` is a ContextVar, which ``to_thread`` propagates via
-        ``copy_context()``. Threading this is how a caller bounds a blocking ``__init__`` with a
-        timeout without also moving class resolution off the loop.
+        a plain value, so it touches no state the event loop mutates, and both context managers it
+        enters are ContextVar-based, which ``to_thread`` propagates via ``copy_context()``.
+        Threading this is how a caller bounds a blocking ``__init__`` with a timeout without also
+        moving class resolution off the loop.
 
         What the node's own ``__init__`` touches is of course not controlled here -- that is the
         same exposure ``DescribeNodeType`` and the worker schema pass already accept.
         """
         try:
-            # Wrap in ``LibraryRegistry.constructing_node()`` so the parameter-mutation detector
-            # skips this ephemeral probe's declarative ``add_parameter`` calls (this construction
+            # ``LibraryRegistry.constructing_node()`` makes the parameter-mutation detector skip
+            # this ephemeral probe's declarative ``add_parameter`` calls (this construction
             # bypasses ``LibraryRegistry.create_node``).
+            #
+            # ``suppress_event_publication()`` keeps the probe off the event bus. ``add_parameter``
+            # publishes an ``AlterElementEvent`` per parameter, so without this the editor receives
+            # element events for a node named ``__node_type_probe__*`` that does not exist and
+            # never will -- once per parameter per node type per library on a port summary pass.
             #
             # Pass the node's library and type so declarative ``__init__`` logic that resolves
             # against the library -- e.g. ``get_declared_models`` populating a model dropdown
             # from the ``model_catalog`` -- works during the probe just as it does under
             # ``create_node``.
-            with LibraryRegistry.constructing_node():
+            with LibraryRegistry.constructing_node(), suppress_event_publication():
                 probe_node = node_class(
                     name=f"{self.PROBE_NODE_NAME_PREFIX}{node_type}",
                     metadata={
@@ -3176,6 +3191,12 @@ class LibraryManager(EngineScoped):
             return False
 
     def unload_library_from_registry_request(self, request: UnloadLibraryFromRegistryRequest) -> ResultPayload:
+        # Drop cached port summaries first: the library's node types are about to go, and a
+        # subsequent load may bring back different ones. Every reload path unloads first, so this
+        # covers reloads too. Before the unload rather than after so an unload that fails partway
+        # cannot leave summaries cached for a half-dismantled library.
+        self._invalidate_port_summaries(request.library_name)
+
         try:
             LibraryRegistry.unregister_library(
                 library_name=request.library_name, event_manager=self.engine.event_manager
@@ -3183,10 +3204,6 @@ class LibraryManager(EngineScoped):
         except Exception as e:
             details = f"Attempted to unload library '{request.library_name}'. Failed due to {e}"
             return UnloadLibraryFromRegistryResultFailure(result_details=details)
-
-        # Drop cached port summaries: the library's node types are gone, and a subsequent load may
-        # bring back different ones. Every reload path unloads first, so this covers reloads too.
-        self._invalidate_port_summaries(request.library_name)
 
         # Clean up all stable module aliases for this library. Note first whether any of its node
         # modules had actually been imported: if so, this process is stuck with that code and the
@@ -3280,23 +3297,37 @@ class LibraryManager(EngineScoped):
         Cached until the library changes -- a reload, an unload, or node types being registered
         into it -- because a node type's declared ports cannot change without one of those.
 
-        The lock means concurrent callers do the probe pass once rather than once each; the second
-        caller waits and then reads the cache. It is deliberately not held for the cache-hit path:
-        the probe pass can take seconds, and a request that only needs already-computed summaries
-        should not queue behind an unrelated library being probed for the first time.
+        A cached library with node types owed a retry (their probe timed out) is topped up rather
+        than recomputed: only those node types are probed again, and the retry is spent whether or
+        not it succeeds. That bounds the damage a node whose ``__init__`` blocks can do. Probing it
+        burns a thread ``asyncio.to_thread`` cannot cancel, so re-probing on every request would
+        drain the loop's shared executor and eventually stall every other threaded operation in the
+        engine -- a far worse outcome than one node type going unranked in the Add Node menu.
+
+        The per-library lock means concurrent callers do the probe pass once rather than once each;
+        the second caller waits and then reads the cache. It is deliberately not held for the
+        cache-hit path: the probe pass can take seconds, and a request that only needs
+        already-computed summaries should not queue behind another library's first pass.
         """
         cached_summaries = self._library_to_port_summaries.get(library_name)
-        if cached_summaries is not None:
+        retry_node_types = self._library_to_port_summary_retries.get(library_name, frozenset())
+        if cached_summaries is not None and not retry_node_types:
             return dict(cached_summaries)
 
-        async with self._port_summaries_lock:
-            # Re-check: another caller may have computed these while we waited for the lock.
+        async with self._library_to_port_summaries_lock.setdefault(library_name, asyncio.Lock()):
+            # Re-check: another caller may have computed or topped these up while we waited.
             cached_summaries = self._library_to_port_summaries.get(library_name)
-            if cached_summaries is not None:
+            retry_node_types = self._library_to_port_summary_retries.get(library_name, frozenset())
+            if cached_summaries is not None and not retry_node_types:
                 return dict(cached_summaries)
 
             generation_before = self._library_to_port_summaries_generation.get(library_name, 0)
-            computation = await self._compute_port_summaries_for_library(library_name)
+            if cached_summaries is None:
+                computation = await self._compute_port_summaries_for_library(library_name)
+                summaries = computation.summaries
+            else:
+                computation = await self._compute_port_summaries_for_library(library_name, retry_node_types)
+                summaries = {**cached_summaries, **computation.summaries}
 
             # The pass above awaited, so the library may have been reloaded, unloaded, or had node
             # types registered into it in the meantime. Caching what we just measured would pin
@@ -3310,24 +3341,25 @@ class LibraryManager(EngineScoped):
                     "serving this result without caching it.",
                     library_name,
                 )
-                return computation.summaries
+                return summaries
 
-            # Likewise for a pass that hit a transient failure. Nothing invalidates this library
-            # again on its own, so caching an incomplete result would make a one-off timeout or a
-            # saturated thread pool permanent.
-            if not computation.is_complete:
-                logger.debug(
-                    "Port summaries for library '%s' are incomplete for a reason that may not "
-                    "recur; serving this result without caching it.",
-                    library_name,
-                )
-                return computation.summaries
+            self._library_to_port_summaries[library_name] = summaries
+            # Only a first pass earns retries. A top-up pass has spent them, so clearing the entry
+            # here is what stops a permanently stuck node type from being re-probed forever.
+            if cached_summaries is None and computation.retry_node_types:
+                self._library_to_port_summary_retries[library_name] = computation.retry_node_types
+            else:
+                self._library_to_port_summary_retries.pop(library_name, None)
 
-            self._library_to_port_summaries[library_name] = computation.summaries
-            return dict(computation.summaries)
+            return dict(summaries)
 
-    async def _compute_port_summaries_for_library(self, library_name: str) -> PortSummaryComputation:
-        """Probe every node type in a library and derive its port summary.
+    async def _compute_port_summaries_for_library(
+        self, library_name: str, node_types: frozenset[str] | None = None
+    ) -> PortSummaryComputation:
+        """Probe a library's node types and derive each one's port summary.
+
+        Covers every registered node type unless `node_types` narrows it, which is how a cached
+        library's timed-out node types get their one retry without re-probing the rest.
 
         Node types the engine cannot construct are left out of the result entirely rather than
         recorded as portless, so callers leave them unranked instead of ranking them as
@@ -3339,25 +3371,28 @@ class LibraryManager(EngineScoped):
         bounds it: a node's ``__init__`` can block indefinitely, and one such node must not stall
         the rest.
 
-        `is_complete` on the result separates the two kinds of gap. A node type whose module fails
-        to import or whose ``__init__`` raises will keep failing until the library is reloaded, so
-        that gap is stable and the result is worth caching. A timeout or an unexpected error might
-        not recur -- ``asyncio.to_thread`` shares the loop's default executor, so a saturated pool
-        can time out probes that would otherwise have succeeded -- so a pass that hits one reports
-        itself incomplete and is not cached.
+        Only a timeout is reported in `retry_node_types` -- see `PortSummaryComputation` for why
+        every other gap is stable.
         """
         try:
             library = LibraryRegistry.get_library(library_name)
         except KeyError:
-            # Registration publishes a library before its node types are populated, so this can
-            # mean "not yet" rather than "never". Reported incomplete so it is not cached.
+            # Reachable when a library is unloaded between LibraryRegistry.list_libraries() and
+            # this lookup. That path bumps the generation counter, so the caller already declines
+            # to cache what comes back; nothing here is worth retrying.
             logger.warning("Cannot compute port summaries: library '%s' not found in registry.", library_name)
-            return PortSummaryComputation(summaries={}, is_complete=False)
+            return PortSummaryComputation(summaries={}, retry_node_types=frozenset())
+
+        node_types_to_probe = library.get_registered_nodes()
+        if node_types is not None:
+            # Intersect rather than trust the caller's set: a node type can have been unregistered
+            # since it earned its retry.
+            node_types_to_probe = [node_type for node_type in node_types_to_probe if node_type in node_types]
 
         summaries: dict[str, NodePortSummary] = {}
         skipped_node_types: list[str] = []
-        is_complete = True
-        for node_type in library.get_registered_nodes():
+        retry_node_types: set[str] = set()
+        for node_type in node_types_to_probe:
             # Yield between node types so a large library's resolve calls, which run on the loop,
             # interleave with other work instead of monopolizing it for the whole pass.
             await asyncio.sleep(0)
@@ -3377,7 +3412,6 @@ class LibraryManager(EngineScoped):
                     exc_info=True,
                 )
                 skipped_node_types.append(node_type)
-                is_complete = False
                 continue
 
             if resolution.node_class is None:
@@ -3390,6 +3424,10 @@ class LibraryManager(EngineScoped):
                 skipped_node_types.append(node_type)
                 continue
 
+            # Built before the try because it reads the library's node-metadata dict, and a failure
+            # doing so is a defect in that data rather than anything a retry would fix.
+            library_node_metadata = self._library_node_metadata_for_probe(library=library, node_type=node_type)
+
             try:
                 probe_result = await asyncio.wait_for(
                     asyncio.to_thread(
@@ -3397,14 +3435,15 @@ class LibraryManager(EngineScoped):
                         library_name,
                         node_type,
                         resolution.node_class,
-                        self._library_node_metadata_for_probe(library=library, node_type=node_type),
+                        library_node_metadata,
                     ),
                     timeout=self._SCHEMA_PROBE_TIMEOUT_S,
                 )
             except TimeoutError:
                 # asyncio.to_thread cannot be cancelled, so the thread is not reclaimed: it holds a
                 # worker of the loop's default executor until __init__ returns, which for a truly
-                # stuck node means for the life of the process.
+                # stuck node means for the life of the process. That is also why this node type
+                # gets one retry rather than one per request.
                 logger.warning(
                     "Port summary probe for node type '%s' in library '%s' timed out after %.1fs; "
                     "skipping it and leaking the probe thread, which cannot be cancelled. The "
@@ -3414,11 +3453,12 @@ class LibraryManager(EngineScoped):
                     self._SCHEMA_PROBE_TIMEOUT_S,
                 )
                 skipped_node_types.append(node_type)
-                is_complete = False
+                retry_node_types.add(node_type)
                 continue
             except Exception:
                 # _construct_probe_node already converts a raising __init__ into a result, so
-                # reaching here means the failure was outside it.
+                # reaching here means the failure was outside it -- the executor refusing work
+                # during interpreter shutdown, for instance, which a retry cannot help either.
                 logger.debug(
                     "Unexpected failure probing node type '%s' in library '%s' for its port summary; skipping.",
                     node_type,
@@ -3426,7 +3466,6 @@ class LibraryManager(EngineScoped):
                     exc_info=True,
                 )
                 skipped_node_types.append(node_type)
-                is_complete = False
                 continue
 
             if probe_result.node is None:
@@ -3449,7 +3488,7 @@ class LibraryManager(EngineScoped):
                 len(skipped_node_types),
                 ", ".join(skipped_node_types),
             )
-        return PortSummaryComputation(summaries=summaries, is_complete=is_complete)
+        return PortSummaryComputation(summaries=summaries, retry_node_types=frozenset(retry_node_types))
 
     def _invalidate_port_summaries(self, library_name: str) -> None:
         """Drop a library's cached port summaries after its node types change.
@@ -3458,8 +3497,12 @@ class LibraryManager(EngineScoped):
         already in flight for this library can tell that its result is stale and decline to cache
         it. Call this *before* mutating the library, so a mutation that bails out partway through
         still leaves the cache cleared.
+
+        Outstanding retries go too: a reload replaces the node's code, so a probe that timed out
+        against the old code has earned a fresh full attempt rather than a top-up.
         """
         self._library_to_port_summaries.pop(library_name, None)
+        self._library_to_port_summary_retries.pop(library_name, None)
         self._library_to_port_summaries_generation[library_name] = (
             self._library_to_port_summaries_generation.get(library_name, 0) + 1
         )

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -125,6 +125,8 @@ from griptape_nodes.retained_mode.events.library_events import (
     GetNodeMetadataFromLibraryRequest,
     GetNodeMetadataFromLibraryResultFailure,
     GetNodeMetadataFromLibraryResultSuccess,
+    GetPortSummariesForAllLibrariesRequest,
+    GetPortSummariesForAllLibrariesResultSuccess,
     InspectLibraryRepoRequest,
     InspectLibraryRepoResultFailure,
     InspectLibraryRepoResultSuccess,
@@ -153,6 +155,7 @@ from griptape_nodes.retained_mode.events.library_events import (
     LoadLibraryMetadataFromFileResultSuccess,
     LoadMetadataForAllLibrariesRequest,
     LoadMetadataForAllLibrariesResultSuccess,
+    NodePortSummary,
     ParameterDescription,
     PreviewProjectProvisioningRequest,
     PreviewProjectProvisioningResultFailure,
@@ -355,6 +358,18 @@ class StableNamespaceImportFinder(importlib.abc.MetaPathFinder, importlib.abc.Lo
         """No-op: the module was fully executed by the memoized loader in create_module."""
 
 
+class NodeProbeResult(NamedTuple):
+    """Outcome of constructing a throwaway node to read the parameters its __init__ declares.
+
+    `node` is None exactly when the probe failed -- either the node's module could not be
+    imported or its __init__ raised -- and `error_message` says why. On success `error_message`
+    is empty.
+    """
+
+    node: BaseNode | None
+    error_message: str
+
+
 class LibraryGitOperationContext(NamedTuple):
     """Context information for git operations on a library."""
 
@@ -428,6 +443,11 @@ class LibraryManager(EngineScoped):
     # Sandbox library constants
     UNRESOLVED_SANDBOX_CLASS_NAME = "<NOT YET RESOLVED>"
     SANDBOX_CATEGORY_NAME = "Griptape Nodes Sandbox"
+
+    # Name given to the throwaway nodes `_probe_node_type` constructs to read a node type's
+    # declared parameters. They are never registered with the ObjectManager, so the prefix only
+    # exists to make one obvious in a log line or traceback.
+    PROBE_NODE_NAME_PREFIX = "__node_type_probe__"
 
     _library_file_path_to_info: dict[str, LibraryInfo]
 
@@ -585,7 +605,7 @@ class LibraryManager(EngineScoped):
     # Callbacks invoked immediately before all libraries are reloaded.
     _pre_reload_callbacks: list[Callable[[], Awaitable[None]]]
 
-    def __init__(
+    def __init__(  # noqa: PLR0915 (mostly a flat list of request-handler registrations)
         self, event_manager: EventManager, *, worker_manager: WorkerManager, engine: Engine | None = None
     ) -> None:
         super().__init__(engine)
@@ -613,6 +633,10 @@ class LibraryManager(EngineScoped):
         self._library_event_handler_mappings: dict[
             type[Payload], dict[str, LibraryManager.RegisteredEventHandler[Any]]
         ] = {}
+        # Per-library node type -> port summary, computed on the first GetPortSummaries request
+        # and dropped when the library is unloaded (which a reload goes through).
+        self._library_to_port_summaries: dict[str, dict[str, NodePortSummary]] = {}
+        self._port_summaries_lock = asyncio.Lock()
         self._libraries_loading_complete = asyncio.Event()
         self._libraries_loading_complete.set()  # Not loading initially; load_all_libraries_from_config will clear/set this
         # True for the duration of the engine's initialization sequence (library + workflow
@@ -666,6 +690,9 @@ class LibraryManager(EngineScoped):
         )
         event_manager.assign_manager_to_request_type(
             GetAllInfoForAllLibrariesRequest, self.on_get_all_info_for_all_libraries_request
+        )
+        event_manager.assign_manager_to_request_type(
+            GetPortSummariesForAllLibrariesRequest, self.on_get_port_summaries_for_all_libraries_request
         )
         event_manager.assign_manager_to_request_type(
             LoadMetadataForAllLibrariesRequest, self.load_metadata_for_all_libraries_request
@@ -1920,6 +1947,10 @@ class LibraryManager(EngineScoped):
             )
             return RegisterSandboxNodeFromSourceResultFailure(result_details=details)
 
+        # These node types were added to (or replaced within) an already-registered library, so
+        # its cached port summaries no longer describe it.
+        self._library_to_port_summaries.pop(LibraryManager.SANDBOX_LIBRARY_NAME, None)
+
         summary = (
             f"Registered {len(registered_class_names)} node type(s) from '{file_path}' "
             f"into the {LibraryManager.SANDBOX_LIBRARY_NAME} "
@@ -1954,20 +1985,13 @@ class LibraryManager(EngineScoped):
             return DescribeNodeTypeResultFailure(result_details=details)
 
         # Instantiate a throwaway node so we can read the parameters its __init__ declares.
-        # The node is never added to a flow or the ObjectManager, so it is garbage-collected
-        # when this method returns.
         #
-        # Nodes whose __init__ performs I/O (network calls, auth checks, disk reads) can raise.
-        # In that case we still return a success payload with the library-level metadata and a
-        # WARNING entry in result_details, so callers can present the node at all instead of
-        # getting an opaque failure for every such node type.
-        # Resolving the class imports the node's module (lazy registration defers this to
-        # first use). A broken module raises here; return the library-level metadata with a
-        # WARNING rather than an opaque failure, matching the probe-failure path below.
-        try:
-            node_class = library.get_node_class(request.node_type)
-        except (ImportError, AttributeError, TypeError) as err:
-            import_error = f"{type(err).__name__}: {err}"
+        # The import or the __init__ can fail (a broken module, or __init__ I/O such as network
+        # calls, auth checks, disk reads). In that case we still return a success payload with
+        # the library-level metadata and a WARNING entry in result_details, so callers can
+        # present the node at all instead of getting an opaque failure for every such node type.
+        probe_result = self._probe_node_type(library=library, node_type=request.node_type)
+        if probe_result.node is None:
             return DescribeNodeTypeResultSuccess(
                 library=library_name,
                 node_type=request.node_type,
@@ -1983,49 +2007,12 @@ class LibraryManager(EngineScoped):
                     ),
                     ResultDetail(
                         level=logging.WARNING,
-                        message=f"Node module failed to import: {import_error}",
-                    ),
-                ),
-            )
-        probe_name = f"__describe_node_type_probe__{request.node_type}"
-        try:
-            # Wrap in ``LibraryRegistry.constructing_node()`` so the
-            # parameter-mutation detector skips this ephemeral probe's
-            # declarative ``add_parameter`` calls (this construction
-            # bypasses ``LibraryRegistry.create_node``).
-            #
-            # Pass the node's library and type so declarative ``__init__`` logic
-            # that resolves against the library -- e.g. ``get_declared_models``
-            # populating a model dropdown from the ``model_catalog`` -- works
-            # during the probe just as it does under ``create_node``.
-            with LibraryRegistry.constructing_node():
-                probe_node = node_class(
-                    name=probe_name,
-                    metadata={"library": library_name, "node_type": request.node_type},
-                )
-        except Exception as err:
-            probe_error = f"{type(err).__name__}: {err}"
-            return DescribeNodeTypeResultSuccess(
-                library=library_name,
-                node_type=request.node_type,
-                metadata=node_metadata,
-                parameters=[],
-                result_details=ResultDetails(
-                    ResultDetail(
-                        level=logging.INFO,
-                        message=(
-                            f"Described node type '{request.node_type}' in Library '{library_name}' "
-                            "with library metadata only."
-                        ),
-                    ),
-                    ResultDetail(
-                        level=logging.WARNING,
-                        message=f"Parameter probe failed because: {probe_error}",
+                        message=probe_result.error_message,
                     ),
                 ),
             )
 
-        parameters = [ParameterDescription.from_parameter(param) for param in probe_node.parameters]
+        parameters = [ParameterDescription.from_parameter(param) for param in probe_result.node.parameters]
 
         details = f"Successfully described node type '{request.node_type}' in Library '{library_name}'."
         return DescribeNodeTypeResultSuccess(
@@ -2035,6 +2022,55 @@ class LibraryManager(EngineScoped):
             parameters=parameters,
             result_details=details,
         )
+
+    def _probe_node_type(self, library: Library, node_type: str) -> NodeProbeResult:
+        """Construct a throwaway node so callers can read the parameters its __init__ declares.
+
+        Parameters are usually added in __init__ rather than declared as class attributes, so
+        constructing the node is the only way to see its ports. The probe is never added to a
+        flow or the ObjectManager, so it is garbage-collected once the caller drops it.
+
+        Two things can fail and neither is exceptional from a caller's point of view, so both
+        come back as `error_message` on the result:
+
+        - Resolving the class imports the node's module, which lazy registration defers to first
+          use. A broken module raises here.
+        - A node's __init__ may perform I/O (network calls, auth checks, disk reads).
+
+        Callers on the event loop should note that both can block; ``__init__`` in particular has
+        no bound on how long it takes.
+        """
+        library_name = library.get_library_data().name
+
+        try:
+            node_class = library.get_node_class(node_type)
+        except (ImportError, AttributeError, TypeError) as err:
+            return NodeProbeResult(
+                node=None,
+                error_message=f"Node module failed to import: {type(err).__name__}: {err}",
+            )
+
+        try:
+            # Wrap in ``LibraryRegistry.constructing_node()`` so the parameter-mutation detector
+            # skips this ephemeral probe's declarative ``add_parameter`` calls (this construction
+            # bypasses ``LibraryRegistry.create_node``).
+            #
+            # Pass the node's library and type so declarative ``__init__`` logic that resolves
+            # against the library -- e.g. ``get_declared_models`` populating a model dropdown
+            # from the ``model_catalog`` -- works during the probe just as it does under
+            # ``create_node``.
+            with LibraryRegistry.constructing_node():
+                probe_node = node_class(
+                    name=f"{self.PROBE_NODE_NAME_PREFIX}{node_type}",
+                    metadata={"library": library_name, "node_type": node_type},
+                )
+        except Exception as err:
+            return NodeProbeResult(
+                node=None,
+                error_message=f"Parameter probe failed because: {type(err).__name__}: {err}",
+            )
+
+        return NodeProbeResult(node=probe_node, error_message="")
 
     def list_categories_in_library_request(self, request: ListCategoriesInLibraryRequest) -> ResultPayload:
         # Does this library exist?
@@ -3042,6 +3078,10 @@ class LibraryManager(EngineScoped):
             details = f"Attempted to unload library '{request.library_name}'. Failed due to {e}"
             return UnloadLibraryFromRegistryResultFailure(result_details=details)
 
+        # Drop cached port summaries: the library's node types are gone, and a subsequent load may
+        # bring back different ones. Every reload path unloads first, so this covers reloads too.
+        self._library_to_port_summaries.pop(request.library_name, None)
+
         # Clean up all stable module aliases for this library. Note first whether any of its node
         # modules had actually been imported: if so, this process is stuck with that code and the
         # library's next load cannot replace it.
@@ -3102,6 +3142,106 @@ class LibraryManager(EngineScoped):
         """Registered entry point: hold the caller until any in-flight reload finishes."""
         await self._libraries_loading_complete.wait()
         return await self.get_all_info_for_all_libraries_request(request)
+
+    async def on_get_port_summaries_for_all_libraries_request(
+        self,
+        request: GetPortSummariesForAllLibrariesRequest,  # noqa: ARG002
+    ) -> ResultPayload:
+        """Async handler for GetPortSummariesForAllLibrariesRequest.
+
+        Waits for library loading to finish, then serves each library's summaries from the cache,
+        computing them on first request.
+        """
+        await self._libraries_loading_complete.wait()
+
+        library_name_to_port_summaries: dict[str, dict[str, NodePortSummary]] = {}
+        for library_name in LibraryRegistry.list_libraries():
+            library_name_to_port_summaries[library_name] = await self._get_port_summaries_for_library(library_name)
+
+        node_type_count = sum(len(summaries) for summaries in library_name_to_port_summaries.values())
+        details = (
+            f"Successfully retrieved port summaries for {node_type_count} node type(s) "
+            f"across {len(library_name_to_port_summaries)} librar(ies)."
+        )
+        return GetPortSummariesForAllLibrariesResultSuccess(
+            library_name_to_port_summaries=library_name_to_port_summaries,
+            result_details=details,
+        )
+
+    async def _get_port_summaries_for_library(self, library_name: str) -> dict[str, NodePortSummary]:
+        """Return the port summary for every node type in a library, computing it on first call.
+
+        Cached for the process lifetime because a node type's declared ports cannot change
+        without the library being reloaded, which clears the entry.
+
+        The lock means concurrent callers do the probe pass once rather than once each; the
+        second caller waits and then reads the cache.
+        """
+        async with self._port_summaries_lock:
+            cached_summaries = self._library_to_port_summaries.get(library_name)
+            if cached_summaries is not None:
+                return cached_summaries
+
+            summaries = await self._compute_port_summaries_for_library(library_name)
+            self._library_to_port_summaries[library_name] = summaries
+            return summaries
+
+    async def _compute_port_summaries_for_library(self, library_name: str) -> dict[str, NodePortSummary]:
+        """Probe every node type in a library and derive its port summary.
+
+        Node types the engine cannot construct are left out of the result entirely rather than
+        recorded as portless, so callers leave them unranked instead of ranking them as
+        connecting to nothing.
+
+        Each probe runs in a thread under the same timeout the worker-side schema pass uses:
+        a node's __init__ can block indefinitely, and one such node must not stall the rest.
+        """
+        try:
+            library = LibraryRegistry.get_library(library_name)
+        except KeyError:
+            logger.warning("Cannot compute port summaries: library '%s' not found in registry.", library_name)
+            return {}
+
+        summaries: dict[str, NodePortSummary] = {}
+        skipped_node_types: list[str] = []
+        for node_type in library.get_registered_nodes():
+            try:
+                probe_result = await asyncio.wait_for(
+                    asyncio.to_thread(self._probe_node_type, library, node_type),
+                    timeout=self._SCHEMA_PROBE_TIMEOUT_S,
+                )
+            except TimeoutError:
+                logger.warning(
+                    "Port summary probe for node type '%s' in library '%s' timed out after %.1fs; skipping. "
+                    "The node's __init__ likely makes a blocking call.",
+                    node_type,
+                    library_name,
+                    self._SCHEMA_PROBE_TIMEOUT_S,
+                )
+                skipped_node_types.append(node_type)
+                continue
+
+            if probe_result.node is None:
+                logger.debug(
+                    "Could not probe node type '%s' in library '%s' for its port summary: %s",
+                    node_type,
+                    library_name,
+                    probe_result.error_message,
+                )
+                skipped_node_types.append(node_type)
+                continue
+
+            summaries[node_type] = NodePortSummary.from_parameters(probe_result.node.parameters)
+
+        if skipped_node_types:
+            logger.info(
+                "Computed port summaries for %d node type(s) in library '%s'; %d could not be probed: %s",
+                len(summaries),
+                library_name,
+                len(skipped_node_types),
+                ", ".join(skipped_node_types),
+            )
+        return summaries
 
     async def on_get_all_info_for_library_request(self, request: GetAllInfoForLibraryRequest) -> ResultPayload:
         """Registered entry point: hold the caller until any in-flight reload finishes.
@@ -4461,6 +4601,10 @@ class LibraryManager(EngineScoped):
         except KeyError:
             logger.warning("Cannot register worker node schemas: library '%s' not found in registry.", library_name)
             return
+
+        # Stub classes are about to replace whatever this library previously advertised, so any
+        # port summaries cached from an earlier load are stale.
+        self._library_to_port_summaries.pop(library_name, None)
 
         # Build a lookup from class_name -> NodeMetadata using the library JSON schema.
         library_data = library.get_library_data()

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -358,6 +358,17 @@ class StableNamespaceImportFinder(importlib.abc.MetaPathFinder, importlib.abc.Lo
         """No-op: the module was fully executed by the memoized loader in create_module."""
 
 
+class NodeClassResolution(NamedTuple):
+    """Outcome of resolving a node type to its class, importing the module if needed.
+
+    `node_class` is None exactly when the import failed, and `error_message` says why. On success
+    `error_message` is empty.
+    """
+
+    node_class: type[BaseNode] | None
+    error_message: str
+
+
 class NodeProbeResult(NamedTuple):
     """Outcome of constructing a throwaway node to read the parameters its __init__ declares.
 
@@ -636,6 +647,10 @@ class LibraryManager(EngineScoped):
         # Per-library node type -> port summary, computed on the first GetPortSummaries request
         # and dropped when the library is unloaded (which a reload goes through).
         self._library_to_port_summaries: dict[str, dict[str, NodePortSummary]] = {}
+        # Bumped by _invalidate_port_summaries. The compute pass awaits, so a library can be
+        # mutated while its summaries are being computed; comparing the counter before and after
+        # tells the pass whether its now-stale result is still safe to cache.
+        self._library_to_port_summaries_generation: dict[str, int] = {}
         self._port_summaries_lock = asyncio.Lock()
         self._libraries_loading_complete = asyncio.Event()
         self._libraries_loading_complete.set()  # Not loading initially; load_all_libraries_from_config will clear/set this
@@ -1906,6 +1921,11 @@ class LibraryManager(EngineScoped):
             )
             return RegisterSandboxNodeFromSourceResultFailure(result_details=details)
 
+        # Invalidate before the loop below, not after it. The loop mutates the library as it goes
+        # and can bail out partway through (replace_if_exists=False), which would otherwise leave
+        # a mutated library described by cached summaries for the rest of the process's life.
+        self._invalidate_port_summaries(LibraryManager.SANDBOX_LIBRARY_NAME)
+
         # Discover BaseNode subclasses defined in this module. The filter matches the one in
         # `_attempt_load_nodes_from_sandbox_library_using_existing_schema` so that files
         # registered via MCP and files scanned at startup surface identically.
@@ -1946,10 +1966,6 @@ class LibraryManager(EngineScoped):
                 "re-exported from another module). Nothing was registered."
             )
             return RegisterSandboxNodeFromSourceResultFailure(result_details=details)
-
-        # These node types were added to (or replaced within) an already-registered library, so
-        # its cached port summaries no longer describe it.
-        self._library_to_port_summaries.pop(LibraryManager.SANDBOX_LIBRARY_NAME, None)
 
         summary = (
             f"Registered {len(registered_class_names)} node type(s) from '{file_path}' "
@@ -2039,16 +2055,61 @@ class LibraryManager(EngineScoped):
 
         Callers on the event loop should note that both can block; ``__init__`` in particular has
         no bound on how long it takes.
-        """
-        library_name = library.get_library_data().name
 
+        MUST run on the event loop, because resolving the class is not thread-safe (see
+        ``_resolve_node_class_for_probe``). A caller that wants to bound a blocking ``__init__``
+        with a timeout should call the two halves separately rather than threading this: resolve
+        here on the loop, then hand ``_construct_probe_node`` to ``asyncio.to_thread``.
+        """
+        resolution = self._resolve_node_class_for_probe(library=library, node_type=node_type)
+        if resolution.node_class is None:
+            return NodeProbeResult(node=None, error_message=resolution.error_message)
+
+        return self._construct_probe_node(library=library, node_type=node_type, node_class=resolution.node_class)
+
+    def _resolve_node_class_for_probe(self, library: Library, node_type: str) -> NodeClassResolution:
+        """Resolve a node type to its class, importing the module now if registration was lazy.
+
+        MUST run on the event loop. ``NodeTypeEntry.resolve()`` documents itself as not
+        thread-safe: it assumes single-threaded resolution, so concurrent callers could each run
+        the loader and hand out two different class objects for one node type. The loader also
+        mutates process- and manager-wide state as a side effect (``sys.modules``, the stable
+        namespace alias maps), which would then race the loop.
+
+        The import can be slow -- a node module pulling in torch or diffusers costs seconds -- and
+        that cost lands on the loop. That is the same trade the (synchronous) DescribeNodeType and
+        CreateNode handlers already make; a caller resolving many node types in a row should yield
+        between them so it does not monopolize the loop.
+        """
         try:
             node_class = library.get_node_class(node_type)
         except (ImportError, AttributeError, TypeError) as err:
-            return NodeProbeResult(
-                node=None,
+            return NodeClassResolution(
+                node_class=None,
                 error_message=f"Node module failed to import: {type(err).__name__}: {err}",
             )
+
+        return NodeClassResolution(node_class=node_class, error_message="")
+
+    def _construct_probe_node(self, library: Library, node_type: str, node_class: type[BaseNode]) -> NodeProbeResult:
+        """Construct a probe instance of an already-resolved node class.
+
+        Safe to hand to ``asyncio.to_thread``: it touches no shared registry state, and
+        ``constructing_node()`` is a ContextVar, which ``to_thread`` propagates via
+        ``copy_context()``. Threading this is how a caller bounds a blocking ``__init__`` with a
+        timeout without also moving class resolution off the loop.
+        """
+        library_name = library.get_library_data().name
+        # Mirror the metadata blob ``Library.create_node`` builds, so declarative ``__init__``
+        # logic reading ``library_node_metadata`` sees under probe what it sees when the artist
+        # really creates the node. Diverging here would let a node declare different parameters
+        # during the probe than on the canvas -- i.e. report ports it does not have.
+        try:
+            node_metadata_model = library.get_node_metadata(node_type)
+        except LibraryRegistryError:
+            library_node_metadata = {}
+        else:
+            library_node_metadata = node_metadata_model.model_dump(mode="json")
 
         try:
             # Wrap in ``LibraryRegistry.constructing_node()`` so the parameter-mutation detector
@@ -2062,7 +2123,11 @@ class LibraryManager(EngineScoped):
             with LibraryRegistry.constructing_node():
                 probe_node = node_class(
                     name=f"{self.PROBE_NODE_NAME_PREFIX}{node_type}",
-                    metadata={"library": library_name, "node_type": node_type},
+                    metadata={
+                        "library": library_name,
+                        "node_type": node_type,
+                        "library_node_metadata": library_node_metadata,
+                    },
                 )
         except Exception as err:
             return NodeProbeResult(
@@ -3080,7 +3145,7 @@ class LibraryManager(EngineScoped):
 
         # Drop cached port summaries: the library's node types are gone, and a subsequent load may
         # bring back different ones. Every reload path unloads first, so this covers reloads too.
-        self._library_to_port_summaries.pop(request.library_name, None)
+        self._invalidate_port_summaries(request.library_name)
 
         # Clean up all stable module aliases for this library. Note first whether any of its node
         # modules had actually been imported: if so, this process is stuck with that code and the
@@ -3171,18 +3236,41 @@ class LibraryManager(EngineScoped):
     async def _get_port_summaries_for_library(self, library_name: str) -> dict[str, NodePortSummary]:
         """Return the port summary for every node type in a library, computing it on first call.
 
-        Cached for the process lifetime because a node type's declared ports cannot change
-        without the library being reloaded, which clears the entry.
+        Cached until the library is mutated or unloaded, because a node type's declared ports
+        cannot change without one of those happening.
 
-        The lock means concurrent callers do the probe pass once rather than once each; the
-        second caller waits and then reads the cache.
+        The lock means concurrent callers do the probe pass once rather than once each; the second
+        caller waits and then reads the cache. It is deliberately not held for the cache-hit path:
+        the probe pass can take seconds, and a request that only needs already-computed summaries
+        should not queue behind an unrelated library being probed for the first time.
         """
+        cached_summaries = self._library_to_port_summaries.get(library_name)
+        if cached_summaries is not None:
+            return cached_summaries
+
         async with self._port_summaries_lock:
+            # Re-check: another caller may have computed these while we waited for the lock.
             cached_summaries = self._library_to_port_summaries.get(library_name)
             if cached_summaries is not None:
                 return cached_summaries
 
+            generation_before = self._library_to_port_summaries_generation.get(library_name, 0)
             summaries = await self._compute_port_summaries_for_library(library_name)
+
+            # The pass above awaited, so the library may have been reloaded, unloaded, or had node
+            # types registered into it in the meantime. Caching what we just measured would pin
+            # pre-mutation ports for the rest of the process's life, so return them to this caller
+            # (they are the best answer we have) without writing them back. The next request
+            # recomputes.
+            generation_after = self._library_to_port_summaries_generation.get(library_name, 0)
+            if generation_after != generation_before:
+                logger.debug(
+                    "Library '%s' changed while its port summaries were being computed; "
+                    "serving this result without caching it.",
+                    library_name,
+                )
+                return summaries
+
             self._library_to_port_summaries[library_name] = summaries
             return summaries
 
@@ -3193,8 +3281,11 @@ class LibraryManager(EngineScoped):
         recorded as portless, so callers leave them unranked instead of ranking them as
         connecting to nothing.
 
-        Each probe runs in a thread under the same timeout the worker-side schema pass uses:
-        a node's __init__ can block indefinitely, and one such node must not stall the rest.
+        The two halves of the probe run in different places on purpose. Resolving the node class
+        stays on the event loop because ``NodeTypeEntry.resolve()`` is not thread-safe, and only
+        construction goes to a thread, where the same timeout the worker-side schema pass uses
+        bounds it: a node's ``__init__`` can block indefinitely, and one such node must not stall
+        the rest.
         """
         try:
             library = LibraryRegistry.get_library(library_name)
@@ -3205,9 +3296,24 @@ class LibraryManager(EngineScoped):
         summaries: dict[str, NodePortSummary] = {}
         skipped_node_types: list[str] = []
         for node_type in library.get_registered_nodes():
+            # Yield between node types so a large library's resolve calls, which run on the loop,
+            # interleave with other work instead of monopolizing it for the whole pass.
+            await asyncio.sleep(0)
+
+            resolution = self._resolve_node_class_for_probe(library=library, node_type=node_type)
+            if resolution.node_class is None:
+                logger.debug(
+                    "Could not probe node type '%s' in library '%s' for its port summary: %s",
+                    node_type,
+                    library_name,
+                    resolution.error_message,
+                )
+                skipped_node_types.append(node_type)
+                continue
+
             try:
                 probe_result = await asyncio.wait_for(
-                    asyncio.to_thread(self._probe_node_type, library, node_type),
+                    asyncio.to_thread(self._construct_probe_node, library, node_type, resolution.node_class),
                     timeout=self._SCHEMA_PROBE_TIMEOUT_S,
                 )
             except TimeoutError:
@@ -3217,6 +3323,18 @@ class LibraryManager(EngineScoped):
                     node_type,
                     library_name,
                     self._SCHEMA_PROBE_TIMEOUT_S,
+                )
+                skipped_node_types.append(node_type)
+                continue
+            except Exception:
+                # _construct_probe_node already converts a raising __init__ into a result, so
+                # reaching here means the failure was outside it. Skip the one node type rather
+                # than failing summaries for every library in the response.
+                logger.debug(
+                    "Unexpected failure probing node type '%s' in library '%s' for its port summary; skipping.",
+                    node_type,
+                    library_name,
+                    exc_info=True,
                 )
                 skipped_node_types.append(node_type)
                 continue
@@ -3242,6 +3360,19 @@ class LibraryManager(EngineScoped):
                 ", ".join(skipped_node_types),
             )
         return summaries
+
+    def _invalidate_port_summaries(self, library_name: str) -> None:
+        """Drop a library's cached port summaries after its node types change.
+
+        Bumps a per-library generation counter as well as clearing the entry, so a probe pass
+        already in flight for this library can tell that its result is stale and decline to cache
+        it. Call this *before* mutating the library, so a mutation that bails out partway through
+        still leaves the cache cleared.
+        """
+        self._library_to_port_summaries.pop(library_name, None)
+        self._library_to_port_summaries_generation[library_name] = (
+            self._library_to_port_summaries_generation.get(library_name, 0) + 1
+        )
 
     async def on_get_all_info_for_library_request(self, request: GetAllInfoForLibraryRequest) -> ResultPayload:
         """Registered entry point: hold the caller until any in-flight reload finishes.
@@ -4604,7 +4735,7 @@ class LibraryManager(EngineScoped):
 
         # Stub classes are about to replace whatever this library previously advertised, so any
         # port summaries cached from an earlier load are stale.
-        self._library_to_port_summaries.pop(library_name, None)
+        self._invalidate_port_summaries(library_name)
 
         # Build a lookup from class_name -> NodeMetadata using the library JSON schema.
         library_data = library.get_library_data()

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import hashlib
 import importlib.abc
 import importlib.machinery
@@ -730,8 +729,10 @@ class LibraryManager(EngineScoped):
         # tells the pass whether its now-stale result is still safe to cache.
         self._library_to_port_summaries_generation: dict[str, int] = {}
         # One lock per library, so a request that only needs an already-computed library's
-        # summaries does not queue behind a different library's first probe pass.
+        # summaries does not queue behind a different library's first probe pass. Reached only
+        # through _port_summaries_lock_for, which discards the lot when the running loop changes.
         self._library_to_port_summaries_lock: dict[str, asyncio.Lock] = {}
+        self._port_summaries_lock_loop: asyncio.AbstractEventLoop | None = None
         # Probe threads this engine has leaked, for the life of the process. Counted here rather
         # than only per library or per request because the pool the leaks come out of is shared
         # engine-wide: the per-library allowance resets on reload and the per-request one resets
@@ -739,6 +740,10 @@ class LibraryManager(EngineScoped):
         # This is the only counter that never resets, and _PROBE_THREAD_LEAK_CEILING is the only
         # bound expressed in terms of the executor actually being drained.
         self._port_summary_threads_leaked: int = 0
+        # How many port summary requests are currently being answered. Non-zero means someone is
+        # blocked on the machinery below, which is what tells the background warm pass to stop
+        # spacing its probes out -- see _effective_probe_throttle_s.
+        self._port_summary_interactive_waiters: int = 0
         # The in-flight background pass filling the cache above, if any. Retained rather than
         # fire-and-forget because a reload has to cancel it: the pass resolves node classes, so
         # one still running while a library is torn down would import that library's modules
@@ -3285,6 +3290,17 @@ class LibraryManager(EngineScoped):
             return False
 
     def unload_library_from_registry_request(self, request: UnloadLibraryFromRegistryRequest) -> ResultPayload:
+        if request.library_name not in LibraryRegistry.list_libraries():
+            # Checked here rather than left to the unregister call below so that nothing is recorded
+            # against a name that was never a library. The invalidation that follows creates a
+            # generation entry keyed by name, and entries are never removed, so answering repeated
+            # requests for names that do not exist would grow that map without bound.
+            details = (
+                f"Attempted to unload library '{request.library_name}'. Failed because no library with that name is "
+                f"registered."
+            )
+            return UnloadLibraryFromRegistryResultFailure(result_details=details)
+
         # Drop cached port summaries first: the library's node types are about to go, and a
         # subsequent load may bring back different ones. Every reload path unloads first, so this
         # covers reloads too. Before the unload rather than after so an unload that fails partway
@@ -3378,16 +3394,25 @@ class LibraryManager(EngineScoped):
         ran out here keeps them pending, so the next request resumes them.
 
         No throttle between node types: a caller is waiting on this, so it takes the loop for as
-        long as it needs. The warm pass is the one that spaces its probes out.
+        long as it needs. The warm pass is the one that spaces its probes out -- and it stops doing
+        so while this is registered as waiting, because a request that queues behind a deliberately
+        slowed pass pays that slowdown in full.
         """
         await self._libraries_loading_complete.wait()
 
         allowance = ProbeTimeoutAllowance(remaining=self._PORT_SUMMARY_TIMEOUT_BUDGET)
         library_name_to_port_summaries: dict[str, dict[str, NodePortSummary]] = {}
-        for library_name in LibraryRegistry.list_libraries():
-            library_name_to_port_summaries[library_name] = await self._get_port_summaries_for_library(
-                library_name, allowance, throttle_s=0.0
-            )
+        # Counted rather than flagged so concurrent requests do not un-register each other, and
+        # decremented in `finally` so a cancelled request does not leave the warm pass unthrottled
+        # for the life of the process.
+        self._port_summary_interactive_waiters += 1
+        try:
+            for library_name in LibraryRegistry.list_libraries():
+                library_name_to_port_summaries[library_name] = await self._get_port_summaries_for_library(
+                    library_name, allowance, throttle_s=0.0
+                )
+        finally:
+            self._port_summary_interactive_waiters -= 1
 
         node_type_count = sum(len(summaries) for summaries in library_name_to_port_summaries.values())
         details = (
@@ -3488,8 +3513,23 @@ class LibraryManager(EngineScoped):
             return
 
         task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
+        try:
             await task
+        except asyncio.CancelledError:
+            # The expected outcome, and not this coroutine's own cancellation: `task` is not the
+            # caller's task, so awaiting it raises the cancellation we just requested.
+            pass
+        except Exception as err:
+            # The pass had already failed for its own reasons and finished between the check above
+            # and the cancel, so awaiting it re-raises that. Callers use this to make an unload safe,
+            # not to find out how warming went, and letting it propagate would abort a reload over a
+            # background task that is already off the loop -- exactly what the reload would fix.
+            logger.warning(
+                "Port summary warming had already failed when it was stopped: %s: %s. Summaries will be recomputed "
+                "after this reload.",
+                type(err).__name__,
+                err,
+            )
 
     async def _warm_port_summaries(self) -> None:
         """Probe every registered library's node types so the first real request is a cache hit.
@@ -3536,8 +3576,8 @@ class LibraryManager(EngineScoped):
         request ran out of timeout allowance before getting to it, is owed a real attempt and stays
         pending until it gets one.
 
-        Three bounds cap all of it, and `_probe_stop_reason` holds them: the caller's per-pass
-        `allowance`, `_PORT_SUMMARY_TIMEOUT_BUDGET` per library per load, and
+        Three bounds cap all of it, and `_probe_stop_reason` holds them alongside its reload check:
+        the caller's per-pass `allowance`, `_PORT_SUMMARY_TIMEOUT_BUDGET` per library per load, and
         `_PROBE_THREAD_LEAK_CEILING` for the whole process. The last one is what actually protects
         the engine: the first two reset (every request, and every reload), so neither bounds the
         running total. Each timeout burned a thread ``asyncio.to_thread`` cannot cancel, and
@@ -3558,10 +3598,7 @@ class LibraryManager(EngineScoped):
         if entry is not None and not entry.pending_node_types():
             return dict(entry.summaries)
 
-        if library_name not in self._library_to_port_summaries_lock:
-            self._library_to_port_summaries_lock[library_name] = asyncio.Lock()
-
-        async with self._library_to_port_summaries_lock[library_name]:
+        async with self._port_summaries_lock_for(library_name):
             # Re-check: another caller may have computed or topped these up while we waited.
             entry = self._library_to_port_summary_cache.get(library_name)
             if entry is not None and not entry.pending_node_types():
@@ -3574,6 +3611,7 @@ class LibraryManager(EngineScoped):
                 )
                 summaries = computation.summaries
                 timeouts_spent = len(computation.timed_out_node_types)
+                already_retried_node_types = frozenset()
             else:
                 computation = await self._compute_port_summaries_for_library(
                     library_name,
@@ -3584,6 +3622,8 @@ class LibraryManager(EngineScoped):
                 )
                 summaries = {**entry.summaries, **computation.summaries}
                 timeouts_spent = entry.timeouts_spent + len(computation.timed_out_node_types)
+                # What this pass was retrying is exactly what has now had its one retry.
+                already_retried_node_types = entry.retry_node_types
 
             # The pass above awaited, so the library may have been reloaded, unloaded, or had node
             # types registered into it in the meantime. Caching what we just measured would pin
@@ -3604,9 +3644,28 @@ class LibraryManager(EngineScoped):
                 summaries=summaries,
                 computation=computation,
                 timeouts_spent=timeouts_spent,
-                is_first_pass=entry is None,
+                already_retried_node_types=already_retried_node_types,
             )
             return dict(summaries)
+
+    def _port_summaries_lock_for(self, library_name: str) -> asyncio.Lock:
+        """Hand out a library's probe lock, discarding locks left behind by a previous event loop.
+
+        `asyncio.Lock` binds to the loop that first awaits it and raises RuntimeError when awaited
+        from another -- the same staleness `_close_libraries_loading_gate` handles for its Event, and
+        reachable for the same reason: a manager outlives any one `asyncio.run()` call. Dropping
+        every lock on a loop change is safe because these locks only stop two callers doing the same
+        probe pass twice. Correctness rests on the generation counter, which is plain integers.
+        """
+        running_loop = asyncio.get_running_loop()
+        if self._port_summaries_lock_loop is not running_loop:
+            self._library_to_port_summaries_lock.clear()
+            self._port_summaries_lock_loop = running_loop
+
+        if library_name not in self._library_to_port_summaries_lock:
+            self._library_to_port_summaries_lock[library_name] = asyncio.Lock()
+
+        return self._library_to_port_summaries_lock[library_name]
 
     def _next_port_summary_cache_entry(
         self,
@@ -3615,7 +3674,7 @@ class LibraryManager(EngineScoped):
         summaries: dict[str, NodePortSummary],
         computation: PortSummaryComputation,
         timeouts_spent: int,
-        is_first_pass: bool,
+        already_retried_node_types: frozenset[str],
     ) -> PortSummaryCacheEntry:
         """Decide what a completed pass leaves pending for the library.
 
@@ -3662,14 +3721,21 @@ class LibraryManager(EngineScoped):
                 timeouts_spent=timeouts_spent,
             )
 
-        # Only a first pass earns retries. A top-up pass has spent the ones it was given, so not
-        # re-recording its own timeouts is what stops a stuck node type cycling forever.
-        retry_node_types = frozenset()
-        if is_first_pass:
-            retry_node_types = computation.timed_out_node_types
+        # One retry per node type per library load, granted the first time that node type's own probe
+        # times out -- which is not the same as the first pass over the library. A pass that stopped
+        # early leaves node types unreached, and the pass that finally reaches one is the pass where
+        # its first timeout can happen. Subtracting the set this pass was already retrying is what
+        # makes it exactly one: a node type that times out again while being retried is not
+        # re-recorded, so nothing cycles.
+        retry_node_types = computation.timed_out_node_types - already_retried_node_types
 
-        # Node types never reached are always carried: a later pass shrinks the set by at least one
-        # timeout's worth before it can stop early again, so this converges.
+        # Node types never reached are always carried, and the two branches above are what stops
+        # that from being unbounded. A later pass is not guaranteed to make progress on *this*
+        # library -- the per-request allowance can be spent on an earlier one, and a reload closing
+        # the gate stops a pass having probed nothing -- so the set can survive a pass unchanged.
+        # What it cannot do is survive indefinitely: every stop for allowance cost the engine a
+        # leaked thread, so after `_PROBE_THREAD_LEAK_CEILING` of them the first branch drops
+        # everything pending, and a reload discards the entry outright rather than carrying it.
         return PortSummaryCacheEntry(
             summaries=summaries,
             retry_node_types=retry_node_types,
@@ -3752,7 +3818,7 @@ class LibraryManager(EngineScoped):
             # interleave with other work instead of monopolizing it for the whole pass. A zero
             # sleep only lets already-ready callbacks run; the warm pass passes a real interval,
             # which is what actually leaves the loop usable while it works.
-            await asyncio.sleep(throttle_s)
+            await asyncio.sleep(self._effective_probe_throttle_s(throttle_s))
 
             outcome = await self._probe_node_type_port_summary(
                 library=library, library_name=library_name, node_type=node_type
@@ -3783,13 +3849,40 @@ class LibraryManager(EngineScoped):
             unprobed_node_types=frozenset(unprobed_node_types),
         )
 
+    def _effective_probe_throttle_s(self, throttle_s: float) -> float:
+        """Drop a background pass's throttle for as long as an interactive request is waiting.
+
+        The throttle buys loop responsiveness with wall-clock time, which is only a good trade while
+        nothing is blocked on the pass. Once a request arrives, something is: it either queues on
+        this library's per-library lock or reaches this library later in its own walk, and either way
+        every pause here lands inside an artist's drag. A library of 200 node types would add its
+        count times the interval to that drag -- the exact cost warming exists to remove -- so the
+        pass gives up its spacing until the request is answered.
+        """
+        if self._port_summary_interactive_waiters > 0:
+            return 0.0
+
+        return throttle_s
+
     def _probe_stop_reason(self, *, allowance: ProbeTimeoutAllowance, timeouts_spent: int) -> str | None:
         """Say why probing must stop now, or None to keep going.
 
-        Three bounds, checked before every node type because each one has to hold *during* a pass,
+        Four reasons, checked before every node type because each one has to hold *during* a pass,
         not merely be true of it afterwards. Returns the reason as text because its only use is the
         log line explaining why a library came back partly unranked.
+
+        The first is about correctness and the other three are cost bounds.
         """
+        if not self._libraries_loading_complete.is_set():
+            # A reload started after this pass did. Every entry point waits on this gate before
+            # starting, so reaching here means the gate closed mid-pass -- and the pass is about to
+            # resolve node classes belonging to libraries the reload is unloading, importing modules
+            # of the very code the reload exists to replace. The background warm pass is cancelled
+            # outright for this reason; an interactive request cannot be, so it stops here instead.
+            # What it has measured so far is still served; the rest stays pending for a later
+            # request, which will see the rebuilt registry.
+            return "a library reload has started, so the node classes this pass would resolve are being replaced"
+
         if self._port_summary_threads_leaked >= self._PROBE_THREAD_LEAK_CEILING:
             return (
                 f"this engine has leaked {self._port_summary_threads_leaked} probe thread(s), its lifetime ceiling. "
@@ -5855,8 +5948,11 @@ class LibraryManager(EngineScoped):
     # to_thread caller in the engine (library loading, sandbox generation, worker schema
     # serialization) draws from that same pool. Leaving most of it available matters more than
     # ranking the last few node types, so keep this a fraction of the pool rather than a
-    # constant that can exceed it on small machines.
-    _PROBE_THREAD_LEAK_CEILING: int = max(1, min(32, (os.cpu_count() or 1) + 4) // 4)
+    # constant that can exceed it on small machines. The floor is 2, not 1: a quarter of the
+    # pool rounds down to a single thread on any host with 1-3 CPUs, and a ceiling of 1 makes
+    # the very first slow node type in the very first library terminal for the whole process,
+    # so a CI box or a small container would rank almost nothing.
+    _PROBE_THREAD_LEAK_CEILING: int = max(2, min(32, (os.cpu_count() or 1) + 4) // 4)
     # Gap left between node types during the warm pass. Resolving a node class imports its
     # module on the event loop, which nothing can interrupt, so the pass cannot avoid blocking
     # the loop in bursts -- it can only space them out. A warm pass has no deadline, so it
@@ -6418,8 +6514,16 @@ class LibraryManager(EngineScoped):
         # Bracket the reload like on_app_initialization_complete so the heartbeat reports
         # is_initializing during a mid-session reload too. finally clears it even on failure.
         self._is_initializing = True
+        restart_warming = True
         try:
             return await self._run_reload_libraries(request)
+        except asyncio.CancelledError:
+            # The reload itself was cancelled, which happens when the engine is shutting down or the
+            # task driving this request is torn down. Starting a background pass on the way out would
+            # spawn work over a half-dismantled registry that nothing will ever read, and that the
+            # canceller has no handle to stop.
+            restart_warming = False
+            raise
         finally:
             self._is_initializing = False
 
@@ -6428,7 +6532,8 @@ class LibraryManager(EngineScoped):
             # reload that failed would otherwise leave warming off for the life of the process,
             # handing the probe cost back to the next artist to drag a connection. Whichever
             # libraries are registered at this point still have node types worth ranking.
-            self._start_port_summary_warm()
+            if restart_warming:
+                self._start_port_summary_warm()
 
     async def _run_reload_libraries(self, request: ReloadAllLibrariesRequest) -> ResultPayload:  # noqa: ARG002
         # Start with a clean slate.

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -732,11 +732,22 @@ class LibraryManager(EngineScoped):
         # One lock per library, so a request that only needs an already-computed library's
         # summaries does not queue behind a different library's first probe pass.
         self._library_to_port_summaries_lock: dict[str, asyncio.Lock] = {}
+        # Probe threads this engine has leaked, for the life of the process. Counted here rather
+        # than only per library or per request because the pool the leaks come out of is shared
+        # engine-wide: the per-library allowance resets on reload and the per-request one resets
+        # every request, so N libraries over M requests can leak far past anything either bounds.
+        # This is the only counter that never resets, and _PROBE_THREAD_LEAK_CEILING is the only
+        # bound expressed in terms of the executor actually being drained.
+        self._port_summary_threads_leaked: int = 0
         # The in-flight background pass filling the cache above, if any. Retained rather than
         # fire-and-forget because a reload has to cancel it: the pass resolves node classes, so
         # one still running while a library is torn down would import that library's modules
         # back in. See _start_port_summary_warm.
         self._port_summary_warm_task: asyncio.Task[None] | None = None
+        # Whether the host that started this engine has anything that will ask for port summaries.
+        # Set from AppInitializationComplete, which defaults it to True, so an engine that is never
+        # told still behaves as if an editor is attached.
+        self._warm_port_summaries_requested: bool = True
         self._libraries_loading_complete = asyncio.Event()
         self._libraries_loading_complete.set()  # Not loading initially; load_all_libraries_from_config will clear/set this
         # True for the duration of the engine's initialization sequence (library + workflow
@@ -879,6 +890,11 @@ class LibraryManager(EngineScoped):
         # Skip on the worker itself -- it already has the real node classes registered.
         if notification.node_schemas and not self._is_worker:
             self._register_nodes_from_worker_schemas(notification.library_name, notification.node_schemas)
+            # Registering those stubs dropped this library's cached summaries, and a worker can
+            # report at any point -- including long after the startup warm pass finished. Without
+            # restarting the pass here, worker-hosted libraries would be the only ones left cold,
+            # so the artist pays the probe cost mid-drag for exactly those.
+            self._start_port_summary_warm()
         # Unblock any code awaiting this library's worker_ready event.
         if library_info.worker_ready is not None:
             library_info.worker_ready.set()
@@ -2131,11 +2147,13 @@ class LibraryManager(EngineScoped):
         constructing the node is the only way to see its ports. The probe is never added to a
         flow or the ObjectManager, so it is garbage-collected once the caller drops it.
 
-        Two things can fail and neither is exceptional from a caller's point of view, so both
+        Three things can fail and none is exceptional from a caller's point of view, so all
         come back as `error_message` on the result:
 
         - Resolving the class imports the node's module, which lazy registration defers to first
           use. A broken module raises here.
+        - Reading the library's node metadata serializes values the library author supplied, so an
+          entry holding something unserializable raises here.
         - A node's __init__ may perform I/O (network calls, auth checks, disk reads).
 
         Callers on the event loop should note that both can block; ``__init__`` in particular has
@@ -2150,11 +2168,25 @@ class LibraryManager(EngineScoped):
         if resolution.node_class is None:
             return NodeProbeResult(node=None, error_message=resolution.error_message)
 
+        try:
+            library_node_metadata = self._library_node_metadata_for_probe(library=library, node_type=node_type)
+        except Exception as err:
+            # Serializing the library author's node metadata, so a malformed entry raises here.
+            # Reported rather than raised because the caller (DescribeNodeType) answers about a
+            # single node type and can still describe it from library metadata alone; letting this
+            # out would turn one bad metadata entry into an opaque failure for that node type.
+            # Probing without the blob is not an option: __init__ logic reads it, so the node
+            # would declare different parameters than it does on the canvas.
+            return NodeProbeResult(
+                node=None,
+                error_message=f"Node metadata could not be read: {type(err).__name__}: {err}",
+            )
+
         return self._construct_probe_node(
             library_name=library.get_library_data().name,
             node_type=node_type,
             node_class=resolution.node_class,
-            library_node_metadata=self._library_node_metadata_for_probe(library=library, node_type=node_type),
+            library_node_metadata=library_node_metadata,
         )
 
     def _resolve_node_class_for_probe(self, library: Library, node_type: str) -> NodeClassResolution:
@@ -3387,6 +3419,13 @@ class LibraryManager(EngineScoped):
             # probe precisely because they carry no library code.
             return
 
+        if not self._warm_port_summaries_requested:
+            # A headless host said nothing here will ask what ports node types have. Constructing
+            # every node type in every library to answer a question nobody asks would only take CPU
+            # from the workflow the process actually exists to run.
+            logger.debug("Port summary warming skipped: the host did not ask for it.")
+            return
+
         if not self.engine.config_manager.get_config_value(LIBRARY_WARM_PORT_SUMMARIES_KEY, default=True):
             logger.debug(
                 "Port summary warming is disabled by configuration ('%s'); summaries will be computed on demand.",
@@ -3394,7 +3433,40 @@ class LibraryManager(EngineScoped):
             )
             return
 
-        self._port_summary_warm_task = asyncio.create_task(self._warm_port_summaries())
+        # Replace a pass already in flight rather than running a second one alongside it. Two
+        # concurrent passes would still be correct -- the per-library lock and the generation
+        # counter see to that -- but only one handle is kept, and a pass nothing holds a handle to
+        # is a pass a reload cannot cancel, which is the one thing here that has to work.
+        # Restarting costs little: libraries the previous pass already finished are cache hits.
+        previous_task = self._port_summary_warm_task
+        if previous_task is not None and not previous_task.done():
+            previous_task.cancel()
+
+        task = asyncio.create_task(self._warm_port_summaries())
+        self._port_summary_warm_task = task
+        task.add_done_callback(self._on_port_summary_warm_done)
+
+    def _on_port_summary_warm_done(self, task: asyncio.Task[None]) -> None:
+        """Clear the handle and surface anything the warm pass raised.
+
+        Nothing awaits a warm task that finishes on its own, so without retrieving the exception
+        here a failed pass leaves no trace but CPython's "Task exception was never retrieved" at
+        GC -- no library name, and no hint that the cache is cold and every drag will pay for it.
+        """
+        if self._port_summary_warm_task is task:
+            self._port_summary_warm_task = None
+
+        if task.cancelled():
+            return
+
+        error = task.exception()
+        if error is not None:
+            logger.warning(
+                "Port summary warming stopped early: %s: %s. Summaries will be computed on demand instead, so the "
+                "first connection drag in the Add Node menu will be slower.",
+                type(error).__name__,
+                error,
+            )
 
     async def _cancel_port_summary_warm(self) -> None:
         """Stop any in-flight warm pass and wait for it to actually be off the loop.
@@ -3464,12 +3536,14 @@ class LibraryManager(EngineScoped):
         request ran out of timeout allowance before getting to it, is owed a real attempt and stays
         pending until it gets one.
 
-        What caps all of it is `_PORT_SUMMARY_TIMEOUT_BUDGET` per library per load: once a library's
-        probes have timed out that many times, nothing pending is attempted again until it reloads.
-        Each of those timeouts burned a thread ``asyncio.to_thread`` cannot cancel, so continuing to
-        pay would drain the loop's shared executor and eventually stall every other threaded
-        operation in the engine -- a far worse outcome than part of one library going unranked in
-        the Add Node menu.
+        Three bounds cap all of it, and `_probe_stop_reason` holds them: the caller's per-pass
+        `allowance`, `_PORT_SUMMARY_TIMEOUT_BUDGET` per library per load, and
+        `_PROBE_THREAD_LEAK_CEILING` for the whole process. The last one is what actually protects
+        the engine: the first two reset (every request, and every reload), so neither bounds the
+        running total. Each timeout burned a thread ``asyncio.to_thread`` cannot cancel, and
+        continuing to pay would drain the loop's shared executor and eventually stall every other
+        threaded operation in the engine -- a far worse outcome than part of one library going
+        unranked in the Add Node menu.
 
         The per-library lock means concurrent callers do the probe pass once rather than once each;
         the second caller waits and then reads the cache. It is deliberately not held for the
@@ -3502,7 +3576,11 @@ class LibraryManager(EngineScoped):
                 timeouts_spent = len(computation.timed_out_node_types)
             else:
                 computation = await self._compute_port_summaries_for_library(
-                    library_name, allowance, node_types=entry.pending_node_types(), throttle_s=throttle_s
+                    library_name,
+                    allowance,
+                    node_types=entry.pending_node_types(),
+                    throttle_s=throttle_s,
+                    timeouts_already_spent=entry.timeouts_spent,
                 )
                 summaries = {**entry.summaries, **computation.summaries}
                 timeouts_spent = entry.timeouts_spent + len(computation.timed_out_node_types)
@@ -3544,6 +3622,25 @@ class LibraryManager(EngineScoped):
         Separated from the pass itself because it is the whole termination argument in one place:
         each rule below is what stops some node type from being probed forever.
         """
+        if self._port_summary_threads_leaked >= self._PROBE_THREAD_LEAK_CEILING:
+            # No pass in this process will probe again, so carrying anything as pending would only
+            # make every future request take the lock and run a pass that stops immediately.
+            if computation.unprobed_node_types:
+                logger.warning(
+                    "Giving up on port summaries for %d node type(s) in library '%s': this engine has leaked %d "
+                    "probe thread(s), its lifetime ceiling. These go unranked in the Add Node menu until the "
+                    "engine restarts.",
+                    len(computation.unprobed_node_types),
+                    library_name,
+                    self._port_summary_threads_leaked,
+                )
+            return PortSummaryCacheEntry(
+                summaries=summaries,
+                retry_node_types=frozenset(),
+                unprobed_node_types=frozenset(),
+                timeouts_spent=timeouts_spent,
+            )
+
         if timeouts_spent >= self._PORT_SUMMARY_TIMEOUT_BUDGET:
             # The library has spent its whole allowance of un-reclaimable threads. Everything still
             # pending is dropped -- including node types never attempted, which cannot be told apart
@@ -3586,6 +3683,7 @@ class LibraryManager(EngineScoped):
         allowance: ProbeTimeoutAllowance,
         *,
         throttle_s: float,
+        timeouts_already_spent: int = 0,
         node_types: frozenset[str] | None = None,
     ) -> PortSummaryComputation:
         """Probe a library's node types and derive each one's port summary.
@@ -3603,9 +3701,12 @@ class LibraryManager(EngineScoped):
         bounds it: a node's ``__init__`` can block indefinitely, and one such node must not stall
         the rest.
 
-        The pass stops as soon as `allowance` is exhausted, since each timeout has cost a thread
-        that cannot be handed back, and reports the node types it never reached separately from the
-        ones it attempted and failed -- see `PortSummaryComputation`.
+        The pass stops as soon as any of the three timeout bounds is reached -- see
+        `_probe_stop_reason` -- since each timeout has cost a thread that cannot be handed back,
+        and reports the node types it never reached separately from the ones it attempted and
+        failed (see `PortSummaryComputation`). `timeouts_already_spent` is what this library has
+        cost on earlier passes, and is required for the per-library bound to be enforced *during*
+        a pass rather than only after it.
         """
         try:
             library = LibraryRegistry.get_library(library_name)
@@ -3631,15 +3732,19 @@ class LibraryManager(EngineScoped):
         timed_out_node_types: set[str] = set()
         unprobed_node_types: list[str] = []
         for probe_index, node_type in enumerate(node_types_to_probe):
-            if allowance.remaining <= 0:
-                # Out of allowance, and any node type here could be another blocking one. These were
+            stop_reason = self._probe_stop_reason(
+                allowance=allowance, timeouts_spent=timeouts_already_spent + len(timed_out_node_types)
+            )
+            if stop_reason is not None:
+                # Out of budget, and any node type here could be another blocking one. These were
                 # never attempted, so they stay pending rather than being recorded as unrankable.
                 unprobed_node_types = node_types_to_probe[probe_index:]
                 logger.info(
-                    "Stopped probing library '%s' with %d node type(s) left; this request has spent its probe "
-                    "timeout allowance. They will be attempted on a later request.",
+                    "Stopped probing library '%s' with %d node type(s) left: %s. They will be attempted on a "
+                    "later request unless the library has spent its own allowance.",
                     library_name,
                     len(unprobed_node_types),
+                    stop_reason,
                 )
                 break
 
@@ -3657,6 +3762,9 @@ class LibraryManager(EngineScoped):
                 if outcome.timed_out:
                     timed_out_node_types.add(node_type)
                     allowance.remaining -= 1
+                    # Counted for the life of the process: this thread is never coming back, and
+                    # the two allowances above both reset.
+                    self._port_summary_threads_leaked += 1
                 continue
 
             summaries[node_type] = outcome.summary
@@ -3675,6 +3783,27 @@ class LibraryManager(EngineScoped):
             unprobed_node_types=frozenset(unprobed_node_types),
         )
 
+    def _probe_stop_reason(self, *, allowance: ProbeTimeoutAllowance, timeouts_spent: int) -> str | None:
+        """Say why probing must stop now, or None to keep going.
+
+        Three bounds, checked before every node type because each one has to hold *during* a pass,
+        not merely be true of it afterwards. Returns the reason as text because its only use is the
+        log line explaining why a library came back partly unranked.
+        """
+        if self._port_summary_threads_leaked >= self._PROBE_THREAD_LEAK_CEILING:
+            return (
+                f"this engine has leaked {self._port_summary_threads_leaked} probe thread(s), its lifetime ceiling. "
+                f"No further probing will be attempted in this process"
+            )
+
+        if timeouts_spent >= self._PORT_SUMMARY_TIMEOUT_BUDGET:
+            return f"this library has spent its {self._PORT_SUMMARY_TIMEOUT_BUDGET}-timeout allowance for this load"
+
+        if allowance.remaining <= 0:
+            return "this pass has spent its probe timeout allowance"
+
+        return None
+
     async def _probe_node_type_port_summary(  # noqa: PLR0911
         self, *, library: Library, library_name: str, node_type: str
     ) -> NodeTypePortProbeOutcome:
@@ -3691,7 +3820,12 @@ class LibraryManager(EngineScoped):
             # else went wrong -- a LibraryRegistryError for a node type unregistered since
             # get_registered_nodes() was read (the caller awaits, so that is reachable), or a
             # NodeTypeEntry with neither class nor loader.
-            logger.debug(
+            #
+            # WARNING, unlike the library-authored failures below: nothing a library did explains
+            # this, so it points at registry state the engine got wrong, and an operator debugging
+            # a node type missing from connection ranking needs it visible without raising the
+            # whole engine's log level.
+            logger.warning(
                 "Unexpected failure resolving node type '%s' in library '%s' for its port summary; skipping.",
                 node_type,
                 library_name,
@@ -3751,8 +3885,10 @@ class LibraryManager(EngineScoped):
         except Exception:
             # _construct_probe_node already converts a raising __init__ into a result, so reaching
             # here means the failure was outside it -- the executor refusing work during interpreter
-            # shutdown, for instance, which a retry cannot help either.
-            logger.debug(
+            # shutdown, for instance. WARNING for the same reason as the resolution branch above:
+            # this is the engine's own threading machinery failing, not a library's code, and it
+            # would otherwise be invisible while every node type quietly went unranked.
+            logger.warning(
                 "Unexpected failure probing node type '%s' in library '%s' for its port summary; skipping.",
                 node_type,
                 library_name,
@@ -3790,13 +3926,22 @@ class LibraryManager(EngineScoped):
 
         Bumps a per-library generation counter as well as clearing the entry, so a probe pass
         already in flight for this library can tell that its result is stale and decline to cache
-        it. Call this *before* mutating the library, so a mutation that bails out partway through
-        still leaves the cache cleared.
+        it.
+
+        Where to call it depends on the mutation. A mutation that can bail out partway -- an unload,
+        or a registration loop that stops on the first conflict -- invalidates *before*, so an
+        aborted attempt still leaves the cache cleared rather than describing a half-changed
+        library. A mutation that has already completed and had no earlier invalidation point --
+        node types registered during the final load phase -- invalidates *after*, because there is
+        nothing left to abort and the stale entry to drop is the one a request may have cached
+        while the load was still awaiting.
 
         Dropping the entry drops everything pending and the library's spent timeout allowance with
         it: a reload replaces the node's code, so a probe that timed out against the old code has
         earned a fresh full attempt rather than a top-up, and node types abandoned under the old
-        code get another chance under the new.
+        code get another chance under the new. The engine-wide leak ceiling is deliberately not
+        reset here -- the threads those timeouts cost are still held, whatever the library does
+        next -- so once that ceiling is reached, invalidating stops buying new attempts.
         """
         self._library_to_port_summary_cache.pop(library_name, None)
         self._library_to_port_summaries_generation[library_name] = (
@@ -4969,6 +5114,10 @@ class LibraryManager(EngineScoped):
             self._is_initializing = False
 
     async def _run_app_initialization(self, payload: AppInitializationComplete) -> None:
+        # Recorded before the skip branch below because it outlives this call: a worker reporting
+        # its node schemas, or a mid-session reload, both consult it long after initialization.
+        self._warm_port_summaries_requested = payload.warm_port_summaries
+
         if payload.skip_library_loading:
             # Register all secrets even in headless mode
             self.engine.secrets_manager.register_all_secrets()
@@ -5695,10 +5844,19 @@ class LibraryManager(EngineScoped):
     # The same allowance for the background warm pass, which needs its own number because it
     # covers every library rather than the one a caller asked about: given the interactive
     # budget, a single library of blocking nodes would spend the whole thing and leave every
-    # other library cold, which is the one outcome that makes warming pointless. Still far
-    # below the default executor's worker count, since every timeout counted here is a thread
-    # the engine never gets back.
+    # other library cold, which is the one outcome that makes warming pointless.
     _PORT_SUMMARY_WARM_TIMEOUT_BUDGET: int = 8
+    # Hard engine-wide ceiling on leaked probe threads, and the only bound that is stated in
+    # terms of the resource actually at stake. The two budgets above are per request and per
+    # library-load, so neither bounds the total: three libraries of blocking nodes cost
+    # 3 * _PORT_SUMMARY_TIMEOUT_BUDGET threads, and a reload lets the bill start over. asyncio
+    # .to_thread hands work to the loop's *default* executor, which is
+    # min(32, (os.cpu_count() or 1) + 4) wide -- 6 on a 2-core CI box -- and every other
+    # to_thread caller in the engine (library loading, sandbox generation, worker schema
+    # serialization) draws from that same pool. Leaving most of it available matters more than
+    # ranking the last few node types, so keep this a fraction of the pool rather than a
+    # constant that can exceed it on small machines.
+    _PROBE_THREAD_LEAK_CEILING: int = max(1, min(32, (os.cpu_count() or 1) + 4) // 4)
     # Gap left between node types during the warm pass. Resolving a node class imports its
     # module on the event loop, which nothing can interrupt, so the pass cannot avoid blocking
     # the loop in bursts -- it can only space them out. A warm pass has no deadline, so it
@@ -6252,6 +6410,11 @@ class LibraryManager(EngineScoped):
         return new_downloads
 
     async def reload_libraries_request(self, request: ReloadAllLibrariesRequest) -> ResultPayload:
+        # Stop any background port summary warming before anything is torn down. The pass resolves
+        # node classes, so one left running would import modules belonging to libraries this is
+        # about to unload -- reviving exactly what the reload exists to replace.
+        await self._cancel_port_summary_warm()
+
         # Bracket the reload like on_app_initialization_complete so the heartbeat reports
         # is_initializing during a mid-session reload too. finally clears it even on failure.
         self._is_initializing = True
@@ -6260,12 +6423,14 @@ class LibraryManager(EngineScoped):
         finally:
             self._is_initializing = False
 
-    async def _run_reload_libraries(self, request: ReloadAllLibrariesRequest) -> ResultPayload:  # noqa: ARG002
-        # Stop any background port summary warming before anything is torn down. The pass resolves
-        # node classes, so one left running would import modules belonging to libraries this is
-        # about to unload -- reviving exactly what the reload exists to replace.
-        await self._cancel_port_summary_warm()
+            # Re-warm in finally, not on the success path: every way out of the reload leaves the
+            # cache dropped, because the unloads either completed or were abandoned partway. A
+            # reload that failed would otherwise leave warming off for the life of the process,
+            # handing the probe cost back to the next artist to drag a connection. Whichever
+            # libraries are registered at this point still have node types worth ranking.
+            self._start_port_summary_warm()
 
+    async def _run_reload_libraries(self, request: ReloadAllLibrariesRequest) -> ResultPayload:  # noqa: ARG002
         # Start with a clean slate.
         clear_all_request = ClearAllObjectStateRequest(i_know_what_im_doing=True)
         clear_all_result = await self.engine.ahandle_request(clear_all_request)
@@ -6340,12 +6505,6 @@ class LibraryManager(EngineScoped):
                     )
                 )
             )
-
-        # Re-warm against the reloaded libraries. Their cached summaries were dropped when they
-        # unloaded, so without this a reload silently hands the cost back to the next artist to
-        # drag a connection. Started even when reconcile reported problems below: the libraries
-        # that did load still have node types worth ranking.
-        self._start_port_summary_warm()
 
         # Hard activation: a reload is interactive (project switch / explicit reload), so a
         # reconcile failure (bad engine_version gate or a sourced library that could not be

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -381,6 +381,19 @@ class NodeProbeResult(NamedTuple):
     error_message: str
 
 
+class PortSummaryComputation(NamedTuple):
+    """Outcome of probing a whole library for its per-node-type port summaries.
+
+    `is_complete` is False when a node type was skipped for a reason that may not recur -- a probe
+    timeout, an unexpected error, or the library not being in the registry yet. Callers use it to
+    decide whether the result is worth caching; a node type whose module is simply broken does not
+    make the pass incomplete, because that gap is stable until the library reloads.
+    """
+
+    summaries: dict[str, NodePortSummary]
+    is_complete: bool
+
+
 class LibraryGitOperationContext(NamedTuple):
     """Context information for git operations on a library."""
 
@@ -455,7 +468,7 @@ class LibraryManager(EngineScoped):
     UNRESOLVED_SANDBOX_CLASS_NAME = "<NOT YET RESOLVED>"
     SANDBOX_CATEGORY_NAME = "Griptape Nodes Sandbox"
 
-    # Name given to the throwaway nodes `_probe_node_type` constructs to read a node type's
+    # Name given to the throwaway nodes `_construct_probe_node` builds to read a node type's
     # declared parameters. They are never registered with the ObjectManager, so the prefix only
     # exists to make one obvious in a log line or traceback.
     PROBE_NODE_NAME_PREFIX = "__node_type_probe__"
@@ -2057,15 +2070,20 @@ class LibraryManager(EngineScoped):
         no bound on how long it takes.
 
         MUST run on the event loop, because resolving the class is not thread-safe (see
-        ``_resolve_node_class_for_probe``). A caller that wants to bound a blocking ``__init__``
-        with a timeout should call the two halves separately rather than threading this: resolve
-        here on the loop, then hand ``_construct_probe_node`` to ``asyncio.to_thread``.
+        ``_resolve_node_class_for_probe``). Only ``_construct_probe_node`` is safe to thread, so a
+        caller that needs to bound a blocking ``__init__`` with a timeout calls the three steps
+        below itself rather than threading this whole method.
         """
         resolution = self._resolve_node_class_for_probe(library=library, node_type=node_type)
         if resolution.node_class is None:
             return NodeProbeResult(node=None, error_message=resolution.error_message)
 
-        return self._construct_probe_node(library=library, node_type=node_type, node_class=resolution.node_class)
+        return self._construct_probe_node(
+            library_name=library.get_library_data().name,
+            node_type=node_type,
+            node_class=resolution.node_class,
+            library_node_metadata=self._library_node_metadata_for_probe(library=library, node_type=node_type),
+        )
 
     def _resolve_node_class_for_probe(self, library: Library, node_type: str) -> NodeClassResolution:
         """Resolve a node type to its class, importing the module now if registration was lazy.
@@ -2091,26 +2109,42 @@ class LibraryManager(EngineScoped):
 
         return NodeClassResolution(node_class=node_class, error_message="")
 
-    def _construct_probe_node(self, library: Library, node_type: str, node_class: type[BaseNode]) -> NodeProbeResult:
-        """Construct a probe instance of an already-resolved node class.
+    def _library_node_metadata_for_probe(self, library: Library, node_type: str) -> dict[str, Any]:
+        """Build the ``library_node_metadata`` blob ``Library.create_node`` injects.
 
-        Safe to hand to ``asyncio.to_thread``: it touches no shared registry state, and
-        ``constructing_node()`` is a ContextVar, which ``to_thread`` propagates via
-        ``copy_context()``. Threading this is how a caller bounds a blocking ``__init__`` with a
-        timeout without also moving class resolution off the loop.
+        Kept identical to ``create_node`` so declarative ``__init__`` logic reading this blob sees
+        under probe what it sees when the artist really creates the node. Diverging would let a
+        node declare different parameters during the probe than on the canvas -- i.e. report ports
+        it does not have.
+
+        Reads the library's node-metadata dict, which the event loop mutates on register/unregister,
+        so it belongs on the loop rather than inside the threaded construction step.
         """
-        library_name = library.get_library_data().name
-        # Mirror the metadata blob ``Library.create_node`` builds, so declarative ``__init__``
-        # logic reading ``library_node_metadata`` sees under probe what it sees when the artist
-        # really creates the node. Diverging here would let a node declare different parameters
-        # during the probe than on the canvas -- i.e. report ports it does not have.
         try:
             node_metadata_model = library.get_node_metadata(node_type)
         except LibraryRegistryError:
-            library_node_metadata = {}
-        else:
-            library_node_metadata = node_metadata_model.model_dump(mode="json")
+            return {}
 
+        return node_metadata_model.model_dump(mode="json")
+
+    def _construct_probe_node(
+        self,
+        library_name: str,
+        node_type: str,
+        node_class: type[BaseNode],
+        library_node_metadata: dict[str, Any],
+    ) -> NodeProbeResult:
+        """Construct a probe instance of an already-resolved node class.
+
+        Safe to hand to ``asyncio.to_thread``. Everything it reads from the library is passed in as
+        a plain value, so it touches no state the event loop mutates, and
+        ``LibraryRegistry.constructing_node()`` is a ContextVar, which ``to_thread`` propagates via
+        ``copy_context()``. Threading this is how a caller bounds a blocking ``__init__`` with a
+        timeout without also moving class resolution off the loop.
+
+        What the node's own ``__init__`` touches is of course not controlled here -- that is the
+        same exposure ``DescribeNodeType`` and the worker schema pass already accept.
+        """
         try:
             # Wrap in ``LibraryRegistry.constructing_node()`` so the parameter-mutation detector
             # skips this ephemeral probe's declarative ``add_parameter`` calls (this construction
@@ -2718,6 +2752,13 @@ class LibraryManager(EngineScoped):
                         # Function handles registration and updates library_info with problems
                         # lifecycle_state set to LOADED by _attempt_load_nodes_from_library
 
+                    # Node types have just been registered into a library that LibraryRegistry
+                    # published earlier in this method, and the loading above awaited. A port
+                    # summary request landing in that window measured a library with no node types
+                    # (or only some of them), and nothing invalidates afterwards, so that empty
+                    # result would be served for the rest of the process's life.
+                    self._invalidate_port_summaries(library_data.name)
+
                     # Exit loop after final phase
                     break
 
@@ -3236,8 +3277,8 @@ class LibraryManager(EngineScoped):
     async def _get_port_summaries_for_library(self, library_name: str) -> dict[str, NodePortSummary]:
         """Return the port summary for every node type in a library, computing it on first call.
 
-        Cached until the library is mutated or unloaded, because a node type's declared ports
-        cannot change without one of those happening.
+        Cached until the library changes -- a reload, an unload, or node types being registered
+        into it -- because a node type's declared ports cannot change without one of those.
 
         The lock means concurrent callers do the probe pass once rather than once each; the second
         caller waits and then reads the cache. It is deliberately not held for the cache-hit path:
@@ -3246,16 +3287,16 @@ class LibraryManager(EngineScoped):
         """
         cached_summaries = self._library_to_port_summaries.get(library_name)
         if cached_summaries is not None:
-            return cached_summaries
+            return dict(cached_summaries)
 
         async with self._port_summaries_lock:
             # Re-check: another caller may have computed these while we waited for the lock.
             cached_summaries = self._library_to_port_summaries.get(library_name)
             if cached_summaries is not None:
-                return cached_summaries
+                return dict(cached_summaries)
 
             generation_before = self._library_to_port_summaries_generation.get(library_name, 0)
-            summaries = await self._compute_port_summaries_for_library(library_name)
+            computation = await self._compute_port_summaries_for_library(library_name)
 
             # The pass above awaited, so the library may have been reloaded, unloaded, or had node
             # types registered into it in the meantime. Caching what we just measured would pin
@@ -3269,12 +3310,23 @@ class LibraryManager(EngineScoped):
                     "serving this result without caching it.",
                     library_name,
                 )
-                return summaries
+                return computation.summaries
 
-            self._library_to_port_summaries[library_name] = summaries
-            return summaries
+            # Likewise for a pass that hit a transient failure. Nothing invalidates this library
+            # again on its own, so caching an incomplete result would make a one-off timeout or a
+            # saturated thread pool permanent.
+            if not computation.is_complete:
+                logger.debug(
+                    "Port summaries for library '%s' are incomplete for a reason that may not "
+                    "recur; serving this result without caching it.",
+                    library_name,
+                )
+                return computation.summaries
 
-    async def _compute_port_summaries_for_library(self, library_name: str) -> dict[str, NodePortSummary]:
+            self._library_to_port_summaries[library_name] = computation.summaries
+            return dict(computation.summaries)
+
+    async def _compute_port_summaries_for_library(self, library_name: str) -> PortSummaryComputation:
         """Probe every node type in a library and derive its port summary.
 
         Node types the engine cannot construct are left out of the result entirely rather than
@@ -3286,21 +3338,48 @@ class LibraryManager(EngineScoped):
         construction goes to a thread, where the same timeout the worker-side schema pass uses
         bounds it: a node's ``__init__`` can block indefinitely, and one such node must not stall
         the rest.
+
+        `is_complete` on the result separates the two kinds of gap. A node type whose module fails
+        to import or whose ``__init__`` raises will keep failing until the library is reloaded, so
+        that gap is stable and the result is worth caching. A timeout or an unexpected error might
+        not recur -- ``asyncio.to_thread`` shares the loop's default executor, so a saturated pool
+        can time out probes that would otherwise have succeeded -- so a pass that hits one reports
+        itself incomplete and is not cached.
         """
         try:
             library = LibraryRegistry.get_library(library_name)
         except KeyError:
+            # Registration publishes a library before its node types are populated, so this can
+            # mean "not yet" rather than "never". Reported incomplete so it is not cached.
             logger.warning("Cannot compute port summaries: library '%s' not found in registry.", library_name)
-            return {}
+            return PortSummaryComputation(summaries={}, is_complete=False)
 
         summaries: dict[str, NodePortSummary] = {}
         skipped_node_types: list[str] = []
+        is_complete = True
         for node_type in library.get_registered_nodes():
             # Yield between node types so a large library's resolve calls, which run on the loop,
             # interleave with other work instead of monopolizing it for the whole pass.
             await asyncio.sleep(0)
 
-            resolution = self._resolve_node_class_for_probe(library=library, node_type=node_type)
+            try:
+                resolution = self._resolve_node_class_for_probe(library=library, node_type=node_type)
+            except Exception:
+                # Resolution converts import failures into a result, so reaching here means
+                # something else went wrong -- a LibraryRegistryError for a node type unregistered
+                # since get_registered_nodes() was read (the loop awaits, so that is reachable), or
+                # a NodeTypeEntry with neither class nor loader. Skip the one node type rather than
+                # failing summaries for every library in the response.
+                logger.debug(
+                    "Unexpected failure resolving node type '%s' in library '%s' for its port summary; skipping.",
+                    node_type,
+                    library_name,
+                    exc_info=True,
+                )
+                skipped_node_types.append(node_type)
+                is_complete = False
+                continue
+
             if resolution.node_class is None:
                 logger.debug(
                     "Could not probe node type '%s' in library '%s' for its port summary: %s",
@@ -3313,23 +3392,33 @@ class LibraryManager(EngineScoped):
 
             try:
                 probe_result = await asyncio.wait_for(
-                    asyncio.to_thread(self._construct_probe_node, library, node_type, resolution.node_class),
+                    asyncio.to_thread(
+                        self._construct_probe_node,
+                        library_name,
+                        node_type,
+                        resolution.node_class,
+                        self._library_node_metadata_for_probe(library=library, node_type=node_type),
+                    ),
                     timeout=self._SCHEMA_PROBE_TIMEOUT_S,
                 )
             except TimeoutError:
+                # asyncio.to_thread cannot be cancelled, so the thread is not reclaimed: it holds a
+                # worker of the loop's default executor until __init__ returns, which for a truly
+                # stuck node means for the life of the process.
                 logger.warning(
-                    "Port summary probe for node type '%s' in library '%s' timed out after %.1fs; skipping. "
-                    "The node's __init__ likely makes a blocking call.",
+                    "Port summary probe for node type '%s' in library '%s' timed out after %.1fs; "
+                    "skipping it and leaking the probe thread, which cannot be cancelled. The "
+                    "node's __init__ likely makes a blocking call.",
                     node_type,
                     library_name,
                     self._SCHEMA_PROBE_TIMEOUT_S,
                 )
                 skipped_node_types.append(node_type)
+                is_complete = False
                 continue
             except Exception:
                 # _construct_probe_node already converts a raising __init__ into a result, so
-                # reaching here means the failure was outside it. Skip the one node type rather
-                # than failing summaries for every library in the response.
+                # reaching here means the failure was outside it.
                 logger.debug(
                     "Unexpected failure probing node type '%s' in library '%s' for its port summary; skipping.",
                     node_type,
@@ -3337,6 +3426,7 @@ class LibraryManager(EngineScoped):
                     exc_info=True,
                 )
                 skipped_node_types.append(node_type)
+                is_complete = False
                 continue
 
             if probe_result.node is None:
@@ -3359,7 +3449,7 @@ class LibraryManager(EngineScoped):
                 len(skipped_node_types),
                 ", ".join(skipped_node_types),
             )
-        return summaries
+        return PortSummaryComputation(summaries=summaries, is_complete=is_complete)
 
     def _invalidate_port_summaries(self, library_name: str) -> None:
         """Drop a library's cached port summaries after its node types change.

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import importlib.abc
 import importlib.machinery
@@ -249,6 +250,7 @@ from griptape_nodes.retained_mode.managers.settings import (
     LIBRARY_DEPENDENCY_INSTALL_BEHAVIOR_KEY,
     LIBRARY_LAZY_NODE_LOADING_KEY,
     LIBRARY_MINIMUM_RELEASE_AGE_KEY,
+    LIBRARY_WARM_PORT_SUMMARIES_KEY,
     REQUIRES_ENGINE_KEY,
     WORKER_HEARTBEAT_STARTUP_GRACE_KEY,
     LibraryDependencyInstallBehavior,
@@ -730,6 +732,11 @@ class LibraryManager(EngineScoped):
         # One lock per library, so a request that only needs an already-computed library's
         # summaries does not queue behind a different library's first probe pass.
         self._library_to_port_summaries_lock: dict[str, asyncio.Lock] = {}
+        # The in-flight background pass filling the cache above, if any. Retained rather than
+        # fire-and-forget because a reload has to cancel it: the pass resolves node classes, so
+        # one still running while a library is torn down would import that library's modules
+        # back in. See _start_port_summary_warm.
+        self._port_summary_warm_task: asyncio.Task[None] | None = None
         self._libraries_loading_complete = asyncio.Event()
         self._libraries_loading_complete.set()  # Not loading initially; load_all_libraries_from_config will clear/set this
         # True for the duration of the engine's initialization sequence (library + workflow
@@ -3328,12 +3335,18 @@ class LibraryManager(EngineScoped):
         """Async handler for GetPortSummariesForAllLibrariesRequest.
 
         Waits for library loading to finish, then serves each library's summaries from the cache,
-        computing them on first request.
+        computing them on first request. Usually that cache is already warm, because
+        `_start_port_summary_warm` fills it in the background once libraries are loaded; this path
+        still computes so the request is correct when warming is disabled, was cancelled by a
+        reload, or has not reached this library yet.
 
         One timeout allowance covers the whole request rather than each library separately, because
         the cost a timeout imposes -- a worker of the loop's default executor, held for good -- is
         paid by the engine as a whole. A library whose node types go unreached because the allowance
         ran out here keeps them pending, so the next request resumes them.
+
+        No throttle between node types: a caller is waiting on this, so it takes the loop for as
+        long as it needs. The warm pass is the one that spaces its probes out.
         """
         await self._libraries_loading_complete.wait()
 
@@ -3341,7 +3354,7 @@ class LibraryManager(EngineScoped):
         library_name_to_port_summaries: dict[str, dict[str, NodePortSummary]] = {}
         for library_name in LibraryRegistry.list_libraries():
             library_name_to_port_summaries[library_name] = await self._get_port_summaries_for_library(
-                library_name, allowance
+                library_name, allowance, throttle_s=0.0
             )
 
         node_type_count = sum(len(summaries) for summaries in library_name_to_port_summaries.values())
@@ -3354,8 +3367,89 @@ class LibraryManager(EngineScoped):
             result_details=details,
         )
 
+    def _start_port_summary_warm(self) -> None:
+        """Launch the background pass that fills the port summary cache before anything asks for it.
+
+        Called after the engine has announced readiness rather than awaited inside the
+        initialization sequence, because that sequence is bracketed by `_is_initializing`, which
+        the heartbeat reports: awaiting a probe pass in there would have the engine advertise
+        "initializing" to clients for the pass's whole duration, and delay `EngineReadyEvent`
+        behind work no client is waiting on.
+
+        Warming only moves this cost, it does not remove it. What it buys is paying it while
+        nobody is blocked instead of mid-drag in the Add Node menu, which is the only moment the
+        summaries are ever needed.
+        """
+        if self._is_worker:
+            # Nothing to warm on a worker: it loads eagerly and already constructs every node type
+            # to serialize its schemas. The orchestrator answers port summary requests for a
+            # worker-hosted library from the stub classes those schemas produce, which are cheap to
+            # probe precisely because they carry no library code.
+            return
+
+        if not self.engine.config_manager.get_config_value(LIBRARY_WARM_PORT_SUMMARIES_KEY, default=True):
+            logger.debug(
+                "Port summary warming is disabled by configuration ('%s'); summaries will be computed on demand.",
+                LIBRARY_WARM_PORT_SUMMARIES_KEY,
+            )
+            return
+
+        self._port_summary_warm_task = asyncio.create_task(self._warm_port_summaries())
+
+    async def _cancel_port_summary_warm(self) -> None:
+        """Stop any in-flight warm pass and wait for it to actually be off the loop.
+
+        Awaited rather than just cancelled because the caller is about to unload libraries, and a
+        pass between awaits could still resolve a node class -- importing a module belonging to a
+        library being dismantled. Returns promptly even when the pass is inside a probe: the
+        construction thread cannot be cancelled, but the coroutine awaiting it can, which is the
+        same leaked-thread trade the probe path already documents.
+
+        Clearing the handle before awaiting keeps a second caller from awaiting the same task.
+        """
+        task = self._port_summary_warm_task
+        if task is None:
+            return
+
+        self._port_summary_warm_task = None
+        if task.done():
+            return
+
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    async def _warm_port_summaries(self) -> None:
+        """Probe every registered library's node types so the first real request is a cache hit.
+
+        Deliberately just another caller of `_get_port_summaries_for_library`: the per-library lock
+        there means a request arriving mid-pass never duplicates the work -- it either reads what
+        this pass has already cached or waits on the one library it needs -- and the generation
+        counter already decides whether a result computed across a library mutation is safe to
+        keep. Warming needed no new cache machinery for that reason.
+
+        Runs on its own timeout allowance, and throttled, both because it covers every library at
+        once and because nothing is waiting on it.
+        """
+        await self._libraries_loading_complete.wait()
+
+        allowance = ProbeTimeoutAllowance(remaining=self._PORT_SUMMARY_WARM_TIMEOUT_BUDGET)
+        library_names = LibraryRegistry.list_libraries()
+        node_type_count = 0
+        for library_name in library_names:
+            summaries = await self._get_port_summaries_for_library(
+                library_name, allowance, throttle_s=self._PORT_SUMMARY_WARM_THROTTLE_S
+            )
+            node_type_count += len(summaries)
+
+        logger.info(
+            "Warmed port summaries for %d node type(s) across %d librar(ies); connection ranking is ready.",
+            node_type_count,
+            len(library_names),
+        )
+
     async def _get_port_summaries_for_library(
-        self, library_name: str, allowance: ProbeTimeoutAllowance
+        self, library_name: str, allowance: ProbeTimeoutAllowance, *, throttle_s: float
     ) -> dict[str, NodePortSummary]:
         """Return the port summary for every node type in a library, computing it on first call.
 
@@ -3381,6 +3475,10 @@ class LibraryManager(EngineScoped):
         the second caller waits and then reads the cache. It is deliberately not held for the
         cache-hit path: the probe pass can take seconds, and a request that only needs
         already-computed summaries should not queue behind another library's first pass.
+
+        `throttle_s` is how long to pause between node types, and is the only thing separating the
+        background warm pass from an interactive request. Both share this function so the cache,
+        lock, and generation handling above have exactly one implementation.
         """
         entry = self._library_to_port_summary_cache.get(library_name)
         if entry is not None and not entry.pending_node_types():
@@ -3397,12 +3495,14 @@ class LibraryManager(EngineScoped):
 
             generation_before = self._library_to_port_summaries_generation.get(library_name, 0)
             if entry is None:
-                computation = await self._compute_port_summaries_for_library(library_name, allowance)
+                computation = await self._compute_port_summaries_for_library(
+                    library_name, allowance, throttle_s=throttle_s
+                )
                 summaries = computation.summaries
                 timeouts_spent = len(computation.timed_out_node_types)
             else:
                 computation = await self._compute_port_summaries_for_library(
-                    library_name, allowance, entry.pending_node_types()
+                    library_name, allowance, node_types=entry.pending_node_types(), throttle_s=throttle_s
                 )
                 summaries = {**entry.summaries, **computation.summaries}
                 timeouts_spent = entry.timeouts_spent + len(computation.timed_out_node_types)
@@ -3481,7 +3581,12 @@ class LibraryManager(EngineScoped):
         )
 
     async def _compute_port_summaries_for_library(
-        self, library_name: str, allowance: ProbeTimeoutAllowance, node_types: frozenset[str] | None = None
+        self,
+        library_name: str,
+        allowance: ProbeTimeoutAllowance,
+        *,
+        throttle_s: float,
+        node_types: frozenset[str] | None = None,
     ) -> PortSummaryComputation:
         """Probe a library's node types and derive each one's port summary.
 
@@ -3539,8 +3644,10 @@ class LibraryManager(EngineScoped):
                 break
 
             # Yield between node types so a large library's resolve calls, which run on the loop,
-            # interleave with other work instead of monopolizing it for the whole pass.
-            await asyncio.sleep(0)
+            # interleave with other work instead of monopolizing it for the whole pass. A zero
+            # sleep only lets already-ready callbacks run; the warm pass passes a real interval,
+            # which is what actually leaves the loop usable while it works.
+            await asyncio.sleep(throttle_s)
 
             outcome = await self._probe_node_type_port_summary(
                 library=library, library_name=library_name, node_type=node_type
@@ -4935,6 +5042,10 @@ class LibraryManager(EngineScoped):
                 )
             )
 
+        # Strictly after readiness is announced: warming is for the editor's benefit, so it must
+        # not sit between the engine being usable and the app being told so.
+        self._start_port_summary_warm()
+
     async def _collect_library_workflow_files(self) -> list[str]:
         """Collect workflow file paths declared by all registered libraries.
 
@@ -5581,6 +5692,18 @@ class LibraryManager(EngineScoped):
     # blocking nodes would starve every other to_thread caller in the engine.
     # Leaving part of one library unranked until it reloads is the cheaper failure.
     _PORT_SUMMARY_TIMEOUT_BUDGET: int = 4
+    # The same allowance for the background warm pass, which needs its own number because it
+    # covers every library rather than the one a caller asked about: given the interactive
+    # budget, a single library of blocking nodes would spend the whole thing and leave every
+    # other library cold, which is the one outcome that makes warming pointless. Still far
+    # below the default executor's worker count, since every timeout counted here is a thread
+    # the engine never gets back.
+    _PORT_SUMMARY_WARM_TIMEOUT_BUDGET: int = 8
+    # Gap left between node types during the warm pass. Resolving a node class imports its
+    # module on the event loop, which nothing can interrupt, so the pass cannot avoid blocking
+    # the loop in bursts -- it can only space them out. A warm pass has no deadline, so it
+    # buys editor responsiveness with wall-clock time an interactive request cannot spend.
+    _PORT_SUMMARY_WARM_THROTTLE_S: float = 0.05
     # Sentinel name passed to the throwaway node instance built for schema
     # discovery. The instance is discarded after its parameters are read.
     _SCHEMA_PROBE_NODE_NAME: str = "__schema_probe__"
@@ -6138,6 +6261,11 @@ class LibraryManager(EngineScoped):
             self._is_initializing = False
 
     async def _run_reload_libraries(self, request: ReloadAllLibrariesRequest) -> ResultPayload:  # noqa: ARG002
+        # Stop any background port summary warming before anything is torn down. The pass resolves
+        # node classes, so one left running would import modules belonging to libraries this is
+        # about to unload -- reviving exactly what the reload exists to replace.
+        await self._cancel_port_summary_warm()
+
         # Start with a clean slate.
         clear_all_request = ClearAllObjectStateRequest(i_know_what_im_doing=True)
         clear_all_result = await self.engine.ahandle_request(clear_all_request)
@@ -6212,6 +6340,12 @@ class LibraryManager(EngineScoped):
                     )
                 )
             )
+
+        # Re-warm against the reloaded libraries. Their cached summaries were dropped when they
+        # unloaded, so without this a reload silently hands the cost back to the next artist to
+        # drag a connection. Started even when reconcile reported problems below: the libraries
+        # that did load still have node types worth ranking.
+        self._start_port_summary_warm()
 
         # Hard activation: a reload is interactive (project switch / explicit reload), so a
         # reconcile failure (bad engine_version gate or a sourced library that could not be

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -456,12 +456,18 @@ class NodeTypePortProbeOutcome(NamedTuple):
     leave it unranked, not rank it as connecting to nothing.
 
     `timed_out` separates the one gap worth another attempt from the ones that are stable until the
-    library reloads. It also tells the caller a thread was spent that cannot be reclaimed, which is
-    what the per-pass timeout budget counts.
+    library reloads. It is also what the per-pass and per-library timeout budgets count, both of
+    which are about the pass rather than about any thread.
+
+    `thread_lost` is the narrower fact that the engine gave up on a construction thread it will not
+    get back, and is what the engine-wide ceiling counts. Not the same as `timed_out`: a
+    construction that finishes inside the window between its deadline passing and the timeout being
+    raised is a timeout the pass must account for, but no thread was lost.
     """
 
     summary: NodePortSummary | None
     timed_out: bool
+    thread_lost: bool = False
 
 
 class LibraryGitOperationContext(NamedTuple):
@@ -740,13 +746,21 @@ class LibraryManager(EngineScoped):
         # through _port_summaries_lock_for, which discards the lot when the running loop changes.
         self._library_to_port_summaries_lock: dict[str, asyncio.Lock] = {}
         self._port_summaries_lock_loop: asyncio.AbstractEventLoop | None = None
-        # Probe threads this engine has leaked, for the life of the process. Counted here rather
+        # Probe threads this engine has given up on for good: one per timeout. Counted here rather
         # than only per library or per request because the pool the leaks come out of is shared
         # engine-wide: the per-library allowance resets on reload and the per-request one resets
         # every request, so N libraries over M requests can leak far past anything either bounds.
-        # This is the only counter that never resets, and _PROBE_THREAD_LEAK_CEILING is the only
-        # bound expressed in terms of the executor actually being drained.
-        self._port_summary_threads_leaked: int = 0
+        # This never decreases, and _PROBE_THREAD_LEAK_CEILING is the only bound expressed in terms
+        # of the executor actually being drained.
+        self._port_summary_timed_out_threads: int = 0
+        # The "worker finished" signal of every construction abandoned by a cancellation, kept until
+        # it fires. A timeout means the thread is gone for the life of the process, but a
+        # cancellation usually catches a perfectly healthy __init__ a few milliseconds in, and that
+        # thread is back in the pool almost immediately. Charging those permanently would walk the
+        # ceiling up on every reload -- each one cancels the warm pass, often mid-probe -- and
+        # silently disable connection ranking for the session. Read through
+        # _leaked_probe_thread_count, which drops the ones that have finished.
+        self._abandoned_probe_signals: list[threading.Event] = []
         # How many port summary requests are currently being answered. Non-zero means someone is
         # blocked on the machinery below, which is what tells the background warm pass to stop
         # spacing its probes out -- see _effective_probe_throttle_s.
@@ -756,6 +770,14 @@ class LibraryManager(EngineScoped):
         # one still running while a library is torn down would import that library's modules
         # back in. See _start_port_summary_warm.
         self._port_summary_warm_task: asyncio.Task[None] | None = None
+        # How many library rebuilds are currently refusing to let a warm pass start. Cancelling the
+        # pass in hand is not enough on its own: a reload takes several awaits to tear the registry
+        # down, and anything that starts a pass in that window -- a worker reporting its node schemas
+        # is the everyday case -- would begin resolving node classes for libraries about to be
+        # unloaded, which is the import the cancellation exists to prevent. Counted rather than
+        # flagged so nested or overlapping rebuilds cannot un-suppress each other, and each rebuild
+        # restarts warming as it decrements. See _start_port_summary_warm.
+        self._port_summary_warm_suppressed: int = 0
         # Whether the host that started this engine has anything that will ask for port summaries.
         # Set from AppInitializationComplete, which defaults it to True, so an engine that is never
         # told still behaves as if an editor is attached.
@@ -3497,6 +3519,14 @@ class LibraryManager(EngineScoped):
             )
             return
 
+        if self._port_summary_warm_suppressed > 0:
+            # A library rebuild is in progress and has already cancelled the pass it found. Starting
+            # another now would resolve node classes for libraries it is partway through unloading,
+            # putting their modules back into `sys.modules` behind it. The rebuild restarts warming
+            # on its way out, so whatever this caller invalidated is still covered.
+            logger.debug("Port summary warming deferred: a library rebuild is in progress and will restart it.")
+            return
+
         # Leave a pass already in flight alone rather than replacing it. Only one handle is kept --
         # a pass nothing holds a handle to is a pass a reload cannot cancel, which is the one thing
         # here that has to work -- so this cannot start a second one, and it should not cancel the
@@ -3566,8 +3596,9 @@ class LibraryManager(EngineScoped):
         pass between awaits could still resolve a node class -- importing a module belonging to a
         library being dismantled. Returns promptly even when the pass is inside a probe: the
         construction thread cannot be cancelled, but the coroutine awaiting it can. That abandons the
-        thread, so the probe path charges it to the engine-wide leak ceiling exactly as a timeout is
-        charged -- reloading repeatedly is not a free way past that bound.
+        thread, and the probe path holds it against the engine-wide ceiling for as long as it really
+        is held -- reloading repeatedly is not a free way past that bound, but nor does it spend it
+        (see `_leaked_probe_thread_count`).
 
         Clearing the handle before awaiting keeps a second caller from awaiting the same task.
         """
@@ -3584,13 +3615,16 @@ class LibraryManager(EngineScoped):
             # caller's task, so awaiting it raises the cancellation we just requested.
             pass
         except Exception as err:
-            # The pass had already failed for its own reasons and finished between the check above
-            # and the cancel, so awaiting it re-raises that. Callers use this to make an unload safe,
-            # not to find out how warming went, and letting it propagate would abort a reload over a
-            # background task that is already off the loop -- exactly what the reload would fix.
-            logger.warning(
-                "Port summary warming had already failed when it was stopped: %s: %s. Summaries will be recomputed "
-                "after this reload.",
+            # The pass answered the cancellation by failing instead -- a broken `finally` on its way
+            # out, say. (A pass that had already failed cannot arrive here: the check above skips a
+            # task that is `done()`.) Callers use this to make an unload safe, not to find out how
+            # warming went, and letting it propagate would abort a reload over a background task that
+            # is already off the loop -- exactly what the reload would fix. DEBUG rather than WARNING
+            # because `_on_port_summary_warm_done` has already logged this same exception for the
+            # operator; two warnings for one failure only invite chasing it twice.
+            logger.debug(
+                "Port summary warming raised while being stopped: %s: %s. Summaries will be recomputed after this "
+                "reload.",
                 type(err).__name__,
                 err,
             )
@@ -3610,13 +3644,29 @@ class LibraryManager(EngineScoped):
         Sweeps the library list repeatedly rather than once, because a library can be invalidated
         after this pass has already walked past it -- a worker reporting its node schemas is the
         everyday case. That is what lets those callers leave a running pass alone instead of
-        cancelling and restarting it. A sweep that finds every library warm ends the pass, so the
-        sweep cap only binds when something is invalidating in a loop.
+        cancelling and restarting it. A sweep that finds every library warm ends the pass, as does
+        one that finds the pass has nothing left to spend, so the sweep cap only binds when something
+        is invalidating in a loop.
         """
         await self._libraries_loading_complete.wait()
 
         allowance = ProbeTimeoutAllowance(remaining=self._PORT_SUMMARY_WARM_TIMEOUT_BUDGET)
         for sweep in range(self._PORT_SUMMARY_WARM_MAX_SWEEPS):
+            # Asked once per sweep, and about the pass rather than any library, so `timeouts_spent`
+            # is 0. Without this a pass that has spent its allowance -- or an engine holding its
+            # ceiling of probe threads -- would run every remaining sweep, each one taking every
+            # cold library's lock only to stop at its first node type, and then report that
+            # libraries kept changing. An operator would go looking for the wrong thing.
+            pass_stop_reason = self._probe_stop_reason(allowance=allowance, timeouts_spent=0)
+            if pass_stop_reason is not None:
+                logger.info(
+                    "Stopped warming port summaries after %d sweep(s): %s. Anything still uncomputed will be "
+                    "computed by the first request that needs it, which starts with a fresh allowance.",
+                    sweep,
+                    pass_stop_reason,
+                )
+                return
+
             cold_library_names = [
                 library_name
                 for library_name in LibraryRegistry.list_libraries()
@@ -3792,17 +3842,22 @@ class LibraryManager(EngineScoped):
         # node type would otherwise clear the grant and let the next timeout re-grant it.
         retried_node_types = already_retried_node_types | computation.timed_out_node_types
 
-        if self._port_summary_threads_leaked >= self._PROBE_THREAD_LEAK_CEILING:
+        # The permanently-lost threads specifically, not the live count `_probe_stop_reason` gates on.
+        # A pass can also have stopped because threads abandoned by a cancellation are still busy,
+        # and those come back: giving up on the node types they displaced would turn a reload into a
+        # permanent loss of ranking. Only timeouts are unrecoverable, so only timeouts end this
+        # library's probing for good.
+        if self._port_summary_timed_out_threads >= self._PROBE_THREAD_LEAK_CEILING:
             # No pass in this process will probe again, so carrying anything as pending would only
             # make every future request take the lock and run a pass that stops immediately.
             if computation.unprobed_node_types:
                 logger.warning(
-                    "Giving up on port summaries for %d node type(s) in library '%s': this engine has leaked %d "
-                    "probe thread(s), its lifetime ceiling. These go unranked in the Add Node menu until the "
-                    "engine restarts.",
+                    "Giving up on port summaries for %d node type(s) in library '%s': this engine has lost %d "
+                    "probe thread(s) to timeouts, its lifetime ceiling. These go unranked in the Add Node menu "
+                    "until the engine restarts.",
                     len(computation.unprobed_node_types),
                     library_name,
-                    self._port_summary_threads_leaked,
+                    self._port_summary_timed_out_threads,
                 )
             return PortSummaryCacheEntry(
                 summaries=summaries,
@@ -3959,9 +4014,11 @@ class LibraryManager(EngineScoped):
                 if outcome.timed_out:
                     timed_out_node_types.add(node_type)
                     allowance.remaining -= 1
-                    # Counted for the life of the process: this thread is never coming back, and
-                    # the two allowances above both reset.
-                    self._port_summary_threads_leaked += 1
+                    if outcome.thread_lost:
+                        # Counted for the life of the process: a construction still running past the
+                        # deadline is one nothing can interrupt, and the two allowances above both
+                        # reset. A timeout whose thread did come back is charged to neither.
+                        self._port_summary_timed_out_threads += 1
                 continue
 
             summaries[node_type] = outcome.summary
@@ -4029,10 +4086,11 @@ class LibraryManager(EngineScoped):
             # request, which will see the rebuilt registry.
             return "a library reload has started, so the node classes this pass would resolve are being replaced"
 
-        if self._port_summary_threads_leaked >= self._PROBE_THREAD_LEAK_CEILING:
+        threads_held = self._leaked_probe_thread_count()
+        if threads_held >= self._PROBE_THREAD_LEAK_CEILING:
             return (
-                f"this engine has leaked {self._port_summary_threads_leaked} probe thread(s), its lifetime ceiling. "
-                f"No further probing will be attempted in this process"
+                f"this engine is holding {threads_held} probe thread(s) it cannot reclaim, its ceiling. Probing "
+                f"resumes only if threads abandoned by a reload finish; the ones lost to timeouts never do"
             )
 
         if timeouts_spent >= self._PORT_SUMMARY_LIBRARY_TIMEOUT_BUDGET:
@@ -4045,6 +4103,25 @@ class LibraryManager(EngineScoped):
             return "this pass has spent its probe timeout allowance"
 
         return None
+
+    def _leaked_probe_thread_count(self) -> int:
+        """How many probe threads this engine is currently holding without being able to reclaim them.
+
+        Two kinds, counted together because the executor they come out of cannot tell them apart.
+
+        A timeout means the node's `__init__` is still running past the deadline, which for a
+        genuinely stuck node means for the life of the process, so it is charged permanently.
+
+        A cancellation is different, and treating it the same was a real bug: every library reload
+        cancels the warm pass, frequently mid-probe, and what it usually abandons is a healthy
+        `__init__` a few milliseconds in whose thread is back in the pool almost immediately. Charged
+        permanently against a ceiling of two or three, a couple of reloads would disable connection
+        ranking for the rest of the session. So an abandoned construction is kept as its own
+        "worker finished" signal and stops counting the moment it fires, making this a live measure
+        of threads actually held rather than a tally of times one was abandoned.
+        """
+        self._abandoned_probe_signals = [signal for signal in self._abandoned_probe_signals if not signal.is_set()]
+        return self._port_summary_timed_out_threads + len(self._abandoned_probe_signals)
 
     async def _probe_node_type_port_summary(  # noqa: PLR0911
         self, *, library: Library, library_name: str, node_type: str
@@ -4116,38 +4193,29 @@ class LibraryManager(EngineScoped):
             )
         except asyncio.CancelledError:
             # A reload stopping the warm pass mid-probe. The construction thread is not cancellable,
-            # so if it has not finished it is held exactly as a timeout would hold it, and the
-            # engine-wide ceiling has to hear about it: cancellation is not rare (every reload does
-            # it), and a ceiling that only counted timeouts would let repeated reloads drain the
-            # loop's executor without ever tripping. Not counted against the library or the pass --
-            # both are about to be discarded -- and not counted at all when the thread did finish,
-            # since charging a leak that did not happen would disable probing for the session.
+            # so while it runs on it holds a worker exactly as a timeout would, and the engine-wide
+            # ceiling has to hear about it: cancellation is not rare -- every reload does it -- and a
+            # ceiling that only counted timeouts would let repeated reloads drain the loop's executor
+            # without ever tripping. Handed over as the signal rather than as a count, though, because
+            # the usual abandoned construction is a healthy one that finishes moments later: see
+            # `_leaked_probe_thread_count`. Not charged to the library or the pass either way, both
+            # being about to be discarded.
             if not probe_finished.is_set():
-                self._port_summary_threads_leaked += 1
+                self._abandoned_probe_signals.append(probe_finished)
                 logger.warning(
                     "Port summary probing was stopped while constructing node type '%s' in library '%s'. Its thread "
-                    "cannot be cancelled, so it is leaked (%d so far); probing stops for this process after %d.",
+                    "cannot be cancelled, so it is held until that construction returns (%d thread(s) held now); "
+                    "probing pauses while %d are held.",
                     node_type,
                     library_name,
-                    self._port_summary_threads_leaked,
+                    self._leaked_probe_thread_count(),
                     self._PROBE_THREAD_LEAK_CEILING,
                 )
             raise
         except TimeoutError:
-            # asyncio.to_thread cannot be cancelled, so the thread is not reclaimed: it holds a
-            # worker of the loop's default executor until __init__ returns, which for a truly stuck
-            # node means for the life of the process. That is why the caller both bounds how many
-            # timeouts one pass will spend and gives this node type one retry rather than one per
-            # request.
-            logger.warning(
-                "Port summary probe for node type '%s' in library '%s' timed out after %.1fs; skipping it and "
-                "leaking the probe thread, which cannot be cancelled. The node's __init__ likely makes a "
-                "blocking call.",
-                node_type,
-                library_name,
-                self._SCHEMA_PROBE_TIMEOUT_S,
+            return self._timed_out_probe_outcome(
+                library_name=library_name, node_type=node_type, probe_finished=probe_finished
             )
-            return NodeTypePortProbeOutcome(summary=None, timed_out=True)
         except Exception:
             # _construct_probe_node already converts a raising __init__ into a result, so reaching
             # here means the failure was outside it -- the executor refusing work during interpreter
@@ -4186,6 +4254,40 @@ class LibraryManager(EngineScoped):
             return NodeTypePortProbeOutcome(summary=None, timed_out=False)
 
         return NodeTypePortProbeOutcome(summary=summary, timed_out=False)
+
+    def _timed_out_probe_outcome(
+        self, *, library_name: str, node_type: str, probe_finished: threading.Event
+    ) -> NodeTypePortProbeOutcome:
+        """Report a construction that missed its deadline, saying whether its thread went with it.
+
+        `asyncio.to_thread` cannot be cancelled, so a timed-out construction usually holds a worker
+        of the loop's default executor until `__init__` returns, which for a genuinely stuck node
+        means for the life of the process. That is why the caller both bounds how many timeouts one
+        pass will spend and grants a node type one retry rather than one per request.
+
+        Except when the construction landed in the window between its deadline passing and
+        `TimeoutError` being raised, in which case the worker is already back in the pool and only
+        the result was lost. Same question the cancellation branch asks, and the same answer: nothing
+        is charged to the engine-wide ceiling for a thread that is not held. Past the deadline the
+        engine has no basis to expect a *later* return, though, so a node that hands its thread back
+        at 10.5s is still charged -- conservative on purpose, and exactly the shape of node the
+        ceiling exists to stop paying for.
+        """
+        thread_lost = not probe_finished.is_set()
+        if thread_lost:
+            thread_note = " and leaking its probe thread, which cannot be cancelled"
+        else:
+            thread_note = ", though its probe thread finished in time to go back to the pool"
+
+        logger.warning(
+            "Port summary probe for node type '%s' in library '%s' timed out after %.1fs; skipping it%s. The node's "
+            "__init__ likely makes a blocking call.",
+            node_type,
+            library_name,
+            self._SCHEMA_PROBE_TIMEOUT_S,
+            thread_note,
+        )
+        return NodeTypePortProbeOutcome(summary=None, timed_out=True, thread_lost=thread_lost)
 
     def _invalidate_port_summaries(self, library_name: str) -> None:
         """Drop a library's cached port summaries after its node types change.
@@ -6689,10 +6791,13 @@ class LibraryManager(EngineScoped):
         return new_downloads
 
     async def reload_libraries_request(self, request: ReloadAllLibrariesRequest) -> ResultPayload:
-        # Stop any background port summary warming before anything is torn down. The pass resolves
-        # node classes, so one left running would import modules belonging to libraries this is
-        # about to unload -- reviving exactly what the reload exists to replace.
+        # Stop any background port summary warming before anything is torn down, and keep anything
+        # else from starting one until this is finished. The pass resolves node classes, so one left
+        # running -- or one begun in the several awaits it takes to tear the registry down -- would
+        # import modules belonging to libraries this is about to unload, reviving exactly what the
+        # reload exists to replace.
         await self._cancel_port_summary_warm()
+        self._port_summary_warm_suppressed += 1
 
         # Bracket the reload like on_app_initialization_complete so the heartbeat reports
         # is_initializing during a mid-session reload too. finally clears it even on failure.
@@ -6709,6 +6814,8 @@ class LibraryManager(EngineScoped):
             raise
         finally:
             self._is_initializing = False
+            # Lifted before the restart below, which would otherwise defer itself.
+            self._port_summary_warm_suppressed -= 1
 
             # Re-warm in finally, not on the success path: every way out of the reload leaves the
             # cache dropped, because the unloads either completed or were abandoned partway. A
@@ -7611,17 +7718,31 @@ class LibraryManager(EngineScoped):
             On failure: ResultPayloadFailure instance
         """
         await self._cancel_port_summary_warm()
+        self._port_summary_warm_suppressed += 1
+        restart_warming = True
         try:
             return await self._run_reload_library_after_git_operation(
                 library_name=library_name,
                 library_file_path=library_file_path,
                 failure_result_class=failure_result_class,
             )
+        except asyncio.CancelledError:
+            # The same exception `reload_libraries_request` makes: the caller is going away, so
+            # starting a background pass on the way out would leave it resolving node classes over a
+            # registry this abandoned partway through rebuilding, with nothing holding a handle to
+            # stop it a second time. Worse here than there, because this path never closes
+            # `_libraries_loading_complete`, so the pass has no gate to notice either.
+            restart_warming = False
+            raise
         finally:
+            # Lifted before the restart below, which would otherwise defer itself.
+            self._port_summary_warm_suppressed -= 1
+
             # In `finally`, not on the success path: a reload that failed partway has still dropped
             # this library's summaries, and leaving warming stopped would make every other library's
             # first connection drag pay the probe cost too.
-            self._start_port_summary_warm()
+            if restart_warming:
+                self._start_port_summary_warm()
 
     async def _run_reload_library_after_git_operation(
         self,

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -385,16 +385,59 @@ class NodeProbeResult(NamedTuple):
 class PortSummaryComputation(NamedTuple):
     """Outcome of probing a library's node types for their port summaries.
 
-    `retry_node_types` holds the node types whose gap might close on its own, which in practice
-    means only the ones whose probe timed out: `asyncio.to_thread` shares the loop's default
-    executor, so a saturated pool can time out a probe that would otherwise have succeeded. Every
-    other gap is stable until the library reloads -- a module that fails to import keeps failing,
-    an `__init__` that raises keeps raising -- so those node types are simply absent from
-    `summaries` and are not worth another pass.
+    `timed_out_node_types` holds the node types whose gap might close on its own: `asyncio.to_thread`
+    shares the loop's default executor, so a saturated pool can time out a probe that would
+    otherwise have succeeded. Every other *attempted* gap is treated as stable until the library
+    reloads, so those node types are simply absent from `summaries`. That is exactly right for a
+    module that fails to import, and a deliberate simplification for an `__init__` that raises: node
+    `__init__` does make network and disk calls, so a raise can be a blip rather than a defect, but
+    nothing here can tell the two apart, and re-probing every broken node type on every menu open
+    costs more than leaving it unranked until its library reloads.
+
+    `unprobed_node_types` is a different thing entirely: node types the pass never reached, because
+    it ran out of the request's timeout allowance first. Nothing is known about them, so they are
+    owed a real attempt rather than being recorded as unrankable.
     """
 
     summaries: dict[str, NodePortSummary]
+    timed_out_node_types: frozenset[str]
+    unprobed_node_types: frozenset[str]
+
+
+class PortSummaryCacheEntry(NamedTuple):
+    """A library's cached port summaries plus the state deciding what a later pass still owes it.
+
+    Held as one value rather than parallel dicts because the four fields are only ever correct
+    together: a summary map is complete exactly when nothing is pending, and `timeouts_spent` is
+    what decides whether anything pending will actually be attempted.
+    """
+
+    summaries: dict[str, NodePortSummary]
+    # Node types whose probe timed out, owed exactly one more attempt. Spent by the pass that makes
+    # that attempt, whether or not it succeeds.
     retry_node_types: frozenset[str]
+    # Node types no pass has attempted yet, carried until one does.
+    unprobed_node_types: frozenset[str]
+    # Probe timeouts this library has cost since it last loaded. Each one permanently holds a worker
+    # of the loop's default executor, so this is the library's lifetime bill, not a per-pass count.
+    timeouts_spent: int
+
+    def pending_node_types(self) -> frozenset[str]:
+        """Node types a later pass still owes work on, so the summaries are not yet complete."""
+        return self.retry_node_types | self.unprobed_node_types
+
+
+@dataclass
+class ProbeTimeoutAllowance:
+    """How many more probe timeouts one request will pay for, across every library it touches.
+
+    A timed-out probe cannot be cancelled, so it costs a worker of the event loop's default executor
+    for the life of the process. Spending that budget per library would multiply the leak by the
+    number of libraries installed, which is how an engine ends up with no worker threads left, so
+    one allowance is threaded through the whole request instead.
+    """
+
+    remaining: int
 
 
 class NodeTypePortProbeOutcome(NamedTuple):
@@ -677,13 +720,9 @@ class LibraryManager(EngineScoped):
             type[Payload], dict[str, LibraryManager.RegisteredEventHandler[Any]]
         ] = {}
         # Per-library node type -> port summary, computed on the first GetPortSummaries request
-        # and dropped when the library is unloaded (which a reload goes through).
-        self._library_to_port_summaries: dict[str, dict[str, NodePortSummary]] = {}
-        # Node types in a cached library whose probe timed out, owed exactly one more attempt on the
-        # next request. Emptied by that attempt whether or not it succeeds, so a node whose __init__
-        # blocks forever costs two un-reclaimable threads per library generation -- one per pass --
-        # rather than one per request. Each reload of the library starts that allowance over.
-        self._library_to_port_summary_retries: dict[str, frozenset[str]] = {}
+        # and dropped when the library is unloaded (which a reload goes through). The entry also
+        # carries what a later pass still owes the library -- see PortSummaryCacheEntry.
+        self._library_to_port_summary_cache: dict[str, PortSummaryCacheEntry] = {}
         # Bumped by _invalidate_port_summaries. The compute pass awaits, so a library can be
         # mutated while its summaries are being computed; comparing the counter before and after
         # tells the pass whether its now-stale result is still safe to cache.
@@ -3290,12 +3329,20 @@ class LibraryManager(EngineScoped):
 
         Waits for library loading to finish, then serves each library's summaries from the cache,
         computing them on first request.
+
+        One timeout allowance covers the whole request rather than each library separately, because
+        the cost a timeout imposes -- a worker of the loop's default executor, held for good -- is
+        paid by the engine as a whole. A library whose node types go unreached because the allowance
+        ran out here keeps them pending, so the next request resumes them.
         """
         await self._libraries_loading_complete.wait()
 
+        allowance = ProbeTimeoutAllowance(remaining=self._PORT_SUMMARY_TIMEOUT_BUDGET)
         library_name_to_port_summaries: dict[str, dict[str, NodePortSummary]] = {}
         for library_name in LibraryRegistry.list_libraries():
-            library_name_to_port_summaries[library_name] = await self._get_port_summaries_for_library(library_name)
+            library_name_to_port_summaries[library_name] = await self._get_port_summaries_for_library(
+                library_name, allowance
+            )
 
         node_type_count = sum(len(summaries) for summaries in library_name_to_port_summaries.values())
         details = (
@@ -3307,43 +3354,58 @@ class LibraryManager(EngineScoped):
             result_details=details,
         )
 
-    async def _get_port_summaries_for_library(self, library_name: str) -> dict[str, NodePortSummary]:
+    async def _get_port_summaries_for_library(
+        self, library_name: str, allowance: ProbeTimeoutAllowance
+    ) -> dict[str, NodePortSummary]:
         """Return the port summary for every node type in a library, computing it on first call.
 
         Cached until the library changes -- a reload, an unload, or node types being registered
         into it -- because a node type's declared ports cannot change without one of those.
 
-        A cached library with node types owed a retry (their probe timed out) is topped up rather
-        than recomputed: only those node types are probed again, and the retry is spent whether or
-        not it succeeds. That bounds the damage a node whose ``__init__`` blocks can do. Probing it
-        burns a thread ``asyncio.to_thread`` cannot cancel, so re-probing on every request would
-        drain the loop's shared executor and eventually stall every other threaded operation in the
-        engine -- a far worse outcome than one node type going unranked in the Add Node menu.
+        A cached library with node types still pending is topped up rather than recomputed: only
+        those node types are probed again. Two different things can be pending, and they are owed
+        different treatment. A node type whose probe *timed out* gets exactly one more attempt,
+        because a saturated executor can time out a probe that would otherwise have worked, and the
+        attempt is spent whether or not it succeeds. A node type a pass never *reached*, because the
+        request ran out of timeout allowance before getting to it, is owed a real attempt and stays
+        pending until it gets one.
+
+        What caps all of it is `_PORT_SUMMARY_TIMEOUT_BUDGET` per library per load: once a library's
+        probes have timed out that many times, nothing pending is attempted again until it reloads.
+        Each of those timeouts burned a thread ``asyncio.to_thread`` cannot cancel, so continuing to
+        pay would drain the loop's shared executor and eventually stall every other threaded
+        operation in the engine -- a far worse outcome than part of one library going unranked in
+        the Add Node menu.
 
         The per-library lock means concurrent callers do the probe pass once rather than once each;
         the second caller waits and then reads the cache. It is deliberately not held for the
         cache-hit path: the probe pass can take seconds, and a request that only needs
         already-computed summaries should not queue behind another library's first pass.
         """
-        cached_summaries = self._library_to_port_summaries.get(library_name)
-        retry_node_types = self._library_to_port_summary_retries.get(library_name, frozenset())
-        if cached_summaries is not None and not retry_node_types:
-            return dict(cached_summaries)
+        entry = self._library_to_port_summary_cache.get(library_name)
+        if entry is not None and not entry.pending_node_types():
+            return dict(entry.summaries)
 
-        async with self._library_to_port_summaries_lock.setdefault(library_name, asyncio.Lock()):
+        if library_name not in self._library_to_port_summaries_lock:
+            self._library_to_port_summaries_lock[library_name] = asyncio.Lock()
+
+        async with self._library_to_port_summaries_lock[library_name]:
             # Re-check: another caller may have computed or topped these up while we waited.
-            cached_summaries = self._library_to_port_summaries.get(library_name)
-            retry_node_types = self._library_to_port_summary_retries.get(library_name, frozenset())
-            if cached_summaries is not None and not retry_node_types:
-                return dict(cached_summaries)
+            entry = self._library_to_port_summary_cache.get(library_name)
+            if entry is not None and not entry.pending_node_types():
+                return dict(entry.summaries)
 
             generation_before = self._library_to_port_summaries_generation.get(library_name, 0)
-            if cached_summaries is None:
-                computation = await self._compute_port_summaries_for_library(library_name)
+            if entry is None:
+                computation = await self._compute_port_summaries_for_library(library_name, allowance)
                 summaries = computation.summaries
+                timeouts_spent = len(computation.timed_out_node_types)
             else:
-                computation = await self._compute_port_summaries_for_library(library_name, retry_node_types)
-                summaries = {**cached_summaries, **computation.summaries}
+                computation = await self._compute_port_summaries_for_library(
+                    library_name, allowance, entry.pending_node_types()
+                )
+                summaries = {**entry.summaries, **computation.summaries}
+                timeouts_spent = entry.timeouts_spent + len(computation.timed_out_node_types)
 
             # The pass above awaited, so the library may have been reloaded, unloaded, or had node
             # types registered into it in the meantime. Caching what we just measured would pin
@@ -3359,23 +3421,72 @@ class LibraryManager(EngineScoped):
                 )
                 return summaries
 
-            self._library_to_port_summaries[library_name] = summaries
-            # Only a first pass earns retries. A top-up pass has spent them, so clearing the entry
-            # here is what stops a permanently stuck node type from being re-probed forever.
-            if cached_summaries is None and computation.retry_node_types:
-                self._library_to_port_summary_retries[library_name] = computation.retry_node_types
-            else:
-                self._library_to_port_summary_retries.pop(library_name, None)
-
+            self._library_to_port_summary_cache[library_name] = self._next_port_summary_cache_entry(
+                library_name=library_name,
+                summaries=summaries,
+                computation=computation,
+                timeouts_spent=timeouts_spent,
+                is_first_pass=entry is None,
+            )
             return dict(summaries)
 
+    def _next_port_summary_cache_entry(
+        self,
+        *,
+        library_name: str,
+        summaries: dict[str, NodePortSummary],
+        computation: PortSummaryComputation,
+        timeouts_spent: int,
+        is_first_pass: bool,
+    ) -> PortSummaryCacheEntry:
+        """Decide what a completed pass leaves pending for the library.
+
+        Separated from the pass itself because it is the whole termination argument in one place:
+        each rule below is what stops some node type from being probed forever.
+        """
+        if timeouts_spent >= self._PORT_SUMMARY_TIMEOUT_BUDGET:
+            # The library has spent its whole allowance of un-reclaimable threads. Everything still
+            # pending is dropped -- including node types never attempted, which cannot be told apart
+            # from the blocking ones without paying again.
+            if computation.unprobed_node_types:
+                logger.warning(
+                    "Giving up on port summaries for %d node type(s) in library '%s' after %d probe timeout(s): %s. "
+                    "Each timeout costs a thread the engine cannot reclaim, so these go unranked in the Add Node "
+                    "menu until the library is reloaded.",
+                    len(computation.unprobed_node_types),
+                    library_name,
+                    timeouts_spent,
+                    ", ".join(sorted(computation.unprobed_node_types)),
+                )
+            return PortSummaryCacheEntry(
+                summaries=summaries,
+                retry_node_types=frozenset(),
+                unprobed_node_types=frozenset(),
+                timeouts_spent=timeouts_spent,
+            )
+
+        # Only a first pass earns retries. A top-up pass has spent the ones it was given, so not
+        # re-recording its own timeouts is what stops a stuck node type cycling forever.
+        retry_node_types = frozenset()
+        if is_first_pass:
+            retry_node_types = computation.timed_out_node_types
+
+        # Node types never reached are always carried: a later pass shrinks the set by at least one
+        # timeout's worth before it can stop early again, so this converges.
+        return PortSummaryCacheEntry(
+            summaries=summaries,
+            retry_node_types=retry_node_types,
+            unprobed_node_types=computation.unprobed_node_types,
+            timeouts_spent=timeouts_spent,
+        )
+
     async def _compute_port_summaries_for_library(
-        self, library_name: str, node_types: frozenset[str] | None = None
+        self, library_name: str, allowance: ProbeTimeoutAllowance, node_types: frozenset[str] | None = None
     ) -> PortSummaryComputation:
         """Probe a library's node types and derive each one's port summary.
 
         Covers every registered node type unless `node_types` narrows it, which is how a cached
-        library's timed-out node types get their one retry without re-probing the rest.
+        library's pending node types are topped up without re-probing the rest.
 
         Node types the engine cannot construct are left out of the result entirely rather than
         recorded as portless, so callers leave them unranked instead of ranking them as
@@ -3385,11 +3496,11 @@ class LibraryManager(EngineScoped):
         stays on the event loop because ``NodeTypeEntry.resolve()`` is not thread-safe, and only
         construction goes to a thread, where the same timeout the worker-side schema pass uses
         bounds it: a node's ``__init__`` can block indefinitely, and one such node must not stall
-        the rest. A pass gives up entirely after `_PORT_SUMMARY_TIMEOUT_BUDGET` timeouts, because
-        every one of those has cost a thread that cannot be handed back.
+        the rest.
 
-        Only a timeout is reported in `retry_node_types` -- see `PortSummaryComputation` for why
-        every other gap is stable.
+        The pass stops as soon as `allowance` is exhausted, since each timeout has cost a thread
+        that cannot be handed back, and reports the node types it never reached separately from the
+        ones it attempted and failed -- see `PortSummaryComputation`.
         """
         try:
             library = LibraryRegistry.get_library(library_name)
@@ -3398,21 +3509,35 @@ class LibraryManager(EngineScoped):
             # lookup. The caller may well cache this empty result, since unloading only bumps the
             # generation counter when it happens *during* a pass, not before one starts. That is
             # harmless: the entry is for a library nothing can now ask about, and re-registering the
-            # name invalidates it. Nothing here is worth retrying.
+            # name invalidates it. Nothing here is worth another pass.
             logger.warning("Cannot compute port summaries: library '%s' not found in registry.", library_name)
-            return PortSummaryComputation(summaries={}, retry_node_types=frozenset())
+            return PortSummaryComputation(
+                summaries={}, timed_out_node_types=frozenset(), unprobed_node_types=frozenset()
+            )
 
         node_types_to_probe = library.get_registered_nodes()
         if node_types is not None:
             # Intersect rather than trust the caller's set: a node type can have been unregistered
-            # since it earned its retry.
+            # since it was left pending.
             node_types_to_probe = [node_type for node_type in node_types_to_probe if node_type in node_types]
 
         summaries: dict[str, NodePortSummary] = {}
         skipped_node_types: list[str] = []
-        retry_node_types: set[str] = set()
-        timed_out_count = 0
+        timed_out_node_types: set[str] = set()
+        unprobed_node_types: list[str] = []
         for probe_index, node_type in enumerate(node_types_to_probe):
+            if allowance.remaining <= 0:
+                # Out of allowance, and any node type here could be another blocking one. These were
+                # never attempted, so they stay pending rather than being recorded as unrankable.
+                unprobed_node_types = node_types_to_probe[probe_index:]
+                logger.info(
+                    "Stopped probing library '%s' with %d node type(s) left; this request has spent its probe "
+                    "timeout allowance. They will be attempted on a later request.",
+                    library_name,
+                    len(unprobed_node_types),
+                )
+                break
+
             # Yield between node types so a large library's resolve calls, which run on the loop,
             # interleave with other work instead of monopolizing it for the whole pass.
             await asyncio.sleep(0)
@@ -3422,28 +3547,10 @@ class LibraryManager(EngineScoped):
             )
             if outcome.summary is None:
                 skipped_node_types.append(node_type)
-                if not outcome.timed_out:
-                    continue
-
-                retry_node_types.add(node_type)
-                timed_out_count += 1
-                if timed_out_count < self._PORT_SUMMARY_TIMEOUT_BUDGET:
-                    continue
-
-                abandoned_node_types = node_types_to_probe[probe_index + 1 :]
-                logger.warning(
-                    "Abandoning port summaries for the remaining %d node type(s) in library '%s' after %d probe "
-                    "timeout(s): %s. Each timeout costs a thread the engine cannot reclaim, so the rest of this "
-                    "library goes unranked until it is reloaded.",
-                    len(abandoned_node_types),
-                    library_name,
-                    timed_out_count,
-                    ", ".join(abandoned_node_types),
-                )
-                # Not added to retry_node_types: they were never probed, so a retry would walk
-                # straight back into the same timeouts that stopped this pass.
-                skipped_node_types.extend(abandoned_node_types)
-                break
+                if outcome.timed_out:
+                    timed_out_node_types.add(node_type)
+                    allowance.remaining -= 1
+                continue
 
             summaries[node_type] = outcome.summary
 
@@ -3455,7 +3562,11 @@ class LibraryManager(EngineScoped):
                 len(skipped_node_types),
                 ", ".join(skipped_node_types),
             )
-        return PortSummaryComputation(summaries=summaries, retry_node_types=frozenset(retry_node_types))
+        return PortSummaryComputation(
+            summaries=summaries,
+            timed_out_node_types=frozenset(timed_out_node_types),
+            unprobed_node_types=frozenset(unprobed_node_types),
+        )
 
     async def _probe_node_type_port_summary(  # noqa: PLR0911
         self, *, library: Library, library_name: str, node_type: str
@@ -3575,11 +3686,12 @@ class LibraryManager(EngineScoped):
         it. Call this *before* mutating the library, so a mutation that bails out partway through
         still leaves the cache cleared.
 
-        Outstanding retries go too: a reload replaces the node's code, so a probe that timed out
-        against the old code has earned a fresh full attempt rather than a top-up.
+        Dropping the entry drops everything pending and the library's spent timeout allowance with
+        it: a reload replaces the node's code, so a probe that timed out against the old code has
+        earned a fresh full attempt rather than a top-up, and node types abandoned under the old
+        code get another chance under the new.
         """
-        self._library_to_port_summaries.pop(library_name, None)
-        self._library_to_port_summary_retries.pop(library_name, None)
+        self._library_to_port_summary_cache.pop(library_name, None)
         self._library_to_port_summaries_generation[library_name] = (
             self._library_to_port_summaries_generation.get(library_name, 0) + 1
         )
@@ -5461,12 +5573,13 @@ class LibraryManager(EngineScoped):
     # await init-time events (e.g. WorkflowManager._workflows_loading_complete),
     # so each probe runs in a worker thread with this ceiling.
     _SCHEMA_PROBE_TIMEOUT_S: float = 10.0
-    # How many probe timeouts one port summary pass tolerates before abandoning
-    # the library's remaining node types. Each timeout permanently costs a worker
-    # of the event loop's default executor -- asyncio.to_thread cannot cancel the
-    # thread it started -- so an unbounded pass over a library of blocking nodes
-    # would starve every other to_thread caller in the engine. Leaving the tail
-    # of one library unranked until it reloads is the cheaper failure.
+    # How many probe timeouts the port summary machinery will pay for, counted two
+    # ways: per request across every library it touches, and per library across
+    # every request until that library reloads. Each timeout permanently costs a
+    # worker of the event loop's default executor -- asyncio.to_thread cannot
+    # cancel the thread it started -- so an unbounded count over a library of
+    # blocking nodes would starve every other to_thread caller in the engine.
+    # Leaving part of one library unranked until it reloads is the cheaper failure.
     _PORT_SUMMARY_TIMEOUT_BUDGET: int = 4
     # Sentinel name passed to the throwaway node instance built for schema
     # discovery. The instance is discarded after its parameters are read.

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -29,6 +29,7 @@ DEFAULT_LIBRARIES_DIRECTORY = "libraries"
 LIBRARY_DEPENDENCY_INSTALL_BEHAVIOR_KEY = "library.dependency_install_behavior"
 LIBRARY_MINIMUM_RELEASE_AGE_KEY = "library.minimum_release_age"
 LIBRARY_LAZY_NODE_LOADING_KEY = "library.lazy_node_loading"
+LIBRARY_WARM_PORT_SUMMARIES_KEY = "library.warm_port_summaries"
 
 
 class Category(BaseModel):
@@ -315,6 +316,19 @@ class LibrarySettings(BaseModel):
             "import error surfaces immediately as a library problem, before the node is placed on a "
             "canvas; set this while authoring nodes if you want that check. Nodes in the sandbox library "
             "are always loaded eagerly regardless of this setting."
+        ),
+    )
+    warm_port_summaries: bool = Field(
+        default=True,
+        description=(
+            "When True (the default), the engine computes each node type's port summary in the background "
+            "once libraries have finished loading, so the editor's 'which node types accept this connection?' "
+            "ranking is instant the first time it is needed. Computing a summary means constructing the node "
+            "type, which imports its Python module, so this trades background work after startup for not "
+            "making the artist wait mid-drag. Set to False on a constrained machine, or while authoring, to "
+            "leave the cost where it was: paid on demand by the first request that needs ranking. Either way "
+            "the summaries are computed at most once per library per load. Has no effect on a dedicated "
+            "library worker, which already imports every node module to report its schemas."
         ),
     )
     minimum_release_age: float = Field(

--- a/src/griptape_nodes/retained_mode/managers/settings.py
+++ b/src/griptape_nodes/retained_mode/managers/settings.py
@@ -325,10 +325,13 @@ class LibrarySettings(BaseModel):
             "once libraries have finished loading, so the editor's 'which node types accept this connection?' "
             "ranking is instant the first time it is needed. Computing a summary means constructing the node "
             "type, which imports its Python module, so this trades background work after startup for not "
-            "making the artist wait mid-drag. Set to False on a constrained machine, or while authoring, to "
-            "leave the cost where it was: paid on demand by the first request that needs ranking. Either way "
-            "the summaries are computed at most once per library per load. Has no effect on a dedicated "
-            "library worker, which already imports every node module to report its schemas."
+            "making the artist wait mid-drag. Note that it therefore imports every node module shortly "
+            "after startup even when 'lazy_node_loading' is True: lazy loading still keeps those imports "
+            "off the startup path, but it no longer avoids them altogether. Set to False on a constrained "
+            "machine, or while authoring, to leave the cost where it was: paid on demand by the first "
+            "request that needs ranking. Either way the summaries are computed at most once per library "
+            "per load. Has no effect on a dedicated library worker, which already imports every node "
+            "module to report its schemas."
         ),
     )
     minimum_release_age: float = Field(

--- a/tests/unit/retained_mode/managers/test_event_manager.py
+++ b/tests/unit/retained_mode/managers/test_event_manager.py
@@ -38,7 +38,11 @@ from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
     CheckpointFailure,
     CheckpointSubjectType,
 )
-from griptape_nodes.retained_mode.managers.event_manager import EventManager, ResultContext
+from griptape_nodes.retained_mode.managers.event_manager import (
+    EventManager,
+    ResultContext,
+    suppress_event_publication,
+)
 
 
 class TestEventManagerBroadcasting:
@@ -1944,3 +1948,70 @@ class TestExecutionEventSubscription:
         manager.put_event(ProgressEvent(value="x", node_name="n", parameter_name="output"))
 
         assert received == []
+
+
+class TestSuppressEventPublication:
+    """Exercise the block LibraryManager wraps its throwaway probe construction in.
+
+    The contract that matters is not just "events inside are dropped" but that the drop ends when
+    the block does. Suppression follows the context, and several asyncio primitives copy the
+    context out of the block, so getting the end wrong silences the editor rather than one probe.
+    """
+
+    @pytest.mark.asyncio
+    async def test_drops_events_published_inside_the_block_and_nothing_after(self) -> None:
+        manager = EventManager()
+        queue: asyncio.Queue = asyncio.Queue()
+        manager.initialize_queue(queue)
+
+        with suppress_event_publication():
+            manager.put_event("published while inspecting a throwaway object")
+            await manager.aput_event("the async path is suppressed too")
+        manager.put_event("published after the block")
+
+        assert queue.qsize() == 1
+        assert queue.get_nowait() == "published after the block"
+
+    @pytest.mark.asyncio
+    async def test_a_task_started_inside_the_block_publishes_again_once_it_returns(self) -> None:
+        """A copied context cannot be reset from here, so the block has to revoke itself.
+
+        `asyncio.create_task` snapshots the context at creation, so a task an inspected object's
+        `__init__` starts inherits the suppression. Resetting the ContextVar token on the way out
+        only touches this coroutine's context -- the task would keep the value it copied and drop
+        the editor's events for as long as it lived, which for a stray task is the whole process.
+        """
+        manager = EventManager()
+        queue: asyncio.Queue = asyncio.Queue()
+        manager.initialize_queue(queue)
+        block_exited = asyncio.Event()
+        reached_its_await = asyncio.Event()
+
+        async def publish_after_the_block_returns() -> None:
+            reached_its_await.set()
+            await block_exited.wait()
+            await manager.aput_event("published by a task the block started")
+
+        with suppress_event_publication():
+            stray_task = asyncio.create_task(publish_after_the_block_returns())
+            # Really running inside the block, not merely created there: the context copy this
+            # task carries was taken while suppression was live.
+            await reached_its_await.wait()
+        block_exited.set()
+        await stray_task
+
+        assert queue.get_nowait() == "published by a task the block started"
+
+    @pytest.mark.asyncio
+    async def test_a_nested_block_leaves_the_enclosing_one_suppressing(self) -> None:
+        """Probing is reentrant in principle -- an inspected object may inspect another one."""
+        manager = EventManager()
+        queue: asyncio.Queue = asyncio.Queue()
+        manager.initialize_queue(queue)
+
+        with suppress_event_publication():
+            with suppress_event_publication():
+                manager.put_event("inner")
+            manager.put_event("still inside the outer block")
+
+        assert queue.empty()

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -36,6 +36,7 @@ from griptape_nodes.node_library.library_registry import (
     LibraryRegistry,
     LibraryRegistryError,
     LibrarySchema,
+    NodeDefinition,
     NodeMetadata,
     get_declared_models,
 )
@@ -69,6 +70,7 @@ from griptape_nodes.retained_mode.events.library_events import (
     RegisterLibraryFromFileResultFailure,
     RegisterLibraryFromFileResultSuccess,
     UnloadLibraryFromRegistryRequest,
+    UnloadLibraryFromRegistryResultFailure,
     UnloadLibraryFromRegistryResultSuccess,
 )
 from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
@@ -2491,6 +2493,10 @@ class TestGetPortSummariesForAllLibrariesRequest:
         try:
             with (
                 patch.object(_LibraryManager, "_SCHEMA_PROBE_TIMEOUT_S", 1.0),
+                # Pinned because the real ceiling is derived from the host's CPU count. Two is what
+                # this test needs -- one leaked thread, then a retry -- and leaving it unpatched
+                # would make the retry below depend on the machine the suite runs on.
+                patch.object(_LibraryManager, "_PROBE_THREAD_LEAK_CEILING", 2),
                 patch.object(_LibraryManager, "_construct_probe_node", side_effect=block_one_node_type, autospec=True),
             ):
                 first = await library_manager.on_get_port_summaries_for_all_libraries_request(
@@ -2512,9 +2518,12 @@ class TestGetPortSummariesForAllLibrariesRequest:
 
         # ...and the retry probes that node type alone.
         real_construct = _LibraryManager._construct_probe_node
-        with patch.object(
-            _LibraryManager, "_construct_probe_node", side_effect=real_construct, autospec=True
-        ) as probe_spy:
+        with (
+            patch.object(_LibraryManager, "_PROBE_THREAD_LEAK_CEILING", 2),
+            patch.object(
+                _LibraryManager, "_construct_probe_node", side_effect=real_construct, autospec=True
+            ) as probe_spy,
+        ):
             second = await library_manager.on_get_port_summaries_for_all_libraries_request(
                 GetPortSummariesForAllLibrariesRequest()
             )
@@ -2612,6 +2621,10 @@ class TestGetPortSummariesForAllLibrariesRequest:
             with (
                 patch.object(_LibraryManager, "_SCHEMA_PROBE_TIMEOUT_S", 0.2),
                 patch.object(_LibraryManager, "_PORT_SUMMARY_TIMEOUT_BUDGET", 1),
+                # Pinned because the real ceiling is derived from the host's CPU count. This test
+                # spends one leaked thread on the blocking library and then requires a second
+                # request to still probe the healthy one, which a ceiling of 1 would forbid.
+                patch.object(_LibraryManager, "_PROBE_THREAD_LEAK_CEILING", 2),
                 patch.object(
                     _LibraryManager, "_construct_probe_node", side_effect=block_the_first_library, autospec=True
                 ),
@@ -2666,6 +2679,10 @@ class TestGetPortSummariesForAllLibrariesRequest:
             with (
                 patch.object(_LibraryManager, "_SCHEMA_PROBE_TIMEOUT_S", 0.2),
                 patch.object(_LibraryManager, "_PORT_SUMMARY_TIMEOUT_BUDGET", 1),
+                # Deliberately generous, and pinned rather than left to the host's CPU count: the
+                # library-level allowance must be what stops the second request, not the
+                # engine-wide ceiling, or this passes without testing the bound it names.
+                patch.object(_LibraryManager, "_PROBE_THREAD_LEAK_CEILING", 10),
                 patch.object(
                     _LibraryManager, "_construct_probe_node", side_effect=block_one_node_type, autospec=True
                 ) as probe_spy,
@@ -2753,6 +2770,110 @@ class TestGetPortSummariesForAllLibrariesRequest:
         # immediately.
         for library_name in (blocking_library, self._LIBRARY_NAME):
             assert not library_manager._library_to_port_summary_cache[library_name].pending_node_types()
+
+    @pytest.mark.asyncio
+    async def test_grants_a_retry_the_first_time_a_node_type_is_actually_probed(self, engine: Engine) -> None:
+        """The retry is owed to a node type's first timeout, which is not always its library's first pass.
+
+        A pass that runs out of allowance leaves node types unreached, so the pass that finally
+        reaches one is where its first timeout happens. Keying the retry on "the library's first
+        pass" would deny it to exactly the node types an earlier library's blocking nodes pushed
+        out of reach.
+        """
+        library_manager = engine.library_manager
+        allowance_eating_library = "port-summary-allowance-eating-library"
+        # Registered first, so the handler walks it first and spends the whole request allowance on
+        # it, leaving the library below unreached rather than probed.
+        self._register_probe_library(_PortSummaryProbe, _RaisingProbe, library_name=allowance_eating_library)
+        self._register_probe_library(_PortSummaryDataOnlyProbe)
+        late_node_type = _PortSummaryDataOnlyProbe.__name__
+        release_blocked_probes = threading.Event()
+        real_construct = _LibraryManager._construct_probe_node
+
+        def block_everything(
+            manager: _LibraryManager, library_name: str, node_type: str, *args: Any, **kwargs: Any
+        ) -> Any:
+            release_blocked_probes.wait(timeout=30)
+            return real_construct(manager, library_name, node_type, *args, **kwargs)
+
+        try:
+            with (
+                patch.object(_LibraryManager, "_SCHEMA_PROBE_TIMEOUT_S", 0.2),
+                # Two, so the first library eats the request allowance without any single library
+                # hitting its own allowance, which would drop pending node types instead.
+                patch.object(_LibraryManager, "_PORT_SUMMARY_TIMEOUT_BUDGET", 2),
+                # Generous and pinned: this test leaks three threads, and the engine-wide ceiling
+                # must not be what ends it.
+                patch.object(_LibraryManager, "_PROBE_THREAD_LEAK_CEILING", 10),
+                patch.object(_LibraryManager, "_construct_probe_node", side_effect=block_everything, autospec=True),
+            ):
+                await library_manager.on_get_port_summaries_for_all_libraries_request(
+                    GetPortSummariesForAllLibrariesRequest()
+                )
+                # Never attempted, so nothing is owed a retry yet -- it is owed a first attempt.
+                unreached_entry = library_manager._library_to_port_summary_cache[self._LIBRARY_NAME]
+                assert unreached_entry.unprobed_node_types == frozenset({late_node_type})
+                assert unreached_entry.retry_node_types == frozenset()
+
+                await library_manager.on_get_port_summaries_for_all_libraries_request(
+                    GetPortSummariesForAllLibrariesRequest()
+                )
+        finally:
+            release_blocked_probes.set()
+
+        # Probed for the first time on the second request, timed out, and earned its one retry.
+        probed_entry = library_manager._library_to_port_summary_cache[self._LIBRARY_NAME]
+        assert probed_entry.retry_node_types == frozenset({late_node_type})
+        assert probed_entry.unprobed_node_types == frozenset()
+        assert probed_entry.timeouts_spent == 1
+
+    @pytest.mark.asyncio
+    async def test_stops_probing_when_a_reload_closes_the_gate_mid_pass(self, engine: Engine) -> None:
+        """An in-flight request cannot be cancelled the way the warm pass can, so it has to notice.
+
+        Every entry point waits on the loading gate before starting, so a pass that finds it closed
+        was overtaken by a reload -- and the node classes it would resolve next belong to libraries
+        that reload is unloading, whose modules it would import straight back in.
+        """
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryDataOnlyProbe, _PortSummaryProbe)
+        real_probe = library_manager._probe_node_type_port_summary
+
+        async def close_the_gate_after_the_first_probe(**kwargs: Any) -> Any:
+            outcome = await real_probe(**kwargs)
+            library_manager._close_libraries_loading_gate()
+            return outcome
+
+        with patch.object(
+            library_manager, "_probe_node_type_port_summary", side_effect=close_the_gate_after_the_first_probe
+        ) as probe_spy:
+            result = await library_manager.on_get_port_summaries_for_all_libraries_request(
+                GetPortSummariesForAllLibrariesRequest()
+            )
+
+        assert probe_spy.call_count == 1
+        # What it measured before the reload started is still served...
+        assert isinstance(result, GetPortSummariesForAllLibrariesResultSuccess)
+        assert set(result.library_name_to_port_summaries[self._LIBRARY_NAME]) == {_PortSummaryDataOnlyProbe.__name__}
+        # ...and the node type it stopped short of is owed a real attempt, not recorded as unrankable.
+        entry = library_manager._library_to_port_summary_cache[self._LIBRARY_NAME]
+        assert entry.unprobed_node_types == frozenset({_PortSummaryProbe.__name__})
+        assert entry.timeouts_spent == 0
+
+    def test_unloading_a_name_that_was_never_a_library_records_nothing_against_it(self, engine: Engine) -> None:
+        """The generation counter is keyed by library name and its entries are never removed.
+
+        Invalidating before checking the registry would let repeated requests for names that do not
+        exist grow that map for the life of the process.
+        """
+        library_manager = engine.library_manager
+
+        result = library_manager.unload_library_from_registry_request(
+            UnloadLibraryFromRegistryRequest(library_name="never-registered-library")
+        )
+
+        assert isinstance(result, UnloadLibraryFromRegistryResultFailure)
+        assert library_manager._library_to_port_summaries_generation == {}
 
     @pytest.mark.asyncio
     async def test_caches_a_pass_whose_only_gap_is_a_broken_node_type(self, engine: Engine) -> None:
@@ -2866,7 +2987,9 @@ class TestPortSummaryWarming:
         yield
         LibraryRegistry._clear()
 
-    def _register_probe_library(self, *node_classes: type[BaseNode]) -> None:
+    def _register_probe_library(
+        self, *node_classes: type[BaseNode], node_definitions: list[NodeDefinition] | None = None
+    ) -> None:
         schema = LibrarySchema(
             name=self._LIBRARY_NAME,
             library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
@@ -2878,7 +3001,9 @@ class TestPortSummaryWarming:
                 tags=[],
             ),
             categories=[],
-            nodes=[],
+            # Declared node types, as opposed to the classes registered below: the worker-stub path
+            # reads its metadata from here rather than from a Python class it cannot import.
+            nodes=node_definitions or [],
         )
         library = LibraryRegistry.generate_new_library(library_data=schema)
         for node_class in node_classes:
@@ -2951,13 +3076,15 @@ class TestPortSummaryWarming:
         library_manager = engine.library_manager
         self._register_probe_library(_PortSummaryDataOnlyProbe, _PortSummaryProbe)
         pass_reached_first_probe = asyncio.Event()
-        release_first_probe = asyncio.Event()
-        real_construct = _LibraryManager._construct_probe_node
+        # Deliberately never set: the pass has to come off the loop by being cancelled, so there is
+        # no path out of the probe below other than the cancellation this test is about.
+        never_release_first_probe = asyncio.Event()
 
-        async def block_on_first_probe(*args: Any, **kwargs: Any) -> Any:
+        async def block_on_first_probe(*_args: Any, **_kwargs: Any) -> Any:
             pass_reached_first_probe.set()
-            await release_first_probe.wait()
-            return real_construct(*args, **kwargs)
+            await never_release_first_probe.wait()
+            msg = "The warm pass was expected to be cancelled while suspended on this probe."
+            raise AssertionError(msg)
 
         # Patch the awaited probe rather than the threaded construction: this test is about the
         # coroutine being cancellable at an await point, which is what cancellation acts on.
@@ -2974,6 +3101,64 @@ class TestPortSummaryWarming:
         # Cancelled mid-library, so nothing was written back -- the next request recomputes rather
         # than serving a half-probed library as complete.
         assert self._LIBRARY_NAME not in library_manager._library_to_port_summary_cache
+
+    @pytest.mark.asyncio
+    async def test_a_waiting_request_takes_the_throttle_off_the_warm_pass(self, engine: Engine) -> None:
+        """The throttle is only a good trade while nothing is blocked on the pass.
+
+        Spacing probes out keeps the loop usable, paid for in wall-clock time. Once a request is in
+        flight that time comes out of an artist's drag -- the request either queues on the library's
+        lock or reaches it later in its own walk -- and on a large library the spacing alone would
+        add its node type count times the interval. That is the cost warming exists to remove.
+        """
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryDataOnlyProbe)
+        warm_throttle = _LibraryManager._PORT_SUMMARY_WARM_THROTTLE_S
+        throttle_during_request: list[float] = []
+        real_probe = library_manager._probe_node_type_port_summary
+
+        async def record_the_throttle_a_warm_pass_would_use(**kwargs: Any) -> Any:
+            throttle_during_request.append(library_manager._effective_probe_throttle_s(warm_throttle))
+            return await real_probe(**kwargs)
+
+        with patch.object(
+            library_manager, "_probe_node_type_port_summary", side_effect=record_the_throttle_a_warm_pass_would_use
+        ):
+            await library_manager.on_get_port_summaries_for_all_libraries_request(
+                GetPortSummariesForAllLibrariesRequest()
+            )
+
+        assert throttle_during_request == [0.0]
+        # And back to spacing its probes out the moment nobody is waiting, which is what makes
+        # warming free for everything else on the loop.
+        assert library_manager._effective_probe_throttle_s(warm_throttle) == warm_throttle
+
+    @pytest.mark.asyncio
+    async def test_cancelling_does_not_propagate_a_pass_that_failed_on_its_way_out(self, engine: Engine) -> None:
+        """A reload calls this first, so anything raised here aborts the reload before it starts.
+
+        The warm pass is background work nothing waits on; a reload asks it to stop, not how it went.
+        Letting its failure through would mean a broken pass could block the reload that would have
+        replaced it.
+        """
+        library_manager = engine.library_manager
+
+        async def fail_while_stopping() -> None:
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                msg = "simulated failure while the warm pass was shutting down"
+                raise RuntimeError(msg) from None
+
+        task = asyncio.create_task(fail_while_stopping())
+        library_manager._port_summary_warm_task = task
+        # Let it reach the await, so the cancel below lands in the except above.
+        await asyncio.sleep(0)
+
+        await library_manager._cancel_port_summary_warm()
+
+        assert task.done()
+        assert library_manager._port_summary_warm_task is None
 
     @pytest.mark.asyncio
     async def test_cancelling_is_a_no_op_when_nothing_is_warming(self, engine: Engine) -> None:
@@ -3034,6 +3219,32 @@ class TestPortSummaryWarming:
             await library_manager.reload_libraries_request(ReloadAllLibrariesRequest())
 
         assert restarted == [True]
+
+    @pytest.mark.asyncio
+    async def test_a_cancelled_reload_does_not_restart_warming(
+        self, engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Cancellation means the caller is going away -- a shutdown, or a request being torn down.
+
+        This is the one way out of a reload that must not re-warm. Starting a background pass on the
+        way out would leave it resolving node classes over a half-dismantled registry, with nothing
+        holding a handle to stop it a second time.
+        """
+        library_manager = engine.library_manager
+        restarted: list[bool] = []
+
+        async def cancelled(_request: object) -> None:
+            raise asyncio.CancelledError
+
+        monkeypatch.setattr(library_manager, "_run_reload_libraries", cancelled)
+        monkeypatch.setattr(library_manager, "_start_port_summary_warm", lambda: restarted.append(True))
+
+        from griptape_nodes.retained_mode.events.library_events import ReloadAllLibrariesRequest
+
+        with pytest.raises(asyncio.CancelledError):
+            await library_manager.reload_libraries_request(ReloadAllLibrariesRequest())
+
+        assert restarted == []
 
     def test_does_not_warm_on_a_worker(self, engine: Engine) -> None:
         """A worker already constructs every node type to serialize its schemas."""
@@ -3111,9 +3322,30 @@ class TestPortSummaryWarming:
 
     @pytest.mark.asyncio
     async def test_worker_stub_registration_rewarms(self, engine: Engine) -> None:
-        """Registering worker stubs drops that library's summaries, and a worker can report late."""
+        """Registering worker stubs drops that library's summaries, and a worker can report late.
+
+        Both halves are asserted through the real registration path rather than a patched one,
+        because the restart is only worth anything if something was actually invalidated: a worker
+        reporting after the startup pass finished is otherwise the one case left permanently cold.
+        """
         library_manager = engine.library_manager
         library_manager._is_worker = False
+        stub_node_type = _PortSummaryDataOnlyProbe.__name__
+        # The stub class is built from the worker's reported schema, but its metadata comes from the
+        # library JSON, so the node has to be declared there or registration skips it.
+        self._register_probe_library(
+            node_definitions=[
+                NodeDefinition(
+                    class_name=stub_node_type,
+                    file_path="unused_on_the_orchestrator.py",
+                    metadata=NodeMetadata(
+                        category="test",
+                        description="worker-hosted node type",
+                        display_name=stub_node_type,
+                    ),
+                )
+            ]
+        )
         library_info = _LibraryManager.LibraryInfo(
             lifecycle_state=_LibraryManager.LibraryLifecycleState.WORKER_PENDING,
             fitness=_LibraryManager.LibraryFitness.NOT_EVALUATED,
@@ -3121,24 +3353,25 @@ class TestPortSummaryWarming:
             is_sandbox=False,
             library_name=self._LIBRARY_NAME,
         )
+        generation_before = library_manager._library_to_port_summaries_generation.get(self._LIBRARY_NAME, 0)
         restarted: list[bool] = []
 
         with (
             patch.object(library_manager, "get_library_info_by_library_name", return_value=library_info),
-            patch.object(library_manager, "_register_nodes_from_worker_schemas") as register_stubs,
             patch.object(library_manager, "_start_port_summary_warm", side_effect=lambda: restarted.append(True)),
         ):
             await library_manager._on_library_loaded_notification(
                 LibraryLoadedNotification(
                     library_name=self._LIBRARY_NAME,
                     fitness=_LibraryManager.LibraryFitness.GOOD,
-                    node_schemas=[
-                        WorkerNodeSchema(class_name=_PortSummaryDataOnlyProbe.__name__, parameters=[]),
-                    ],
+                    node_schemas=[WorkerNodeSchema(class_name=stub_node_type, parameters=[])],
                 )
             )
 
-        register_stubs.assert_called_once()
+        # The stub really was registered, so there really was something to invalidate...
+        assert stub_node_type in LibraryRegistry.get_library(self._LIBRARY_NAME).get_registered_nodes()
+        assert library_manager._library_to_port_summaries_generation[self._LIBRARY_NAME] > generation_before
+        # ...and the pass that would otherwise never cover this library was restarted.
         assert restarted == [True]
 
 
@@ -4951,6 +5184,9 @@ class TestLibraryManagerDuplicateEntryHygiene:
 
         with (
             patch.object(library_manager, "_library_file_path_to_info", entries),
+            # The handler checks the registry before touching anything, so the name has to be there
+            # even though the unregister call itself is stubbed out.
+            patch.object(LibraryRegistry, "list_libraries", return_value=["MyLib"]),
             patch.object(LibraryRegistry, "unregister_library"),
             patch.object(library_manager, "_unregister_all_stable_module_aliases_for_library"),
         ):

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -3357,6 +3357,81 @@ class TestPortSummaryWarming:
         assert library_manager._leaked_probe_thread_count() == 0
 
     @pytest.mark.asyncio
+    async def test_a_probe_the_thread_pool_never_picked_up_charges_nothing(
+        self, engine: Engine, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A work item cancelled out of the executor's queue ran no code and holds no thread.
+
+        `asyncio.to_thread` submits to the loop's shared default executor, and a future still waiting
+        in that queue cancels for real: the callable never runs. Reading a clear "finished" signal as
+        "still holding a thread" charged the engine-wide ceiling for these, and a busy executor is
+        exactly when it happens -- so a burst of contention could permanently stop probing on an
+        engine holding no probe threads at all. It also told the operator that a node's `__init__`
+        blocks when that `__init__` had never run.
+        """
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryDataOnlyProbe)
+        library = LibraryRegistry.get_library(self._LIBRARY_NAME)
+
+        async def never_reach_the_worker(_func: Callable[..., Any], *_args: Any) -> Any:
+            # Never calls the callable, which is what a work item cancelled out of the queue looks
+            # like: from the loop's side, identical to a construction that hung.
+            await asyncio.sleep(0.2)
+
+        with (
+            patch.object(_LibraryManager, "_SCHEMA_PROBE_TIMEOUT_S", 0.05),
+            patch.object(asyncio, "to_thread", new=never_reach_the_worker),
+            caplog.at_level(logging.WARNING, logger="griptape_nodes"),
+        ):
+            outcome = await library_manager._probe_node_type_port_summary(
+                library=library,
+                library_name=self._LIBRARY_NAME,
+                node_type=_PortSummaryDataOnlyProbe.__name__,
+            )
+
+        assert outcome.timed_out is True
+        assert outcome.thread_lost is False
+        assert library_manager._leaked_probe_thread_count() == 0
+        # And the warning says what actually happened rather than blaming the node.
+        timeout_warnings = [record.getMessage() for record in caplog.records if "timed out" in record.getMessage()]
+        assert len(timeout_warnings) == 1
+        assert "never started" in timeout_warnings[0]
+        assert "blocking call" not in timeout_warnings[0]
+
+    @pytest.mark.asyncio
+    async def test_cancelling_a_probe_the_thread_pool_never_picked_up_charges_nothing(self, engine: Engine) -> None:
+        """The cancellation path asks the same question as the timeout path and must answer it the same.
+
+        A reload cancels the warm pass, and the probe it lands on may be one the executor never got
+        to. Holding a signal that nothing will ever set would pause probing engine-wide until the
+        process restarted, for a thread that was never taken.
+        """
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryDataOnlyProbe)
+        library = LibraryRegistry.get_library(self._LIBRARY_NAME)
+
+        async def never_reach_the_worker(_func: Callable[..., Any], *_args: Any) -> Any:
+            await asyncio.Event().wait()
+
+        with patch.object(asyncio, "to_thread", new=never_reach_the_worker):
+            probe_task = asyncio.create_task(
+                library_manager._probe_node_type_port_summary(
+                    library=library,
+                    library_name=self._LIBRARY_NAME,
+                    node_type=_PortSummaryDataOnlyProbe.__name__,
+                )
+            )
+            # One cycle puts the probe inside the construction it will be cancelled in: everything
+            # before that await is synchronous.
+            await asyncio.sleep(0)
+            probe_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await probe_task
+
+        assert library_manager._abandoned_probe_signals == []
+        assert library_manager._leaked_probe_thread_count() == 0
+
+    @pytest.mark.asyncio
     async def test_a_warm_handle_left_by_a_previous_event_loop_is_discarded(self, engine: Engine) -> None:
         """The manager outlives any one loop, and a task suspended in a closed one cannot be cancelled.
 
@@ -3486,6 +3561,106 @@ class TestPortSummaryWarming:
             assert library_manager._port_summary_warm_task is not None
         finally:
             await library_manager._cancel_port_summary_warm()
+
+    @pytest.mark.asyncio
+    async def test_nothing_can_start_a_pass_inside_the_reloads_own_cancel(self, engine: Engine) -> None:
+        """Stopping the running pass suspends, and clears the handle first, so that window counts too.
+
+        `_on_library_loaded_notification` runs as its own task and asks for a warm pass whenever a
+        worker reports its node types, so the ask can land anywhere -- including inside the reload's
+        own cancel. A pass started there is not the one the reload cancelled, and the restart at the
+        end finds it in flight and deliberately leaves it, so it runs on across the teardown the
+        cancel was there to protect.
+        """
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryDataOnlyProbe)
+        task_started_inside_the_cancel: list[Any] = []
+
+        async def start_a_pass_while_cancelling() -> None:
+            library_manager._start_port_summary_warm()
+            task_started_inside_the_cancel.append(library_manager._port_summary_warm_task)
+
+        async def reload_nothing(_request: object) -> Any:
+            return MagicMock()
+
+        with (
+            patch.object(library_manager, "_cancel_port_summary_warm", side_effect=start_a_pass_while_cancelling),
+            patch.object(library_manager, "_run_reload_libraries", side_effect=reload_nothing),
+        ):
+            await library_manager.reload_libraries_request(ReloadAllLibrariesRequest())
+
+        assert task_started_inside_the_cancel == [None]
+        # The reload's own restart, on the far side of the rebuild, is the one pass that survives.
+        await library_manager._cancel_port_summary_warm()
+
+    @pytest.mark.asyncio
+    async def test_nothing_can_start_a_pass_inside_a_git_reloads_own_cancel(self, engine: Engine) -> None:
+        """The same window, with less behind it: this path never closes the loading gate.
+
+        A pass that escapes here has only the registry-identity check to stop it, and that cannot fire
+        until the library has actually been swapped -- which is after the unload the pass would
+        otherwise resolve node classes across.
+        """
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryDataOnlyProbe)
+        task_started_inside_the_cancel: list[Any] = []
+
+        async def start_a_pass_while_cancelling() -> None:
+            library_manager._start_port_summary_warm()
+            task_started_inside_the_cancel.append(library_manager._port_summary_warm_task)
+
+        def fail_the_unload(_request: object) -> Any:
+            failure = MagicMock()
+            failure.succeeded.return_value = False
+            return failure
+
+        with (
+            patch.object(library_manager, "_cancel_port_summary_warm", side_effect=start_a_pass_while_cancelling),
+            patch.object(engine, "handle_request", side_effect=fail_the_unload),
+        ):
+            await library_manager._reload_library_after_git_operation(
+                library_name="updated-library",
+                library_file_path="/libs/updated-library/griptape_nodes_library.json",
+                failure_result_class=RegisterLibraryFromFileResultFailure,
+            )
+
+        assert task_started_inside_the_cancel == [None]
+        await library_manager._cancel_port_summary_warm()
+
+    @pytest.mark.asyncio
+    async def test_cancelling_the_caller_that_is_stopping_a_pass_is_not_swallowed(self, engine: Engine) -> None:
+        """A reload cancelled while it waits for the pass to stop must not carry on reloading.
+
+        Awaiting the pass directly makes it the caller's `_fut_waiter`, so cancelling the caller
+        cancels the pass and raises here indistinguishably from the cancellation the caller itself
+        requested. Swallowing that as "the pass has stopped, carry on" is how a shutdown ends up
+        tearing the registry down on behalf of a request that has already gone away.
+        """
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryDataOnlyProbe)
+        pass_reached_first_probe = asyncio.Event()
+
+        async def block_on_first_probe(*_args: Any, **_kwargs: Any) -> Any:
+            pass_reached_first_probe.set()
+            await asyncio.Event().wait()
+
+        with patch.object(library_manager, "_probe_node_type_port_summary", side_effect=block_on_first_probe):
+            library_manager._start_port_summary_warm()
+            warm_task = library_manager._port_summary_warm_task
+            assert warm_task is not None
+            await pass_reached_first_probe.wait()
+
+            stopper = asyncio.create_task(library_manager._cancel_port_summary_warm())
+            # One cycle is enough to reach the wait: everything before it is synchronous.
+            await asyncio.sleep(0)
+            stopper.cancel()
+
+            with pytest.raises(asyncio.CancelledError):
+                await stopper
+
+        # And the pass it was stopping is off the loop either way, cancelled on the way in.
+        await asyncio.wait({warm_task})
+        assert warm_task.cancelled()
 
     @pytest.mark.asyncio
     async def test_a_waiting_request_takes_the_throttle_off_the_warm_pass(self, engine: Engine) -> None:

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -34,6 +34,7 @@ from griptape_nodes.node_library.library_declarations import (
 from griptape_nodes.node_library.library_registry import (
     LibraryMetadata,
     LibraryRegistry,
+    LibraryRegistryError,
     LibrarySchema,
     NodeMetadata,
     get_declared_models,
@@ -2201,11 +2202,27 @@ class TestNodePortSummary:
         assert "list[str]" in summary.output_types
         assert "str" in summary.output_types
 
-    def test_container_element_type_matches_what_a_real_child_declares(self) -> None:
-        """Pin the element type to add_child_parameter, so the two cannot drift apart."""
-        probe = _PortSummaryContainerProbe(name="probe")
-        container = probe.get_parameter_by_name("items")
-        assert isinstance(container, ParameterList)
+    @pytest.mark.parametrize(
+        "declared",
+        [
+            # Fully declared: nothing can drift.
+            {"input_types": ["str"], "output_type": "str"},
+            # Only `type`: both element sides resolve through Parameter's fallback chain.
+            {"type": "int"},
+            # Only one direction declared: the other inherits it.
+            {"input_types": ["ImageArtifact"]},
+            {"output_type": "ImageArtifact"},
+            # Nothing declared: both sides fall through to "str".
+            {},
+        ],
+    )
+    def test_container_element_type_matches_what_a_real_child_declares(self, declared: dict[str, Any]) -> None:
+        """Pin the element type to add_child_parameter across every declaration shape.
+
+        The interesting cases are the ones that resolve through `Parameter`'s fallback chain --
+        those are what a future change to that chain would silently break.
+        """
+        container = ParameterList(name="items", tooltip="Accepts many.", **declared)
 
         child = container.add_child_parameter()
 
@@ -2346,11 +2363,11 @@ class TestGetPortSummariesForAllLibrariesRequest:
         library_manager = engine.library_manager
         self._register_probe_library(_PortSummaryDataOnlyProbe)
 
-        async def invalidate_midway(library_name: str) -> dict[str, NodePortSummary]:
-            summaries = await _LibraryManager._compute_port_summaries_for_library(library_manager, library_name)
+        async def invalidate_midway(library_name: str) -> Any:
+            computation = await _LibraryManager._compute_port_summaries_for_library(library_manager, library_name)
             # Stand in for a reload / sandbox registration landing while the pass was awaiting.
             library_manager._invalidate_port_summaries(library_name)
-            return summaries
+            return computation
 
         with patch.object(
             library_manager, "_compute_port_summaries_for_library", side_effect=invalidate_midway
@@ -2369,6 +2386,99 @@ class TestGetPortSummariesForAllLibrariesRequest:
         assert isinstance(second, GetPortSummariesForAllLibrariesResultSuccess)
         assert compute_spy.call_count == expected_compute_calls
         assert self._LIBRARY_NAME not in library_manager._library_to_port_summaries
+
+    @pytest.mark.asyncio
+    async def test_a_node_type_that_fails_to_resolve_does_not_fail_the_whole_response(
+        self, engine: Engine
+    ) -> None:
+        """Resolution raises more than import errors, and the response covers every library.
+
+        `Library.get_node_class` raises `LibraryRegistryError` for a node type unregistered since
+        the loop read `get_registered_nodes()`, and `NodeTypeEntry.resolve()` raises `RuntimeError`
+        for an entry with neither class nor loader. Neither may take down the other libraries.
+        """
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryDataOnlyProbe, _PortSummaryProbe)
+        library = LibraryRegistry.get_library(self._LIBRARY_NAME)
+        real_get_node_class = library.get_node_class
+
+        def raise_for_one_node_type(node_type: str) -> Any:
+            if node_type == _PortSummaryProbe.__name__:
+                msg = f"Node type '{node_type}' vanished mid-pass."
+                raise LibraryRegistryError(msg)
+            return real_get_node_class(node_type)
+
+        with patch.object(library, "get_node_class", side_effect=raise_for_one_node_type):
+            result = await library_manager.on_get_port_summaries_for_all_libraries_request(
+                GetPortSummariesForAllLibrariesRequest()
+            )
+
+        assert isinstance(result, GetPortSummariesForAllLibrariesResultSuccess)
+        summaries = result.library_name_to_port_summaries[self._LIBRARY_NAME]
+        assert _PortSummaryProbe.__name__ not in summaries
+        assert _PortSummaryDataOnlyProbe.__name__ in summaries
+
+    @pytest.mark.asyncio
+    async def test_does_not_cache_a_pass_that_hit_a_transient_failure(self, engine: Engine) -> None:
+        """A timeout may not recur, so baking its gap into the cache would make it permanent.
+
+        `asyncio.to_thread` shares the loop's default executor, so a saturated pool can time out a
+        probe that would otherwise have succeeded. Nothing invalidates the library afterwards.
+        """
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryDataOnlyProbe)
+
+        async def time_out_once(awaitable: Any, *_args: Any, **_kwargs: Any) -> Any:
+            # Standing in for wait_for, so nothing else will await the to_thread coroutine.
+            awaitable.close()
+            raise TimeoutError
+
+        with patch.object(asyncio, "wait_for", side_effect=time_out_once):
+            first = await library_manager.on_get_port_summaries_for_all_libraries_request(
+                GetPortSummariesForAllLibrariesRequest()
+            )
+
+        assert isinstance(first, GetPortSummariesForAllLibrariesResultSuccess)
+        assert first.library_name_to_port_summaries[self._LIBRARY_NAME] == {}
+        assert self._LIBRARY_NAME not in library_manager._library_to_port_summaries
+
+        # With the pool no longer saturated, the next request must actually probe again.
+        second = await library_manager.on_get_port_summaries_for_all_libraries_request(
+            GetPortSummariesForAllLibrariesRequest()
+        )
+
+        assert isinstance(second, GetPortSummariesForAllLibrariesResultSuccess)
+        assert _PortSummaryDataOnlyProbe.__name__ in second.library_name_to_port_summaries[self._LIBRARY_NAME]
+
+    @pytest.mark.asyncio
+    async def test_caches_a_pass_whose_only_gap_is_a_broken_node_type(self, engine: Engine) -> None:
+        """A node whose __init__ raises will keep raising until the library reloads.
+
+        That gap is stable, so the pass is still worth caching -- otherwise one broken node type in
+        a library would mean re-probing every node type in it on every menu open.
+        """
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryDataOnlyProbe, _RaisingProbe)
+
+        await library_manager.on_get_port_summaries_for_all_libraries_request(GetPortSummariesForAllLibrariesRequest())
+
+        assert self._LIBRARY_NAME in library_manager._library_to_port_summaries
+
+    @pytest.mark.asyncio
+    async def test_result_does_not_alias_the_cache(self, engine: Engine) -> None:
+        """The payload must not hand out the cache's own dict, or a consumer can corrupt it."""
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryDataOnlyProbe)
+
+        result = await library_manager.on_get_port_summaries_for_all_libraries_request(
+            GetPortSummariesForAllLibrariesRequest()
+        )
+
+        assert isinstance(result, GetPortSummariesForAllLibrariesResultSuccess)
+        served = result.library_name_to_port_summaries[self._LIBRARY_NAME]
+        served.pop(_PortSummaryDataOnlyProbe.__name__)
+
+        assert _PortSummaryDataOnlyProbe.__name__ in library_manager._library_to_port_summaries[self._LIBRARY_NAME]
 
     @pytest.mark.asyncio
     async def test_recomputes_after_library_is_unloaded(self, engine: Engine) -> None:

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -2155,8 +2155,8 @@ class TestNodePortSummary:
         summary = NodePortSummary.from_parameters(probe.parameters)
 
         # "str" appears on two parameters but is unioned once; the control type is excluded.
-        assert summary.input_types == ["str", "ImageArtifact", "int"]
-        assert summary.output_types == ["str", "int"]
+        assert summary.input_types == ("str", "ImageArtifact", "int")
+        assert summary.output_types == ("str", "int")
         assert summary.has_control_input is True
         assert summary.has_control_output is True
 
@@ -2174,14 +2174,14 @@ class TestNodePortSummary:
         assert summary.has_control_input is False
         assert summary.has_control_output is False
         # Output-only mode means the parameter is emitted but not accepted.
-        assert summary.input_types == []
-        assert summary.output_types == ["str"]
+        assert summary.input_types == ()
+        assert summary.output_types == ("str",)
 
     def test_returns_empty_summary_for_portless_node(self) -> None:
         summary = NodePortSummary.from_parameters([])
 
-        assert summary.input_types == []
-        assert summary.output_types == []
+        assert summary.input_types == ()
+        assert summary.output_types == ()
         assert summary.has_control_input is False
         assert summary.has_control_output is False
 
@@ -2280,7 +2280,7 @@ class TestGetPortSummariesForAllLibrariesRequest:
         summaries = result.library_name_to_port_summaries[self._LIBRARY_NAME]
         assert set(summaries) == {_PortSummaryProbe.__name__, _PortSummaryDataOnlyProbe.__name__}
         assert summaries[_PortSummaryProbe.__name__].has_control_input is True
-        assert summaries[_PortSummaryDataOnlyProbe.__name__].output_types == ["str"]
+        assert summaries[_PortSummaryDataOnlyProbe.__name__].output_types == ("str",)
 
     @pytest.mark.asyncio
     async def test_omits_node_types_that_cannot_be_probed(self, engine: Engine) -> None:
@@ -2419,36 +2419,65 @@ class TestGetPortSummariesForAllLibrariesRequest:
         assert _PortSummaryDataOnlyProbe.__name__ in summaries
 
     @pytest.mark.asyncio
-    async def test_does_not_cache_a_pass_that_hit_a_transient_failure(self, engine: Engine) -> None:
-        """A timeout may not recur, so baking its gap into the cache would make it permanent.
+    async def test_retries_only_the_timed_out_node_type_and_only_once(self, engine: Engine) -> None:
+        """A timeout may not recur, so it earns one retry -- and exactly one.
 
         `asyncio.to_thread` shares the loop's default executor, so a saturated pool can time out a
-        probe that would otherwise have succeeded. Nothing invalidates the library afterwards.
+        probe that would otherwise have succeeded, which is worth a second look. Looking forever is
+        not: the timed-out thread cannot be cancelled, so re-probing on every request would drain
+        the executor and stall every other threaded operation in the engine.
         """
         library_manager = engine.library_manager
-        self._register_probe_library(_PortSummaryDataOnlyProbe)
+        self._register_probe_library(_PortSummaryDataOnlyProbe, _PortSummaryProbe)
+        timed_out_node_type = _PortSummaryProbe.__name__
+        real_construct = _LibraryManager._construct_probe_node
+        release_blocked_probe = threading.Event()
 
-        async def time_out_once(awaitable: Any, *_args: Any, **_kwargs: Any) -> Any:
-            # Standing in for wait_for, so nothing else will await the to_thread coroutine.
-            awaitable.close()
-            raise TimeoutError
+        def block_one_node_type(manager: _LibraryManager, *args: Any, **kwargs: Any) -> Any:
+            if args[1] == timed_out_node_type:
+                # Stand in for an __init__ that makes a blocking call, exercising the real
+                # wait_for/to_thread timeout rather than a patched one. Released below so the
+                # worker thread does not outlive the test.
+                release_blocked_probe.wait(timeout=30)
+            return real_construct(manager, *args, **kwargs)
 
-        with patch.object(asyncio, "wait_for", side_effect=time_out_once):
-            first = await library_manager.on_get_port_summaries_for_all_libraries_request(
+        try:
+            with (
+                patch.object(_LibraryManager, "_SCHEMA_PROBE_TIMEOUT_S", 1.0),
+                patch.object(_LibraryManager, "_construct_probe_node", side_effect=block_one_node_type, autospec=True),
+            ):
+                first = await library_manager.on_get_port_summaries_for_all_libraries_request(
+                    GetPortSummariesForAllLibrariesRequest()
+                )
+        finally:
+            release_blocked_probe.set()
+
+        # The node types that did probe are cached, so the retry does not re-pay for them...
+        assert isinstance(first, GetPortSummariesForAllLibrariesResultSuccess)
+        assert timed_out_node_type not in first.library_name_to_port_summaries[self._LIBRARY_NAME]
+        assert _PortSummaryDataOnlyProbe.__name__ in library_manager._library_to_port_summaries[self._LIBRARY_NAME]
+        assert library_manager._library_to_port_summary_retries[self._LIBRARY_NAME] == frozenset({timed_out_node_type})
+
+        # ...and the retry probes that node type alone.
+        real_construct = _LibraryManager._construct_probe_node
+        with patch.object(
+            _LibraryManager, "_construct_probe_node", side_effect=real_construct, autospec=True
+        ) as probe_spy:
+            second = await library_manager.on_get_port_summaries_for_all_libraries_request(
+                GetPortSummariesForAllLibrariesRequest()
+            )
+            probed_node_types = [call.args[2] for call in probe_spy.call_args_list]
+
+            # A third request has no retries left to spend, so it probes nothing at all -- this is
+            # what stops a permanently stuck __init__ from leaking a thread per menu open.
+            await library_manager.on_get_port_summaries_for_all_libraries_request(
                 GetPortSummariesForAllLibrariesRequest()
             )
 
-        assert isinstance(first, GetPortSummariesForAllLibrariesResultSuccess)
-        assert first.library_name_to_port_summaries[self._LIBRARY_NAME] == {}
-        assert self._LIBRARY_NAME not in library_manager._library_to_port_summaries
-
-        # With the pool no longer saturated, the next request must actually probe again.
-        second = await library_manager.on_get_port_summaries_for_all_libraries_request(
-            GetPortSummariesForAllLibrariesRequest()
-        )
-
         assert isinstance(second, GetPortSummariesForAllLibrariesResultSuccess)
-        assert _PortSummaryDataOnlyProbe.__name__ in second.library_name_to_port_summaries[self._LIBRARY_NAME]
+        assert probed_node_types == [timed_out_node_type]
+        assert timed_out_node_type in second.library_name_to_port_summaries[self._LIBRARY_NAME]
+        assert self._LIBRARY_NAME not in library_manager._library_to_port_summary_retries
 
     @pytest.mark.asyncio
     async def test_caches_a_pass_whose_only_gap_is_a_broken_node_type(self, engine: Engine) -> None:
@@ -2462,7 +2491,12 @@ class TestGetPortSummariesForAllLibrariesRequest:
 
         await library_manager.on_get_port_summaries_for_all_libraries_request(GetPortSummariesForAllLibrariesRequest())
 
-        assert self._LIBRARY_NAME in library_manager._library_to_port_summaries
+        cached = library_manager._library_to_port_summaries[self._LIBRARY_NAME]
+        # Both halves: the working node type is cached with its ports, and the broken one is cached
+        # as absent rather than earning a retry that would never succeed.
+        assert set(cached) == {_PortSummaryDataOnlyProbe.__name__}
+        assert cached[_PortSummaryDataOnlyProbe.__name__].output_types == ("str",)
+        assert self._LIBRARY_NAME not in library_manager._library_to_port_summary_retries
 
     @pytest.mark.asyncio
     async def test_result_does_not_alias_the_cache(self, engine: Engine) -> None:
@@ -2479,6 +2513,34 @@ class TestGetPortSummariesForAllLibrariesRequest:
         served.pop(_PortSummaryDataOnlyProbe.__name__)
 
         assert _PortSummaryDataOnlyProbe.__name__ in library_manager._library_to_port_summaries[self._LIBRARY_NAME]
+
+    @pytest.mark.asyncio
+    async def test_probing_publishes_no_events(self, engine: Engine) -> None:
+        """A probe node is not on anyone's canvas, so it must not reach the event bus.
+
+        `add_parameter` publishes an AlterElementEvent per parameter, so without suppression the
+        editor would receive element events naming `__node_type_probe__*` nodes that do not exist
+        -- once per parameter per node type per library.
+        """
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryProbe)
+        event_queue: asyncio.Queue = asyncio.Queue()
+        engine.event_manager.initialize_queue(event_queue)
+
+        await library_manager.on_get_port_summaries_for_all_libraries_request(GetPortSummariesForAllLibrariesRequest())
+        # Probes run in worker threads, whose events are enqueued via call_soon_threadsafe, so let
+        # the loop drain any that were scheduled before asserting none were.
+        await asyncio.sleep(0.05)
+
+        assert event_queue.empty()
+
+        # Control: the same construction without suppression does publish, which is what makes the
+        # assertion above mean something.
+        with LibraryRegistry.constructing_node():
+            _PortSummaryProbe(name="unsuppressed")
+        await asyncio.sleep(0.05)
+
+        assert not event_queue.empty()
 
     @pytest.mark.asyncio
     async def test_recomputes_after_library_is_unloaded(self, engine: Engine) -> None:
@@ -2502,6 +2564,89 @@ class TestGetPortSummariesForAllLibrariesRequest:
         assert isinstance(result, GetPortSummariesForAllLibrariesResultSuccess)
         summaries = result.library_name_to_port_summaries[self._LIBRARY_NAME]
         assert set(summaries) == {_PortSummaryProbe.__name__}
+
+
+class TestPortSummaryInvalidationOnLibraryLoad:
+    """The last lifecycle phase must drop cached port summaries for the library it just loaded.
+
+    `LibraryRegistry.generate_new_library` publishes the library before its node types are
+    populated, and the node loading that follows awaits. A port summary request landing in that
+    window measures a library with no node types, and nothing invalidates afterwards, so that
+    empty result would be served for the rest of the process's life.
+    """
+
+    _LIBRARY_NAME = "port-summary-invalidation-library"
+
+    @pytest.fixture(autouse=True)
+    def _clean_registry(self) -> Generator[None, None, None]:
+        LibraryRegistry._clear()
+        yield
+        LibraryRegistry._clear()
+
+    @pytest.mark.parametrize("library_kind", ["regular", "sandbox"])
+    @pytest.mark.asyncio
+    async def test_final_lifecycle_phase_drops_cached_port_summaries(
+        self, engine: Engine, tmp_path: Path, library_kind: str
+    ) -> None:
+        """Both branches of the final phase reach the invalidation, sandbox and regular alike."""
+        is_sandbox = library_kind == "sandbox"
+        library_manager = engine.library_manager
+        library_json = tmp_path / "griptape_nodes_library.json"
+        library_json.write_text("{}")
+        file_path = str(library_json)
+        schema = LibrarySchema(
+            name=self._LIBRARY_NAME,
+            library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+            metadata=LibraryMetadata(
+                author="test",
+                description="port summary invalidation library",
+                library_version="1.0.0",
+                engine_version="1.0.0",
+                tags=[],
+            ),
+            categories=[],
+            nodes=[],
+        )
+
+        # Stand in for a port summary request that landed while the library was published but
+        # empty, which is exactly the state the invalidation exists to discard.
+        library_manager._library_to_port_summaries[self._LIBRARY_NAME] = {}
+        generation_before = library_manager._library_to_port_summaries_generation.get(self._LIBRARY_NAME, 0)
+
+        library_info = _LibraryManager.LibraryInfo(
+            lifecycle_state=_LibraryManager.LibraryLifecycleState.DEPENDENCIES_INSTALLED,
+            fitness=_LibraryManager.LibraryFitness.NOT_EVALUATED,
+            library_path=file_path,
+            is_sandbox=is_sandbox,
+        )
+        library_manager._library_file_path_to_info = {file_path: library_info}
+
+        with (
+            patch.object(
+                library_manager,
+                "load_library_metadata_from_file_request",
+                return_value=LoadLibraryMetadataFromFileResultSuccess(
+                    library_schema=schema,
+                    file_path=file_path,
+                    git_remote=None,
+                    git_ref=None,
+                    enabled=True,
+                    is_registered=False,
+                    result_details=ResultDetails(message="OK", level=20),
+                ),
+            ),
+            patch.object(library_manager, "_add_library_paths_to_sys_path", new=AsyncMock()),
+            patch.object(library_manager, "_attempt_load_nodes_from_library"),
+            patch.object(library_manager, "_attempt_generate_sandbox_library_from_schema", new=AsyncMock()),
+        ):
+            result = await library_manager._progress_library_through_lifecycle(
+                library_info, file_path, RegisterLibraryFromFileRequest(file_path=file_path)
+            )
+
+        assert result is None
+        assert self._LIBRARY_NAME not in library_manager._library_to_port_summaries
+        # The generation bump is what lets a probe pass already in flight discard its stale result.
+        assert library_manager._library_to_port_summaries_generation[self._LIBRARY_NAME] > generation_before
 
 
 class _LifecycleProbe(BaseNode):

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -69,6 +69,7 @@ from griptape_nodes.retained_mode.events.library_events import (
     RegisterLibraryFromFileRequest,
     RegisterLibraryFromFileResultFailure,
     RegisterLibraryFromFileResultSuccess,
+    ReloadAllLibrariesRequest,
     UnloadLibraryFromRegistryRequest,
     UnloadLibraryFromRegistryResultFailure,
     UnloadLibraryFromRegistryResultSuccess,
@@ -2769,7 +2770,11 @@ class TestGetPortSummariesForAllLibrariesRequest:
         finally:
             release_blocked_probe.set()
 
-        assert library_manager._port_summary_threads_leaked == 1
+        # A timeout is charged permanently: the deadline passed with the thread still held, so the
+        # engine has no basis to expect it back and stops counting on it. Released above, and the
+        # gauge still reads it.
+        assert library_manager._port_summary_timed_out_threads == 1
+        assert library_manager._leaked_probe_thread_count() == 1
         # One probe in total, across two requests and two libraries: the one that leaked the thread.
         assert probed_node_types == [_PortSummaryProbe.__name__]
         assert isinstance(second, GetPortSummariesForAllLibrariesResultSuccess)
@@ -3219,17 +3224,24 @@ class TestPortSummaryWarming:
         assert self._LIBRARY_NAME not in library_manager._library_to_port_summary_cache
         # No construction thread was ever started here, so the engine-wide ceiling hears nothing.
         # Cancelling *inside* a construction is the case that charges it.
-        assert library_manager._port_summary_threads_leaked == 0
+        assert library_manager._leaked_probe_thread_count() == 0
 
     @pytest.mark.asyncio
-    async def test_cancelling_mid_construction_charges_the_thread_it_abandons(self, engine: Engine) -> None:
+    async def test_cancelling_mid_construction_charges_the_thread_it_abandons_until_it_returns(
+        self, engine: Engine
+    ) -> None:
         """`asyncio.to_thread` cannot cancel its worker, so stopping the pass abandons one.
 
         The thread goes on running the node's `__init__` with nobody waiting for it -- the same
-        unreclaimable worker a timeout costs -- so it has to come out of the same engine-wide
-        ceiling. Charging only timeouts would let a reload loop abandon a worker per reload while
-        the count meant to bound them stayed at zero, and draining the loop's executor stalls far
-        more than the Add Node menu.
+        unreclaimable worker a timeout costs -- so while it runs it has to come out of the same
+        engine-wide ceiling. Charging only timeouts would let a reload loop abandon a worker per
+        reload while the count meant to bound them stayed at zero, and draining the loop's executor
+        stalls far more than the Add Node menu.
+
+        The charge has to come back off, though, and that is the other half of this test: the usual
+        abandoned construction is a healthy one that finishes moments later, so a count that only
+        ever went up would walk a healthy engine into its ceiling one reload at a time and stop
+        probing for the life of the process.
         """
         library_manager = engine.library_manager
         self._register_probe_library(_PortSummaryDataOnlyProbe)
@@ -3256,13 +3268,20 @@ class TestPortSummaryWarming:
                 await asyncio.to_thread(probe_entered_the_thread.wait, 30)
 
                 await library_manager._cancel_port_summary_warm()
+
+                # Read while the worker is really still blocked in `__init__`, which is the state
+                # the engine-wide ceiling exists to notice.
+                assert library_manager._leaked_probe_thread_count() == 1
+                abandoned_signal = library_manager._abandoned_probe_signals[0]
         finally:
-            # Only so the test does not really strand a worker for the rest of the session; the
-            # charge above is made while the thread is still blocked, which is the real case.
             release_the_thread.set()
 
+        # The worker's own signal, waited on off the loop: nothing else can tell the engine its
+        # thread came back, since cancelling the task left the future looking finished either way.
+        await asyncio.to_thread(abandoned_signal.wait, 30)
+
         assert warm_task.cancelled()
-        assert library_manager._port_summary_threads_leaked == 1
+        assert library_manager._leaked_probe_thread_count() == 0
 
     @pytest.mark.asyncio
     async def test_cancelling_after_the_construction_finished_charges_nothing(self, engine: Engine) -> None:
@@ -3299,7 +3318,43 @@ class TestPortSummaryWarming:
             with pytest.raises(asyncio.CancelledError):
                 await probe_task
 
-        assert library_manager._port_summary_threads_leaked == 0
+        assert library_manager._leaked_probe_thread_count() == 0
+
+    @pytest.mark.asyncio
+    async def test_a_timeout_whose_thread_beat_the_deadline_reports_no_lost_thread(self, engine: Engine) -> None:
+        """The result can be lost to a timeout without the thread being lost with it.
+
+        `asyncio.wait_for` raises once the loop gets back to it, which can be after the construction
+        already returned; the summary is gone either way, but the worker is back in the pool. Only
+        the outcome's `thread_lost` decides whether the engine-wide ceiling hears about it, so a
+        timeout in that window must not spend one of the very few charges the ceiling allows.
+        """
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryDataOnlyProbe)
+        library = LibraryRegistry.get_library(self._LIBRARY_NAME)
+
+        async def construct_then_outlast_the_deadline(func: Callable[..., Any], *args: Any) -> Any:
+            # Same shape as the cancellation case above -- construction completes, including the
+            # signal the worker sets on its way out -- but here the deadline is what fires next.
+            func(*args)
+            await asyncio.sleep(0.2)
+
+        with (
+            patch.object(_LibraryManager, "_SCHEMA_PROBE_TIMEOUT_S", 0.05),
+            patch.object(asyncio, "to_thread", new=construct_then_outlast_the_deadline),
+        ):
+            outcome = await library_manager._probe_node_type_port_summary(
+                library=library,
+                library_name=self._LIBRARY_NAME,
+                node_type=_PortSummaryDataOnlyProbe.__name__,
+            )
+
+        assert outcome.summary is None
+        # Still charged to the library and the pass, which bound how long one request spends.
+        assert outcome.timed_out is True
+        # But not to the ceiling, which bounds threads the engine cannot get back.
+        assert outcome.thread_lost is False
+        assert library_manager._leaked_probe_thread_count() == 0
 
     @pytest.mark.asyncio
     async def test_a_warm_handle_left_by_a_previous_event_loop_is_discarded(self, engine: Engine) -> None:
@@ -3363,6 +3418,74 @@ class TestPortSummaryWarming:
 
         assert isinstance(result, RegisterLibraryFromFileResultFailure)
         assert call_order == ["cancel", "unload", "restart"]
+
+    @pytest.mark.asyncio
+    async def test_a_cancelled_git_reload_does_not_restart_warming(self, engine: Engine) -> None:
+        """The one way out of this path that must not re-warm, for the same reason as a full reload.
+
+        Cancellation means the caller is going away mid-swap. A pass started on the way out resolves
+        node classes over a library this abandoned partway through re-registering, and nothing holds
+        a handle to stop it a second time -- worse here than in a full reload, because this path
+        never closes the loading gate, so the pass has no gate to notice either.
+        """
+        library_manager = engine.library_manager
+        call_order: list[str] = []
+
+        async def record_cancel() -> None:
+            call_order.append("cancel")
+
+        def abandon_the_reload(_request: object) -> Any:
+            call_order.append("unload")
+            raise asyncio.CancelledError
+
+        with (
+            patch.object(library_manager, "_cancel_port_summary_warm", side_effect=record_cancel),
+            patch.object(library_manager, "_start_port_summary_warm", side_effect=lambda: call_order.append("restart")),
+            patch.object(engine, "handle_request", side_effect=abandon_the_reload),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await library_manager._reload_library_after_git_operation(
+                library_name="updated-library",
+                library_file_path="/libs/updated-library/griptape_nodes_library.json",
+                failure_result_class=RegisterLibraryFromFileResultFailure,
+            )
+
+        assert call_order == ["cancel", "unload"]
+        # And the deferral is lifted regardless, or the next reload to finish normally would find
+        # warming still suppressed and never restart it.
+        assert library_manager._port_summary_warm_suppressed == 0
+
+    @pytest.mark.asyncio
+    async def test_a_pass_asked_for_mid_reload_is_deferred_until_the_reload_restarts_it(
+        self, engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Registering a library asks for a warm pass, and a reload registers every library it rebuilds.
+
+        Cancelling once on the way in does not hold if something the reload itself does can start a
+        new pass: that pass resolves node classes over a registry mid-rebuild, and the reload has
+        already spent the one cancellation that was meant to protect the swap. Since the reload
+        restarts warming on its way out, deferring costs nothing.
+        """
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryDataOnlyProbe)
+        task_seen_mid_reload: list[Any] = []
+
+        async def ask_for_a_warm_pass(_request: object) -> Any:
+            # Stands in for the library registrations the real reload performs, each of which asks.
+            library_manager._start_port_summary_warm()
+            task_seen_mid_reload.append(library_manager._port_summary_warm_task)
+            return MagicMock()
+
+        monkeypatch.setattr(library_manager, "_run_reload_libraries", ask_for_a_warm_pass)
+
+        await library_manager.reload_libraries_request(ReloadAllLibrariesRequest())
+
+        assert task_seen_mid_reload == [None]
+        try:
+            # Started exactly once, by the reload, after the rebuild it was waiting on.
+            assert library_manager._port_summary_warm_task is not None
+        finally:
+            await library_manager._cancel_port_summary_warm()
 
     @pytest.mark.asyncio
     async def test_a_waiting_request_takes_the_throttle_off_the_warm_pass(self, engine: Engine) -> None:
@@ -3454,8 +3577,6 @@ class TestPortSummaryWarming:
         monkeypatch.setattr(library_manager, "_start_port_summary_warm", lambda: call_order.append("restart"))
         monkeypatch.setattr(library_manager.engine, "ahandle_request", fail_after_clearing)
 
-        from griptape_nodes.retained_mode.events.library_events import ReloadAllLibrariesRequest
-
         await library_manager.reload_libraries_request(ReloadAllLibrariesRequest())
 
         assert call_order == ["cancel", "clear_state", "restart"]
@@ -3474,8 +3595,6 @@ class TestPortSummaryWarming:
 
         monkeypatch.setattr(library_manager, "_run_reload_libraries", boom)
         monkeypatch.setattr(library_manager, "_start_port_summary_warm", lambda: restarted.append(True))
-
-        from griptape_nodes.retained_mode.events.library_events import ReloadAllLibrariesRequest
 
         with pytest.raises(RuntimeError, match="reload exploded"):
             await library_manager.reload_libraries_request(ReloadAllLibrariesRequest())
@@ -3500,8 +3619,6 @@ class TestPortSummaryWarming:
 
         monkeypatch.setattr(library_manager, "_run_reload_libraries", cancelled)
         monkeypatch.setattr(library_manager, "_start_port_summary_warm", lambda: restarted.append(True))
-
-        from griptape_nodes.retained_mode.events.library_events import ReloadAllLibrariesRequest
 
         with pytest.raises(asyncio.CancelledError):
             await library_manager.reload_libraries_request(ReloadAllLibrariesRequest())
@@ -3636,6 +3753,51 @@ class TestPortSummaryWarming:
 
         # One pass per sweep and then it gives up, rather than sweeping forever.
         assert get_spy.call_count == sweep_cap
+
+    @pytest.mark.asyncio
+    async def test_warming_stops_once_its_timeout_allowance_is_spent_and_says_so(
+        self, engine: Engine, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A spent allowance ends the pass, and the sweep cap's explanation must not be borrowed for it.
+
+        Every library left is still pending, so without noticing the allowance the loop would run
+        each remaining sweep -- taking every cold library's lock to stop at its first node type --
+        and then report that libraries kept changing. An operator reading that would go looking for
+        something invalidating in a loop instead of the node whose `__init__` blocks.
+        """
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryProbe)
+        release_blocked_probe = threading.Event()
+        real_construct = _LibraryManager._construct_probe_node
+        real_get = library_manager._get_port_summaries_for_library
+
+        def block_the_probe(manager: _LibraryManager, *args: Any, **kwargs: Any) -> Any:
+            release_blocked_probe.wait(timeout=30)
+            return real_construct(manager, *args, **kwargs)
+
+        sweep_cap = 3
+        try:
+            with (
+                patch.object(_LibraryManager, "_SCHEMA_PROBE_TIMEOUT_S", 0.2),
+                patch.object(_LibraryManager, "_PORT_SUMMARY_WARM_TIMEOUT_BUDGET", 1),
+                patch.object(_LibraryManager, "_PORT_SUMMARY_WARM_MAX_SWEEPS", sweep_cap),
+                patch.object(_LibraryManager, "_construct_probe_node", side_effect=block_the_probe, autospec=True),
+                patch.object(library_manager, "_get_port_summaries_for_library", wraps=real_get) as get_spy,
+                caplog.at_level(logging.INFO, logger="griptape_nodes"),
+            ):
+                await library_manager._warm_port_summaries()
+        finally:
+            release_blocked_probe.set()
+
+        # One sweep, not the cap: the second one has nothing to spend and stops before taking a lock.
+        assert get_spy.call_count == 1
+        # And it stopped with work outstanding, which is what makes the reason worth reporting.
+        assert library_manager._library_to_port_summary_cache[self._LIBRARY_NAME].pending_node_types()
+        messages = [record.getMessage() for record in caplog.records if record.levelno == logging.INFO]
+        stop_messages = [message for message in messages if "Stopped warming port summaries" in message]
+        assert len(stop_messages) == 1
+        assert "spent its probe timeout allowance" in stop_messages[0]
+        assert "libraries kept changing" not in stop_messages[0]
 
     @pytest.mark.asyncio
     async def test_worker_stub_registration_rewarms(self, engine: Engine) -> None:

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -1858,6 +1858,32 @@ class _RaisingProbe(BaseNode):
         raise RuntimeError(msg)
 
 
+class _HostileElementTypesList(ParameterList):
+    """Container whose element-type accessor raises, as a library's subclass is free to do.
+
+    `get_element_input_types` is an override point nothing calls during construction -- only the
+    port summary pass does -- so a subclass can raise there on a node that builds perfectly well.
+    """
+
+    def get_element_input_types(self) -> list[str]:
+        msg = "simulated failure computing element types"
+        raise RuntimeError(msg)
+
+
+class _HostileTypesProbe(BaseNode):
+    """Node type that constructs fine but cannot be summarized."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name=name, metadata=metadata)
+        self.add_parameter(
+            _HostileElementTypesList(
+                name="hostile",
+                input_types=["str"],
+                tooltip="Container whose element types cannot be read.",
+            )
+        )
+
+
 class _CatalogProbe(BaseNode):
     """Probe whose __init__ sources a parameter default from the library model_catalog.
 
@@ -2433,13 +2459,15 @@ class TestGetPortSummariesForAllLibrariesRequest:
         real_construct = _LibraryManager._construct_probe_node
         release_blocked_probe = threading.Event()
 
-        def block_one_node_type(manager: _LibraryManager, *args: Any, **kwargs: Any) -> Any:
-            if args[1] == timed_out_node_type:
+        def block_one_node_type(
+            manager: _LibraryManager, library_name: str, node_type: str, *args: Any, **kwargs: Any
+        ) -> Any:
+            if node_type == timed_out_node_type:
                 # Stand in for an __init__ that makes a blocking call, exercising the real
                 # wait_for/to_thread timeout rather than a patched one. Released below so the
                 # worker thread does not outlive the test.
                 release_blocked_probe.wait(timeout=30)
-            return real_construct(manager, *args, **kwargs)
+            return real_construct(manager, library_name, node_type, *args, **kwargs)
 
         try:
             with (
@@ -2466,18 +2494,123 @@ class TestGetPortSummariesForAllLibrariesRequest:
             second = await library_manager.on_get_port_summaries_for_all_libraries_request(
                 GetPortSummariesForAllLibrariesRequest()
             )
-            probed_node_types = [call.args[2] for call in probe_spy.call_args_list]
 
             # A third request has no retries left to spend, so it probes nothing at all -- this is
-            # what stops a permanently stuck __init__ from leaking a thread per menu open.
+            # what stops a permanently stuck __init__ from leaking a thread per menu open. Both
+            # requests share one spy, so the single recorded call below covers that claim too.
             await library_manager.on_get_port_summaries_for_all_libraries_request(
                 GetPortSummariesForAllLibrariesRequest()
             )
+            # autospec passes self positionally: (manager, library_name, node_type, node_class, ...).
+            probed_node_types = [call.args[2] for call in probe_spy.call_args_list]
 
         assert isinstance(second, GetPortSummariesForAllLibrariesResultSuccess)
         assert probed_node_types == [timed_out_node_type]
         assert timed_out_node_type in second.library_name_to_port_summaries[self._LIBRARY_NAME]
         assert self._LIBRARY_NAME not in library_manager._library_to_port_summary_retries
+
+    @pytest.mark.asyncio
+    async def test_contains_a_node_type_whose_element_types_cannot_be_read(self, engine: Engine) -> None:
+        """Summarizing a container's element types runs library code construction never reached.
+
+        `get_element_input_types` exists for this pass alone, so a subclass that raises there gets
+        past construction and lands in the summarize step. One library's Parameter subclass must not
+        take down the summaries for every library in the response -- the handler answers for all of
+        them at once.
+        """
+        library_manager = engine.library_manager
+        self._register_probe_library(_HostileTypesProbe, _PortSummaryDataOnlyProbe)
+
+        result = await library_manager.on_get_port_summaries_for_all_libraries_request(
+            GetPortSummariesForAllLibrariesRequest()
+        )
+
+        assert isinstance(result, GetPortSummariesForAllLibrariesResultSuccess)
+        summaries = result.library_name_to_port_summaries[self._LIBRARY_NAME]
+        # The unsummarizable node type is left out; the healthy one behind it is not collateral.
+        assert set(summaries) == {_PortSummaryDataOnlyProbe.__name__}
+        # Its getter will raise again next request, so it is a stable gap rather than a retry.
+        assert self._LIBRARY_NAME not in library_manager._library_to_port_summary_retries
+
+    @pytest.mark.asyncio
+    async def test_contains_a_node_type_whose_library_metadata_cannot_be_read(
+        self, engine: Engine
+    ) -> None:
+        """Building the probe's metadata reads and serializes the library author's node metadata.
+
+        A malformed entry raises there, outside the node's own __init__, and must be contained to
+        the one node type for the same reason as an unreadable parameter.
+        """
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryProbe, _PortSummaryDataOnlyProbe)
+        broken_node_type = _PortSummaryProbe.__name__
+        real_metadata = _LibraryManager._library_node_metadata_for_probe
+
+        def fail_for_one_node_type(manager: _LibraryManager, *, library: Any, node_type: str) -> Any:
+            if node_type == broken_node_type:
+                msg = "simulated malformed library node metadata"
+                raise RuntimeError(msg)
+            return real_metadata(manager, library=library, node_type=node_type)
+
+        with patch.object(
+            _LibraryManager, "_library_node_metadata_for_probe", side_effect=fail_for_one_node_type, autospec=True
+        ):
+            result = await library_manager.on_get_port_summaries_for_all_libraries_request(
+                GetPortSummariesForAllLibrariesRequest()
+            )
+
+        assert isinstance(result, GetPortSummariesForAllLibrariesResultSuccess)
+        assert set(result.library_name_to_port_summaries[self._LIBRARY_NAME]) == {_PortSummaryDataOnlyProbe.__name__}
+        assert self._LIBRARY_NAME not in library_manager._library_to_port_summary_retries
+
+    @pytest.mark.asyncio
+    async def test_stops_probing_a_library_once_its_timeout_budget_is_spent(
+        self, engine: Engine
+    ) -> None:
+        """Each timeout costs a thread that cannot be reclaimed, so one pass cannot keep spending.
+
+        A library of blocking nodes would otherwise drain the loop's default executor in a single
+        request and stall every other threaded operation in the engine. The abandoned node types get
+        no retry either -- a retry would walk straight back into the timeouts that stopped the pass.
+        """
+        library_manager = engine.library_manager
+        # The blocking node type is registered first so the pass aborts while a healthy one is still
+        # unprobed, which is the collateral this bound accepts.
+        self._register_probe_library(_PortSummaryProbe, _PortSummaryDataOnlyProbe)
+        timed_out_node_type = _PortSummaryProbe.__name__
+        abandoned_node_type = _PortSummaryDataOnlyProbe.__name__
+        real_construct = _LibraryManager._construct_probe_node
+        release_blocked_probe = threading.Event()
+
+        def block_one_node_type(
+            manager: _LibraryManager, library_name: str, node_type: str, *args: Any, **kwargs: Any
+        ) -> Any:
+            if node_type == timed_out_node_type:
+                release_blocked_probe.wait(timeout=30)
+            return real_construct(manager, library_name, node_type, *args, **kwargs)
+
+        try:
+            with (
+                patch.object(_LibraryManager, "_SCHEMA_PROBE_TIMEOUT_S", 0.2),
+                patch.object(_LibraryManager, "_PORT_SUMMARY_TIMEOUT_BUDGET", 1),
+                patch.object(
+                    _LibraryManager, "_construct_probe_node", side_effect=block_one_node_type, autospec=True
+                ) as probe_spy,
+            ):
+                result = await library_manager.on_get_port_summaries_for_all_libraries_request(
+                    GetPortSummariesForAllLibrariesRequest()
+                )
+                probed_node_types = [call.args[2] for call in probe_spy.call_args_list]
+        finally:
+            release_blocked_probe.set()
+
+        assert isinstance(result, GetPortSummariesForAllLibrariesResultSuccess)
+        # The healthy node type after the abort is never even attempted...
+        assert probed_node_types == [timed_out_node_type]
+        assert result.library_name_to_port_summaries[self._LIBRARY_NAME] == {}
+        # ...and only the node type that actually timed out is owed a retry.
+        assert library_manager._library_to_port_summary_retries[self._LIBRARY_NAME] == frozenset({timed_out_node_type})
+        assert abandoned_node_type not in library_manager._library_to_port_summaries[self._LIBRARY_NAME]
 
     @pytest.mark.asyncio
     async def test_caches_a_pass_whose_only_gap_is_a_broken_node_type(self, engine: Engine) -> None:
@@ -2534,10 +2667,14 @@ class TestGetPortSummariesForAllLibrariesRequest:
 
         assert event_queue.empty()
 
-        # Control: the same construction without suppression does publish, which is what makes the
-        # assertion above mean something.
-        with LibraryRegistry.constructing_node():
-            _PortSummaryProbe(name="unsuppressed")
+        # Control: the same construction in a worker thread, differing only in that it does not
+        # suppress, does publish. That is what makes the assertion above mean something -- it pins
+        # the silence on the ContextVar rather than on the thread boundary swallowing events.
+        def construct_without_suppression() -> None:
+            with LibraryRegistry.constructing_node():
+                _PortSummaryProbe(name="unsuppressed")
+
+        await asyncio.to_thread(construct_without_suppression)
         await asyncio.sleep(0.05)
 
         assert not event_queue.empty()

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -12,7 +12,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.core_types import (
+    ControlParameterInput,
+    ControlParameterOutput,
+    Parameter,
+    ParameterMode,
+)
 from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.node_library.library_declarations import (
     KeySupport,
@@ -41,6 +46,8 @@ from griptape_nodes.retained_mode.events.library_events import (
     GetAllInfoForAllLibrariesResultFailure,
     GetAllInfoForAllLibrariesResultSuccess,
     GetAllInfoForLibraryRequest,
+    GetPortSummariesForAllLibrariesRequest,
+    GetPortSummariesForAllLibrariesResultSuccess,
     InstallLibraryDependenciesRequest,
     InstallLibraryDependenciesResultFailure,
     InstallLibraryDependenciesResultSuccess,
@@ -49,6 +56,7 @@ from griptape_nodes.retained_mode.events.library_events import (
     LoadLibrariesRequest,
     LoadLibrariesResultSuccess,
     LoadLibraryMetadataFromFileResultSuccess,
+    NodePortSummary,
     RegisterLibraryFromFileRequest,
     RegisterLibraryFromFileResultFailure,
     RegisterLibraryFromFileResultSuccess,
@@ -1940,7 +1948,7 @@ class TestDescribeNodeTypeRequest:
         # Probe node must not leak into the ObjectManager.
         assert (
             engine.object_manager.attempt_get_object_by_name(
-                f"__describe_node_type_probe__{_DescribeNodeTypeProbe.__name__}"
+                f"{_LibraryManager.PROBE_NODE_NAME_PREFIX}{_DescribeNodeTypeProbe.__name__}"
             )
             is None
         )
@@ -2007,6 +2015,207 @@ class TestDescribeNodeTypeRequest:
         assert isinstance(result.result_details, ResultDetails)
         assert any(detail.level == logging.WARNING for detail in result.result_details.result_details)
         assert "simulated I/O failure" in str(result.result_details)
+
+
+class _PortSummaryProbe(BaseNode):
+    """Node whose ports cover every case NodePortSummary has to sort out."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name=name, metadata=metadata)
+
+        # Control ports belong to the booleans, never to the data type unions.
+        self.add_parameter(ControlParameterInput())
+        self.add_parameter(ControlParameterOutput())
+
+        # Multi-type input; "str" also appears below, so it must not be duplicated.
+        self.add_parameter(
+            Parameter(
+                name="subject",
+                input_types=["str", "ImageArtifact"],
+                output_type="str",
+                tooltip="Input and output.",
+            )
+        )
+
+        # No input_types/output_type declared -- both unions fall back to `type`.
+        self.add_parameter(Parameter(name="count", type="int", tooltip="Falls back to type."))
+
+        # Property-only: connectable in neither direction, so it appears in neither union.
+        self.add_parameter(
+            Parameter(
+                name="seed",
+                type="float",
+                tooltip="Property only.",
+                allowed_modes={ParameterMode.PROPERTY},
+            )
+        )
+
+        # Private parameters are engine bookkeeping, never offered as ports.
+        self.add_parameter(Parameter(name="internal_state", type="dict", tooltip="Private.", private=True))
+
+
+class _PortSummaryDataOnlyProbe(BaseNode):
+    """Node with data ports but no control ports, e.g. a pure value provider."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name=name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="value",
+                type="str",
+                tooltip="Emitted value.",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+
+class TestNodePortSummary:
+    """Exercise NodePortSummary.from_parameters, the derivation the ranking depends on."""
+
+    def test_derives_unions_and_control_flags(self) -> None:
+        probe = _PortSummaryProbe(name="probe")
+
+        summary = NodePortSummary.from_parameters(probe.parameters)
+
+        # "str" appears on two parameters but is unioned once; the control type is excluded.
+        assert summary.input_types == ["str", "ImageArtifact", "int"]
+        assert summary.output_types == ["str", "int"]
+        assert summary.has_control_input is True
+        assert summary.has_control_output is True
+
+        # The property-only and private parameters contribute to neither union.
+        assert "float" not in summary.input_types
+        assert "float" not in summary.output_types
+        assert "dict" not in summary.input_types
+        assert "dict" not in summary.output_types
+
+    def test_reports_no_control_when_node_declares_none(self) -> None:
+        probe = _PortSummaryDataOnlyProbe(name="probe")
+
+        summary = NodePortSummary.from_parameters(probe.parameters)
+
+        assert summary.has_control_input is False
+        assert summary.has_control_output is False
+        # Output-only mode means the parameter is emitted but not accepted.
+        assert summary.input_types == []
+        assert summary.output_types == ["str"]
+
+    def test_returns_empty_summary_for_portless_node(self) -> None:
+        summary = NodePortSummary.from_parameters([])
+
+        assert summary.input_types == []
+        assert summary.output_types == []
+        assert summary.has_control_input is False
+        assert summary.has_control_output is False
+
+
+class TestGetPortSummariesForAllLibrariesRequest:
+    """Exercise LibraryManager.on_get_port_summaries_for_all_libraries_request."""
+
+    _LIBRARY_NAME = "port-summary-test-library"
+
+    @pytest.fixture(autouse=True)
+    def _clean_registry(self) -> Generator[None, None, None]:
+        """LibraryRegistry holds class-level state that survives the singleton reset fixture."""
+        LibraryRegistry._clear()
+        yield
+        LibraryRegistry._clear()
+
+    def _register_probe_library(self, *node_classes: type[BaseNode]) -> None:
+        schema = LibrarySchema(
+            name=self._LIBRARY_NAME,
+            library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+            metadata=LibraryMetadata(
+                author="test",
+                description="port summary library",
+                library_version="1.0.0",
+                engine_version="1.0.0",
+                tags=[],
+            ),
+            categories=[],
+            nodes=[],
+        )
+        library = LibraryRegistry.generate_new_library(library_data=schema)
+        for node_class in node_classes:
+            library.register_new_node_type(
+                node_class,
+                NodeMetadata(
+                    category="test",
+                    description=f"{node_class.__name__} used by port summary tests",
+                    display_name=node_class.__name__,
+                ),
+            )
+
+    @pytest.mark.asyncio
+    async def test_returns_a_summary_for_every_node_type(self, engine: Engine) -> None:
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryProbe, _PortSummaryDataOnlyProbe)
+
+        result = await library_manager.on_get_port_summaries_for_all_libraries_request(
+            GetPortSummariesForAllLibrariesRequest()
+        )
+
+        assert isinstance(result, GetPortSummariesForAllLibrariesResultSuccess)
+        summaries = result.library_name_to_port_summaries[self._LIBRARY_NAME]
+        assert set(summaries) == {_PortSummaryProbe.__name__, _PortSummaryDataOnlyProbe.__name__}
+        assert summaries[_PortSummaryProbe.__name__].has_control_input is True
+        assert summaries[_PortSummaryDataOnlyProbe.__name__].output_types == ["str"]
+
+    @pytest.mark.asyncio
+    async def test_omits_node_types_that_cannot_be_probed(self, engine: Engine) -> None:
+        """A node whose __init__ raises is left out rather than reported as having no ports."""
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryDataOnlyProbe, _RaisingProbe)
+
+        result = await library_manager.on_get_port_summaries_for_all_libraries_request(
+            GetPortSummariesForAllLibrariesRequest()
+        )
+
+        assert isinstance(result, GetPortSummariesForAllLibrariesResultSuccess)
+        summaries = result.library_name_to_port_summaries[self._LIBRARY_NAME]
+        assert _RaisingProbe.__name__ not in summaries
+        assert _PortSummaryDataOnlyProbe.__name__ in summaries
+
+    @pytest.mark.asyncio
+    async def test_probes_each_node_type_once_across_requests(self, engine: Engine) -> None:
+        """Probing is the expensive part, so a second request must be served from the cache."""
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryDataOnlyProbe)
+
+        with patch.object(
+            _LibraryManager, "_probe_node_type", side_effect=_LibraryManager._probe_node_type, autospec=True
+        ) as probe_spy:
+            await library_manager.on_get_port_summaries_for_all_libraries_request(
+                GetPortSummariesForAllLibrariesRequest()
+            )
+            await library_manager.on_get_port_summaries_for_all_libraries_request(
+                GetPortSummariesForAllLibrariesRequest()
+            )
+
+        assert probe_spy.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_recomputes_after_library_is_unloaded(self, engine: Engine) -> None:
+        """Unloading is the choke point every reload goes through, so it must drop the cache."""
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryDataOnlyProbe)
+
+        await library_manager.on_get_port_summaries_for_all_libraries_request(GetPortSummariesForAllLibrariesRequest())
+        library_manager.unload_library_from_registry_request(
+            UnloadLibraryFromRegistryRequest(library_name=self._LIBRARY_NAME)
+        )
+
+        assert self._LIBRARY_NAME not in library_manager._library_to_port_summaries
+
+        # Re-registering with a different node type must be reflected, not served stale.
+        self._register_probe_library(_PortSummaryProbe)
+        result = await library_manager.on_get_port_summaries_for_all_libraries_request(
+            GetPortSummariesForAllLibrariesRequest()
+        )
+
+        assert isinstance(result, GetPortSummariesForAllLibrariesResultSuccess)
+        summaries = result.library_name_to_port_summaries[self._LIBRARY_NAME]
+        assert set(summaries) == {_PortSummaryProbe.__name__}
 
 
 class _LifecycleProbe(BaseNode):

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -68,7 +68,11 @@ from griptape_nodes.retained_mode.events.library_events import (
 )
 from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
 from griptape_nodes.retained_mode.managers.library_manager import LibraryManager as _LibraryManager
-from griptape_nodes.retained_mode.managers.library_manager import LibraryVenvInitResult
+from griptape_nodes.retained_mode.managers.library_manager import (
+    LibraryVenvInitResult,
+    PortSummaryCacheEntry,
+    ProbeTimeoutAllowance,
+)
 from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY
 from griptape_nodes.retained_mode.managers.settings import (
     LIBRARIES_TO_DOWNLOAD_KEY,
@@ -1695,7 +1699,7 @@ class TestRegisterSandboxNodeFromSourceRequest:
         assert isinstance(first, RegisterSandboxNodeFromSourceResultSuccess)
 
         # Pretend a port summary request already ran and cached a result for this library.
-        library_manager._library_to_port_summaries[self._LIBRARY_NAME] = {}
+        library_manager._library_to_port_summary_cache[self._LIBRARY_NAME] = _empty_port_summary_cache_entry()
 
         # A file whose first class is new and whose second is already registered. With
         # replace_if_exists=False the loop registers the first, then bails on the second.
@@ -1718,7 +1722,7 @@ class TestRegisterSandboxNodeFromSourceRequest:
         assert isinstance(second, RegisterSandboxNodeFromSourceResultFailure)
         # The library really was mutated before the bail-out, so the cache must be gone.
         assert LibraryRegistry.get_library(self._LIBRARY_NAME).has_node_type("SandboxBrandNew")
-        assert self._LIBRARY_NAME not in library_manager._library_to_port_summaries
+        assert self._LIBRARY_NAME not in library_manager._library_to_port_summary_cache
 
     def test_fails_when_sandbox_directory_is_not_configured(
         self,
@@ -1847,6 +1851,13 @@ class _DescribeNodeTypeProbe(BaseNode):
             allowed_modes={ParameterMode.PROPERTY},
         )
         self.add_parameter(temperature)
+
+
+def _empty_port_summary_cache_entry() -> PortSummaryCacheEntry:
+    """A complete-but-empty cache entry, standing in for a port summary request that already ran."""
+    return PortSummaryCacheEntry(
+        summaries={}, retry_node_types=frozenset(), unprobed_node_types=frozenset(), timeouts_spent=0
+    )
 
 
 class _RaisingProbe(BaseNode):
@@ -2268,9 +2279,9 @@ class TestGetPortSummariesForAllLibrariesRequest:
         yield
         LibraryRegistry._clear()
 
-    def _register_probe_library(self, *node_classes: type[BaseNode]) -> None:
+    def _register_probe_library(self, *node_classes: type[BaseNode], library_name: str | None = None) -> None:
         schema = LibrarySchema(
-            name=self._LIBRARY_NAME,
+            name=library_name or self._LIBRARY_NAME,
             library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
             metadata=LibraryMetadata(
                 author="test",
@@ -2389,8 +2400,10 @@ class TestGetPortSummariesForAllLibrariesRequest:
         library_manager = engine.library_manager
         self._register_probe_library(_PortSummaryDataOnlyProbe)
 
-        async def invalidate_midway(library_name: str) -> Any:
-            computation = await _LibraryManager._compute_port_summaries_for_library(library_manager, library_name)
+        async def invalidate_midway(library_name: str, allowance: ProbeTimeoutAllowance) -> Any:
+            computation = await _LibraryManager._compute_port_summaries_for_library(
+                library_manager, library_name, allowance
+            )
             # Stand in for a reload / sandbox registration landing while the pass was awaiting.
             library_manager._invalidate_port_summaries(library_name)
             return computation
@@ -2411,7 +2424,7 @@ class TestGetPortSummariesForAllLibrariesRequest:
         assert isinstance(first, GetPortSummariesForAllLibrariesResultSuccess)
         assert isinstance(second, GetPortSummariesForAllLibrariesResultSuccess)
         assert compute_spy.call_count == expected_compute_calls
-        assert self._LIBRARY_NAME not in library_manager._library_to_port_summaries
+        assert self._LIBRARY_NAME not in library_manager._library_to_port_summary_cache
 
     @pytest.mark.asyncio
     async def test_a_node_type_that_fails_to_resolve_does_not_fail_the_whole_response(
@@ -2483,8 +2496,13 @@ class TestGetPortSummariesForAllLibrariesRequest:
         # The node types that did probe are cached, so the retry does not re-pay for them...
         assert isinstance(first, GetPortSummariesForAllLibrariesResultSuccess)
         assert timed_out_node_type not in first.library_name_to_port_summaries[self._LIBRARY_NAME]
-        assert _PortSummaryDataOnlyProbe.__name__ in library_manager._library_to_port_summaries[self._LIBRARY_NAME]
-        assert library_manager._library_to_port_summary_retries[self._LIBRARY_NAME] == frozenset({timed_out_node_type})
+        assert (
+            _PortSummaryDataOnlyProbe.__name__
+            in library_manager._library_to_port_summary_cache[self._LIBRARY_NAME].summaries
+        )
+        assert library_manager._library_to_port_summary_cache[self._LIBRARY_NAME].retry_node_types == frozenset(
+            {timed_out_node_type}
+        )
 
         # ...and the retry probes that node type alone.
         real_construct = _LibraryManager._construct_probe_node
@@ -2507,7 +2525,7 @@ class TestGetPortSummariesForAllLibrariesRequest:
         assert isinstance(second, GetPortSummariesForAllLibrariesResultSuccess)
         assert probed_node_types == [timed_out_node_type]
         assert timed_out_node_type in second.library_name_to_port_summaries[self._LIBRARY_NAME]
-        assert self._LIBRARY_NAME not in library_manager._library_to_port_summary_retries
+        assert not library_manager._library_to_port_summary_cache[self._LIBRARY_NAME].pending_node_types()
 
     @pytest.mark.asyncio
     async def test_contains_a_node_type_whose_element_types_cannot_be_read(self, engine: Engine) -> None:
@@ -2530,7 +2548,7 @@ class TestGetPortSummariesForAllLibrariesRequest:
         # The unsummarizable node type is left out; the healthy one behind it is not collateral.
         assert set(summaries) == {_PortSummaryDataOnlyProbe.__name__}
         # Its getter will raise again next request, so it is a stable gap rather than a retry.
-        assert self._LIBRARY_NAME not in library_manager._library_to_port_summary_retries
+        assert not library_manager._library_to_port_summary_cache[self._LIBRARY_NAME].pending_node_types()
 
     @pytest.mark.asyncio
     async def test_contains_a_node_type_whose_library_metadata_cannot_be_read(
@@ -2561,26 +2579,81 @@ class TestGetPortSummariesForAllLibrariesRequest:
 
         assert isinstance(result, GetPortSummariesForAllLibrariesResultSuccess)
         assert set(result.library_name_to_port_summaries[self._LIBRARY_NAME]) == {_PortSummaryDataOnlyProbe.__name__}
-        assert self._LIBRARY_NAME not in library_manager._library_to_port_summary_retries
+        assert not library_manager._library_to_port_summary_cache[self._LIBRARY_NAME].pending_node_types()
 
     @pytest.mark.asyncio
-    async def test_stops_probing_a_library_once_its_timeout_budget_is_spent(
+    async def test_resumes_node_types_a_request_ran_out_of_allowance_before_reaching(
         self, engine: Engine
     ) -> None:
-        """Each timeout costs a thread that cannot be reclaimed, so one pass cannot keep spending.
+        """One library's blocking node must not cost another library its ranking for good.
 
-        A library of blocking nodes would otherwise drain the loop's default executor in a single
-        request and stall every other threaded operation in the engine. The abandoned node types get
-        no retry either -- a retry would walk straight back into the timeouts that stopped the pass.
+        The timeout allowance is spent per request across every library, so a library reached after
+        it runs out is never attempted at all. Nothing is known about those node types, so they stay
+        pending and the next request -- with a fresh allowance -- probes them.
         """
         library_manager = engine.library_manager
-        # The blocking node type is registered first so the pass aborts while a healthy one is still
-        # unprobed, which is the collateral this bound accepts.
+        blocking_library = "port-summary-blocking-library"
+        # Registration order decides which library the handler walks first.
+        self._register_probe_library(_PortSummaryProbe, library_name=blocking_library)
+        self._register_probe_library(_PortSummaryDataOnlyProbe)
+        release_blocked_probe = threading.Event()
+        real_construct = _LibraryManager._construct_probe_node
+
+        def block_the_first_library(
+            manager: _LibraryManager, library_name: str, node_type: str, *args: Any, **kwargs: Any
+        ) -> Any:
+            if library_name == blocking_library:
+                release_blocked_probe.wait(timeout=30)
+            return real_construct(manager, library_name, node_type, *args, **kwargs)
+
+        try:
+            with (
+                patch.object(_LibraryManager, "_SCHEMA_PROBE_TIMEOUT_S", 0.2),
+                patch.object(_LibraryManager, "_PORT_SUMMARY_TIMEOUT_BUDGET", 1),
+                patch.object(
+                    _LibraryManager, "_construct_probe_node", side_effect=block_the_first_library, autospec=True
+                ),
+            ):
+                first = await library_manager.on_get_port_summaries_for_all_libraries_request(
+                    GetPortSummariesForAllLibrariesRequest()
+                )
+                # The healthy library was never reached, so it is owed a real attempt rather than
+                # being recorded as unrankable.
+                assert isinstance(first, GetPortSummariesForAllLibrariesResultSuccess)
+                assert first.library_name_to_port_summaries[self._LIBRARY_NAME] == {}
+                healthy_entry = library_manager._library_to_port_summary_cache[self._LIBRARY_NAME]
+                assert healthy_entry.unprobed_node_types == frozenset({_PortSummaryDataOnlyProbe.__name__})
+                assert healthy_entry.timeouts_spent == 0
+
+                second = await library_manager.on_get_port_summaries_for_all_libraries_request(
+                    GetPortSummariesForAllLibrariesRequest()
+                )
+        finally:
+            release_blocked_probe.set()
+
+        assert isinstance(second, GetPortSummariesForAllLibrariesResultSuccess)
+        assert set(second.library_name_to_port_summaries[self._LIBRARY_NAME]) == {_PortSummaryDataOnlyProbe.__name__}
+        assert not library_manager._library_to_port_summary_cache[self._LIBRARY_NAME].pending_node_types()
+
+    @pytest.mark.asyncio
+    async def test_gives_up_on_a_library_that_has_spent_its_lifetime_timeout_allowance(
+        self, engine: Engine
+    ) -> None:
+        """Carrying unreached node types forever would let a stuck library leak a thread per request.
+
+        Each timeout permanently holds a worker of the loop's default executor, so once a library has
+        cost its whole allowance, everything still pending is dropped until it reloads -- including
+        node types never attempted, which cannot be told apart from the blocking ones without paying
+        again. That is the trade this bound makes, and it is why the allowance is not per request
+        alone.
+        """
+        library_manager = engine.library_manager
+        # The blocking node type is registered first so a healthy one is still unreached when the
+        # library's allowance runs out.
         self._register_probe_library(_PortSummaryProbe, _PortSummaryDataOnlyProbe)
         timed_out_node_type = _PortSummaryProbe.__name__
-        abandoned_node_type = _PortSummaryDataOnlyProbe.__name__
-        real_construct = _LibraryManager._construct_probe_node
         release_blocked_probe = threading.Event()
+        real_construct = _LibraryManager._construct_probe_node
 
         def block_one_node_type(
             manager: _LibraryManager, library_name: str, node_type: str, *args: Any, **kwargs: Any
@@ -2597,20 +2670,26 @@ class TestGetPortSummariesForAllLibrariesRequest:
                     _LibraryManager, "_construct_probe_node", side_effect=block_one_node_type, autospec=True
                 ) as probe_spy,
             ):
-                result = await library_manager.on_get_port_summaries_for_all_libraries_request(
+                first = await library_manager.on_get_port_summaries_for_all_libraries_request(
                     GetPortSummariesForAllLibrariesRequest()
                 )
+                # A second request must not spend anything more on this library, so the spy below
+                # covers both requests.
+                await library_manager.on_get_port_summaries_for_all_libraries_request(
+                    GetPortSummariesForAllLibrariesRequest()
+                )
+                # autospec passes self positionally: (manager, library_name, node_type, node_class, ...).
                 probed_node_types = [call.args[2] for call in probe_spy.call_args_list]
         finally:
             release_blocked_probe.set()
 
-        assert isinstance(result, GetPortSummariesForAllLibrariesResultSuccess)
-        # The healthy node type after the abort is never even attempted...
+        assert isinstance(first, GetPortSummariesForAllLibrariesResultSuccess)
         assert probed_node_types == [timed_out_node_type]
-        assert result.library_name_to_port_summaries[self._LIBRARY_NAME] == {}
-        # ...and only the node type that actually timed out is owed a retry.
-        assert library_manager._library_to_port_summary_retries[self._LIBRARY_NAME] == frozenset({timed_out_node_type})
-        assert abandoned_node_type not in library_manager._library_to_port_summaries[self._LIBRARY_NAME]
+        entry = library_manager._library_to_port_summary_cache[self._LIBRARY_NAME]
+        # The empty map is cached as complete: nothing pending is what stops the next request from
+        # paying for this library again.
+        assert entry.summaries == {}
+        assert not entry.pending_node_types()
 
     @pytest.mark.asyncio
     async def test_caches_a_pass_whose_only_gap_is_a_broken_node_type(self, engine: Engine) -> None:
@@ -2624,12 +2703,12 @@ class TestGetPortSummariesForAllLibrariesRequest:
 
         await library_manager.on_get_port_summaries_for_all_libraries_request(GetPortSummariesForAllLibrariesRequest())
 
-        cached = library_manager._library_to_port_summaries[self._LIBRARY_NAME]
+        cached = library_manager._library_to_port_summary_cache[self._LIBRARY_NAME].summaries
         # Both halves: the working node type is cached with its ports, and the broken one is cached
         # as absent rather than earning a retry that would never succeed.
         assert set(cached) == {_PortSummaryDataOnlyProbe.__name__}
         assert cached[_PortSummaryDataOnlyProbe.__name__].output_types == ("str",)
-        assert self._LIBRARY_NAME not in library_manager._library_to_port_summary_retries
+        assert not library_manager._library_to_port_summary_cache[self._LIBRARY_NAME].pending_node_types()
 
     @pytest.mark.asyncio
     async def test_result_does_not_alias_the_cache(self, engine: Engine) -> None:
@@ -2645,7 +2724,10 @@ class TestGetPortSummariesForAllLibrariesRequest:
         served = result.library_name_to_port_summaries[self._LIBRARY_NAME]
         served.pop(_PortSummaryDataOnlyProbe.__name__)
 
-        assert _PortSummaryDataOnlyProbe.__name__ in library_manager._library_to_port_summaries[self._LIBRARY_NAME]
+        assert (
+            _PortSummaryDataOnlyProbe.__name__
+            in library_manager._library_to_port_summary_cache[self._LIBRARY_NAME].summaries
+        )
 
     @pytest.mark.asyncio
     async def test_probing_publishes_no_events(self, engine: Engine) -> None:
@@ -2690,7 +2772,7 @@ class TestGetPortSummariesForAllLibrariesRequest:
             UnloadLibraryFromRegistryRequest(library_name=self._LIBRARY_NAME)
         )
 
-        assert self._LIBRARY_NAME not in library_manager._library_to_port_summaries
+        assert self._LIBRARY_NAME not in library_manager._library_to_port_summary_cache
 
         # Re-registering with a different node type must be reflected, not served stale.
         self._register_probe_library(_PortSummaryProbe)
@@ -2747,7 +2829,7 @@ class TestPortSummaryInvalidationOnLibraryLoad:
 
         # Stand in for a port summary request that landed while the library was published but
         # empty, which is exactly the state the invalidation exists to discard.
-        library_manager._library_to_port_summaries[self._LIBRARY_NAME] = {}
+        library_manager._library_to_port_summary_cache[self._LIBRARY_NAME] = _empty_port_summary_cache_entry()
         generation_before = library_manager._library_to_port_summaries_generation.get(self._LIBRARY_NAME, 0)
 
         library_info = _LibraryManager.LibraryInfo(
@@ -2781,7 +2863,7 @@ class TestPortSummaryInvalidationOnLibraryLoad:
             )
 
         assert result is None
-        assert self._LIBRARY_NAME not in library_manager._library_to_port_summaries
+        assert self._LIBRARY_NAME not in library_manager._library_to_port_summary_cache
         # The generation bump is what lets a probe pass already in flight discard its stale result.
         assert library_manager._library_to_port_summaries_generation[self._LIBRARY_NAME] > generation_before
 

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -77,6 +77,7 @@ from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULT
 from griptape_nodes.retained_mode.managers.settings import (
     LIBRARIES_TO_DOWNLOAD_KEY,
     LIBRARIES_TO_REGISTER_KEY,
+    LIBRARY_WARM_PORT_SUMMARIES_KEY,
     LibraryDownload,
     LibraryRegistration,
 )
@@ -2400,9 +2401,11 @@ class TestGetPortSummariesForAllLibrariesRequest:
         library_manager = engine.library_manager
         self._register_probe_library(_PortSummaryDataOnlyProbe)
 
-        async def invalidate_midway(library_name: str, allowance: ProbeTimeoutAllowance) -> Any:
+        async def invalidate_midway(
+            library_name: str, allowance: ProbeTimeoutAllowance, *, throttle_s: float, **kwargs: Any
+        ) -> Any:
             computation = await _LibraryManager._compute_port_summaries_for_library(
-                library_manager, library_name, allowance
+                library_manager, library_name, allowance, throttle_s=throttle_s, **kwargs
             )
             # Stand in for a reload / sandbox registration landing while the pass was awaiting.
             library_manager._invalidate_port_summaries(library_name)
@@ -2427,9 +2430,7 @@ class TestGetPortSummariesForAllLibrariesRequest:
         assert self._LIBRARY_NAME not in library_manager._library_to_port_summary_cache
 
     @pytest.mark.asyncio
-    async def test_a_node_type_that_fails_to_resolve_does_not_fail_the_whole_response(
-        self, engine: Engine
-    ) -> None:
+    async def test_a_node_type_that_fails_to_resolve_does_not_fail_the_whole_response(self, engine: Engine) -> None:
         """Resolution raises more than import errors, and the response covers every library.
 
         `Library.get_node_class` raises `LibraryRegistryError` for a node type unregistered since
@@ -2551,9 +2552,7 @@ class TestGetPortSummariesForAllLibrariesRequest:
         assert not library_manager._library_to_port_summary_cache[self._LIBRARY_NAME].pending_node_types()
 
     @pytest.mark.asyncio
-    async def test_contains_a_node_type_whose_library_metadata_cannot_be_read(
-        self, engine: Engine
-    ) -> None:
+    async def test_contains_a_node_type_whose_library_metadata_cannot_be_read(self, engine: Engine) -> None:
         """Building the probe's metadata reads and serializes the library author's node metadata.
 
         A malformed entry raises there, outside the node's own __init__, and must be contained to
@@ -2582,9 +2581,7 @@ class TestGetPortSummariesForAllLibrariesRequest:
         assert not library_manager._library_to_port_summary_cache[self._LIBRARY_NAME].pending_node_types()
 
     @pytest.mark.asyncio
-    async def test_resumes_node_types_a_request_ran_out_of_allowance_before_reaching(
-        self, engine: Engine
-    ) -> None:
+    async def test_resumes_node_types_a_request_ran_out_of_allowance_before_reaching(self, engine: Engine) -> None:
         """One library's blocking node must not cost another library its ranking for good.
 
         The timeout allowance is spent per request across every library, so a library reached after
@@ -2636,9 +2633,7 @@ class TestGetPortSummariesForAllLibrariesRequest:
         assert not library_manager._library_to_port_summary_cache[self._LIBRARY_NAME].pending_node_types()
 
     @pytest.mark.asyncio
-    async def test_gives_up_on_a_library_that_has_spent_its_lifetime_timeout_allowance(
-        self, engine: Engine
-    ) -> None:
+    async def test_gives_up_on_a_library_that_has_spent_its_lifetime_timeout_allowance(self, engine: Engine) -> None:
         """Carrying unreached node types forever would let a stuck library leak a thread per request.
 
         Each timeout permanently holds a worker of the loop's default executor, so once a library has
@@ -2783,6 +2778,194 @@ class TestGetPortSummariesForAllLibrariesRequest:
         assert isinstance(result, GetPortSummariesForAllLibrariesResultSuccess)
         summaries = result.library_name_to_port_summaries[self._LIBRARY_NAME]
         assert set(summaries) == {_PortSummaryProbe.__name__}
+
+
+class TestPortSummaryWarming:
+    """Exercise the background pass that fills the port summary cache before anything asks.
+
+    Warming exists to move the probe cost off the moment an artist drags a connection. These tests
+    pin the two properties that make it worth having -- a warmed request probes nothing, and a
+    reload cannot leave a pass running against libraries it is tearing down -- plus the two ways it
+    declines to run at all.
+    """
+
+    _LIBRARY_NAME = "port-summary-warm-test-library"
+
+    @pytest.fixture(autouse=True)
+    def _clean_registry(self) -> Generator[None, None, None]:
+        """LibraryRegistry holds class-level state that survives the singleton reset fixture."""
+        LibraryRegistry._clear()
+        yield
+        LibraryRegistry._clear()
+
+    def _register_probe_library(self, *node_classes: type[BaseNode]) -> None:
+        schema = LibrarySchema(
+            name=self._LIBRARY_NAME,
+            library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+            metadata=LibraryMetadata(
+                author="test",
+                description="port summary warming library",
+                library_version="1.0.0",
+                engine_version="1.0.0",
+                tags=[],
+            ),
+            categories=[],
+            nodes=[],
+        )
+        library = LibraryRegistry.generate_new_library(library_data=schema)
+        for node_class in node_classes:
+            library.register_new_node_type(
+                node_class,
+                NodeMetadata(
+                    category="test",
+                    description=f"{node_class.__name__} used by port summary warming tests",
+                    display_name=node_class.__name__,
+                ),
+            )
+
+    @pytest.mark.asyncio
+    async def test_a_warmed_request_probes_nothing(self, engine: Engine) -> None:
+        """The whole point: after warming, the request an artist waits on constructs no nodes."""
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryDataOnlyProbe, _PortSummaryProbe)
+
+        await library_manager._warm_port_summaries()
+
+        with patch.object(
+            _LibraryManager,
+            "_construct_probe_node",
+            side_effect=_LibraryManager._construct_probe_node,
+            autospec=True,
+        ) as probe_spy:
+            result = await library_manager.on_get_port_summaries_for_all_libraries_request(
+                GetPortSummariesForAllLibrariesRequest()
+            )
+
+        assert probe_spy.call_count == 0
+        assert isinstance(result, GetPortSummariesForAllLibrariesResultSuccess)
+        summaries = result.library_name_to_port_summaries[self._LIBRARY_NAME]
+        assert set(summaries) == {_PortSummaryDataOnlyProbe.__name__, _PortSummaryProbe.__name__}
+
+    @pytest.mark.asyncio
+    async def test_a_request_landing_mid_warm_does_not_duplicate_the_probing(self, engine: Engine) -> None:
+        """Warming adds a second concurrent caller, so the per-library lock has to hold.
+
+        Without it the two passes would each probe every node type, making warming a pessimization
+        for exactly the request it is supposed to speed up.
+        """
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryDataOnlyProbe, _PortSummaryProbe)
+
+        with patch.object(
+            _LibraryManager,
+            "_construct_probe_node",
+            side_effect=_LibraryManager._construct_probe_node,
+            autospec=True,
+        ) as probe_spy:
+            warm = asyncio.create_task(library_manager._warm_port_summaries())
+            request = asyncio.create_task(
+                library_manager.on_get_port_summaries_for_all_libraries_request(
+                    GetPortSummariesForAllLibrariesRequest()
+                )
+            )
+            await asyncio.gather(warm, request)
+
+        expected_probe_calls = 2  # One per node type, total, across both callers.
+        assert probe_spy.call_count == expected_probe_calls
+
+    @pytest.mark.asyncio
+    async def test_cancelling_stops_an_in_flight_pass_before_it_caches(self, engine: Engine) -> None:
+        """A reload calls this before unloading, so the pass must really be off the loop after it.
+
+        The pass resolves node classes, which imports their modules; one still running would pull
+        a library being dismantled back into sys.modules.
+        """
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryDataOnlyProbe, _PortSummaryProbe)
+        pass_reached_first_probe = asyncio.Event()
+        release_first_probe = asyncio.Event()
+        real_construct = _LibraryManager._construct_probe_node
+
+        async def block_on_first_probe(*args: Any, **kwargs: Any) -> Any:
+            pass_reached_first_probe.set()
+            await release_first_probe.wait()
+            return real_construct(*args, **kwargs)
+
+        # Patch the awaited probe rather than the threaded construction: this test is about the
+        # coroutine being cancellable at an await point, which is what cancellation acts on.
+        with patch.object(library_manager, "_probe_node_type_port_summary", side_effect=block_on_first_probe):
+            library_manager._start_port_summary_warm()
+            warm_task = library_manager._port_summary_warm_task
+            assert warm_task is not None
+            await pass_reached_first_probe.wait()
+
+            await library_manager._cancel_port_summary_warm()
+
+        assert warm_task.cancelled()
+        assert library_manager._port_summary_warm_task is None
+        # Cancelled mid-library, so nothing was written back -- the next request recomputes rather
+        # than serving a half-probed library as complete.
+        assert self._LIBRARY_NAME not in library_manager._library_to_port_summary_cache
+
+    @pytest.mark.asyncio
+    async def test_cancelling_is_a_no_op_when_nothing_is_warming(self, engine: Engine) -> None:
+        """Reload always calls this, including on a boot where warming never started."""
+        library_manager = engine.library_manager
+
+        await library_manager._cancel_port_summary_warm()
+
+        assert library_manager._port_summary_warm_task is None
+
+    @pytest.mark.asyncio
+    async def test_reload_cancels_warming_before_it_unloads_anything(
+        self, engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Ordering is the whole protection, so pin it rather than trusting the call's placement."""
+        library_manager = engine.library_manager
+        call_order: list[str] = []
+
+        async def record_cancel() -> None:
+            call_order.append("cancel")
+
+        async def fail_after_clearing(_request: object) -> Any:
+            # Stands in for the first thing _run_reload_libraries does after cancelling. Failing it
+            # short-circuits the rest of the reload, which this test does not exercise.
+            call_order.append("clear_state")
+            failure = MagicMock()
+            failure.succeeded.return_value = False
+            return failure
+
+        monkeypatch.setattr(library_manager, "_cancel_port_summary_warm", record_cancel)
+        monkeypatch.setattr(library_manager.engine, "ahandle_request", fail_after_clearing)
+
+        from griptape_nodes.retained_mode.events.library_events import ReloadAllLibrariesRequest
+
+        await library_manager._run_reload_libraries(ReloadAllLibrariesRequest())
+
+        assert call_order == ["cancel", "clear_state"]
+
+    def test_does_not_warm_on_a_worker(self, engine: Engine) -> None:
+        """A worker already constructs every node type to serialize its schemas."""
+        library_manager = engine.library_manager
+        library_manager._is_worker = True
+
+        library_manager._start_port_summary_warm()
+
+        assert library_manager._port_summary_warm_task is None
+
+    def test_does_not_warm_when_the_setting_is_off(self, engine: Engine) -> None:
+        """Opting out has to leave the on-demand path as the only one that probes."""
+        library_manager = engine.library_manager
+
+        def config_value(key: str, **_: object) -> object:
+            if key == LIBRARY_WARM_PORT_SUMMARIES_KEY:
+                return False
+            return None
+
+        with patch.object(library_manager.engine.config_manager, "get_config_value", side_effect=config_value):
+            library_manager._start_port_summary_warm()
+
+        assert library_manager._port_summary_warm_task is None
 
 
 class TestPortSummaryInvalidationOnLibraryLoad:

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -4,6 +4,7 @@ import json
 import logging
 import subprocess
 import sys
+import threading
 from collections.abc import Callable, Generator
 from functools import partial
 from pathlib import Path
@@ -16,6 +17,7 @@ from griptape_nodes.exe_types.core_types import (
     ControlParameterInput,
     ControlParameterOutput,
     Parameter,
+    ParameterList,
     ParameterMode,
 )
 from griptape_nodes.exe_types.node_types import BaseNode
@@ -1658,6 +1660,65 @@ class TestRegisterSandboxNodeFromSourceRequest:
         assert isinstance(second, RegisterSandboxNodeFromSourceResultSuccess)
         assert second.replaced_class_names == ["ProbeSandboxNode"]
 
+    def test_drops_cached_port_summaries_even_when_registration_bails_partway(
+        self,
+        engine: Engine,
+        _isolate_registry_and_config: Path,  # noqa: PT019 - value is used to locate the source file
+    ) -> None:
+        """The registration loop mutates as it goes and can bail out midway.
+
+        If the cache were only dropped on the success path, the library would be left mutated with
+        stale summaries describing it -- for the rest of the process's life, since nothing
+        invalidates again.
+        """
+        from griptape_nodes.retained_mode.events.library_events import (
+            RegisterSandboxNodeFromSourceRequest,
+            RegisterSandboxNodeFromSourceResultFailure,
+            RegisterSandboxNodeFromSourceResultSuccess,
+        )
+
+        library_manager = engine.library_manager
+        sandbox_dir = _isolate_registry_and_config
+
+        existing_source = sandbox_dir / "existing_node.py"
+        existing_source.write_text(
+            "from griptape_nodes.exe_types.node_types import BaseNode\n"
+            "\n"
+            "class SandboxExisting(BaseNode):\n"
+            "    def process(self) -> None:\n"
+            "        return None\n"
+        )
+        first = library_manager.register_sandbox_node_from_source_request(
+            RegisterSandboxNodeFromSourceRequest(file_path=str(existing_source))
+        )
+        assert isinstance(first, RegisterSandboxNodeFromSourceResultSuccess)
+
+        # Pretend a port summary request already ran and cached a result for this library.
+        library_manager._library_to_port_summaries[self._LIBRARY_NAME] = {}
+
+        # A file whose first class is new and whose second is already registered. With
+        # replace_if_exists=False the loop registers the first, then bails on the second.
+        conflicting_source = sandbox_dir / "conflicting_node.py"
+        conflicting_source.write_text(
+            "from griptape_nodes.exe_types.node_types import BaseNode\n"
+            "\n"
+            "class SandboxBrandNew(BaseNode):\n"
+            "    def process(self) -> None:\n"
+            "        return None\n"
+            "\n"
+            "class SandboxExisting(BaseNode):\n"
+            "    def process(self) -> None:\n"
+            "        return None\n"
+        )
+        second = library_manager.register_sandbox_node_from_source_request(
+            RegisterSandboxNodeFromSourceRequest(file_path=str(conflicting_source), replace_if_exists=False)
+        )
+
+        assert isinstance(second, RegisterSandboxNodeFromSourceResultFailure)
+        # The library really was mutated before the bail-out, so the cache must be gone.
+        assert LibraryRegistry.get_library(self._LIBRARY_NAME).has_node_type("SandboxBrandNew")
+        assert self._LIBRARY_NAME not in library_manager._library_to_port_summaries
+
     def test_fails_when_sandbox_directory_is_not_configured(
         self,
         engine: Engine,
@@ -2069,6 +2130,21 @@ class _PortSummaryDataOnlyProbe(BaseNode):
         )
 
 
+class _PortSummaryContainerProbe(BaseNode):
+    """Node whose only data port is a list container, i.e. the expander shape."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name=name, metadata=metadata)
+        self.add_parameter(
+            ParameterList(
+                name="items",
+                input_types=["str"],
+                output_type="str",
+                tooltip="Accepts many strings.",
+            )
+        )
+
+
 class TestNodePortSummary:
     """Exercise NodePortSummary.from_parameters, the derivation the ranking depends on."""
 
@@ -2107,6 +2183,34 @@ class TestNodePortSummary:
         assert summary.output_types == []
         assert summary.has_control_input is False
         assert summary.has_control_output is False
+
+    def test_container_reports_element_type_alongside_container_type(self) -> None:
+        """A list container is how a node says "I take many of these", so both types must appear.
+
+        Without the element type, dragging a single `str` would not surface expander nodes at all
+        -- exactly the case the ranking exists to serve.
+        """
+        probe = _PortSummaryContainerProbe(name="probe")
+
+        summary = NodePortSummary.from_parameters(probe.parameters)
+
+        # The container's own port accepts a whole collection; its children accept one element.
+        assert "list[str]" in summary.input_types
+        assert "list" in summary.input_types
+        assert "str" in summary.input_types
+        assert "list[str]" in summary.output_types
+        assert "str" in summary.output_types
+
+    def test_container_element_type_matches_what_a_real_child_declares(self) -> None:
+        """Pin the element type to add_child_parameter, so the two cannot drift apart."""
+        probe = _PortSummaryContainerProbe(name="probe")
+        container = probe.get_parameter_by_name("items")
+        assert isinstance(container, ParameterList)
+
+        child = container.add_child_parameter()
+
+        assert container.get_element_input_types() == child.input_types
+        assert container.get_element_output_type() == child.output_type
 
 
 class TestGetPortSummariesForAllLibrariesRequest:
@@ -2183,7 +2287,10 @@ class TestGetPortSummariesForAllLibrariesRequest:
         self._register_probe_library(_PortSummaryDataOnlyProbe)
 
         with patch.object(
-            _LibraryManager, "_probe_node_type", side_effect=_LibraryManager._probe_node_type, autospec=True
+            _LibraryManager,
+            "_construct_probe_node",
+            side_effect=_LibraryManager._construct_probe_node,
+            autospec=True,
         ) as probe_spy:
             await library_manager.on_get_port_summaries_for_all_libraries_request(
                 GetPortSummariesForAllLibrariesRequest()
@@ -2193,6 +2300,75 @@ class TestGetPortSummariesForAllLibrariesRequest:
             )
 
         assert probe_spy.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_resolves_node_classes_on_the_event_loop(self, engine: Engine) -> None:
+        """Resolution must stay on the loop: NodeTypeEntry.resolve() is not thread-safe.
+
+        Only construction is allowed off-thread, because a node's __init__ can block.
+        """
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryDataOnlyProbe)
+        loop_thread_id = threading.get_ident()
+        resolve_thread_ids: list[int] = []
+        construct_thread_ids: list[int] = []
+        # Bind the real implementations before patching, or the side effects recurse into the mocks.
+        real_resolve = _LibraryManager._resolve_node_class_for_probe
+        real_construct = _LibraryManager._construct_probe_node
+
+        def record_resolve(manager: _LibraryManager, *args: Any, **kwargs: Any) -> Any:
+            resolve_thread_ids.append(threading.get_ident())
+            return real_resolve(manager, *args, **kwargs)
+
+        def record_construct(manager: _LibraryManager, *args: Any, **kwargs: Any) -> Any:
+            construct_thread_ids.append(threading.get_ident())
+            return real_construct(manager, *args, **kwargs)
+
+        with (
+            patch.object(_LibraryManager, "_resolve_node_class_for_probe", side_effect=record_resolve, autospec=True),
+            patch.object(_LibraryManager, "_construct_probe_node", side_effect=record_construct, autospec=True),
+        ):
+            await library_manager.on_get_port_summaries_for_all_libraries_request(
+                GetPortSummariesForAllLibrariesRequest()
+            )
+
+        assert resolve_thread_ids == [loop_thread_id]
+        assert construct_thread_ids != []
+        assert loop_thread_id not in construct_thread_ids
+
+    @pytest.mark.asyncio
+    async def test_does_not_cache_summaries_measured_before_an_invalidation(self, engine: Engine) -> None:
+        """The probe pass awaits, so the library can change underneath it.
+
+        Caching a result measured before that change would pin the pre-change ports for the rest
+        of the process's life, because nothing invalidates again.
+        """
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryDataOnlyProbe)
+
+        async def invalidate_midway(library_name: str) -> dict[str, NodePortSummary]:
+            summaries = await _LibraryManager._compute_port_summaries_for_library(library_manager, library_name)
+            # Stand in for a reload / sandbox registration landing while the pass was awaiting.
+            library_manager._invalidate_port_summaries(library_name)
+            return summaries
+
+        with patch.object(
+            library_manager, "_compute_port_summaries_for_library", side_effect=invalidate_midway
+        ) as compute_spy:
+            first = await library_manager.on_get_port_summaries_for_all_libraries_request(
+                GetPortSummariesForAllLibrariesRequest()
+            )
+            # The stale result is still served to the caller -- it is the best answer available --
+            # but it must not have been written back, so this request recomputes.
+            second = await library_manager.on_get_port_summaries_for_all_libraries_request(
+                GetPortSummariesForAllLibrariesRequest()
+            )
+
+        expected_compute_calls = 2  # Once per request: the first result was never cached.
+        assert isinstance(first, GetPortSummariesForAllLibrariesResultSuccess)
+        assert isinstance(second, GetPortSummariesForAllLibrariesResultSuccess)
+        assert compute_spy.call_count == expected_compute_calls
+        assert self._LIBRARY_NAME not in library_manager._library_to_port_summaries
 
     @pytest.mark.asyncio
     async def test_recomputes_after_library_is_unloaded(self, engine: Engine) -> None:

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -1864,7 +1864,11 @@ class _DescribeNodeTypeProbe(BaseNode):
 def _empty_port_summary_cache_entry() -> PortSummaryCacheEntry:
     """A complete-but-empty cache entry, standing in for a port summary request that already ran."""
     return PortSummaryCacheEntry(
-        summaries={}, retry_node_types=frozenset(), unprobed_node_types=frozenset(), timeouts_spent=0
+        summaries={},
+        retry_node_types=frozenset(),
+        unprobed_node_types=frozenset(),
+        retried_node_types=frozenset(),
+        timeouts_spent=0,
     )
 
 
@@ -2620,7 +2624,11 @@ class TestGetPortSummariesForAllLibrariesRequest:
         try:
             with (
                 patch.object(_LibraryManager, "_SCHEMA_PROBE_TIMEOUT_S", 0.2),
-                patch.object(_LibraryManager, "_PORT_SUMMARY_TIMEOUT_BUDGET", 1),
+                # One of each: the request bound is what leaves the healthy library unreached, and
+                # the library bound is what stops the second request re-spending the whole allowance
+                # on the blocking library before it gets there.
+                patch.object(_LibraryManager, "_PORT_SUMMARY_REQUEST_TIMEOUT_BUDGET", 1),
+                patch.object(_LibraryManager, "_PORT_SUMMARY_LIBRARY_TIMEOUT_BUDGET", 1),
                 # Pinned because the real ceiling is derived from the host's CPU count. This test
                 # spends one leaked thread on the blocking library and then requires a second
                 # request to still probe the healthy one, which a ceiling of 1 would forbid.
@@ -2678,7 +2686,7 @@ class TestGetPortSummariesForAllLibrariesRequest:
         try:
             with (
                 patch.object(_LibraryManager, "_SCHEMA_PROBE_TIMEOUT_S", 0.2),
-                patch.object(_LibraryManager, "_PORT_SUMMARY_TIMEOUT_BUDGET", 1),
+                patch.object(_LibraryManager, "_PORT_SUMMARY_LIBRARY_TIMEOUT_BUDGET", 1),
                 # Deliberately generous, and pinned rather than left to the host's CPU count: the
                 # library-level allowance must be what stops the second request, not the
                 # engine-wide ceiling, or this passes without testing the bound it names.
@@ -2742,7 +2750,7 @@ class TestGetPortSummariesForAllLibrariesRequest:
                 patch.object(_LibraryManager, "_PROBE_THREAD_LEAK_CEILING", 1),
                 # Deliberately generous: the library-level allowance must not be what stops this,
                 # or the test would pass without the engine-wide ceiling existing.
-                patch.object(_LibraryManager, "_PORT_SUMMARY_TIMEOUT_BUDGET", 10),
+                patch.object(_LibraryManager, "_PORT_SUMMARY_LIBRARY_TIMEOUT_BUDGET", 10),
                 patch.object(
                     _LibraryManager, "_construct_probe_node", side_effect=block_the_first_library, autospec=True
                 ) as probe_spy,
@@ -2799,9 +2807,12 @@ class TestGetPortSummariesForAllLibrariesRequest:
         try:
             with (
                 patch.object(_LibraryManager, "_SCHEMA_PROBE_TIMEOUT_S", 0.2),
-                # Two, so the first library eats the request allowance without any single library
-                # hitting its own allowance, which would drop pending node types instead.
-                patch.object(_LibraryManager, "_PORT_SUMMARY_TIMEOUT_BUDGET", 2),
+                # Two each: the first library's two node types both time out, which is exactly the
+                # request allowance, so the library below is left unreached rather than probed. The
+                # library bound has to match rather than be lower, or the first library would stop on
+                # its own allowance and the request would arrive at the second one with budget left.
+                patch.object(_LibraryManager, "_PORT_SUMMARY_REQUEST_TIMEOUT_BUDGET", 2),
+                patch.object(_LibraryManager, "_PORT_SUMMARY_LIBRARY_TIMEOUT_BUDGET", 2),
                 # Generous and pinned: this test leaks three threads, and the engine-wide ceiling
                 # must not be what ends it.
                 patch.object(_LibraryManager, "_PROBE_THREAD_LEAK_CEILING", 10),
@@ -2826,6 +2837,111 @@ class TestGetPortSummariesForAllLibrariesRequest:
         assert probed_entry.retry_node_types == frozenset({late_node_type})
         assert probed_entry.unprobed_node_types == frozenset()
         assert probed_entry.timeouts_spent == 1
+
+    @pytest.mark.asyncio
+    async def test_does_not_re_grant_a_retry_a_pass_stopped_short_of_taking(self, engine: Engine) -> None:
+        """The record of which node types have had their retry must outlive the pass that granted it.
+
+        A grant is spent the moment it is made, but the pass holding it can stop before reaching the
+        node type -- out of allowance, or because a reload closed the gate. Reading "already
+        retried" off what the *next* pass will retry loses the grant along with that pass, so the
+        same permanently blocking node type earns a fresh retry after every timeout and is probed
+        again and again, leaking a thread each time.
+        """
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryProbe)
+        blocking_node_type = _PortSummaryProbe.__name__
+        release_blocked_probes = threading.Event()
+        real_construct = _LibraryManager._construct_probe_node
+
+        def block_everything(
+            manager: _LibraryManager, library_name: str, node_type: str, *args: Any, **kwargs: Any
+        ) -> Any:
+            release_blocked_probes.wait(timeout=30)
+            return real_construct(manager, library_name, node_type, *args, **kwargs)
+
+        try:
+            with (
+                patch.object(_LibraryManager, "_SCHEMA_PROBE_TIMEOUT_S", 0.2),
+                # Both generous and pinned: the retry accounting has to be what ends this, not a
+                # cost bound quietly dropping the node type from the pending set.
+                patch.object(_LibraryManager, "_PORT_SUMMARY_LIBRARY_TIMEOUT_BUDGET", 10),
+                patch.object(_LibraryManager, "_PROBE_THREAD_LEAK_CEILING", 10),
+                patch.object(
+                    _LibraryManager, "_construct_probe_node", side_effect=block_everything, autospec=True
+                ) as probe_spy,
+            ):
+                # First pass: the node type's first timeout, which is what earns it its one retry.
+                await library_manager._get_port_summaries_for_library(
+                    self._LIBRARY_NAME, ProbeTimeoutAllowance(remaining=4), throttle_s=0.0
+                )
+                assert library_manager._library_to_port_summary_cache[self._LIBRARY_NAME].retry_node_types == frozenset(
+                    {blocking_node_type}
+                )
+
+                # Second pass stops before reaching it, which is exactly what empties
+                # `retry_node_types` without the retry having been taken.
+                library_manager._close_libraries_loading_gate()
+                await library_manager._get_port_summaries_for_library(
+                    self._LIBRARY_NAME, ProbeTimeoutAllowance(remaining=4), throttle_s=0.0
+                )
+                stopped_short = library_manager._library_to_port_summary_cache[self._LIBRARY_NAME]
+                assert stopped_short.retry_node_types == frozenset()
+                assert stopped_short.unprobed_node_types == frozenset({blocking_node_type})
+                library_manager._libraries_loading_complete.set()
+
+                # Third pass takes the retry and times out again. Nothing further is owed.
+                await library_manager._get_port_summaries_for_library(
+                    self._LIBRARY_NAME, ProbeTimeoutAllowance(remaining=4), throttle_s=0.0
+                )
+        finally:
+            release_blocked_probes.set()
+
+        entry = library_manager._library_to_port_summary_cache[self._LIBRARY_NAME]
+        assert entry.retried_node_types == frozenset({blocking_node_type})
+        assert not entry.pending_node_types()
+        # Two attempts across three passes: the first probe and its single retry, not one per pass
+        # that happens to reach it.
+        expected_probe_count = 2
+        assert probe_spy.call_count == expected_probe_count
+
+    @pytest.mark.asyncio
+    async def test_stops_probing_when_the_library_it_started_on_is_replaced(self, engine: Engine) -> None:
+        """Every probe resolves its node class through the `Library` the pass picked up at the start.
+
+        A git update unloads and re-registers one library without closing the loading gate, so a
+        pass already walking that library keeps a handle to the pre-update object. Resolving through
+        it runs the old loader and imports the pre-update modules straight back into `sys.modules`,
+        undoing the unload the artist is waiting on.
+        """
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryDataOnlyProbe, _PortSummaryProbe)
+        real_probe = library_manager._probe_node_type_port_summary
+
+        async def replace_the_library_after_the_first_probe(**kwargs: Any) -> Any:
+            outcome = await real_probe(**kwargs)
+            # What a git update does: same name, a different Library object behind it.
+            LibraryRegistry.unregister_library(self._LIBRARY_NAME, event_manager=engine.event_manager)
+            self._register_probe_library(_PortSummaryDataOnlyProbe, _PortSummaryProbe)
+            return outcome
+
+        with patch.object(
+            library_manager, "_probe_node_type_port_summary", side_effect=replace_the_library_after_the_first_probe
+        ) as probe_spy:
+            result = await library_manager.on_get_port_summaries_for_all_libraries_request(
+                GetPortSummariesForAllLibrariesRequest()
+            )
+
+        assert probe_spy.call_count == 1
+        # Present in the registry under the same name throughout, so a name-only check would have
+        # carried on probing through the stale object.
+        assert LibraryRegistry.get_library(self._LIBRARY_NAME) is not None
+        assert isinstance(result, GetPortSummariesForAllLibrariesResultSuccess)
+        assert set(result.library_name_to_port_summaries[self._LIBRARY_NAME]) == {_PortSummaryDataOnlyProbe.__name__}
+        # Owed a real attempt against the new object, and charged nothing: no probe timed out.
+        entry = library_manager._library_to_port_summary_cache[self._LIBRARY_NAME]
+        assert entry.unprobed_node_types == frozenset({_PortSummaryProbe.__name__})
+        assert entry.timeouts_spent == 0
 
     @pytest.mark.asyncio
     async def test_stops_probing_when_a_reload_closes_the_gate_mid_pass(self, engine: Engine) -> None:
@@ -3101,6 +3217,152 @@ class TestPortSummaryWarming:
         # Cancelled mid-library, so nothing was written back -- the next request recomputes rather
         # than serving a half-probed library as complete.
         assert self._LIBRARY_NAME not in library_manager._library_to_port_summary_cache
+        # No construction thread was ever started here, so the engine-wide ceiling hears nothing.
+        # Cancelling *inside* a construction is the case that charges it.
+        assert library_manager._port_summary_threads_leaked == 0
+
+    @pytest.mark.asyncio
+    async def test_cancelling_mid_construction_charges_the_thread_it_abandons(self, engine: Engine) -> None:
+        """`asyncio.to_thread` cannot cancel its worker, so stopping the pass abandons one.
+
+        The thread goes on running the node's `__init__` with nobody waiting for it -- the same
+        unreclaimable worker a timeout costs -- so it has to come out of the same engine-wide
+        ceiling. Charging only timeouts would let a reload loop abandon a worker per reload while
+        the count meant to bound them stayed at zero, and draining the loop's executor stalls far
+        more than the Add Node menu.
+        """
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryDataOnlyProbe)
+        probe_entered_the_thread = threading.Event()
+        release_the_thread = threading.Event()
+        real_construct = _LibraryManager._construct_probe_node
+
+        def block_inside_the_worker(
+            manager: _LibraryManager, library_name: str, node_type: str, *args: Any, **kwargs: Any
+        ) -> Any:
+            probe_entered_the_thread.set()
+            release_the_thread.wait(timeout=30)
+            return real_construct(manager, library_name, node_type, *args, **kwargs)
+
+        try:
+            with patch.object(
+                _LibraryManager, "_construct_probe_node", side_effect=block_inside_the_worker, autospec=True
+            ):
+                library_manager._start_port_summary_warm()
+                warm_task = library_manager._port_summary_warm_task
+                assert warm_task is not None
+                # Waited off the loop: the worker cannot report in until the loop has handed the
+                # construction a thread, and the loop is what this test then cancels.
+                await asyncio.to_thread(probe_entered_the_thread.wait, 30)
+
+                await library_manager._cancel_port_summary_warm()
+        finally:
+            # Only so the test does not really strand a worker for the rest of the session; the
+            # charge above is made while the thread is still blocked, which is the real case.
+            release_the_thread.set()
+
+        assert warm_task.cancelled()
+        assert library_manager._port_summary_threads_leaked == 1
+
+    @pytest.mark.asyncio
+    async def test_cancelling_after_the_construction_finished_charges_nothing(self, engine: Engine) -> None:
+        """A thread that went back to the pool is not a leaked thread.
+
+        Cancellation cannot ask `asyncio.to_thread` whether its worker is still there -- cancelling
+        the task or the future leaves the thread running either way -- so the worker records for
+        itself that it finished. Charging every cancellation instead would walk the engine-wide
+        ceiling up on every reload and permanently stop probing on a healthy engine.
+        """
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryDataOnlyProbe)
+        library = LibraryRegistry.get_library(self._LIBRARY_NAME)
+        construction_returned = asyncio.Event()
+
+        async def construct_then_hang(func: Callable[..., Any], *args: Any) -> Any:
+            # The construction really completes, including the signal the worker sets on its way
+            # out, and the cancellation below lands on the await that follows it -- the window
+            # where a timeout and a finished thread are indistinguishable from the loop's side.
+            func(*args)
+            construction_returned.set()
+            await asyncio.Event().wait()
+
+        with patch.object(asyncio, "to_thread", new=construct_then_hang):
+            probe_task = asyncio.create_task(
+                library_manager._probe_node_type_port_summary(
+                    library=library,
+                    library_name=self._LIBRARY_NAME,
+                    node_type=_PortSummaryDataOnlyProbe.__name__,
+                )
+            )
+            await construction_returned.wait()
+            probe_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await probe_task
+
+        assert library_manager._port_summary_threads_leaked == 0
+
+    @pytest.mark.asyncio
+    async def test_a_warm_handle_left_by_a_previous_event_loop_is_discarded(self, engine: Engine) -> None:
+        """The manager outlives any one loop, and a task suspended in a closed one cannot be cancelled.
+
+        `Task.cancel()` on such a handle raises from the loop underneath it, so a reload would blow
+        up before it unloaded anything; treating it as in-flight instead would leave the new loop
+        never warming at all. Either way the handle has to be forgotten rather than acted on.
+        """
+        library_manager = engine.library_manager
+        previous_loop = asyncio.new_event_loop()
+        stale_task = MagicMock()
+        stale_task.get_loop.return_value = previous_loop
+
+        try:
+            library_manager._port_summary_warm_task = stale_task
+            in_flight = library_manager._in_flight_port_summary_warm_task()
+
+            library_manager._port_summary_warm_task = stale_task
+            await library_manager._cancel_port_summary_warm()
+        finally:
+            previous_loop.close()
+
+        assert in_flight is None
+        assert library_manager._port_summary_warm_task is None
+        stale_task.cancel.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_a_git_reload_stops_warming_around_the_library_swap(self, engine: Engine) -> None:
+        """This path re-registers one library without closing the loading gate, so it must bracket too.
+
+        Warming resolves node classes, and the git update has just replaced the files behind them.
+        A pass left running across the swap imports the pre-update modules back into `sys.modules`
+        after the unload cleared them -- and restarting has to happen even when the reload failed,
+        since the library's summaries were dropped either way.
+        """
+        library_manager = engine.library_manager
+        call_order: list[str] = []
+
+        async def record_cancel() -> None:
+            call_order.append("cancel")
+
+        def fail_the_unload(_request: object) -> Any:
+            # Stands in for the first thing the reload does after cancelling. Failing it
+            # short-circuits the rest of the reload, which this test does not exercise.
+            call_order.append("unload")
+            failure = MagicMock()
+            failure.succeeded.return_value = False
+            return failure
+
+        with (
+            patch.object(library_manager, "_cancel_port_summary_warm", side_effect=record_cancel),
+            patch.object(library_manager, "_start_port_summary_warm", side_effect=lambda: call_order.append("restart")),
+            patch.object(engine, "handle_request", side_effect=fail_the_unload),
+        ):
+            result = await library_manager._reload_library_after_git_operation(
+                library_name="updated-library",
+                library_file_path="/libs/updated-library/griptape_nodes_library.json",
+                failure_result_class=RegisterLibraryFromFileResultFailure,
+            )
+
+        assert isinstance(result, RegisterLibraryFromFileResultFailure)
+        assert call_order == ["cancel", "unload", "restart"]
 
     @pytest.mark.asyncio
     async def test_a_waiting_request_takes_the_throttle_off_the_warm_pass(self, engine: Engine) -> None:
@@ -3291,11 +3553,16 @@ class TestPortSummaryWarming:
         assert library_manager._warm_port_summaries_requested is False
 
     @pytest.mark.asyncio
-    async def test_starting_again_replaces_the_pass_in_flight(self, engine: Engine) -> None:
-        """Two passes would leave one with no handle, and a pass nothing holds cannot be cancelled."""
+    async def test_starting_again_keeps_the_pass_in_flight(self, engine: Engine) -> None:
+        """Only one handle is kept, so a second pass could not be cancelled -- and neither is started.
+
+        Cancelling the first instead would be worse than not starting a second: the caller is
+        normally a worker reporting its node schemas, and that would discard a large library's
+        half-finished probing and leak the thread of whatever probe was in flight.
+        """
         library_manager = engine.library_manager
         self._register_probe_library(_PortSummaryDataOnlyProbe)
-        # Nothing has loaded in this test, so the gate holds both passes at their first await.
+        # Nothing has loaded in this test, so the gate holds the pass at its first await.
         library_manager._libraries_loading_complete.clear()
         try:
             library_manager._start_port_summary_warm()
@@ -3307,18 +3574,68 @@ class TestPortSummaryWarming:
             library_manager._libraries_loading_complete.set()
 
         assert first_task is not None
-        assert second_task is not None
-        assert second_task is not first_task
-        # The replacement owns the handle straight away, and the cancelled pass's done callback must
-        # not claim it back -- that is what makes the surviving pass cancellable by a later reload.
-        assert library_manager._port_summary_warm_task is second_task
+        assert second_task is first_task
 
-        await asyncio.gather(first_task, second_task, return_exceptions=True)
+        await asyncio.gather(first_task, return_exceptions=True)
 
-        assert first_task.cancelled()
-        assert not second_task.cancelled()
-        # Cleared by the surviving pass's own callback, now that there is nothing left to cancel.
+        assert not first_task.cancelled()
+        # Cleared by the pass's own callback, now that there is nothing left to cancel.
         assert library_manager._port_summary_warm_task is None
+
+    @pytest.mark.asyncio
+    async def test_a_running_pass_picks_up_a_library_invalidated_behind_it(self, engine: Engine) -> None:
+        """Re-sweeping is what lets a caller leave the running pass alone instead of restarting it.
+
+        A worker reporting its node schemas invalidates a library that this pass may already have
+        walked past. Nothing else would warm it, and the pass has to be the one to notice, because
+        cancelling and restarting is exactly the cost the sweep exists to avoid.
+        """
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryDataOnlyProbe)
+        invalidated_once = False
+        real_get = library_manager._get_port_summaries_for_library
+
+        async def invalidate_behind_the_first_pass(*args: Any, **kwargs: Any) -> Any:
+            nonlocal invalidated_once
+            summaries = await real_get(*args, **kwargs)
+            if not invalidated_once:
+                invalidated_once = True
+                library_manager._invalidate_port_summaries(self._LIBRARY_NAME)
+            return summaries
+
+        with patch.object(
+            library_manager, "_get_port_summaries_for_library", side_effect=invalidate_behind_the_first_pass
+        ) as get_spy:
+            await library_manager._warm_port_summaries()
+
+        # Twice: once for the sweep whose work was invalidated, once for the sweep that noticed.
+        expected_pass_count = 2
+        assert get_spy.call_count == expected_pass_count
+        assert set(library_manager._library_to_port_summary_cache[self._LIBRARY_NAME].summaries) == {
+            _PortSummaryDataOnlyProbe.__name__
+        }
+
+    @pytest.mark.asyncio
+    async def test_warming_stops_after_its_sweep_cap_when_libraries_keep_changing(self, engine: Engine) -> None:
+        """Something invalidating in a loop must not keep the pass alive for the life of the process."""
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryDataOnlyProbe)
+        real_get = library_manager._get_port_summaries_for_library
+
+        async def always_invalidate(*args: Any, **kwargs: Any) -> Any:
+            summaries = await real_get(*args, **kwargs)
+            library_manager._invalidate_port_summaries(self._LIBRARY_NAME)
+            return summaries
+
+        sweep_cap = 3
+        with (
+            patch.object(_LibraryManager, "_PORT_SUMMARY_WARM_MAX_SWEEPS", sweep_cap),
+            patch.object(library_manager, "_get_port_summaries_for_library", side_effect=always_invalidate) as get_spy,
+        ):
+            await library_manager._warm_port_summaries()
+
+        # One pass per sweep and then it gives up, rather than sweeping forever.
+        assert get_spy.call_count == sweep_cap
 
     @pytest.mark.asyncio
     async def test_worker_stub_registration_rewarms(self, engine: Engine) -> None:
@@ -3392,17 +3709,19 @@ class TestPortSummaryInvalidationOnLibraryLoad:
         yield
         LibraryRegistry._clear()
 
-    @pytest.mark.parametrize("library_kind", ["regular", "sandbox"])
-    @pytest.mark.asyncio
-    async def test_final_lifecycle_phase_drops_cached_port_summaries(
-        self, engine: Engine, tmp_path: Path, library_kind: str
-    ) -> None:
-        """Both branches of the final phase reach the invalidation, sandbox and regular alike."""
-        is_sandbox = library_kind == "sandbox"
-        library_manager = engine.library_manager
-        library_json = tmp_path / "griptape_nodes_library.json"
-        library_json.write_text("{}")
-        file_path = str(library_json)
+    async def _run_final_lifecycle_phase(
+        self,
+        library_manager: _LibraryManager,
+        file_path: str,
+        *,
+        is_sandbox: bool,
+        node_load_failure: Exception | None = None,
+    ) -> Any:
+        """Drive the final lifecycle phase for one library, stubbing everything but the invalidation.
+
+        `node_load_failure` is raised by the node loading each branch does -- the one step of the
+        phase that can fail after the library has already been published to the registry.
+        """
         schema = LibrarySchema(
             name=self._LIBRARY_NAME,
             library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
@@ -3416,12 +3735,6 @@ class TestPortSummaryInvalidationOnLibraryLoad:
             categories=[],
             nodes=[],
         )
-
-        # Stand in for a port summary request that landed while the library was published but
-        # empty, which is exactly the state the invalidation exists to discard.
-        library_manager._library_to_port_summary_cache[self._LIBRARY_NAME] = _empty_port_summary_cache_entry()
-        generation_before = library_manager._library_to_port_summaries_generation.get(self._LIBRARY_NAME, 0)
-
         library_info = _LibraryManager.LibraryInfo(
             lifecycle_state=_LibraryManager.LibraryLifecycleState.DEPENDENCIES_INSTALLED,
             fitness=_LibraryManager.LibraryFitness.NOT_EVALUATED,
@@ -3445,16 +3758,68 @@ class TestPortSummaryInvalidationOnLibraryLoad:
                 ),
             ),
             patch.object(library_manager, "_add_library_paths_to_sys_path", new=AsyncMock()),
-            patch.object(library_manager, "_attempt_load_nodes_from_library"),
-            patch.object(library_manager, "_attempt_generate_sandbox_library_from_schema", new=AsyncMock()),
+            patch.object(library_manager, "_attempt_load_nodes_from_library", side_effect=node_load_failure),
+            patch.object(
+                library_manager,
+                "_attempt_generate_sandbox_library_from_schema",
+                new=AsyncMock(side_effect=node_load_failure),
+            ),
         ):
-            result = await library_manager._progress_library_through_lifecycle(
+            return await library_manager._progress_library_through_lifecycle(
                 library_info, file_path, RegisterLibraryFromFileRequest(file_path=file_path)
             )
+
+    @pytest.mark.parametrize("library_kind", ["regular", "sandbox"])
+    @pytest.mark.asyncio
+    async def test_final_lifecycle_phase_drops_cached_port_summaries(
+        self, engine: Engine, tmp_path: Path, library_kind: str
+    ) -> None:
+        """Both branches of the final phase reach the invalidation, sandbox and regular alike."""
+        library_manager = engine.library_manager
+        library_json = tmp_path / "griptape_nodes_library.json"
+        library_json.write_text("{}")
+
+        # Stand in for a port summary request that landed while the library was published but
+        # empty, which is exactly the state the invalidation exists to discard.
+        library_manager._library_to_port_summary_cache[self._LIBRARY_NAME] = _empty_port_summary_cache_entry()
+        generation_before = library_manager._library_to_port_summaries_generation.get(self._LIBRARY_NAME, 0)
+
+        result = await self._run_final_lifecycle_phase(
+            library_manager, str(library_json), is_sandbox=library_kind == "sandbox"
+        )
 
         assert result is None
         assert self._LIBRARY_NAME not in library_manager._library_to_port_summary_cache
         # The generation bump is what lets a probe pass already in flight discard its stale result.
+        assert library_manager._library_to_port_summaries_generation[self._LIBRARY_NAME] > generation_before
+
+    @pytest.mark.parametrize("library_kind", ["regular", "sandbox"])
+    @pytest.mark.asyncio
+    async def test_drops_cached_port_summaries_even_when_node_loading_raises(
+        self, engine: Engine, tmp_path: Path, library_kind: str
+    ) -> None:
+        """A load that blew up partway is exactly when the stale entry is worst.
+
+        The library is already published, whichever node types the load managed to register are in
+        it, and no later step will invalidate -- so an entry cached mid-load would describe this
+        library for the rest of the session. Invalidating only on the way out of a clean load would
+        make a raising node module permanently unrankable in the Add Node menu.
+        """
+        library_manager = engine.library_manager
+        library_json = tmp_path / "griptape_nodes_library.json"
+        library_json.write_text("{}")
+        library_manager._library_to_port_summary_cache[self._LIBRARY_NAME] = _empty_port_summary_cache_entry()
+        generation_before = library_manager._library_to_port_summaries_generation.get(self._LIBRARY_NAME, 0)
+
+        with pytest.raises(RuntimeError, match="a node module blew up on import"):
+            await self._run_final_lifecycle_phase(
+                library_manager,
+                str(library_json),
+                is_sandbox=library_kind == "sandbox",
+                node_load_failure=RuntimeError("a node module blew up on import"),
+            )
+
+        assert self._LIBRARY_NAME not in library_manager._library_to_port_summary_cache
         assert library_manager._library_to_port_summaries_generation[self._LIBRARY_NAME] > generation_before
 
 

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -40,6 +40,11 @@ from griptape_nodes.node_library.library_registry import (
     get_declared_models,
 )
 from griptape_nodes.retained_mode.engine import Engine
+from griptape_nodes.retained_mode.events.app_events import (
+    AppInitializationComplete,
+    LibraryLoadedNotification,
+    WorkerNodeSchema,
+)
 from griptape_nodes.retained_mode.events.base_events import ResultDetails
 from griptape_nodes.retained_mode.events.library_events import (
     DescribeNodeTypeRequest,
@@ -2687,6 +2692,69 @@ class TestGetPortSummariesForAllLibrariesRequest:
         assert not entry.pending_node_types()
 
     @pytest.mark.asyncio
+    async def test_stops_probing_the_whole_engine_once_it_has_leaked_its_ceiling_of_threads(
+        self, engine: Engine
+    ) -> None:
+        """The per-library and per-request bounds both reset; only this one bounds the running total.
+
+        The threads timeouts leak come out of one pool shared by every threaded operation in the
+        engine, so the count that matters is engine-wide and never resets. Once it is reached, no
+        library is probed again for the life of the process -- including libraries that never timed
+        out, and including after a reload -- because draining the executor stalls far more than the
+        Add Node menu.
+        """
+        library_manager = engine.library_manager
+        blocking_library = "port-summary-leak-ceiling-library"
+        # Registration order decides which library the handler walks first, so the healthy one is
+        # still unprobed when the ceiling is reached.
+        self._register_probe_library(_PortSummaryProbe, library_name=blocking_library)
+        self._register_probe_library(_PortSummaryDataOnlyProbe)
+        release_blocked_probe = threading.Event()
+        real_construct = _LibraryManager._construct_probe_node
+
+        def block_the_first_library(
+            manager: _LibraryManager, library_name: str, node_type: str, *args: Any, **kwargs: Any
+        ) -> Any:
+            if library_name == blocking_library:
+                release_blocked_probe.wait(timeout=30)
+            return real_construct(manager, library_name, node_type, *args, **kwargs)
+
+        try:
+            with (
+                patch.object(_LibraryManager, "_SCHEMA_PROBE_TIMEOUT_S", 0.2),
+                patch.object(_LibraryManager, "_PROBE_THREAD_LEAK_CEILING", 1),
+                # Deliberately generous: the library-level allowance must not be what stops this,
+                # or the test would pass without the engine-wide ceiling existing.
+                patch.object(_LibraryManager, "_PORT_SUMMARY_TIMEOUT_BUDGET", 10),
+                patch.object(
+                    _LibraryManager, "_construct_probe_node", side_effect=block_the_first_library, autospec=True
+                ) as probe_spy,
+            ):
+                await library_manager.on_get_port_summaries_for_all_libraries_request(
+                    GetPortSummariesForAllLibrariesRequest()
+                )
+                # Invalidating everything is what a reload does, and it must not buy new attempts:
+                # the leaked threads are still held whatever the libraries do next.
+                library_manager._invalidate_port_summaries(blocking_library)
+                library_manager._invalidate_port_summaries(self._LIBRARY_NAME)
+                second = await library_manager.on_get_port_summaries_for_all_libraries_request(
+                    GetPortSummariesForAllLibrariesRequest()
+                )
+                probed_node_types = [call.args[2] for call in probe_spy.call_args_list]
+        finally:
+            release_blocked_probe.set()
+
+        assert library_manager._port_summary_threads_leaked == 1
+        # One probe in total, across two requests and two libraries: the one that leaked the thread.
+        assert probed_node_types == [_PortSummaryProbe.__name__]
+        assert isinstance(second, GetPortSummariesForAllLibrariesResultSuccess)
+        assert second.library_name_to_port_summaries[self._LIBRARY_NAME] == {}
+        # Nothing pending anywhere, so no future request takes a lock to run a pass that stops
+        # immediately.
+        for library_name in (blocking_library, self._LIBRARY_NAME):
+            assert not library_manager._library_to_port_summary_cache[library_name].pending_node_types()
+
+    @pytest.mark.asyncio
     async def test_caches_a_pass_whose_only_gap_is_a_broken_node_type(self, engine: Engine) -> None:
         """A node whose __init__ raises will keep raising until the library reloads.
 
@@ -2928,7 +2996,7 @@ class TestPortSummaryWarming:
             call_order.append("cancel")
 
         async def fail_after_clearing(_request: object) -> Any:
-            # Stands in for the first thing _run_reload_libraries does after cancelling. Failing it
+            # Stands in for the first thing the reload does after cancelling. Failing it
             # short-circuits the rest of the reload, which this test does not exercise.
             call_order.append("clear_state")
             failure = MagicMock()
@@ -2936,13 +3004,36 @@ class TestPortSummaryWarming:
             return failure
 
         monkeypatch.setattr(library_manager, "_cancel_port_summary_warm", record_cancel)
+        monkeypatch.setattr(library_manager, "_start_port_summary_warm", lambda: call_order.append("restart"))
         monkeypatch.setattr(library_manager.engine, "ahandle_request", fail_after_clearing)
 
         from griptape_nodes.retained_mode.events.library_events import ReloadAllLibrariesRequest
 
-        await library_manager._run_reload_libraries(ReloadAllLibrariesRequest())
+        await library_manager.reload_libraries_request(ReloadAllLibrariesRequest())
 
-        assert call_order == ["cancel", "clear_state"]
+        assert call_order == ["cancel", "clear_state", "restart"]
+
+    @pytest.mark.asyncio
+    async def test_reload_restarts_warming_even_when_it_raises(
+        self, engine: Engine, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A reload that blew up cancelled warming on the way in; leaving it off is permanent."""
+        library_manager = engine.library_manager
+        restarted: list[bool] = []
+
+        async def boom(_request: object) -> None:
+            msg = "reload exploded"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr(library_manager, "_run_reload_libraries", boom)
+        monkeypatch.setattr(library_manager, "_start_port_summary_warm", lambda: restarted.append(True))
+
+        from griptape_nodes.retained_mode.events.library_events import ReloadAllLibrariesRequest
+
+        with pytest.raises(RuntimeError, match="reload exploded"):
+            await library_manager.reload_libraries_request(ReloadAllLibrariesRequest())
+
+        assert restarted == [True]
 
     def test_does_not_warm_on_a_worker(self, engine: Engine) -> None:
         """A worker already constructs every node type to serialize its schemas."""
@@ -2966,6 +3057,89 @@ class TestPortSummaryWarming:
             library_manager._start_port_summary_warm()
 
         assert library_manager._port_summary_warm_task is None
+
+    def test_does_not_warm_when_the_host_said_nothing_will_ask(self, engine: Engine) -> None:
+        """A headless run executes a built graph, so probing every node type is pure overhead."""
+        library_manager = engine.library_manager
+        library_manager._warm_port_summaries_requested = False
+
+        library_manager._start_port_summary_warm()
+
+        assert library_manager._port_summary_warm_task is None
+
+    @pytest.mark.asyncio
+    async def test_app_initialization_records_the_hosts_warming_choice(self, engine: Engine) -> None:
+        """The flag outlives initialization -- a reload and a worker report both consult it."""
+        library_manager = engine.library_manager
+
+        with patch.object(library_manager, "load_all_libraries_from_config", return_value=[]):
+            await library_manager._run_app_initialization(
+                AppInitializationComplete(skip_library_loading=True, warm_port_summaries=False)
+            )
+
+        assert library_manager._warm_port_summaries_requested is False
+
+    @pytest.mark.asyncio
+    async def test_starting_again_replaces_the_pass_in_flight(self, engine: Engine) -> None:
+        """Two passes would leave one with no handle, and a pass nothing holds cannot be cancelled."""
+        library_manager = engine.library_manager
+        self._register_probe_library(_PortSummaryDataOnlyProbe)
+        # Nothing has loaded in this test, so the gate holds both passes at their first await.
+        library_manager._libraries_loading_complete.clear()
+        try:
+            library_manager._start_port_summary_warm()
+            first_task = library_manager._port_summary_warm_task
+
+            library_manager._start_port_summary_warm()
+            second_task = library_manager._port_summary_warm_task
+        finally:
+            library_manager._libraries_loading_complete.set()
+
+        assert first_task is not None
+        assert second_task is not None
+        assert second_task is not first_task
+        # The replacement owns the handle straight away, and the cancelled pass's done callback must
+        # not claim it back -- that is what makes the surviving pass cancellable by a later reload.
+        assert library_manager._port_summary_warm_task is second_task
+
+        await asyncio.gather(first_task, second_task, return_exceptions=True)
+
+        assert first_task.cancelled()
+        assert not second_task.cancelled()
+        # Cleared by the surviving pass's own callback, now that there is nothing left to cancel.
+        assert library_manager._port_summary_warm_task is None
+
+    @pytest.mark.asyncio
+    async def test_worker_stub_registration_rewarms(self, engine: Engine) -> None:
+        """Registering worker stubs drops that library's summaries, and a worker can report late."""
+        library_manager = engine.library_manager
+        library_manager._is_worker = False
+        library_info = _LibraryManager.LibraryInfo(
+            lifecycle_state=_LibraryManager.LibraryLifecycleState.WORKER_PENDING,
+            fitness=_LibraryManager.LibraryFitness.NOT_EVALUATED,
+            library_path="unused",
+            is_sandbox=False,
+            library_name=self._LIBRARY_NAME,
+        )
+        restarted: list[bool] = []
+
+        with (
+            patch.object(library_manager, "get_library_info_by_library_name", return_value=library_info),
+            patch.object(library_manager, "_register_nodes_from_worker_schemas") as register_stubs,
+            patch.object(library_manager, "_start_port_summary_warm", side_effect=lambda: restarted.append(True)),
+        ):
+            await library_manager._on_library_loaded_notification(
+                LibraryLoadedNotification(
+                    library_name=self._LIBRARY_NAME,
+                    fitness=_LibraryManager.LibraryFitness.GOOD,
+                    node_schemas=[
+                        WorkerNodeSchema(class_name=_PortSummaryDataOnlyProbe.__name__, parameters=[]),
+                    ],
+                )
+            )
+
+        register_stubs.assert_called_once()
+        assert restarted == [True]
 
 
 class TestPortSummaryInvalidationOnLibraryLoad:


### PR DESCRIPTION
Engine half of the work for https://github.com/griptape-ai/griptape-vsl-gui/issues/2879 ("Create Node via Connection to Nothing"). Referenced rather than linked to close: the issue lives in the GUI repo and is only satisfied once the editor side lands.

Pairs with griptape-ai/griptape-vsl-gui#2873 (`Aodhan/260827/drag-connection-to-create`), the consumer of this request. Both sides are additive and independently mergeable — the GUI opens an unranked menu until this ships, and this request has no other caller until the GUI does.

## Problem

The editor wants to create-and-connect in one motion: drag a connection off a parameter, drop it on empty canvas, and have the Add Node menu that opens float compatible node types to the top. Ranking that menu needs to know what each node type *can* connect to before any node of that type exists.

Nothing in the engine can answer that today. `GetAllInfoForLibrary` carries display metadata only, and a node type's ports are not declared anywhere readable — parameters are added in `__init__` via `add_parameter`, so the ports are only knowable by constructing the node.

## Approach

Adds `GetPortSummariesForAllLibrariesRequest`, returning per library a map of node type name → `NodePortSummary`:

| Field | Meaning |
| --- | --- |
| `input_types` | Accepted types, unioned over every port allowing `INPUT` |
| `output_types` | Emitted types, unioned over every port allowing `OUTPUT` |
| `has_control_input` | Node declares an incoming control (execution) port |
| `has_control_output` | Node declares an outgoing control (execution) port |

All four are derived from the parameters a probed node declares, so there is no hand-written field on node classes to drift out of sync with the params. `Parameter.input_types` / `.output_type` already implement the declared-else-`type` fallback, `allowed_modes` decides which side a param lands on, and `private=True` params are skipped.

Control flow is carried **solely by the two booleans** — `parametercontroltype` never enters the type unions, because control and data connections never interconnect. Detection is by type rather than `isinstance(ControlParameterInput)`, matching the convention used everywhere else in the engine; the class check would miss custom control params.

### Why a separate request and not a field on the library catalog

The original design sketch put a precomputed `port_summary` inside `node_type_name_to_node_metadata_details[type].metadata`. That does not work here, for two reasons:

- **Cost.** The metadata-assembly path reads only declared JSON and never instantiates, and node modules are imported lazily by default (`library.lazy_node_loading`) for fast startup. Precomputing summaries there would import and instantiate every node type in every library on every editor connect — `lazy_node_loading` becomes dead config.
- **Wrong home.** `metadata` is a library-authored pydantic model, and for sandbox libraries the engine writes it back to disk via `model_dump_json()`. A derived field there gets persisted as stale author data and becomes declarable in JSON — the exact drift the sketch was trying to avoid.

So the cost is paid once per library per load, and cached until the library unloads — which every reload passes through.

### Where that cost is paid

Once per load is still a real cost the first time: under lazy node loading, computing a library's summaries imports every one of its node modules and runs every `__init__`. Left on demand, that lands at the one moment the summaries are ever wanted — while an artist is mid-drag in the Add Node menu.

So the engine warms the cache in the background instead, after libraries finish loading and again after a reload. This does not make the work cheaper; it pays for it while nobody is blocked. `library.warm_port_summaries` (default on) turns it off for a constrained machine or while authoring, which puts the cost back on the first request exactly as before.

The pass is deliberately just another caller of `_get_port_summaries_for_library`, so the per-library lock keeps a request landing mid-pass from duplicating the probing, and the generation counter still decides what is safe to cache. Three things it does not share with an interactive request:

- **Its own timeout allowance.** The interactive budget is scoped to the libraries one request touches. Spending that across every library would let a single library of blocking nodes leave all the others cold — the one outcome that makes warming pointless.
- **A real throttle between node types.** Resolving a node class imports its module *on the event loop*, which nothing can interrupt, so the pass can only space the bursts out. Affordable because nothing awaits it; not affordable for a request that does.
- **Cancellation.** A reload stops and awaits the pass before unloading anything. One left running would resolve node classes, importing modules belonging to libraries being torn down — reviving what the reload exists to replace.

Warming starts strictly after `EngineReadyEvent`, never inside the initialization sequence: that sequence is bracketed by `_is_initializing`, which the heartbeat reports, so awaiting a probe pass there would have the engine advertise "initializing" to clients for the pass's whole duration. It is skipped entirely on a dedicated library worker, which already constructs every node type to serialize its schemas.

Two invalidation paths deliberately do **not** re-warm: worker stub registration and sandbox node registration. Stub classes carry no library code, so probing them on demand is cheap, and sandbox re-registration fires on every source change while authoring, where re-warming each time would be pure waste.

### One probe path, not a third one

The engine already had two probe → port-schema representations: `ParameterDescription` (via `DescribeNodeType`) and `WorkerNodeSchema` (via the worker schema pass). Rather than hand-roll a third probe loop, construction is now funnelled through one `_probe_node_type` helper shared with `DescribeNodeType`, which also collapses that handler's two near-identical failure branches into one. Each probe runs in a thread under the same `_SCHEMA_PROBE_TIMEOUT_S` the worker-side pass uses, so one node blocking in `__init__` cannot stall the rest.

## Semantics worth knowing before consuming this

**The type lists are unions.** A match means "this node type has *some* port that could accept the dragged connection", not that a specific port will. The real connection is still resolved against the created node's actual parameters, where the node also gets to veto via `allow_incoming_connection` / `allow_outgoing_connection`. So the create-and-connect flow still has to handle the connection being refused after the node is created.

**Known limitation: dynamic ports are absent.** Only ports present right after construction are reported. Ports created later — `ParameterList` container children, a `ParameterTransitionComponent` swapping in a schema after a dropdown changes — do not appear, so a node will not be offered for those types until it is on the canvas. Acceptable for ranking, given the point above.

**Unprobeable node types are omitted, not reported as portless.** A node whose `__init__` raises or blocks past the timeout is left out of the map entirely, so callers leave it unranked rather than ranking it as connecting to nothing. It stays perfectly creatable. Consumers must treat a missing entry as *unknown*, not as `{input_types: [], output_types: []}`.

**Keys match the catalog exactly.** Both halves of the `(library, node_type)` key come from the same functions the catalog uses — `LibraryRegistry.list_libraries()` and `library.get_registered_nodes()` — with no transformation, so lookups against `GetAllInfoForAllLibraries` / `ListNodeTypesInLibrary` cannot silently miss. Node type names are the Python class name (`TextInput`), not `metadata.display_name` (`"Text Input"`).

## Files

- `src/griptape_nodes/retained_mode/events/library_events.py` — `NodePortSummary` + `from_parameters()`; the `GetPortSummariesForAllLibraries` request/success/failure family
- `src/griptape_nodes/retained_mode/managers/library_manager.py` — the handler; the per-library cache (`_library_to_port_summary_cache`, a per-library `asyncio.Lock`, and a per-library generation counter so a pass that spanned a mutation declines to cache); the background warm pass (`_start_port_summary_warm` / `_warm_port_summaries` / `_cancel_port_summary_warm`) wired at the two `EngineReadyEvent` sites, with the cancel as the first statement of `_run_reload_libraries`; the new `_probe_node_type` helper and `NodeProbeResult` NamedTuple; `PROBE_NODE_NAME_PREFIX`; and cache invalidation at the three choke points (library unload, sandbox node registration, worker schema registration)
- `src/griptape_nodes/retained_mode/managers/settings.py` — `library.warm_port_summaries`, defaulting to on
- `docs/development/custom_nodes/parameters.md` — new "How the editor previews your ports before a node exists" section, written for library authors: the four fields, that nothing is hand-declared, and the three things it asks of a node (`__init__` cheap and offline, declare types honestly, dynamic ports absent)
- `tests/unit/retained_mode/managers/test_library_manager.py` — see below

`LibraryManager.__init__` picks up a `# noqa: PLR0915` — three added registration lines tipped it to 53 statements. The file already carries that convention elsewhere; extracting the registration block felt like scope creep on this PR.

## Testing

`tests/unit/retained_mode/managers/test_library_manager.py`, 160 passed:

- `TestNodePortSummary` — union derivation and control flags off a probe node declaring `ControlParameterInput` + `ControlParameterOutput`, a multi-`input_types` param, a type-only fallback param, a PROPERTY-only param, and a `private` param; asserts the PROPERTY-only and private types appear in *neither* union. Plus the no-control and portless cases.
- `TestGetPortSummariesForAllLibrariesRequest` — a summary for every node type; unprobeable types omitted (reusing the existing `_RaisingProbe`); `_probe_node_type` called exactly once across two requests (memoization pinned via `autospec` wrapping the real method, not a stub); recomputation after the library is unloaded.
- `TestPortSummaryWarming` — the two properties that make warming worth having: a warmed request constructs **zero** probe nodes, and a request landing mid-warm probes each node type exactly once *across both callers* (the per-library lock claim — without it warming would be a pessimization for the very request it exists to speed up). Plus cancellation actually cancelling and leaving nothing half-cached, reload cancelling *before* it clears state (asserted on call order rather than on where the line sits), and both opt-outs (worker, setting off).
- The existing probe-leak assertion now keys off `PROBE_NODE_NAME_PREFIX` instead of a hardcoded string, so the two probe paths cannot drift apart silently.

`make check` clean (0 errors, 0 warnings). Full suite green: 4697 unit, 9 integration, 32 e2e. `uv run mkdocs build --strict` passes, and both cross-page anchors in the new docs section were verified to resolve against the generated HTML.

No `docs/reference/configuration_reference.md` row for the new setting: that page lists `library` as an opaque nested object, and none of its sibling sub-keys (`lazy_node_loading`, `minimum_release_age`, `dependency_install_behavior`) have rows either. The `Field` description carries it, matching the existing pattern.

## Not verified

No end-to-end editor run. The consuming frontend now exists (griptape-ai/griptape-vsl-gui#2873) and both sides pass their own checks, but the two branches have not been run against each other, so the round trip is still unexercised. The wire shape was taken from an actual `safe_unstructure()` of the result payload rather than read off the dataclass, and the `(library, node_type)` keying was traced in code against `LibraryRegistry.list_libraries()` / `library.get_registered_nodes()` — but neither substitutes for running the gesture.

Warming's wall-clock benefit is likewise unmeasured against a real library set. The tests pin that a warmed request probes nothing, which is the mechanism; how much time that saves in practice depends entirely on how heavy the installed libraries' imports are.

## Known gap: no cancellation on shutdown

The warm task is cancelled on reload but not on process exit, so an engine shutting down mid-warm can log `Task was destroyed but it is pending`. There is nowhere clean to fix this today: `Engine` has no teardown hook and there is no shutdown app event. `ModelManager`'s startup downloads and `WorkerManager`'s spawn task have the identical exposure, so this matches existing behavior rather than adding a teardown path for one caller. Worth revisiting if an engine-level shutdown hook ever lands.

## Not included

Deliberately **not** added to the MCP `SUPPORTED_REQUEST_EVENTS` allowlist. The consumer is the editor; exposing it to workflow-building agents is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--5381.org.readthedocs.build/en/5381/

<!-- readthedocs-preview griptape-nodes end -->


