### PR TITLE
refactor(events): drop engine_id/session_id ClassVars from BaseEvent

### DIFF
--- a/src/griptape_nodes/retained_mode/events/base_events.py
+++ b/src/griptape_nodes/retained_mode/events/base_events.py
@@ -5,7 +5,7 @@ import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from dataclasses import fields as dataclass_fields
-from typing import TYPE_CHECKING, Any, ClassVar, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -326,13 +326,6 @@ A = TypeVar("A", bound=AppPayload)
 
 class BaseEvent(BaseModel, ABC):
     """Abstract base class for all events."""
-
-    # Instance fields for engine and session identification
-    _engine_id: ClassVar[str | None] = None
-    _session_id: ClassVar[str | None] = None
-
-    engine_id: str | None = Field(default_factory=lambda: BaseEvent._engine_id)
-    session_id: str | None = Field(default_factory=lambda: BaseEvent._session_id)
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 

--- a/src/griptape_nodes/retained_mode/managers/engine_identity_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/engine_identity_manager.py
@@ -27,7 +27,6 @@ from griptape_nodes.retained_mode.events.app_events import (
     SetEngineNameResultSuccess,
 )
 from griptape_nodes.retained_mode.events.base_events import (
-    BaseEvent,
     ResultDetails,
     ResultPayload,
 )
@@ -205,8 +204,6 @@ class EngineIdentityManager:
             )
             self._add_or_update_engine(engine_data)
 
-        # Register engine with BaseEvent
-        BaseEvent._engine_id = engine_data.id
         self._active_engine_id = engine_data.id
         logger.debug("Initialized engine ID: %s", engine_data.id)
         return engine_data

--- a/src/griptape_nodes/retained_mode/managers/session_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/session_manager.py
@@ -2,7 +2,7 @@
 
 Handles storing and retrieving multiple session information across engine restarts.
 Sessions are tied to specific engines, with each engine maintaining its own session store.
-Supports multiple concurrent sessions per engine with one active session managed through BaseEvent.
+Supports multiple concurrent sessions per engine with one active session.
 Storage structure: ~/.local/state/griptape_nodes/engines/{engine_id}/sessions.json
 """
 
@@ -29,11 +29,11 @@ from griptape_nodes.retained_mode.events.app_events import (
     SessionHeartbeatResultFailure,
     SessionHeartbeatResultSuccess,
 )
-from griptape_nodes.retained_mode.events.base_events import BaseEvent, ResultPayload
 
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from griptape_nodes.retained_mode.events.base_events import ResultPayload
     from griptape_nodes.retained_mode.managers.engine_identity_manager import EngineIdentityManager
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
 
@@ -74,7 +74,6 @@ class SessionManager:
         self._engine_identity_manager = engine_identity_manager
         self._sessions_data = self._load_sessions_data()
         self._active_session_id = self._get_or_initialize_active_session()
-        BaseEvent._session_id = self._active_session_id
         if event_manager is not None:
             event_manager.assign_manager_to_request_type(AppStartSessionRequest, self.handle_session_start_request)
             event_manager.assign_manager_to_request_type(AppEndSessionRequest, self.handle_session_end_request)
@@ -98,7 +97,6 @@ class SessionManager:
             session_id: The session ID to set as active
         """
         self._active_session_id = session_id
-        BaseEvent._session_id = session_id
         logger.debug("Set active session ID to: %s", session_id)
 
     @property
@@ -129,7 +127,6 @@ class SessionManager:
 
         # Set as active session
         self._active_session_id = session_id
-        BaseEvent._session_id = session_id
         logger.info("Saved and activated session: %s for engine: %s", session_id, engine_id)
 
     def remove_session(self, session_id: str) -> None:
@@ -151,7 +148,6 @@ class SessionManager:
             self._active_session_id = (
                 self._sessions_data.sessions[0].session_id if self._sessions_data.sessions else None
             )
-            BaseEvent._session_id = self._active_session_id
             logger.info(
                 "Removed active session %s for engine %s, set new active session to: %s",
                 session_id,
@@ -166,7 +162,6 @@ class SessionManager:
         """Clear all saved session data for the current engine."""
         # Clear active session
         self._active_session_id = None
-        BaseEvent._session_id = None
 
         # Clear in-memory session data
         self._sessions_data = SessionsStorage(sessions=[])

--- a/tests/unit/servers/test_mcp.py
+++ b/tests/unit/servers/test_mcp.py
@@ -53,8 +53,6 @@ class TestSummarizeResultDetails:
 class TestTrimResponse:
     def test_drops_envelope_noise_and_flattens_details(self) -> None:
         raw = {
-            "engine_id": "engine-1",
-            "session_id": "session-1",
             "request": {"node_type": "Probe", "library": "demo"},
             "request_id": "abc",
             "response_topic": "response",


### PR DESCRIPTION
`BaseEvent` carried two ClassVars that stamped an engine and session id onto every event, set unconditionally from `EngineIdentityManager.__init__` and `SessionManager.__init__`, so the last `Engine` constructed in a process labeled every other engine's events. Nothing read the resulting wire fields: routing uses the session-scoped topic, and clients take engine identity from the heartbeat result payload.

Follow-ups removing the now-dead readers and padding:

- griptape-ai/griptape-nodes-app#216
- griptape-ai/griptape-vsl-gui#2874
- griptape-ai/griptape-nodes-bridge#14
