### PR TITLE
fix: stop a 404 on transient upload cleanup from failing a successful run

### DIFF
--- a/src/griptape_nodes/drivers/storage/base_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/base_storage_driver.py
@@ -85,6 +85,10 @@ class BaseStorageDriver(ABC):
     def delete_file(self, path: Path) -> None:
         """Delete a file from storage.
 
+        Deleting a path that is already absent is a successful no-op: the requested end
+        state already holds, so implementations must return normally rather than raising.
+        Real failures (permission denied, server errors, timeouts) still raise.
+
         Args:
             path: Workspace-relative path of the file (e.g., ``outputs/image.png``).
         """

--- a/src/griptape_nodes/drivers/storage/griptape_cloud_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/griptape_cloud_storage_driver.py
@@ -406,6 +406,12 @@ class GriptapeCloudStorageDriver(BaseStorageDriver):
     def delete_file(self, path: Path) -> None:
         """Delete a file from the bucket.
 
+        Deleting an asset that is already absent is a successful no-op: a 404 means the
+        requested end state -- the asset not being in the bucket -- already holds. Cleanup
+        paths that delete transient uploads run after the asset may have been removed
+        elsewhere, and must not fail an otherwise-successful operation over it. A 403, a
+        5xx, or a timeout still raises.
+
         Args:
             path: The path of the file to delete.
         """
@@ -415,6 +421,13 @@ class GriptapeCloudStorageDriver(BaseStorageDriver):
         try:
             self._request("DELETE", url)
         except httpx.HTTPStatusError as e:
+            if e.response.status_code == HTTPStatus.NOT_FOUND:
+                logger.debug(
+                    "Asset %s is already absent from bucket %s; nothing to delete",
+                    normalized_path,
+                    self.bucket_id,
+                )
+                return
             msg = f"Failed to delete file {normalized_path}: {e}"
             logger.error(msg)
             raise RuntimeError(msg) from e

--- a/src/griptape_nodes/drivers/storage/local_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/local_storage_driver.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from http import HTTPStatus
 from pathlib import Path
 from urllib.parse import urljoin
 
@@ -183,6 +184,10 @@ class LocalStorageDriver(BaseStorageDriver):
     def delete_file(self, path: Path) -> None:
         """Delete a file from local storage.
 
+        Deleting a file that is already absent is a successful no-op: the static server
+        answers 404 for a missing file, which means the requested end state already holds.
+        Any other HTTP error still raises.
+
         Args:
             path: The path of the file to delete.
         """
@@ -193,6 +198,9 @@ class LocalStorageDriver(BaseStorageDriver):
             response = httpx.delete(delete_url)
             response.raise_for_status()
         except httpx.HTTPStatusError as e:
+            if e.response.status_code == HTTPStatus.NOT_FOUND:
+                logger.debug("File %s is already absent from local storage; nothing to delete", path)
+                return
             msg = f"Failed to delete file {path}: {e}"
             logger.error(msg)
             raise RuntimeError(msg) from e

--- a/src/griptape_nodes/exe_types/param_components/artifact_url/public_artifact_url_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/artifact_url/public_artifact_url_parameter.py
@@ -31,7 +31,6 @@ class PublicArtifactUrlParameter:
     BUCKET_ID_NAME = "GT_CLOUD_BUCKET_ID"
     supported_artifact_types: ClassVar[list[type]] = [ImageUrlArtifact, VideoUrlArtifact, AudioUrlArtifact]
     supported_artifact_type_names: ClassVar[list[str]] = [cls.__name__ for cls in supported_artifact_types]
-    gtc_file_path: Path | None = None
 
     def __init__(
         self,
@@ -44,6 +43,7 @@ class PublicArtifactUrlParameter:
         self._parameter = artifact_url_parameter
         self._disclaimer_message = disclaimer_message
         self._request_timeout = request_timeout
+        self.gtc_file_path: Path | None = None
 
         if artifact_url_parameter.type.lower() not in [name.lower() for name in self.supported_artifact_type_names]:
             msg = (
@@ -154,6 +154,12 @@ class PublicArtifactUrlParameter:
         )
 
     def get_public_url_for_parameter(self) -> str:
+        # A helper instance lives as long as the node, so an upload path recorded by an
+        # earlier run is cleared before anything else: it would otherwise be re-deleted by
+        # delete_uploaded_artifact, and callers read gtc_file_path to tell an upload from
+        # the already-public pass-through below.
+        self.gtc_file_path = None
+
         # Parameter values that crossed a JSON boundary (orchestrator <-> worker, workflow load)
         # arrive as serialized artifact dicts; rehydrate them back into artifacts first.
         parameter_value = hydrate_value(self._node.get_parameter_value(self._parameter.name))
@@ -189,6 +195,9 @@ class PublicArtifactUrlParameter:
         if not self.gtc_file_path:
             return
         self._storage_driver.delete_file(self.gtc_file_path)
+        # The upload is gone, so the path is forgotten: a second cleanup pass over the same
+        # helper must not issue another delete.
+        self.gtc_file_path = None
 
     @staticmethod
     def _derive_upload_filename(url: str) -> str:

--- a/tests/unit/drivers/storage/test_griptape_cloud_storage_driver.py
+++ b/tests/unit/drivers/storage/test_griptape_cloud_storage_driver.py
@@ -477,3 +477,52 @@ class TestGriptapeCloudStorageDriverExtractBucketId:
         url = "https://cloud.griptape.ai/buckets/my-bucket_test-123/assets/file.txt"
         result = GriptapeCloudStorageDriver.extract_bucket_id_from_url(url)
         assert result == "my-bucket_test-123"
+
+
+class TestGriptapeCloudStorageDriverDeleteFile:
+    """Test GriptapeCloudStorageDriver.delete_file() idempotency.
+
+    Deleting an asset that is already gone means the requested end state holds, so a 404
+    is a no-op. Cleanup of a transient upload must not fail an otherwise-successful run
+    over it. See griptape-ai/griptape-nodes-engine#4872.
+    """
+
+    @pytest.fixture
+    def cloud_storage_driver(self) -> GriptapeCloudStorageDriver:
+        return GriptapeCloudStorageDriver(
+            workspace_directory=Path("/workspace"),
+            bucket_id=TEST_BUCKET_ID,
+            api_key=TEST_API_KEY,
+        )
+
+    @staticmethod
+    def _status_error(status_code: int) -> httpx.HTTPStatusError:
+        response = Mock()
+        response.status_code = status_code
+        return httpx.HTTPStatusError(f"http {status_code}", request=Mock(), response=response)
+
+    def test_deletes_asset_at_workspace_relative_path(self, cloud_storage_driver: GriptapeCloudStorageDriver) -> None:
+        with patch.object(cloud_storage_driver, "_request") as mock_request:
+            cloud_storage_driver.delete_file(Path("artifact_url_storage/abc/video.mp4"))
+
+        args, _ = mock_request.call_args
+        assert args[0] == "DELETE"
+        assert args[1].endswith(f"/api/buckets/{TEST_BUCKET_ID}/assets/artifact_url_storage/abc/video.mp4")
+
+    def test_absent_asset_is_a_no_op(self, cloud_storage_driver: GriptapeCloudStorageDriver) -> None:
+        with patch.object(cloud_storage_driver, "_request", side_effect=self._status_error(404)):
+            cloud_storage_driver.delete_file(TEST_FILE_PATH)
+
+    def test_raises_on_permission_denied(self, cloud_storage_driver: GriptapeCloudStorageDriver) -> None:
+        with (
+            patch.object(cloud_storage_driver, "_request", side_effect=self._status_error(403)),
+            pytest.raises(RuntimeError, match="Failed to delete file"),
+        ):
+            cloud_storage_driver.delete_file(TEST_FILE_PATH)
+
+    def test_raises_on_server_error(self, cloud_storage_driver: GriptapeCloudStorageDriver) -> None:
+        with (
+            patch.object(cloud_storage_driver, "_request", side_effect=self._status_error(500)),
+            pytest.raises(RuntimeError, match="Failed to delete file"),
+        ):
+            cloud_storage_driver.delete_file(TEST_FILE_PATH)

--- a/tests/unit/drivers/storage/test_local_storage_driver.py
+++ b/tests/unit/drivers/storage/test_local_storage_driver.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import Mock, patch
 
+import httpx
 import pytest
 
 from griptape_nodes.drivers.storage.local_storage_driver import LocalStorageDriver
@@ -409,3 +410,50 @@ class TestLocalStorageDriverGetAssetUrl:
         url = driver.get_asset_url(Path("/elsewhere/media/photo.png"))
 
         assert url == str(Path("/elsewhere/media/photo.png").resolve())
+
+
+class TestLocalStorageDriverDeleteFile:
+    """Test LocalStorageDriver.delete_file() idempotency.
+
+    The static server answers 404 for a missing file, which means the requested end state
+    already holds. See griptape-ai/griptape-nodes-engine#4872.
+    """
+
+    MODULE = "griptape_nodes.drivers.storage.local_storage_driver"
+
+    @staticmethod
+    def _delete_mock(status_code: int | None) -> Mock:
+        response = Mock()
+        response.status_code = status_code
+        if status_code is None:
+            response.raise_for_status.return_value = None
+        else:
+            response.raise_for_status.side_effect = httpx.HTTPStatusError(
+                f"http {status_code}", request=Mock(), response=response
+            )
+        return Mock(return_value=response)
+
+    def test_deletes_through_static_files_endpoint(self) -> None:
+        driver = LocalStorageDriver(Path("/workspace"))
+        delete_mock = self._delete_mock(None)
+
+        with patch(f"{self.MODULE}.httpx.delete", delete_mock):
+            driver.delete_file(Path("artifact_url_storage/abc/video.mp4"))
+
+        args, _ = delete_mock.call_args
+        assert args[0].endswith("/static-files/artifact_url_storage/abc/video.mp4")
+
+    def test_absent_file_is_a_no_op(self) -> None:
+        driver = LocalStorageDriver(Path("/workspace"))
+
+        with patch(f"{self.MODULE}.httpx.delete", self._delete_mock(404)):
+            driver.delete_file(TEST_FILE_PATH)
+
+    def test_raises_on_server_error(self) -> None:
+        driver = LocalStorageDriver(Path("/workspace"))
+
+        with (
+            patch(f"{self.MODULE}.httpx.delete", self._delete_mock(500)),
+            pytest.raises(RuntimeError, match="Failed to delete file"),
+        ):
+            driver.delete_file(TEST_FILE_PATH)

--- a/tests/unit/exe_types/param_components/artifact_url/test_public_artifact_url_parameter.py
+++ b/tests/unit/exe_types/param_components/artifact_url/test_public_artifact_url_parameter.py
@@ -7,6 +7,7 @@ paths. See griptape-ai/griptape-nodes-engine#4688.
 """
 
 import re
+from pathlib import Path
 from typing import Any, NamedTuple
 from unittest.mock import Mock
 
@@ -201,3 +202,58 @@ class TestGetBucketId:
 
         with pytest.raises(RuntimeError, match="No Griptape Cloud storage buckets found"):
             PublicArtifactUrlParameter._get_bucket_id("https://base", "key")
+
+
+class TestUploadPathLifecycle:
+    """Covers gtc_file_path across runs -- see griptape-ai/griptape-nodes-engine#4872.
+
+    A helper instance lives as long as the node, so the path recorded by an upload used to
+    outlive the run that made it. A later run whose input was already public took the
+    pass-through path and then deleted that stale path, 404ing on an asset it had already
+    deleted itself and failing a successful generation in cleanup.
+    """
+
+    STALE_PATH = Path("artifact_url_storage/deadbeef/reference.mp4")
+
+    def test_pass_through_clears_a_path_from_an_earlier_run(self) -> None:
+        component, driver = _make_component("https://example.com/img.png")
+        component.gtc_file_path = self.STALE_PATH
+
+        component.get_public_url_for_parameter()
+
+        assert component.gtc_file_path is None
+        driver.upload_file.assert_not_called()
+
+    def test_cleanup_after_a_pass_through_run_deletes_nothing(self) -> None:
+        component, driver = _make_component("https://example.com/img.png")
+        component.gtc_file_path = self.STALE_PATH
+
+        component.get_public_url_for_parameter()
+        component.delete_uploaded_artifact()
+
+        driver.delete_file.assert_not_called()
+
+    def test_delete_forgets_the_path(self) -> None:
+        component, driver = _make_component("https://example.com/img.png")
+        component.gtc_file_path = self.STALE_PATH
+
+        component.delete_uploaded_artifact()
+
+        driver.delete_file.assert_called_once_with(self.STALE_PATH)
+        assert component.gtc_file_path is None
+
+    def test_second_cleanup_pass_deletes_nothing(self) -> None:
+        component, driver = _make_component("https://example.com/img.png")
+        component.gtc_file_path = self.STALE_PATH
+
+        component.delete_uploaded_artifact()
+        component.delete_uploaded_artifact()
+
+        assert driver.delete_file.call_count == 1
+
+    def test_delete_is_skipped_when_nothing_was_uploaded(self) -> None:
+        component, driver = _make_component("https://example.com/img.png")
+
+        component.delete_uploaded_artifact()
+
+        driver.delete_file.assert_not_called()


### PR DESCRIPTION
Closes #4872