### PR TITLE
refactor(tests): drive tests through an injected Engine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,13 @@ ignore = [
 "griptape_nodes.retained_mode.griptape_nodes.GriptapeNodes".msg = "Engine-internal code should take an injected Engine (see griptape_nodes.retained_mode.engine) and reach peers via self.engine, not the process-wide GriptapeNodes facade. The facade exists for saved workflow files, node libraries, and process entry points; those are allowlisted in per-file-ignores."
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["S101", "D104", "TID251"]
+"tests/*" = ["S101", "D104"]
+# Fixture node libraries and saved workflow files under the e2e suite. Node libraries and
+# generated workflows are the intended facade audience, exactly as the ban message says.
+"tests/e2e/fixtures/**" = ["TID251"]
+# These two assert the facade's own behavior, so they have to name it.
+"tests/unit/retained_mode/test_engine.py" = ["TID251"]
+"tests/unit/retained_mode/managers/test_griptape_nodes.py" = ["TID251"]
 "libraries/**/tests/**" = ["S101", "D104", "INP001"]
 "src/griptape_nodes/retained_mode/events/*" = ["TC001"]
 # Example libraries shipped with the Advanced Libraries doc. Authors copy these files

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -11,18 +11,19 @@ import pytest
 import griptape_nodes.retained_mode.managers.config_manager as config_manager_module
 import griptape_nodes.retained_mode.managers.secrets_manager as secrets_manager_module
 from griptape_nodes.node_library.library_registry import LibraryRegistry
-from griptape_nodes.retained_mode.engine import reset_root_engine
+from griptape_nodes.retained_mode.engine import current_engine, reset_root_engine
 from griptape_nodes.retained_mode.events.connection_events import (
     CreateConnectionRequest,
     CreateConnectionResultSuccess,
 )
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.utils.version_utils import engine_version
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator, Sequence
     from pathlib import Path
+
+    from griptape_nodes.retained_mode.engine import Engine
 
 
 @pytest.fixture(autouse=True)
@@ -56,6 +57,12 @@ def _isolated_engine_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Ite
     finally:
         reset_root_engine()
         LibraryRegistry._clear()
+
+
+@pytest.fixture
+def engine() -> Engine:
+    """Provide the engine for this test, building it on first use."""
+    return current_engine()
 
 
 @pytest.fixture
@@ -143,11 +150,11 @@ def write_isolated_config() -> Callable[..., None]:
 
 
 @pytest.fixture
-def create_node() -> Callable[..., str]:
+def create_node(engine: Engine) -> Callable[..., str]:
     """Return a helper that creates a node from the given library and asserts success."""
 
     def _create(node_type: str, node_name: str, flow_name: str, *, library_name: str) -> str:
-        result = GriptapeNodes.handle_request(
+        result = engine.handle_request(
             CreateNodeRequest(
                 node_type=node_type,
                 specific_library_name=library_name,
@@ -162,11 +169,11 @@ def create_node() -> Callable[..., str]:
 
 
 @pytest.fixture
-def connect() -> Callable[..., None]:
+def connect(engine: Engine) -> Callable[..., None]:
     """Return a helper that connects two node parameters and asserts success."""
 
     def _connect(source_node: str, source_param: str, target_node: str, target_param: str) -> None:
-        result = GriptapeNodes.handle_request(
+        result = engine.handle_request(
             CreateConnectionRequest(
                 source_node_name=source_node,
                 source_parameter_name=source_param,

--- a/tests/e2e/test_lazy_loading_stable_namespace.py
+++ b/tests/e2e/test_lazy_loading_stable_namespace.py
@@ -48,11 +48,12 @@ from griptape_nodes.retained_mode.events.parameter_events import (
     SetParameterValueRequest,
     SetParameterValueResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
 
 if TYPE_CHECKING:
     from types import ModuleType
+
+    from griptape_nodes.retained_mode.engine import Engine
 
 FIXTURE_LIBRARY_DIR = Path(__file__).parent / "fixtures" / "lazy_payload_library"
 FIXTURE_LIBRARY_JSON_TEMPLATE = FIXTURE_LIBRARY_DIR / "griptape_nodes_library.json"
@@ -95,11 +96,9 @@ def _purge_stable_namespace_modules() -> None:
             del sys.modules[module_name]
 
 
-def _unload_library_if_registered(library_name: str) -> None:
+def _unload_library_if_registered(engine: Engine, library_name: str) -> None:
     """Unload a library from the shared engine singleton, tolerating it not being registered."""
-    GriptapeNodes.handle_request(
-        UnloadLibraryFromRegistryRequest(library_name=library_name, failure_log_level=logging.DEBUG)
-    )
+    engine.handle_request(UnloadLibraryFromRegistryRequest(library_name=library_name, failure_log_level=logging.DEBUG))
 
 
 def _write_isolated_config(config_root: Path, *, workspace: Path, library_path: Path) -> None:
@@ -132,7 +131,7 @@ def _import_stable_namespace() -> ModuleType:
     return importlib.import_module(STABLE_NAMESPACE)
 
 
-def _generate_payload_workflow_source(library_json: Path, *, lazy_save: bool) -> str:
+def _generate_payload_workflow_source(engine: Engine, library_json: Path, *, lazy_save: bool) -> str:
     """Build a flow holding a LazyPayload parameter value and serialize it to a Python module.
 
     Mirrors the engine's save path: register the library, create a flow, drop a node into it,
@@ -140,13 +139,13 @@ def _generate_payload_workflow_source(library_json: Path, *, lazy_save: bool) ->
     generate the workflow file content. ``lazy_save`` pins whether the saving engine loads
     nodes lazily or eagerly, so both save-time worlds can be round-tripped into a lazy loader.
     """
-    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
-    _unload_library_if_registered(LIBRARY_NAME)
+    engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    _unload_library_if_registered(engine, LIBRARY_NAME)
     _purge_stable_namespace_modules()
 
     # Pin the loading mode for this registration regardless of the developer's ambient config.
     with patch.object(LibraryManager, "_should_lazy_load_nodes", return_value=lazy_save):
-        register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+        register_result = engine.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
     assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
 
     # Under a lazy save no node module has loaded yet, so importing the stable namespace here
@@ -157,14 +156,14 @@ def _generate_payload_workflow_source(library_json: Path, *, lazy_save: bool) ->
     module = _import_stable_namespace()
     payload = module.LazyPayload(PAYLOAD_TAG)
 
-    GriptapeNodes.ContextManager().push_workflow(workflow_name="lazy_payload_e2e_workflow")
+    engine.context_manager.push_workflow(workflow_name="lazy_payload_e2e_workflow")
 
-    flow_result = GriptapeNodes.handle_request(
+    flow_result = engine.handle_request(
         CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False)
     )
     assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
 
-    node_result = GriptapeNodes.handle_request(
+    node_result = engine.handle_request(
         CreateNodeRequest(
             node_type="LazyPayloadNode",
             specific_library_name=LIBRARY_NAME,
@@ -177,12 +176,12 @@ def _generate_payload_workflow_source(library_json: Path, *, lazy_save: bool) ->
         f"Sanity: in-process registration must yield real node, got {node_result.node_type!r}"
     )
 
-    set_value_result = GriptapeNodes.handle_request(
+    set_value_result = engine.handle_request(
         SetParameterValueRequest(parameter_name="payload", value=payload, node_name="LazyPayload_1")
     )
     assert isinstance(set_value_result, SetParameterValueResultSuccess), set_value_result
 
-    serialize_result = GriptapeNodes.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_result.flow_name))
+    serialize_result = engine.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_result.flow_name))
     assert isinstance(serialize_result, SerializeFlowToCommandsResultSuccess), serialize_result
 
     metadata = WorkflowMetadata(
@@ -193,7 +192,7 @@ def _generate_payload_workflow_source(library_json: Path, *, lazy_save: bool) ->
         # Skip the executable wrapper; we only need build_workflow to run end-to-end.
         workflow_shape=None,
     )
-    return GriptapeNodes.WorkflowManager()._generate_workflow_file_content(
+    return engine.workflow_manager._generate_workflow_file_content(
         serialized_flow_commands=serialize_result.serialized_flow_commands,
         workflow_metadata=metadata,
     )
@@ -255,7 +254,7 @@ if __name__ == "__main__":
         pytest.param(False, id="saved-by-eager-engine"),
     ],
 )
-def test_saved_workflow_opens_under_lazy_node_loading(tmp_path: Path, *, lazy_save: bool) -> None:
+def test_saved_workflow_opens_under_lazy_node_loading(tmp_path: Path, engine: Engine, *, lazy_save: bool) -> None:
     """A saved workflow carrying a library-defined value must open with lazy loading enabled.
 
     Regression test for the lazy-node-loading rollback: opening any workflow failed with
@@ -265,12 +264,14 @@ def test_saved_workflow_opens_under_lazy_node_loading(tmp_path: Path, *, lazy_sa
     engines must open after updating to an engine that loads nodes lazily.
     """
     workspace = tmp_path / "workspace"
-    workspace.mkdir()
+    # The engine's ConfigManager creates the configured workspace on init, so this only has to
+    # cover the case where it has not.
+    workspace.mkdir(exist_ok=True)
     config_root = tmp_path / "xdg_config"
     library_json = _materialize_library(tmp_path / "library")
     _write_isolated_config(config_root, workspace=workspace, library_path=library_json)
 
-    workflow_source = _generate_payload_workflow_source(library_json, lazy_save=lazy_save)
+    workflow_source = _generate_payload_workflow_source(engine, library_json, lazy_save=lazy_save)
     runnable_source = _wrap_with_runtime_assertions(workflow_source)
     assert f"from {STABLE_NAMESPACE} import LazyPayload" in workflow_source, (
         "The generator must emit the deferred stable-namespace import for the pickled payload;"
@@ -309,7 +310,7 @@ def test_saved_workflow_opens_under_lazy_node_loading(tmp_path: Path, *, lazy_sa
     not FIXTURE_LIBRARY_JSON_TEMPLATE.exists(),
     reason=f"Lazy Payload Library fixture missing at {FIXTURE_LIBRARY_JSON_TEMPLATE}",
 )
-def test_stable_namespace_import_tracks_library_lifecycle(tmp_path: Path) -> None:
+def test_stable_namespace_import_tracks_library_lifecycle(tmp_path: Path, engine: Engine) -> None:
     """Stable-namespace importability must follow the library's register/unload/re-register lifecycle.
 
     Drives the public request surface only, so it pins the behavioral contract that must
@@ -323,15 +324,15 @@ def test_stable_namespace_import_tracks_library_lifecycle(tmp_path: Path) -> Non
     library_json = _materialize_library(tmp_path / "library", library_name=library_name)
     node_file = library_json.parent / FIXTURE_NODE_FILE.name
 
-    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
-    _unload_library_if_registered(library_name)
+    engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    _unload_library_if_registered(engine, library_name)
     _purge_stable_namespace_modules()
 
     node_file.write_text(FIXTURE_NODE_FILE.read_text() + '\nLIFECYCLE_MARKER = "initial"\n')
 
     # Register: the namespace becomes importable without any node class having resolved.
     with patch.object(LibraryManager, "_should_lazy_load_nodes", return_value=True):
-        register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+        register_result = engine.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
     assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
     assert stable_namespace not in sys.modules, "Sanity: lazy registration must not import the node module"
 
@@ -339,7 +340,7 @@ def test_stable_namespace_import_tracks_library_lifecycle(tmp_path: Path) -> Non
     assert module.LIFECYCLE_MARKER == "initial"
 
     # Unload: the namespace must stop resolving, both from sys.modules and via fresh import.
-    unload_result = GriptapeNodes.handle_request(UnloadLibraryFromRegistryRequest(library_name=library_name))
+    unload_result = engine.handle_request(UnloadLibraryFromRegistryRequest(library_name=library_name))
     assert isinstance(unload_result, UnloadLibraryFromRegistryResultSuccess), unload_result
     assert stable_namespace not in sys.modules, "Unload must remove the stable namespace from sys.modules"
     with pytest.raises(ModuleNotFoundError):
@@ -348,12 +349,12 @@ def test_stable_namespace_import_tracks_library_lifecycle(tmp_path: Path) -> Non
     # Re-register after a source edit: the import must serve the fresh code, not a stale module.
     node_file.write_text(FIXTURE_NODE_FILE.read_text() + '\nLIFECYCLE_MARKER = "reloaded"\n')
     with patch.object(LibraryManager, "_should_lazy_load_nodes", return_value=True):
-        reregister_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+        reregister_result = engine.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
     assert isinstance(reregister_result, RegisterLibraryFromFileResultSuccess), reregister_result
 
     reloaded_module = importlib.import_module(stable_namespace)
     assert reloaded_module.LIFECYCLE_MARKER == "reloaded"
 
     # Leave the shared singleton the way we found it.
-    _unload_library_if_registered(library_name)
+    _unload_library_if_registered(engine, library_name)
     _purge_stable_namespace_modules()

--- a/tests/e2e/test_library_dependency_environment_init.py
+++ b/tests/e2e/test_library_dependency_environment_init.py
@@ -39,12 +39,11 @@ from typing import TYPE_CHECKING
 import pytest
 
 from griptape_nodes.node_library.library_registry import LibraryRegistry, LibrarySchema
-from griptape_nodes.retained_mode.engine import reset_root_engine
+from griptape_nodes.retained_mode.engine import current_engine, reset_root_engine
 from griptape_nodes.retained_mode.events.library_events import (
     RegisterLibraryFromFileRequest,
     RegisterLibraryFromFileResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
 from griptape_nodes.utils.version_utils import engine_version
 
@@ -115,13 +114,15 @@ def _materialize_dep_library(target_dir: Path, *, wheel_dir: Path, name: str, wo
 
 
 def _register(library_json: Path) -> RegisterLibraryFromFileResultSuccess:
-    result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    # Re-resolved on each call, rather than threaded from a fixture: the cold-boot test below
+    # calls `reset_root_engine()` mid-test, and a fixture-captured Engine would go stale then.
+    result = current_engine().handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
     assert isinstance(result, RegisterLibraryFromFileResultSuccess), getattr(result, "result_details", result)
     return result
 
 
 def _library_info(library_json: Path) -> LibraryManager.LibraryInfo:
-    return GriptapeNodes.LibraryManager()._library_file_path_to_info[str(library_json)]
+    return current_engine().library_manager._library_file_path_to_info[str(library_json)]
 
 
 def _hooks_seen(library_name: str) -> list[str]:
@@ -167,7 +168,7 @@ class TestWorkerEnvironmentInitialization:
         library_json = _materialize_dep_library(
             library_dir, wheel_dir=wheel_dir, name="Worker Dep Library Worker", worker_mode=True
         )
-        GriptapeNodes.LibraryManager()._is_worker = True
+        current_engine().library_manager._is_worker = True
 
         _register(library_json)
 
@@ -189,7 +190,7 @@ class TestWorkerEnvironmentInitialization:
         library_json = _materialize_dep_library(
             library_dir, wheel_dir=wheel_dir, name="Worker Dep Library Reboot", worker_mode=True
         )
-        GriptapeNodes.LibraryManager()._is_worker = True
+        current_engine().library_manager._is_worker = True
         _register(library_json)
         advanced = LibraryRegistry.get_library("Worker Dep Library Reboot").get_advanced_library()
         assert advanced is not None
@@ -200,7 +201,7 @@ class TestWorkerEnvironmentInitialization:
         LibraryRegistry._clear()
         sys.modules.pop(DEP_NAME, None)
         sys.modules.pop(advanced_module_name, None)
-        GriptapeNodes.LibraryManager()._is_worker = True
+        current_engine().library_manager._is_worker = True
 
         _register(library_json)
 

--- a/tests/e2e/test_nested_node_group_execution.py
+++ b/tests/e2e/test_nested_node_group_execution.py
@@ -39,10 +39,11 @@ from griptape_nodes.retained_mode.events.node_events import (
 )
 from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
 from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from griptape_nodes.retained_mode.engine import Engine
 
 # Timeout with thread dump.
 pytestmark = pytest.mark.timeout(300, method="thread")
@@ -54,26 +55,26 @@ FIXTURE_NODE_FILE = FIXTURE_LIBRARY_DIR / "subflow_echo_node.py"
 _EXPECTED_TEXT = "hello from a nested subflow"
 
 
-def _build_nested_graph(library_name: str) -> str:
+def _build_nested_graph(engine: Engine, library_name: str) -> str:
     """Build Source -> Outer[ Inner[ Leaf ] ] and return the top-level flow name."""
-    flow_result = GriptapeNodes.handle_request(
+    flow_result = engine.handle_request(
         CreateFlowRequest(parent_flow_name=None, flow_name="NestedParentFlow", set_as_new_context=False)
     )
     assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
     flow_name = flow_result.flow_name
 
-    with GriptapeNodes.ContextManager().flow(flow_name):
-        outer = GriptapeNodes.handle_request(
+    with engine.context_manager.flow(flow_name):
+        outer = engine.handle_request(
             CreateNodeRequest(node_type="SubflowGroupNode", specific_library_name=library_name, node_name="OuterGroup")
         )
         assert isinstance(outer, CreateNodeResultSuccess), outer
 
-        inner = GriptapeNodes.handle_request(
+        inner = engine.handle_request(
             CreateNodeRequest(node_type="SubflowGroupNode", specific_library_name=library_name, node_name="InnerGroup")
         )
         assert isinstance(inner, CreateNodeResultSuccess), inner
 
-        leaf = GriptapeNodes.handle_request(
+        leaf = engine.handle_request(
             CreateNodeRequest(
                 node_type="EchoNode",
                 specific_library_name=library_name,
@@ -83,24 +84,24 @@ def _build_nested_graph(library_name: str) -> str:
         )
         assert isinstance(leaf, CreateNodeResultSuccess), leaf
 
-        source = GriptapeNodes.handle_request(
+        source = engine.handle_request(
             CreateNodeRequest(node_type="EchoNode", specific_library_name=library_name, node_name="Source")
         )
         assert isinstance(source, CreateNodeResultSuccess), source
 
         # Nest the inner group (which already holds Leaf) inside the outer group.
-        nest_result = GriptapeNodes.handle_request(
+        nest_result = engine.handle_request(
             AddNodesToNodeGroupRequest(node_names=[inner.node_name], node_group_name=outer.node_name)
         )
         assert isinstance(nest_result, AddNodesToNodeGroupResultSuccess), nest_result
 
-        GriptapeNodes.handle_request(
+        engine.handle_request(
             SetParameterValueRequest(parameter_name="text", node_name=source.node_name, value=_EXPECTED_TEXT)
         )
 
         # Crossing two boundaries at once is the case that has to keep working: the engine routes
         # this through a proxy parameter on each group it passes through.
-        connect_result = GriptapeNodes.handle_request(
+        connect_result = engine.handle_request(
             CreateConnectionRequest(
                 source_node_name=source.node_name,
                 source_parameter_name="text",
@@ -113,18 +114,18 @@ def _build_nested_graph(library_name: str) -> str:
     return flow_name
 
 
-def _generate_nested_workflow_source(library_json: Path) -> str:
+def _generate_nested_workflow_source(engine: Engine, library_json: Path) -> str:
     """Build the nested graph and serialize it to standalone workflow source."""
-    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
 
-    register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    register_result = engine.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
     assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
     library_name = register_result.library_name
 
-    GriptapeNodes.ContextManager().push_workflow(workflow_name="nested_group_e2e_workflow")
-    flow_name = _build_nested_graph(library_name)
+    engine.context_manager.push_workflow(workflow_name="nested_group_e2e_workflow")
+    flow_name = _build_nested_graph(engine, library_name)
 
-    serialize_result = GriptapeNodes.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_name))
+    serialize_result = engine.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_name))
     assert isinstance(serialize_result, SerializeFlowToCommandsResultSuccess), serialize_result
 
     metadata = WorkflowMetadata(
@@ -134,7 +135,7 @@ def _generate_nested_workflow_source(library_json: Path) -> str:
         node_libraries_referenced=list(serialize_result.serialized_flow_commands.node_dependencies.libraries),
         workflow_shape=None,
     )
-    return GriptapeNodes.WorkflowManager()._generate_workflow_file_content(
+    return engine.workflow_manager._generate_workflow_file_content(
         serialized_flow_commands=serialize_result.serialized_flow_commands,
         workflow_metadata=metadata,
     )
@@ -232,20 +233,23 @@ if __name__ == "__main__":
 )
 def test_nested_node_groups_survive_save_and_execute(
     tmp_path: Path,
+    engine: Engine,
     engine_subprocess_env: Callable[..., dict[str, str]],
     materialize_library: Callable[..., Path],
     write_isolated_config: Callable[..., None],
 ) -> None:
     """A group nested in another group must save, reload, and pass data to its deepest node."""
     workspace = tmp_path / "workspace"
-    workspace.mkdir()
+    # The engine's ConfigManager creates the configured workspace on init, so this only has to
+    # cover the case where it has not.
+    workspace.mkdir(exist_ok=True)
     config_root = tmp_path / "xdg_config"
     library_json = materialize_library(
         tmp_path / "library", template=FIXTURE_LIBRARY_JSON_TEMPLATE, node_file=FIXTURE_NODE_FILE
     )
     write_isolated_config(config_root, workspace=workspace, library_path=library_json)
 
-    workflow_source = _generate_nested_workflow_source(library_json)
+    workflow_source = _generate_nested_workflow_source(engine, library_json)
     runnable_source = _wrap_with_runtime_assertions(workflow_source)
 
     workflow_path = tmp_path / "nested_group_workflow.py"

--- a/tests/e2e/test_node_group_membership_failures.py
+++ b/tests/e2e/test_node_group_membership_failures.py
@@ -18,7 +18,6 @@ from typing import TYPE_CHECKING
 import pytest
 
 from griptape_nodes.exe_types.node_groups.base_node_group import BaseNodeGroup
-from griptape_nodes.retained_mode.engine import current_engine
 from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import (
     RegisterLibraryFromFileRequest,
@@ -39,10 +38,11 @@ from griptape_nodes.retained_mode.events.node_events import (
     RemoveNodeFromNodeGroupResultSuccess,
 )
 from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from griptape_nodes.retained_mode.engine import Engine
 
 FIXTURE_LIBRARY_DIR = Path(__file__).parent / "fixtures" / "subflow_library"
 FIXTURE_LIBRARY_JSON_TEMPLATE = FIXTURE_LIBRARY_DIR / "griptape_nodes_library.json"
@@ -50,43 +50,43 @@ FIXTURE_NODE_FILE = FIXTURE_LIBRARY_DIR / "subflow_echo_node.py"
 
 
 @pytest.fixture
-def library_name(tmp_path: Path, materialize_library: Callable[..., Path]) -> str:
+def library_name(tmp_path: Path, materialize_library: Callable[..., Path], engine: Engine) -> str:
     """Register the subflow fixture library into a clean engine and return its name."""
     library_json = materialize_library(
         tmp_path / "library", template=FIXTURE_LIBRARY_JSON_TEMPLATE, node_file=FIXTURE_NODE_FILE
     )
-    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
-    register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    register_result = engine.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
     assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
-    GriptapeNodes.ContextManager().push_workflow(workflow_name="membership_failure_workflow")
+    engine.context_manager.push_workflow(workflow_name="membership_failure_workflow")
     return register_result.library_name
 
 
-def _create_node(node_type: str, node_name: str, library: str, **kwargs: object) -> str:
-    result = GriptapeNodes.handle_request(
+def _create_node(engine: Engine, node_type: str, node_name: str, library: str, **kwargs: object) -> str:
+    result = engine.handle_request(
         CreateNodeRequest(node_type=node_type, specific_library_name=library, node_name=node_name, **kwargs)  # type: ignore[arg-type]
     )
     assert isinstance(result, CreateNodeResultSuccess), result
     return result.node_name
 
 
-def _get_group(node_name: str) -> BaseNodeGroup:
-    node = GriptapeNodes.NodeManager().get_node_by_name(node_name)
+def _get_group(engine: Engine, node_name: str) -> BaseNodeGroup:
+    node = engine.node_manager.get_node_by_name(node_name)
     assert isinstance(node, BaseNodeGroup), f"expected '{node_name}' to be a group, got {type(node).__name__}"
     return node
 
 
-def _flow_of(node_name: str) -> str:
-    return GriptapeNodes.NodeManager().get_node_parent_flow_by_name(node_name)
+def _flow_of(engine: Engine, node_name: str) -> str:
+    return engine.node_manager.get_node_parent_flow_by_name(node_name)
 
 
-def _fail_every_move(monkeypatch: pytest.MonkeyPatch) -> None:
+def _fail_every_move(engine: Engine, monkeypatch: pytest.MonkeyPatch) -> None:
     """Make every MoveNodeToNewFlowRequest fail, as if the engine refused it.
 
     Patches the event manager's dispatch table rather than NodeManager: the handler was bound into
     that table at registration, so replacing the method on the manager would not be seen.
     """
-    event_manager = current_engine().event_manager
+    event_manager = engine.event_manager
 
     def refuse_move(request: MoveNodeToNewFlowRequest) -> MoveNodeToNewFlowResultFailure:  # noqa: ARG001
         return MoveNodeToNewFlowResultFailure(result_details="refused for this test")
@@ -94,7 +94,7 @@ def _fail_every_move(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setitem(event_manager._request_type_to_manager, MoveNodeToNewFlowRequest, refuse_move)
 
 
-def _fail_the_second_move_into(target_flow_name: str, monkeypatch: pytest.MonkeyPatch) -> None:
+def _fail_the_second_move_into(engine: Engine, target_flow_name: str, monkeypatch: pytest.MonkeyPatch) -> None:
     """Let the first move into a flow through, refuse the second, and allow everything else.
 
     Failing every move leaves nothing to roll back -- the first node never went anywhere. Only a
@@ -105,7 +105,7 @@ def _fail_the_second_move_into(target_flow_name: str, monkeypatch: pytest.Monkey
     where they came from, is allowed to succeed. Refusing that too would test nothing but the
     fixture: no rollback could complete regardless of whether one was attempted.
     """
-    event_manager = current_engine().event_manager
+    event_manager = engine.event_manager
     real_handler = event_manager._request_type_to_manager[MoveNodeToNewFlowRequest]
     moves_into_target = 0
 
@@ -123,42 +123,42 @@ def _fail_the_second_move_into(target_flow_name: str, monkeypatch: pytest.Monkey
 
 class TestFailedAdd:
     def test_reports_failure_rather_than_claiming_a_node_it_could_not_move(
-        self, library_name: str, monkeypatch: pytest.MonkeyPatch
+        self, engine: Engine, library_name: str, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A group that cannot take a node in must not list it as a member anyway."""
-        flow = GriptapeNodes.handle_request(
+        flow = engine.handle_request(
             CreateFlowRequest(parent_flow_name=None, flow_name="FailedAddFlow", set_as_new_context=False)
         )
         assert isinstance(flow, CreateFlowResultSuccess), flow
 
-        with GriptapeNodes.ContextManager().flow(flow.flow_name):
-            group_name = _create_node("SubflowGroupNode", "Group", library_name)
-            loose_name = _create_node("EchoNode", "Loose", library_name)
+        with engine.context_manager.flow(flow.flow_name):
+            group_name = _create_node(engine, "SubflowGroupNode", "Group", library_name)
+            loose_name = _create_node(engine, "EchoNode", "Loose", library_name)
 
-        original_flow = _flow_of(loose_name)
-        _fail_every_move(monkeypatch)
+        original_flow = _flow_of(engine, loose_name)
+        _fail_every_move(engine, monkeypatch)
 
-        with GriptapeNodes.ContextManager().flow(flow.flow_name):
-            result = GriptapeNodes.handle_request(
+        with engine.context_manager.flow(flow.flow_name):
+            result = engine.handle_request(
                 AddNodesToNodeGroupRequest(node_names=[loose_name], node_group_name=group_name)
             )
 
         # The artist has to be told, rather than shown a group that only looks filled.
         assert isinstance(result, AddNodesToNodeGroupResultFailure), result
 
-        group = _get_group(group_name)
-        node = GriptapeNodes.NodeManager().get_node_by_name(loose_name)
+        group = _get_group(engine, group_name)
+        node = engine.node_manager.get_node_by_name(loose_name)
         assert loose_name not in group.nodes
         assert group.metadata.get("node_names_in_group") == []
         assert node.parent_group is None
         # The node never moved, so it is still where the artist left it.
-        assert _flow_of(loose_name) == original_flow
+        assert _flow_of(engine, loose_name) == original_flow
         # This was the group's first add, so the subflow it made to hold the node goes too: an add
         # that failed in full should leave the artist owning nothing it created.
         assert "subflow_name" not in group.metadata
 
     def test_moves_back_the_node_that_did_get_in_before_a_later_one_failed(
-        self, library_name: str, monkeypatch: pytest.MonkeyPatch
+        self, engine: Engine, library_name: str, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A partly-applied add has to undo the moves it already made, not just report the failure.
 
@@ -166,38 +166,38 @@ class TestFailedAdd:
         subflow when the add gives up. Leaving it there strands a node inside a group that no longer
         claims it: the editor draws it outside while a save writes it inside.
         """
-        flow = GriptapeNodes.handle_request(
+        flow = engine.handle_request(
             CreateFlowRequest(parent_flow_name=None, flow_name="PartialAddFlow", set_as_new_context=False)
         )
         assert isinstance(flow, CreateFlowResultSuccess), flow
 
-        with GriptapeNodes.ContextManager().flow(flow.flow_name):
-            group_name = _create_node("SubflowGroupNode", "Group", library_name)
-            first_name = _create_node("EchoNode", "First", library_name)
-            second_name = _create_node("EchoNode", "Second", library_name)
+        with engine.context_manager.flow(flow.flow_name):
+            group_name = _create_node(engine, "SubflowGroupNode", "Group", library_name)
+            first_name = _create_node(engine, "EchoNode", "First", library_name)
+            second_name = _create_node(engine, "EchoNode", "Second", library_name)
 
-        original_flow = _flow_of(first_name)
-        assert _flow_of(second_name) == original_flow
+        original_flow = _flow_of(engine, first_name)
+        assert _flow_of(engine, second_name) == original_flow
 
-        group = _get_group(group_name)
+        group = _get_group(engine, group_name)
         # The group creates its subflow on the first add, so drive one to learn its name, then put
         # things back: the failure this test wants is a refused move, not a missing subflow.
-        with GriptapeNodes.ContextManager().flow(flow.flow_name):
-            setup_result = GriptapeNodes.handle_request(
+        with engine.context_manager.flow(flow.flow_name):
+            setup_result = engine.handle_request(
                 AddNodesToNodeGroupRequest(node_names=[first_name], node_group_name=group_name)
             )
             assert isinstance(setup_result, AddNodesToNodeGroupResultSuccess), setup_result
             subflow_name = group.metadata["subflow_name"]
-            undo_result = GriptapeNodes.handle_request(
+            undo_result = engine.handle_request(
                 RemoveNodeFromNodeGroupRequest(node_names=[first_name], node_group_name=group_name)
             )
             assert isinstance(undo_result, RemoveNodeFromNodeGroupResultSuccess), undo_result
-        assert _flow_of(first_name) == original_flow
+        assert _flow_of(engine, first_name) == original_flow
 
-        _fail_the_second_move_into(subflow_name, monkeypatch)
+        _fail_the_second_move_into(engine, subflow_name, monkeypatch)
 
-        with GriptapeNodes.ContextManager().flow(flow.flow_name):
-            result = GriptapeNodes.handle_request(
+        with engine.context_manager.flow(flow.flow_name):
+            result = engine.handle_request(
                 AddNodesToNodeGroupRequest(node_names=[first_name, second_name], node_group_name=group_name)
             )
 
@@ -207,105 +207,105 @@ class TestFailedAdd:
         assert group.metadata.get("node_names_in_group") == []
 
         # Both nodes are back where the artist left them -- including the one that did move.
-        assert _flow_of(first_name) == original_flow
-        assert _flow_of(second_name) == original_flow
+        assert _flow_of(engine, first_name) == original_flow
+        assert _flow_of(engine, second_name) == original_flow
 
 
 class TestFailedRemove:
     def test_reports_failure_rather_than_dropping_a_node_it_could_not_move_out(
-        self, library_name: str, monkeypatch: pytest.MonkeyPatch
+        self, engine: Engine, library_name: str, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A group that cannot let a node out must keep listing it, and say the remove failed."""
-        flow = GriptapeNodes.handle_request(
+        flow = engine.handle_request(
             CreateFlowRequest(parent_flow_name=None, flow_name="FailedRemoveFlow", set_as_new_context=False)
         )
         assert isinstance(flow, CreateFlowResultSuccess), flow
 
-        with GriptapeNodes.ContextManager().flow(flow.flow_name):
-            group_name = _create_node("SubflowGroupNode", "Group", library_name)
-            member_name = _create_node("EchoNode", "Member", library_name, parent_group_name=group_name)
+        with engine.context_manager.flow(flow.flow_name):
+            group_name = _create_node(engine, "SubflowGroupNode", "Group", library_name)
+            member_name = _create_node(engine, "EchoNode", "Member", library_name, parent_group_name=group_name)
 
-        group = _get_group(group_name)
+        group = _get_group(engine, group_name)
         assert member_name in group.nodes, "member should start out inside the group"
-        subflow_name = _flow_of(member_name)
+        subflow_name = _flow_of(engine, member_name)
 
-        _fail_every_move(monkeypatch)
+        _fail_every_move(engine, monkeypatch)
 
-        with GriptapeNodes.ContextManager().flow(flow.flow_name):
-            result = GriptapeNodes.handle_request(
+        with engine.context_manager.flow(flow.flow_name):
+            result = engine.handle_request(
                 RemoveNodeFromNodeGroupRequest(node_names=[member_name], node_group_name=group_name)
             )
 
         # A move failure has to surface as a failure result, not escape as an unhandled error.
         assert isinstance(result, RemoveNodeFromNodeGroupResultFailure), result
 
-        member = GriptapeNodes.NodeManager().get_node_by_name(member_name)
+        member = engine.node_manager.get_node_by_name(member_name)
         assert member_name in group.nodes
         assert group.metadata.get("node_names_in_group") == [member_name]
         assert member.parent_group is group
         # The node never moved, so the group still holds it in its subflow.
-        assert _flow_of(member_name) == subflow_name
+        assert _flow_of(engine, member_name) == subflow_name
 
-    def test_removes_a_node_from_a_group_when_the_moves_succeed(self, library_name: str) -> None:
+    def test_removes_a_node_from_a_group_when_the_moves_succeed(self, engine: Engine, library_name: str) -> None:
         """The success path still works: the node leaves the group and its subflow."""
-        flow = GriptapeNodes.handle_request(
+        flow = engine.handle_request(
             CreateFlowRequest(parent_flow_name=None, flow_name="RemoveFlow", set_as_new_context=False)
         )
         assert isinstance(flow, CreateFlowResultSuccess), flow
 
-        with GriptapeNodes.ContextManager().flow(flow.flow_name):
-            group_name = _create_node("SubflowGroupNode", "Group", library_name)
-            member_name = _create_node("EchoNode", "Member", library_name, parent_group_name=group_name)
+        with engine.context_manager.flow(flow.flow_name):
+            group_name = _create_node(engine, "SubflowGroupNode", "Group", library_name)
+            member_name = _create_node(engine, "EchoNode", "Member", library_name, parent_group_name=group_name)
 
-            result = GriptapeNodes.handle_request(
+            result = engine.handle_request(
                 RemoveNodeFromNodeGroupRequest(node_names=[member_name], node_group_name=group_name)
             )
 
         assert isinstance(result, RemoveNodeFromNodeGroupResultSuccess), result
 
-        group = _get_group(group_name)
-        member = GriptapeNodes.NodeManager().get_node_by_name(member_name)
+        group = _get_group(engine, group_name)
+        member = engine.node_manager.get_node_by_name(member_name)
         assert member_name not in group.nodes
         assert group.metadata.get("node_names_in_group") == []
         assert member.parent_group is None
         # It went back out to the flow holding the group, not left inside the subflow.
-        assert _flow_of(member_name) == flow.flow_name
+        assert _flow_of(engine, member_name) == flow.flow_name
 
-    def test_moves_a_nested_group_subflow_back_out_with_it(self, library_name: str) -> None:
+    def test_moves_a_nested_group_subflow_back_out_with_it(self, engine: Engine, library_name: str) -> None:
         """Removing a nested group has to take its contents along, or a save loses them."""
-        flow = GriptapeNodes.handle_request(
+        flow = engine.handle_request(
             CreateFlowRequest(parent_flow_name=None, flow_name="UnnestFlow", set_as_new_context=False)
         )
         assert isinstance(flow, CreateFlowResultSuccess), flow
 
-        with GriptapeNodes.ContextManager().flow(flow.flow_name):
-            outer_name = _create_node("SubflowGroupNode", "OuterGroup", library_name)
-            inner_name = _create_node("SubflowGroupNode", "InnerGroup", library_name)
-            _create_node("EchoNode", "Leaf", library_name, parent_group_name=inner_name)
+        with engine.context_manager.flow(flow.flow_name):
+            outer_name = _create_node(engine, "SubflowGroupNode", "OuterGroup", library_name)
+            inner_name = _create_node(engine, "SubflowGroupNode", "InnerGroup", library_name)
+            _create_node(engine, "EchoNode", "Leaf", library_name, parent_group_name=inner_name)
 
-            nest_result = GriptapeNodes.handle_request(
+            nest_result = engine.handle_request(
                 AddNodesToNodeGroupRequest(node_names=[inner_name], node_group_name=outer_name)
             )
             assert isinstance(nest_result, AddNodesToNodeGroupResultSuccess), nest_result
 
-            inner = _get_group(inner_name)
+            inner = _get_group(engine, inner_name)
             inner_subflow = inner.metadata["subflow_name"]
-            outer_subflow = _get_group(outer_name).metadata["subflow_name"]
-            assert GriptapeNodes.FlowManager().get_parent_flow(inner_subflow) == outer_subflow
+            outer_subflow = _get_group(engine, outer_name).metadata["subflow_name"]
+            assert engine.flow_manager.get_parent_flow(inner_subflow) == outer_subflow
 
-            result = GriptapeNodes.handle_request(
+            result = engine.handle_request(
                 RemoveNodeFromNodeGroupRequest(node_names=[inner_name], node_group_name=outer_name)
             )
 
         assert isinstance(result, RemoveNodeFromNodeGroupResultSuccess), result
 
         # The inner group's subflow follows it out, so its Leaf is still reachable from the top.
-        assert GriptapeNodes.FlowManager().get_parent_flow(inner_subflow) == flow.flow_name
-        assert _flow_of(inner_name) == flow.flow_name
+        assert engine.flow_manager.get_parent_flow(inner_subflow) == flow.flow_name
+        assert _flow_of(engine, inner_name) == flow.flow_name
 
 
 class TestDeletedGroup:
-    def test_deleting_an_outer_group_leaves_the_group_it_held_intact(self, library_name: str) -> None:
+    def test_deleting_an_outer_group_leaves_the_group_it_held_intact(self, engine: Engine, library_name: str) -> None:
         """Deleting a group has to release what it held before deleting its own subflow.
 
         `after_node_deleted` un-nests its members and only then deletes its subflow. That ordering is
@@ -313,41 +313,41 @@ class TestDeletedGroup:
         DeleteFlowRequest ran, deleting the outer group would take the inner group's contents down
         with it -- silent data loss on a plain delete of the outer group only.
         """
-        flow = GriptapeNodes.handle_request(
+        flow = engine.handle_request(
             CreateFlowRequest(parent_flow_name=None, flow_name="DeleteOuterFlow", set_as_new_context=False)
         )
         assert isinstance(flow, CreateFlowResultSuccess), flow
 
-        with GriptapeNodes.ContextManager().flow(flow.flow_name):
-            outer_name = _create_node("SubflowGroupNode", "OuterGroup", library_name)
-            inner_name = _create_node("SubflowGroupNode", "InnerGroup", library_name)
-            leaf_name = _create_node("EchoNode", "Leaf", library_name, parent_group_name=inner_name)
+        with engine.context_manager.flow(flow.flow_name):
+            outer_name = _create_node(engine, "SubflowGroupNode", "OuterGroup", library_name)
+            inner_name = _create_node(engine, "SubflowGroupNode", "InnerGroup", library_name)
+            leaf_name = _create_node(engine, "EchoNode", "Leaf", library_name, parent_group_name=inner_name)
 
-            nest_result = GriptapeNodes.handle_request(
+            nest_result = engine.handle_request(
                 AddNodesToNodeGroupRequest(node_names=[inner_name], node_group_name=outer_name)
             )
             assert isinstance(nest_result, AddNodesToNodeGroupResultSuccess), nest_result
 
-            inner_subflow = _get_group(inner_name).metadata["subflow_name"]
-            outer_subflow = _get_group(outer_name).metadata["subflow_name"]
-            assert GriptapeNodes.FlowManager().get_parent_flow(inner_subflow) == outer_subflow
-            assert _flow_of(leaf_name) == inner_subflow
+            inner_subflow = _get_group(engine, inner_name).metadata["subflow_name"]
+            outer_subflow = _get_group(engine, outer_name).metadata["subflow_name"]
+            assert engine.flow_manager.get_parent_flow(inner_subflow) == outer_subflow
+            assert _flow_of(engine, leaf_name) == inner_subflow
 
-            delete_result = GriptapeNodes.handle_request(DeleteNodeRequest(node_name=outer_name))
+            delete_result = engine.handle_request(DeleteNodeRequest(node_name=outer_name))
 
         assert isinstance(delete_result, DeleteNodeResultSuccess), delete_result
 
         # The outer group and its subflow are gone.
-        assert GriptapeNodes.ObjectManager().attempt_get_object_by_name(outer_name) is None
-        assert GriptapeNodes.ObjectManager().attempt_get_object_by_name(outer_subflow) is None
+        assert engine.object_manager.attempt_get_object_by_name(outer_name) is None
+        assert engine.object_manager.attempt_get_object_by_name(outer_subflow) is None
 
         # The inner group survived, reparented to the flow that held the outer group...
-        inner = _get_group(inner_name)
+        inner = _get_group(engine, inner_name)
         assert inner.parent_group is None
-        assert _flow_of(inner_name) == flow.flow_name
+        assert _flow_of(engine, inner_name) == flow.flow_name
 
         # ...and it took its own subflow, and everything in it, along.
-        assert GriptapeNodes.ObjectManager().attempt_get_object_by_name(inner_subflow) is not None
-        assert GriptapeNodes.FlowManager().get_parent_flow(inner_subflow) == flow.flow_name
+        assert engine.object_manager.attempt_get_object_by_name(inner_subflow) is not None
+        assert engine.flow_manager.get_parent_flow(inner_subflow) == flow.flow_name
         assert leaf_name in inner.nodes
-        assert _flow_of(leaf_name) == inner_subflow
+        assert _flow_of(engine, leaf_name) == inner_subflow

--- a/tests/e2e/test_nonserializable_resolution_state.py
+++ b/tests/e2e/test_nonserializable_resolution_state.py
@@ -37,10 +37,11 @@ from griptape_nodes.retained_mode.events.library_events import (
     RegisterLibraryFromFileResultSuccess,
 )
 from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from griptape_nodes.retained_mode.engine import Engine
 
 # Timeout with thread dump.
 pytestmark = pytest.mark.timeout(300, method="thread")
@@ -58,6 +59,7 @@ LIBRARY_NAME = "NonSerializable Library"
 @pytest.mark.asyncio
 async def test_serializable_false_output_reresolved_on_load(
     tmp_path: Path,
+    engine: Engine,
     materialize_library: Callable[..., Path],
     create_node: Callable[..., str],
     connect: Callable[..., None],
@@ -74,12 +76,12 @@ async def test_serializable_false_output_reresolved_on_load(
     library_json = materialize_library(
         tmp_path / "library", template=FIXTURE_LIBRARY_JSON_TEMPLATE, node_file=FIXTURE_NODE_FILE
     )
-    register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    register_result = engine.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
     assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
 
-    GriptapeNodes.ContextManager().push_workflow(workflow_name="nonserializable_test_wf")
+    engine.context_manager.push_workflow(workflow_name="nonserializable_test_wf")
 
-    flow_result = GriptapeNodes.handle_request(
+    flow_result = engine.handle_request(
         CreateFlowRequest(parent_flow_name=None, flow_name="TestFlow", set_as_new_context=False)
     )
     assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
@@ -90,7 +92,7 @@ async def test_serializable_false_output_reresolved_on_load(
     connect("Producer", "session", "Consumer", "session")
 
     # --- Step 2: Run the flow so both nodes become RESOLVED ---
-    run_result = await GriptapeNodes.ahandle_request(
+    run_result = await engine.ahandle_request(
         StartFlowRequest(
             flow_name=flow_name,
             flow_node_name="Consumer",
@@ -100,7 +102,7 @@ async def test_serializable_false_output_reresolved_on_load(
     )
     assert isinstance(run_result, StartFlowResultSuccess), run_result
 
-    node_manager = GriptapeNodes.NodeManager()
+    node_manager = engine.node_manager
     producer = node_manager.get_node_by_name("Producer")
     consumer = node_manager.get_node_by_name("Consumer")
 
@@ -113,15 +115,15 @@ async def test_serializable_false_output_reresolved_on_load(
     assert consumer.parameter_output_values.get("marker") == "live-session-marker"
 
     # --- Step 3: Serialize (save) ---
-    serialize_result = GriptapeNodes.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_name))
+    serialize_result = engine.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_name))
     assert isinstance(serialize_result, SerializeFlowToCommandsResultSuccess), serialize_result
     saved_commands = serialize_result.serialized_flow_commands
 
     # --- Step 4: Clear state and deserialize (load) ---
-    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
-    GriptapeNodes.ContextManager().push_workflow(workflow_name="nonserializable_test_wf_reloaded")
+    engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    engine.context_manager.push_workflow(workflow_name="nonserializable_test_wf_reloaded")
 
-    deserialize_result = GriptapeNodes.handle_request(
+    deserialize_result = engine.handle_request(
         DeserializeFlowFromCommandsRequest(serialized_flow_commands=saved_commands)
     )
     assert isinstance(deserialize_result, DeserializeFlowFromCommandsResultSuccess), deserialize_result
@@ -129,7 +131,7 @@ async def test_serializable_false_output_reresolved_on_load(
 
     # --- Step 5: Run the loaded flow — consumer must get a recomputed Session, not None ---
     restored_consumer_name = deserialize_result.node_name_mappings.get("Consumer", "Consumer")
-    run_result_2 = await GriptapeNodes.ahandle_request(
+    run_result_2 = await engine.ahandle_request(
         StartFlowRequest(
             flow_name=loaded_flow,
             flow_node_name=restored_consumer_name,

--- a/tests/e2e/test_serialize_deserialize_roundtrip.py
+++ b/tests/e2e/test_serialize_deserialize_roundtrip.py
@@ -21,7 +21,6 @@ from typing import TYPE_CHECKING
 import pytest
 
 from griptape_nodes.exe_types.node_groups.base_node_group import BaseNodeGroup
-from griptape_nodes.retained_mode.engine import current_engine
 from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest, CreateConnectionResultSuccess
 from griptape_nodes.retained_mode.events.flow_events import (
     CreateFlowRequest,
@@ -43,11 +42,11 @@ from griptape_nodes.retained_mode.events.node_events import (
 )
 from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
 from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from griptape_nodes.retained_mode.engine import Engine
     from griptape_nodes.retained_mode.events.flow_events import SerializedFlowCommands
 
 FIXTURE_LIBRARY_DIR = Path(__file__).parent / "fixtures" / "subflow_library"
@@ -58,55 +57,56 @@ _EXPECTED_TEXT = "value that has to survive the round trip"
 
 
 @pytest.fixture
-def library_name(tmp_path: Path, materialize_library: Callable[..., Path]) -> str:
+def library_name(tmp_path: Path, materialize_library: Callable[..., Path], engine: Engine) -> str:
     """Register the subflow fixture library into a clean engine and return its name."""
     library_json = materialize_library(
         tmp_path / "library", template=FIXTURE_LIBRARY_JSON_TEMPLATE, node_file=FIXTURE_NODE_FILE
     )
-    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
-    register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    register_result = engine.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
     assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
-    GriptapeNodes.ContextManager().push_workflow(workflow_name="roundtrip_workflow")
+    engine.context_manager.push_workflow(workflow_name="roundtrip_workflow")
     return register_result.library_name
 
 
-def _serialize(flow_name: str) -> SerializedFlowCommands:
-    serialize_result = GriptapeNodes.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_name))
+def _serialize(engine: Engine, flow_name: str) -> SerializedFlowCommands:
+    serialize_result = engine.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_name))
     assert isinstance(serialize_result, SerializeFlowToCommandsResultSuccess), serialize_result
     return serialize_result.serialized_flow_commands
 
 
 def _deserialize_into_fresh_context(
+    engine: Engine,
     serialized_flow_commands: SerializedFlowCommands,
 ) -> DeserializeFlowFromCommandsResultSuccess:
     """Replay commands the way an image-metadata restore does, and require success."""
-    GriptapeNodes.ContextManager().push_workflow(workflow_name="roundtrip_workflow_restored")
-    result = GriptapeNodes.handle_request(
+    engine.context_manager.push_workflow(workflow_name="roundtrip_workflow_restored")
+    result = engine.handle_request(
         DeserializeFlowFromCommandsRequest(serialized_flow_commands=serialized_flow_commands)
     )
     assert isinstance(result, DeserializeFlowFromCommandsResultSuccess), result
     return result
 
 
-def _create_node(node_type: str, node_name: str, library: str, **kwargs: object) -> str:
-    result = GriptapeNodes.handle_request(
+def _create_node(engine: Engine, node_type: str, node_name: str, library: str, **kwargs: object) -> str:
+    result = engine.handle_request(
         CreateNodeRequest(node_type=node_type, specific_library_name=library, node_name=node_name, **kwargs)  # type: ignore[arg-type]
     )
     assert isinstance(result, CreateNodeResultSuccess), result
     return result.node_name
 
 
-def _get_group(node_name: str) -> BaseNodeGroup:
+def _get_group(engine: Engine, node_name: str) -> BaseNodeGroup:
     """Fetch a rebuilt node that must be a group, so group membership can be inspected."""
-    node = GriptapeNodes.NodeManager().get_node_by_name(node_name)
+    node = engine.node_manager.get_node_by_name(node_name)
     assert isinstance(node, BaseNodeGroup), (
         f"expected '{node_name}' to be rebuilt as a group, got {type(node).__name__}"
     )
     return node
 
 
-def _connect(source_node: str, target_node: str, parameter_name: str = "text") -> None:
-    result = GriptapeNodes.handle_request(
+def _connect(engine: Engine, source_node: str, target_node: str, parameter_name: str = "text") -> None:
+    result = engine.handle_request(
         CreateConnectionRequest(
             source_node_name=source_node,
             source_parameter_name=parameter_name,
@@ -117,14 +117,14 @@ def _connect(source_node: str, target_node: str, parameter_name: str = "text") -
     assert isinstance(result, CreateConnectionResultSuccess), result
 
 
-def _edges_from(node_name: str) -> set[str]:
+def _edges_from(engine: Engine, node_name: str) -> set[str]:
     """Every outgoing edge of a node, as 'Source.param->Target.param' strings.
 
     Returned as a set of readable labels so a failure names the edges rather than dumping objects,
     and counted so a duplicated edge is as visible as a missing one.
     """
-    node = GriptapeNodes.NodeManager().get_node_by_name(node_name)
-    connections = GriptapeNodes.FlowManager().get_connections()
+    node = engine.node_manager.get_node_by_name(node_name)
+    connections = engine.flow_manager.get_connections()
     return {
         f"{edge.source_node.name}.{edge.source_parameter.name}->{edge.target_node.name}.{edge.target_parameter.name}"
         for edge in connections.get_all_outgoing_connections(node)
@@ -132,94 +132,92 @@ def _edges_from(node_name: str) -> set[str]:
 
 
 class TestPlainSubflowRoundTrip:
-    def test_restores_a_connection_that_crosses_a_flow_boundary(self, library_name: str) -> None:
+    def test_restores_a_connection_that_crosses_a_flow_boundary(self, engine: Engine, library_name: str) -> None:
         """No node groups involved: two plain flows and one edge between them."""
-        parent = GriptapeNodes.handle_request(
+        parent = engine.handle_request(
             CreateFlowRequest(parent_flow_name=None, flow_name="RoundTripParent", set_as_new_context=False)
         )
         assert isinstance(parent, CreateFlowResultSuccess), parent
-        child = GriptapeNodes.handle_request(
+        child = engine.handle_request(
             CreateFlowRequest(parent_flow_name=parent.flow_name, flow_name="RoundTripChild", set_as_new_context=False)
         )
         assert isinstance(child, CreateFlowResultSuccess), child
 
-        with GriptapeNodes.ContextManager().flow(parent.flow_name):
-            source = _create_node("EchoNode", "Source", library_name)
-        with GriptapeNodes.ContextManager().flow(child.flow_name):
-            target = _create_node("EchoNode", "Target", library_name)
-        _connect(source, target)
+        with engine.context_manager.flow(parent.flow_name):
+            source = _create_node(engine, "EchoNode", "Source", library_name)
+        with engine.context_manager.flow(child.flow_name):
+            target = _create_node(engine, "EchoNode", "Target", library_name)
+        _connect(engine, source, target)
 
-        commands = _serialize(parent.flow_name)
+        commands = _serialize(engine, parent.flow_name)
 
-        GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
-        result = _deserialize_into_fresh_context(commands)
+        engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        result = _deserialize_into_fresh_context(engine, commands)
 
         # The child flow, its node, and the cross-boundary edge all have to come back.
         restored_target = result.node_name_mappings["Target"]
         restored_source = result.node_name_mappings["Source"]
-        node_manager = GriptapeNodes.NodeManager()
+        node_manager = engine.node_manager
         assert node_manager.get_node_by_name(restored_target) is not None
         assert node_manager.get_node_by_name(restored_source) is not None
-        assert _edges_from(restored_source) == {f"{restored_source}.text->{restored_target}.text"}
+        assert _edges_from(engine, restored_source) == {f"{restored_source}.text->{restored_target}.text"}
 
 
 class TestNodeGroupRoundTrip:
-    def test_restores_a_single_level_group(self, library_name: str) -> None:
+    def test_restores_a_single_level_group(self, engine: Engine, library_name: str) -> None:
         """A group's wall connections cross its boundary, so this failed for every group."""
-        flow = GriptapeNodes.handle_request(
+        flow = engine.handle_request(
             CreateFlowRequest(parent_flow_name=None, flow_name="GroupRoundTrip", set_as_new_context=False)
         )
         assert isinstance(flow, CreateFlowResultSuccess), flow
 
-        with GriptapeNodes.ContextManager().flow(flow.flow_name):
-            group = _create_node("SubflowGroupNode", "Group", library_name)
-            leaf = _create_node("EchoNode", "Leaf", library_name, parent_group_name=group)
-            source = _create_node("EchoNode", "Source", library_name)
-            GriptapeNodes.handle_request(
+        with engine.context_manager.flow(flow.flow_name):
+            group = _create_node(engine, "SubflowGroupNode", "Group", library_name)
+            leaf = _create_node(engine, "EchoNode", "Leaf", library_name, parent_group_name=group)
+            source = _create_node(engine, "EchoNode", "Source", library_name)
+            engine.handle_request(
                 SetParameterValueRequest(parameter_name="text", node_name=source, value=_EXPECTED_TEXT)
             )
-            _connect(source, leaf)
+            _connect(engine, source, leaf)
 
-        commands = _serialize(flow.flow_name)
+        commands = _serialize(engine, flow.flow_name)
 
-        GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
-        result = _deserialize_into_fresh_context(commands)
+        engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        result = _deserialize_into_fresh_context(engine, commands)
 
-        restored_group = _get_group(result.node_name_mappings["Group"])
+        restored_group = _get_group(engine, result.node_name_mappings["Group"])
         restored_leaf_name = result.node_name_mappings["Leaf"]
         assert restored_leaf_name in restored_group.nodes
 
-    def test_restores_a_nested_group_and_its_deepest_member(self, library_name: str) -> None:
+    def test_restores_a_nested_group_and_its_deepest_member(self, engine: Engine, library_name: str) -> None:
         """Nesting is the case with edges spanning more than one boundary."""
-        flow = GriptapeNodes.handle_request(
+        flow = engine.handle_request(
             CreateFlowRequest(parent_flow_name=None, flow_name="NestedRoundTrip", set_as_new_context=False)
         )
         assert isinstance(flow, CreateFlowResultSuccess), flow
 
-        with GriptapeNodes.ContextManager().flow(flow.flow_name):
-            outer = _create_node("SubflowGroupNode", "OuterGroup", library_name)
-            inner = _create_node("SubflowGroupNode", "InnerGroup", library_name)
-            leaf = _create_node("EchoNode", "Leaf", library_name, parent_group_name=inner)
-            source = _create_node("EchoNode", "Source", library_name)
+        with engine.context_manager.flow(flow.flow_name):
+            outer = _create_node(engine, "SubflowGroupNode", "OuterGroup", library_name)
+            inner = _create_node(engine, "SubflowGroupNode", "InnerGroup", library_name)
+            leaf = _create_node(engine, "EchoNode", "Leaf", library_name, parent_group_name=inner)
+            source = _create_node(engine, "EchoNode", "Source", library_name)
 
-            nest_result = GriptapeNodes.handle_request(
-                AddNodesToNodeGroupRequest(node_names=[inner], node_group_name=outer)
-            )
+            nest_result = engine.handle_request(AddNodesToNodeGroupRequest(node_names=[inner], node_group_name=outer))
             assert isinstance(nest_result, AddNodesToNodeGroupResultSuccess), nest_result
 
-            GriptapeNodes.handle_request(
+            engine.handle_request(
                 SetParameterValueRequest(parameter_name="text", node_name=source, value=_EXPECTED_TEXT)
             )
-            _connect(source, leaf)
+            _connect(engine, source, leaf)
 
-        commands = _serialize(flow.flow_name)
+        commands = _serialize(engine, flow.flow_name)
 
-        GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
-        result = _deserialize_into_fresh_context(commands)
+        engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        result = _deserialize_into_fresh_context(engine, commands)
 
-        restored_outer = _get_group(result.node_name_mappings["OuterGroup"])
-        restored_inner = _get_group(result.node_name_mappings["InnerGroup"])
-        restored_leaf = GriptapeNodes.NodeManager().get_node_by_name(result.node_name_mappings["Leaf"])
+        restored_outer = _get_group(engine, result.node_name_mappings["OuterGroup"])
+        restored_inner = _get_group(engine, result.node_name_mappings["InnerGroup"])
+        restored_leaf = engine.node_manager.get_node_by_name(result.node_name_mappings["Leaf"])
 
         # Membership has to survive at both levels, and transitively.
         assert restored_inner.name in restored_outer.nodes
@@ -230,10 +228,10 @@ class TestNodeGroupRoundTrip:
         inner_subflow = restored_inner.metadata.get("subflow_name")
         outer_subflow = restored_outer.metadata.get("subflow_name")
         assert isinstance(inner_subflow, str), "inner group lost its subflow on load"
-        assert GriptapeNodes.FlowManager().get_parent_flow(inner_subflow) == outer_subflow
+        assert engine.flow_manager.get_parent_flow(inner_subflow) == outer_subflow
 
     def test_creates_each_connection_once_even_though_every_level_reports_it(
-        self, library_name: str, monkeypatch: pytest.MonkeyPatch
+        self, engine: Engine, library_name: str, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A nested graph must not re-issue an edge once per level of nesting.
 
@@ -246,24 +244,22 @@ class TestNodeGroupRoundTrip:
         The final graph looks identical either way, which is why this counts requests instead of
         inspecting the result.
         """
-        flow = GriptapeNodes.handle_request(
+        flow = engine.handle_request(
             CreateFlowRequest(parent_flow_name=None, flow_name="DedupeRoundTrip", set_as_new_context=False)
         )
         assert isinstance(flow, CreateFlowResultSuccess), flow
 
-        with GriptapeNodes.ContextManager().flow(flow.flow_name):
-            outer = _create_node("SubflowGroupNode", "OuterGroup", library_name)
-            inner = _create_node("SubflowGroupNode", "InnerGroup", library_name)
-            leaf = _create_node("EchoNode", "Leaf", library_name, parent_group_name=inner)
-            source = _create_node("EchoNode", "Source", library_name)
+        with engine.context_manager.flow(flow.flow_name):
+            outer = _create_node(engine, "SubflowGroupNode", "OuterGroup", library_name)
+            inner = _create_node(engine, "SubflowGroupNode", "InnerGroup", library_name)
+            leaf = _create_node(engine, "EchoNode", "Leaf", library_name, parent_group_name=inner)
+            source = _create_node(engine, "EchoNode", "Source", library_name)
 
-            nest_result = GriptapeNodes.handle_request(
-                AddNodesToNodeGroupRequest(node_names=[inner], node_group_name=outer)
-            )
+            nest_result = engine.handle_request(AddNodesToNodeGroupRequest(node_names=[inner], node_group_name=outer))
             assert isinstance(nest_result, AddNodesToNodeGroupResultSuccess), nest_result
-            _connect(source, leaf)
+            _connect(engine, source, leaf)
 
-        commands = _serialize(flow.flow_name)
+        commands = _serialize(engine, flow.flow_name)
 
         # Prove the premise: the same edge really is reported by more than one level.
         def count_serialized_edges(serialized: SerializedFlowCommands) -> int:
@@ -285,9 +281,8 @@ class TestNodeGroupRoundTrip:
             "otherwise this test cannot observe the duplicate-application bug"
         )
 
-        GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
 
-        engine = current_engine()
         connection_requests: list[CreateConnectionRequest] = []
         original_handle_request = engine.handle_request
 
@@ -297,7 +292,7 @@ class TestNodeGroupRoundTrip:
             return original_handle_request(request, **kwargs)  # type: ignore[arg-type]
 
         monkeypatch.setattr(engine, "handle_request", record_connection_requests)
-        _deserialize_into_fresh_context(commands)
+        _deserialize_into_fresh_context(engine, commands)
         monkeypatch.undo()
 
         issued_edges = [
@@ -318,65 +313,61 @@ class TestNodeGroupRoundTrip:
             f"expected at least {len(distinct_edge_keys)} edges to be created, got {len(issued_edges)}"
         )
 
-    def test_restores_an_edge_leaving_a_nested_group(self, library_name: str) -> None:
+    def test_restores_an_edge_leaving_a_nested_group(self, engine: Engine, library_name: str) -> None:
         """The other direction: a nested node is the source and the far end is outside both groups.
 
         Incoming and outgoing edges take separate branches when a group decides whether an edge
         crosses its boundary, and each hands off to a different side of the wall. Every other test
         here wires outside-in, so the outgoing branch was never taken.
         """
-        flow = GriptapeNodes.handle_request(
+        flow = engine.handle_request(
             CreateFlowRequest(parent_flow_name=None, flow_name="OutgoingRoundTrip", set_as_new_context=False)
         )
         assert isinstance(flow, CreateFlowResultSuccess), flow
 
-        with GriptapeNodes.ContextManager().flow(flow.flow_name):
-            outer = _create_node("SubflowGroupNode", "OuterGroup", library_name)
-            inner = _create_node("SubflowGroupNode", "InnerGroup", library_name)
-            leaf = _create_node("EchoNode", "Leaf", library_name, parent_group_name=inner)
-            sink = _create_node("EchoNode", "Sink", library_name)
+        with engine.context_manager.flow(flow.flow_name):
+            outer = _create_node(engine, "SubflowGroupNode", "OuterGroup", library_name)
+            inner = _create_node(engine, "SubflowGroupNode", "InnerGroup", library_name)
+            leaf = _create_node(engine, "EchoNode", "Leaf", library_name, parent_group_name=inner)
+            sink = _create_node(engine, "EchoNode", "Sink", library_name)
 
-            nest_result = GriptapeNodes.handle_request(
-                AddNodesToNodeGroupRequest(node_names=[inner], node_group_name=outer)
-            )
+            nest_result = engine.handle_request(AddNodesToNodeGroupRequest(node_names=[inner], node_group_name=outer))
             assert isinstance(nest_result, AddNodesToNodeGroupResultSuccess), nest_result
 
-            _connect(leaf, sink)
+            _connect(engine, leaf, sink)
 
-        commands = _serialize(flow.flow_name)
+        commands = _serialize(engine, flow.flow_name)
 
-        GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
-        result = _deserialize_into_fresh_context(commands)
+        engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        result = _deserialize_into_fresh_context(engine, commands)
 
-        restored_outer = _get_group(result.node_name_mappings["OuterGroup"])
-        restored_leaf = GriptapeNodes.NodeManager().get_node_by_name(result.node_name_mappings["Leaf"])
+        restored_outer = _get_group(engine, result.node_name_mappings["OuterGroup"])
+        restored_leaf = engine.node_manager.get_node_by_name(result.node_name_mappings["Leaf"])
         assert restored_outer.contains_node(restored_leaf)
 
         # Exactly one: the edge has to come back, and it must not be duplicated per boundary.
-        assert len(_edges_from(restored_leaf.name)) == 1, (
-            f"expected one outgoing edge from the nested leaf, got {_edges_from(restored_leaf.name)}"
+        assert len(_edges_from(engine, restored_leaf.name)) == 1, (
+            f"expected one outgoing edge from the nested leaf, got {_edges_from(engine, restored_leaf.name)}"
         )
 
-    def test_restores_saved_parameter_values_from_inside_a_subflow(self, library_name: str) -> None:
+    def test_restores_saved_parameter_values_from_inside_a_subflow(self, engine: Engine, library_name: str) -> None:
         """Values are stored per level too, so a value on a nested node must come back."""
-        flow = GriptapeNodes.handle_request(
+        flow = engine.handle_request(
             CreateFlowRequest(parent_flow_name=None, flow_name="ValueRoundTrip", set_as_new_context=False)
         )
         assert isinstance(flow, CreateFlowResultSuccess), flow
 
-        with GriptapeNodes.ContextManager().flow(flow.flow_name):
-            group = _create_node("SubflowGroupNode", "Group", library_name)
-            leaf = _create_node("EchoNode", "Leaf", library_name, parent_group_name=group)
-            GriptapeNodes.handle_request(
-                SetParameterValueRequest(parameter_name="text", node_name=leaf, value=_EXPECTED_TEXT)
-            )
+        with engine.context_manager.flow(flow.flow_name):
+            group = _create_node(engine, "SubflowGroupNode", "Group", library_name)
+            leaf = _create_node(engine, "EchoNode", "Leaf", library_name, parent_group_name=group)
+            engine.handle_request(SetParameterValueRequest(parameter_name="text", node_name=leaf, value=_EXPECTED_TEXT))
 
-        commands = _serialize(flow.flow_name)
+        commands = _serialize(engine, flow.flow_name)
 
-        GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
-        result = _deserialize_into_fresh_context(commands)
+        engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        result = _deserialize_into_fresh_context(engine, commands)
 
-        restored_leaf = GriptapeNodes.NodeManager().get_node_by_name(result.node_name_mappings["Leaf"])
+        restored_leaf = engine.node_manager.get_node_by_name(result.node_name_mappings["Leaf"])
         assert restored_leaf.get_parameter_value("text") == _EXPECTED_TEXT
 
 
@@ -388,7 +379,9 @@ class TestLoadingIntoAnOccupiedSession:
     lands alongside whatever the artist already has open, and each name that collides is deduped.
     """
 
-    def test_a_group_loaded_beside_a_same_named_group_gets_its_own_subflow(self, library_name: str) -> None:
+    def test_a_group_loaded_beside_a_same_named_group_gets_its_own_subflow(
+        self, engine: Engine, library_name: str
+    ) -> None:
         """A group records its subflow by name, and that name is deduped like any other.
 
         If the rebuilt group keeps the name it was saved with, it points at the subflow belonging to
@@ -396,42 +389,42 @@ class TestLoadingIntoAnOccupiedSession:
         subflow this load created is left empty, and nothing reports a problem, because the flow the
         group names does exist -- it just is not the group's.
         """
-        canvas = GriptapeNodes.handle_request(
+        canvas = engine.handle_request(
             CreateFlowRequest(parent_flow_name=None, flow_name="OccupiedCanvas", set_as_new_context=False)
         )
         assert isinstance(canvas, CreateFlowResultSuccess), canvas
-        host = GriptapeNodes.handle_request(
+        host = engine.handle_request(
             CreateFlowRequest(parent_flow_name=canvas.flow_name, flow_name="GroupHost", set_as_new_context=False)
         )
         assert isinstance(host, CreateFlowResultSuccess), host
 
-        with GriptapeNodes.ContextManager().flow(host.flow_name):
-            group = _create_node("SubflowGroupNode", "Group", library_name)
-            leaf = _create_node("EchoNode", "Leaf", library_name, parent_group_name=group)
+        with engine.context_manager.flow(host.flow_name):
+            group = _create_node(engine, "SubflowGroupNode", "Group", library_name)
+            leaf = _create_node(engine, "EchoNode", "Leaf", library_name, parent_group_name=group)
 
-        commands = _serialize(host.flow_name)
+        commands = _serialize(engine, host.flow_name)
 
-        original_group = _get_group(group)
+        original_group = _get_group(engine, group)
         original_subflow = original_group.metadata["subflow_name"]
 
         # No ClearAllObjectState: the group above is still open, so its name and its subflow's name
         # are both taken.
-        with GriptapeNodes.ContextManager().flow(canvas.flow_name):
-            result = GriptapeNodes.handle_request(DeserializeFlowFromCommandsRequest(serialized_flow_commands=commands))
+        with engine.context_manager.flow(canvas.flow_name):
+            result = engine.handle_request(DeserializeFlowFromCommandsRequest(serialized_flow_commands=commands))
         assert isinstance(result, DeserializeFlowFromCommandsResultSuccess), result
 
-        restored_group = _get_group(result.node_name_mappings["Group"])
+        restored_group = _get_group(engine, result.node_name_mappings["Group"])
         restored_leaf_name = result.node_name_mappings["Leaf"]
         restored_subflow = restored_group.metadata["subflow_name"]
 
         # The copy got its own subflow, and its member is in that one.
         assert restored_subflow != original_subflow
-        assert GriptapeNodes.NodeManager().get_node_parent_flow_by_name(restored_leaf_name) == restored_subflow
+        assert engine.node_manager.get_node_parent_flow_by_name(restored_leaf_name) == restored_subflow
         assert restored_leaf_name in restored_group.nodes
 
         # And the group that was already open kept exactly what it had.
         assert sorted(original_group.nodes) == [leaf]
-        assert GriptapeNodes.NodeManager().get_node_parent_flow_by_name(leaf) == original_subflow
+        assert engine.node_manager.get_node_parent_flow_by_name(leaf) == original_subflow
 
 
 class TestWhichFlowClaimsAnEdge:
@@ -444,28 +437,30 @@ class TestWhichFlowClaimsAnEdge:
     children only. Nothing else states that, so this is the test that fails if the scope ever widens.
     """
 
-    def test_a_group_subflow_does_not_report_an_edge_reaching_the_group_node_itself(self, library_name: str) -> None:
+    def test_a_group_subflow_does_not_report_an_edge_reaching_the_group_node_itself(
+        self, engine: Engine, library_name: str
+    ) -> None:
         """The group's own subflow must not claim the edge arriving at its wall.
 
         `Group` lives in the parent flow and `Leaf` inside the group's subflow, so the edge from
         `Feeder` to the group's proxy parameter has one endpoint at each level. The parent may report
         it. The subflow may not: it does not hold `Group`, and codegen writes it first.
         """
-        flow = GriptapeNodes.handle_request(
+        flow = engine.handle_request(
             CreateFlowRequest(parent_flow_name=None, flow_name="EdgeOwnership", set_as_new_context=False)
         )
         assert isinstance(flow, CreateFlowResultSuccess), flow
 
-        with GriptapeNodes.ContextManager().flow(flow.flow_name):
-            group = _create_node("SubflowGroupNode", "Group", library_name)
-            leaf = _create_node("EchoNode", "Leaf", library_name, parent_group_name=group)
-            feeder = _create_node("EchoNode", "Feeder", library_name)
-            _connect(feeder, leaf)
+        with engine.context_manager.flow(flow.flow_name):
+            group = _create_node(engine, "SubflowGroupNode", "Group", library_name)
+            leaf = _create_node(engine, "EchoNode", "Leaf", library_name, parent_group_name=group)
+            feeder = _create_node(engine, "EchoNode", "Feeder", library_name)
+            _connect(engine, feeder, leaf)
 
-        subflow_name = _get_group(group).metadata["subflow_name"]
+        subflow_name = _get_group(engine, group).metadata["subflow_name"]
 
         # Serializing the subflow on its own is what codegen does when it recurses into it.
-        subflow_commands = _serialize(subflow_name)
+        subflow_commands = _serialize(engine, subflow_name)
 
         # The wall edge attaches to the group node, which is not in the subflow, so the subflow must
         # not report any edge touching it.

--- a/tests/e2e/test_standalone_workflow_execution.py
+++ b/tests/e2e/test_standalone_workflow_execution.py
@@ -35,10 +35,11 @@ from griptape_nodes.retained_mode.events.library_events import (
 )
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
 from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from griptape_nodes.retained_mode.engine import Engine
 
 # Timeout with thread dump.
 pytestmark = pytest.mark.timeout(300, method="thread")
@@ -48,7 +49,7 @@ FIXTURE_LIBRARY_JSON_TEMPLATE = FIXTURE_LIBRARY_DIR / "griptape_nodes_library.js
 FIXTURE_NODE_FILE = FIXTURE_LIBRARY_DIR / "echo_node.py"
 
 
-def _generate_echo_workflow_source(library_json: Path) -> str:
+def _generate_echo_workflow_source(engine: Engine, library_json: Path) -> str:
     """Build a flow with one EchoNode and serialize it to a Python module.
 
     Uses the same path the engine uses when saving a workflow: register the library,
@@ -56,19 +57,19 @@ def _generate_echo_workflow_source(library_json: Path) -> str:
     serialized commands through ``WorkflowManager._generate_workflow_file_content``.
     The resulting source is what a user would see saved to disk.
     """
-    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
 
-    register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    register_result = engine.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
     assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
 
-    GriptapeNodes.ContextManager().push_workflow(workflow_name="echo_e2e_workflow")
+    engine.context_manager.push_workflow(workflow_name="echo_e2e_workflow")
 
-    flow_result = GriptapeNodes.handle_request(
+    flow_result = engine.handle_request(
         CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False)
     )
     assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
 
-    node_result = GriptapeNodes.handle_request(
+    node_result = engine.handle_request(
         CreateNodeRequest(
             node_type="EchoNode",
             specific_library_name="Echo Library",
@@ -81,7 +82,7 @@ def _generate_echo_workflow_source(library_json: Path) -> str:
         f"Sanity: in-process registration must yield real node, got {node_result.node_type!r}"
     )
 
-    serialize_result = GriptapeNodes.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_result.flow_name))
+    serialize_result = engine.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_result.flow_name))
     assert isinstance(serialize_result, SerializeFlowToCommandsResultSuccess), serialize_result
 
     metadata = WorkflowMetadata(
@@ -94,7 +95,7 @@ def _generate_echo_workflow_source(library_json: Path) -> str:
         # workflow_shape=None keeps the file inert at import time.
         workflow_shape=None,
     )
-    return GriptapeNodes.WorkflowManager()._generate_workflow_file_content(
+    return engine.workflow_manager._generate_workflow_file_content(
         serialized_flow_commands=serialize_result.serialized_flow_commands,
         workflow_metadata=metadata,
     )
@@ -165,6 +166,7 @@ if __name__ == "__main__":
 )
 def test_standalone_workflow_registers_declared_libraries(
     tmp_path: Path,
+    engine: Engine,
     engine_subprocess_env: Callable[..., dict[str, str]],
     materialize_library: Callable[..., Path],
     write_isolated_config: Callable[..., None],
@@ -177,7 +179,9 @@ def test_standalone_workflow_registers_declared_libraries(
     inspection plus a recording stub.
     """
     workspace = tmp_path / "workspace"
-    workspace.mkdir()
+    # The engine's ConfigManager creates the configured workspace on init, so this only has to
+    # cover the case where it has not.
+    workspace.mkdir(exist_ok=True)
     config_root = tmp_path / "xdg_config"
     library_json = materialize_library(
         tmp_path / "library", template=FIXTURE_LIBRARY_JSON_TEMPLATE, node_file=FIXTURE_NODE_FILE
@@ -186,7 +190,7 @@ def test_standalone_workflow_registers_declared_libraries(
 
     # Generator runs in the test process where Echo Library can be registered locally,
     # so SerializeFlowToCommandsRequest can build a faithful command list.
-    workflow_source = _generate_echo_workflow_source(library_json)
+    workflow_source = _generate_echo_workflow_source(engine, library_json)
     runnable_source = _wrap_with_runtime_assertions(workflow_source)
     assert "RegisterLibraryFromFileRequest(library_name='Echo Library'" in workflow_source, (
         "build_workflow must emit the registration call; if this assertion fails the unit"

--- a/tests/e2e/test_subflow_dataflow_execution.py
+++ b/tests/e2e/test_subflow_dataflow_execution.py
@@ -30,10 +30,11 @@ from griptape_nodes.retained_mode.events.library_events import (
     RegisterLibraryFromFileResultSuccess,
 )
 from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from griptape_nodes.retained_mode.engine import Engine
 
 # Timeout with thread dump.
 pytestmark = pytest.mark.timeout(300, method="thread")
@@ -52,6 +53,7 @@ _EXPECTED = "value-through-data-only-subflow"
 @pytest.mark.asyncio
 async def test_isolated_subflow_runs_data_only_graph(
     tmp_path: Path,
+    engine: Engine,
     materialize_library: Callable[..., Path],
     create_node: Callable[..., str],
     connect: Callable[..., None],
@@ -60,19 +62,19 @@ async def test_isolated_subflow_runs_data_only_graph(
     library_json = materialize_library(
         tmp_path / "library", template=FIXTURE_LIBRARY_JSON_TEMPLATE, node_file=FIXTURE_NODE_FILE
     )
-    register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    register_result = engine.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
     assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
 
-    GriptapeNodes.ContextManager().push_workflow(workflow_name="subflow_dataflow_wf")
+    engine.context_manager.push_workflow(workflow_name="subflow_dataflow_wf")
 
     # Parent flow holds the driver; the subflow is a child flow, like an imported referenced workflow.
-    parent_result = GriptapeNodes.handle_request(
+    parent_result = engine.handle_request(
         CreateFlowRequest(parent_flow_name=None, flow_name="ParentFlow", set_as_new_context=False)
     )
     assert isinstance(parent_result, CreateFlowResultSuccess), parent_result
     parent_flow = parent_result.flow_name
 
-    subflow_result = GriptapeNodes.handle_request(
+    subflow_result = engine.handle_request(
         CreateFlowRequest(parent_flow_name=parent_flow, flow_name="SubFlow", set_as_new_context=False)
     )
     assert isinstance(subflow_result, CreateFlowResultSuccess), subflow_result
@@ -85,15 +87,15 @@ async def test_isolated_subflow_runs_data_only_graph(
     connect("Start", "value", "Pass", "value")
     connect("Pass", "value", "End", "value")
 
-    GriptapeNodes.handle_request(SetParameterValueRequest(parameter_name="value", node_name="Start", value=_EXPECTED))
+    engine.handle_request(SetParameterValueRequest(parameter_name="value", node_name="Start", value=_EXPECTED))
 
     # Driver runs the subflow the way SubflowWorkflowNode does.
     create_node("RunSubflowNode", "Driver", parent_flow, library_name=LIBRARY_NAME)
-    driver = GriptapeNodes.NodeManager().get_node_by_name("Driver")
+    driver = engine.node_manager.get_node_by_name("Driver")
     driver.metadata["subflow_name"] = subflow
     driver.metadata["end_node_name"] = "End"
 
-    run_result = await GriptapeNodes.ahandle_request(
+    run_result = await engine.ahandle_request(
         StartFlowRequest(
             flow_name=parent_flow,
             flow_node_name="Driver",
@@ -103,7 +105,7 @@ async def test_isolated_subflow_runs_data_only_graph(
     )
     assert isinstance(run_result, StartFlowResultSuccess), run_result
 
-    node_manager = GriptapeNodes.NodeManager()
+    node_manager = engine.node_manager
     end_node = node_manager.get_node_by_name("End")
     pass_node = node_manager.get_node_by_name("Pass")
     driver = node_manager.get_node_by_name("Driver")

--- a/tests/e2e/test_subflow_execution.py
+++ b/tests/e2e/test_subflow_execution.py
@@ -35,10 +35,11 @@ from griptape_nodes.retained_mode.events.library_events import (
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
 from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
 from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from griptape_nodes.retained_mode.engine import Engine
 
 # Timeout with thread dump.
 pytestmark = pytest.mark.timeout(300, method="thread")
@@ -49,23 +50,23 @@ FIXTURE_LIBRARY_JSON_TEMPLATE = FIXTURE_LIBRARY_DIR / "griptape_nodes_library.js
 _EXPECTED_TEXT = "hello from subflow"
 
 
-def _generate_subflow_workflow_source(library_json: Path) -> str:
+def _generate_subflow_workflow_source(engine: Engine, library_json: Path) -> str:
     """Build a flow with a SubflowGroupNode containing an EchoNode and serialize it."""
-    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
 
-    register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    register_result = engine.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
     assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
 
-    GriptapeNodes.ContextManager().push_workflow(workflow_name="subflow_e2e_workflow")
+    engine.context_manager.push_workflow(workflow_name="subflow_e2e_workflow")
 
-    flow_result = GriptapeNodes.handle_request(
+    flow_result = engine.handle_request(
         CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False)
     )
     assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
     flow_name = flow_result.flow_name
 
-    with GriptapeNodes.ContextManager().flow(flow_name):
-        group_result = GriptapeNodes.handle_request(
+    with engine.context_manager.flow(flow_name):
+        group_result = engine.handle_request(
             CreateNodeRequest(
                 node_type="SubflowGroupNode",
                 specific_library_name="Subflow Library",
@@ -78,7 +79,7 @@ def _generate_subflow_workflow_source(library_json: Path) -> str:
             f"Expected SubflowGroupNode, got {group_result.node_type!r}"
         )
 
-        echo_result = GriptapeNodes.handle_request(
+        echo_result = engine.handle_request(
             CreateNodeRequest(
                 node_type="EchoNode",
                 specific_library_name="Subflow Library",
@@ -89,7 +90,7 @@ def _generate_subflow_workflow_source(library_json: Path) -> str:
         )
         assert isinstance(echo_result, CreateNodeResultSuccess), echo_result
 
-    GriptapeNodes.handle_request(
+    engine.handle_request(
         SetParameterValueRequest(
             parameter_name="text",
             value=_EXPECTED_TEXT,
@@ -97,7 +98,7 @@ def _generate_subflow_workflow_source(library_json: Path) -> str:
         )
     )
 
-    serialize_result = GriptapeNodes.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_name))
+    serialize_result = engine.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_name))
     assert isinstance(serialize_result, SerializeFlowToCommandsResultSuccess), serialize_result
 
     metadata = WorkflowMetadata(
@@ -107,7 +108,7 @@ def _generate_subflow_workflow_source(library_json: Path) -> str:
         node_libraries_referenced=list(serialize_result.serialized_flow_commands.node_dependencies.libraries),
         workflow_shape=None,
     )
-    return GriptapeNodes.WorkflowManager()._generate_workflow_file_content(
+    return engine.workflow_manager._generate_workflow_file_content(
         serialized_flow_commands=serialize_result.serialized_flow_commands,
         workflow_metadata=metadata,
     )
@@ -178,6 +179,7 @@ if __name__ == "__main__":
 )
 def test_subflow_node_group_propagates_output_values(
     tmp_path: Path,
+    engine: Engine,
     engine_subprocess_env: Callable[..., dict[str, str]],
     materialize_library: Callable[..., Path],
     write_isolated_config: Callable[..., None],
@@ -189,7 +191,9 @@ def test_subflow_node_group_propagates_output_values(
     parameter-value round-trip fails this test.
     """
     workspace = tmp_path / "workspace"
-    workspace.mkdir()
+    # The engine's ConfigManager creates the configured workspace on init, so this only has to
+    # cover the case where it has not.
+    workspace.mkdir(exist_ok=True)
     config_root = tmp_path / "xdg_config"
     library_json = materialize_library(
         tmp_path / "library",
@@ -198,7 +202,7 @@ def test_subflow_node_group_propagates_output_values(
     )
     write_isolated_config(config_root, workspace=workspace, library_path=library_json)
 
-    workflow_source = _generate_subflow_workflow_source(library_json)
+    workflow_source = _generate_subflow_workflow_source(engine, library_json)
     runnable_source = _wrap_with_runtime_assertions(workflow_source)
 
     workflow_path = tmp_path / "subflow_workflow.py"

--- a/tests/e2e/test_subflow_group_name_collision.py
+++ b/tests/e2e/test_subflow_group_name_collision.py
@@ -37,10 +37,11 @@ from griptape_nodes.retained_mode.events.object_events import (
     RenameObjectResultSuccess,
 )
 from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from griptape_nodes.retained_mode.engine import Engine
 
 # Timeout with thread dump.
 pytestmark = pytest.mark.timeout(300, method="thread")
@@ -59,7 +60,7 @@ LIBRARY_NAME = "Subflow Group Metadata Collision Library"
 )
 @pytest.mark.asyncio
 async def test_running_first_group_does_not_execute_second_groups_member(
-    tmp_path: Path, materialize_library: Callable[..., Path]
+    tmp_path: Path, engine: Engine, materialize_library: Callable[..., Path]
 ) -> None:
     """Running the first group must execute ONLY its own member, not the second group's.
 
@@ -72,35 +73,35 @@ async def test_running_first_group_does_not_execute_second_groups_member(
     library_json = materialize_library(
         tmp_path / "library", template=FIXTURE_LIBRARY_JSON_TEMPLATE, node_file=FIXTURE_NODE_FILE, name=LIBRARY_NAME
     )
-    register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    register_result = engine.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
     assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
 
-    GriptapeNodes.ContextManager().push_workflow(workflow_name="subflow_collision_wf")
+    engine.context_manager.push_workflow(workflow_name="subflow_collision_wf")
 
-    parent_result = GriptapeNodes.handle_request(
+    parent_result = engine.handle_request(
         CreateFlowRequest(parent_flow_name=None, flow_name="ParentFlow", set_as_new_context=False)
     )
     assert isinstance(parent_result, CreateFlowResultSuccess), parent_result
     parent_flow = parent_result.flow_name
 
-    with GriptapeNodes.ContextManager().flow(parent_flow):
+    with engine.context_manager.flow(parent_flow):
         # ChildA has a valid input; ChildB has none, so ChildB raises if it is ever executed.
-        child_a = GriptapeNodes.handle_request(
+        child_a = engine.handle_request(
             CreateNodeRequest(node_type="EchoNode", specific_library_name=LIBRARY_NAME, node_name="ChildA")
         )
         assert isinstance(child_a, CreateNodeResultSuccess), child_a
-        child_b = GriptapeNodes.handle_request(
+        child_b = engine.handle_request(
             CreateNodeRequest(node_type="EchoNode", specific_library_name=LIBRARY_NAME, node_name="ChildB")
         )
         assert isinstance(child_b, CreateNodeResultSuccess), child_b
 
-        set_result = GriptapeNodes.handle_request(
+        set_result = engine.handle_request(
             SetParameterValueRequest(node_name="ChildA", parameter_name="text", value="hello")
         )
         assert set_result.succeeded(), set_result
 
         # --- Group A around ChildA, then rename it (frees the default group name) ---
-        group_a = GriptapeNodes.handle_request(
+        group_a = engine.handle_request(
             CreateNodeRequest(
                 node_type="SubflowGroupNode",
                 specific_library_name=LIBRARY_NAME,
@@ -109,11 +110,11 @@ async def test_running_first_group_does_not_execute_second_groups_member(
             )
         )
         assert isinstance(group_a, CreateNodeResultSuccess), group_a
-        rename_a = GriptapeNodes.handle_request(RenameObjectRequest(object_name="G", requested_name="GroupA"))
+        rename_a = engine.handle_request(RenameObjectRequest(object_name="G", requested_name="GroupA"))
         assert isinstance(rename_a, RenameObjectResultSuccess), rename_a
 
         # --- Group B reuses the freed name "G", triggering the subflow-name collision ---
-        group_b = GriptapeNodes.handle_request(
+        group_b = engine.handle_request(
             CreateNodeRequest(
                 node_type="SubflowGroupNode",
                 specific_library_name=LIBRARY_NAME,
@@ -122,11 +123,11 @@ async def test_running_first_group_does_not_execute_second_groups_member(
             )
         )
         assert isinstance(group_b, CreateNodeResultSuccess), group_b
-        rename_b = GriptapeNodes.handle_request(RenameObjectRequest(object_name="G", requested_name="GroupB"))
+        rename_b = engine.handle_request(RenameObjectRequest(object_name="G", requested_name="GroupB"))
         assert isinstance(rename_b, RenameObjectResultSuccess), rename_b
 
     # Run ONLY the first group. It must not drag the second group's member into execution.
-    run_result = await GriptapeNodes.ahandle_request(
+    run_result = await engine.ahandle_request(
         StartFlowRequest(
             flow_name=parent_flow,
             flow_node_name="GroupA",
@@ -136,7 +137,7 @@ async def test_running_first_group_does_not_execute_second_groups_member(
     )
     assert isinstance(run_result, StartFlowResultSuccess), run_result
 
-    node_manager = GriptapeNodes.NodeManager()
+    node_manager = engine.node_manager
     child_a_node = node_manager.get_node_by_name("ChildA")
     child_b_node = node_manager.get_node_by_name("ChildB")
 

--- a/tests/e2e/test_subflow_group_parallel_execution.py
+++ b/tests/e2e/test_subflow_group_parallel_execution.py
@@ -27,10 +27,11 @@ from griptape_nodes.retained_mode.events.library_events import (
 )
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
 from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from griptape_nodes.retained_mode.engine import Engine
 
 # Timeout with thread dump.
 pytestmark = pytest.mark.timeout(300, method="thread")
@@ -52,32 +53,32 @@ _DELAY_SECONDS = 0.4
 )
 @pytest.mark.asyncio
 async def test_group_runs_independent_nodes_in_parallel(
-    tmp_path: Path, materialize_library: Callable[..., Path]
+    tmp_path: Path, engine: Engine, materialize_library: Callable[..., Path]
 ) -> None:
     """Every independent child of a group resolves, and they overlap in time under PARALLEL mode."""
     library_json = materialize_library(
         tmp_path / "library", template=FIXTURE_LIBRARY_JSON_TEMPLATE, node_file=FIXTURE_NODE_FILE, name=LIBRARY_NAME
     )
-    register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    register_result = engine.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
     assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
 
-    config_manager = GriptapeNodes.ConfigManager()
+    config_manager = engine.config_manager
     prior_mode = config_manager.get_config_value("workflow_execution_mode")
     prior_max = config_manager.get_config_value("max_nodes_in_parallel")
     config_manager.set_config_value("workflow_execution_mode", "parallel")
     config_manager.set_config_value("max_nodes_in_parallel", 5)
 
     try:
-        GriptapeNodes.ContextManager().push_workflow(workflow_name="repro_4920_wf")
+        engine.context_manager.push_workflow(workflow_name="repro_4920_wf")
 
-        parent_result = GriptapeNodes.handle_request(
+        parent_result = engine.handle_request(
             CreateFlowRequest(parent_flow_name=None, flow_name="ParentFlow", set_as_new_context=False)
         )
         assert isinstance(parent_result, CreateFlowResultSuccess), parent_result
         parent_flow = parent_result.flow_name
 
-        with GriptapeNodes.ContextManager().flow(parent_flow):
-            group_result = GriptapeNodes.handle_request(
+        with engine.context_manager.flow(parent_flow):
+            group_result = engine.handle_request(
                 CreateNodeRequest(
                     node_type="SubflowGroupNode",
                     specific_library_name=LIBRARY_NAME,
@@ -88,7 +89,7 @@ async def test_group_runs_independent_nodes_in_parallel(
 
             node_names = []
             for i in range(_NODE_COUNT):
-                node_result = GriptapeNodes.handle_request(
+                node_result = engine.handle_request(
                     CreateNodeRequest(
                         node_type="TimedEchoNode",
                         specific_library_name=LIBRARY_NAME,
@@ -100,14 +101,12 @@ async def test_group_runs_independent_nodes_in_parallel(
                 node_names.append(node_result.node_name)
 
         for i, name in enumerate(node_names):
-            GriptapeNodes.handle_request(
-                SetParameterValueRequest(parameter_name="text", node_name=name, value=f"n-{i}")
-            )
-            GriptapeNodes.handle_request(
+            engine.handle_request(SetParameterValueRequest(parameter_name="text", node_name=name, value=f"n-{i}"))
+            engine.handle_request(
                 SetParameterValueRequest(parameter_name="delay", node_name=name, value=_DELAY_SECONDS)
             )
 
-        run_result = await GriptapeNodes.ahandle_request(
+        run_result = await engine.ahandle_request(
             StartFlowRequest(
                 flow_name=parent_flow,
                 flow_node_name=group_result.node_name,
@@ -120,7 +119,7 @@ async def test_group_runs_independent_nodes_in_parallel(
         config_manager.set_config_value("workflow_execution_mode", prior_mode)
         config_manager.set_config_value("max_nodes_in_parallel", prior_max)
 
-    node_manager = GriptapeNodes.NodeManager()
+    node_manager = engine.node_manager
     intervals = []
     for i, name in enumerate(node_names):
         node = node_manager.get_node_by_name(name)

--- a/tests/e2e/test_subflow_import_flow_selection.py
+++ b/tests/e2e/test_subflow_import_flow_selection.py
@@ -33,10 +33,11 @@ from griptape_nodes.retained_mode.events.workflow_events import (
     ImportWorkflowRequest,
     ImportWorkflowResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from griptape_nodes.retained_mode.engine import Engine
 
 # Timeout with thread dump.
 pytestmark = pytest.mark.timeout(300, method="thread")
@@ -49,25 +50,25 @@ FIXTURE_NODE_FILE = FIXTURE_LIBRARY_DIR / "subflow_echo_node.py"
 LIBRARY_NAME = "Subflow Import Flow Selection Library"
 
 
-def _write_grouped_workflow_file(library_json: Path, workflow_path: Path) -> None:
+def _write_grouped_workflow_file(engine: Engine, library_json: Path, workflow_path: Path) -> None:
     """Write a self-contained grouped workflow ``.py`` to ``workflow_path``.
 
     Builds a flow whose only node is a group (which owns a nested body flow), serializes it to a
     self-contained module, and clears the in-process build so the import starts from a clean slate.
     """
-    register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    register_result = engine.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
     assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
 
-    GriptapeNodes.ContextManager().push_workflow(workflow_name="grouped_inner_workflow")
+    engine.context_manager.push_workflow(workflow_name="grouped_inner_workflow")
 
-    flow_result = GriptapeNodes.handle_request(
+    flow_result = engine.handle_request(
         CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False)
     )
     assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
     flow_name = flow_result.flow_name
 
-    with GriptapeNodes.ContextManager().flow(flow_name):
-        group_result = GriptapeNodes.handle_request(
+    with engine.context_manager.flow(flow_name):
+        group_result = engine.handle_request(
             CreateNodeRequest(
                 node_type="SubflowGroupNode",
                 specific_library_name=LIBRARY_NAME,
@@ -76,7 +77,7 @@ def _write_grouped_workflow_file(library_json: Path, workflow_path: Path) -> Non
             )
         )
         assert isinstance(group_result, CreateNodeResultSuccess), group_result
-        echo_result = GriptapeNodes.handle_request(
+        echo_result = engine.handle_request(
             CreateNodeRequest(
                 node_type="EchoNode",
                 specific_library_name=LIBRARY_NAME,
@@ -87,7 +88,7 @@ def _write_grouped_workflow_file(library_json: Path, workflow_path: Path) -> Non
         )
         assert isinstance(echo_result, CreateNodeResultSuccess), echo_result
 
-    serialize_result = GriptapeNodes.handle_request(
+    serialize_result = engine.handle_request(
         SerializeFlowToCommandsRequest(flow_name=flow_name, include_create_flow_command=True)
     )
     assert isinstance(serialize_result, SerializeFlowToCommandsResultSuccess), serialize_result
@@ -99,14 +100,14 @@ def _write_grouped_workflow_file(library_json: Path, workflow_path: Path) -> Non
         node_libraries_referenced=list(serialize_result.serialized_flow_commands.node_dependencies.libraries),
         workflow_shape=None,
     )
-    content = GriptapeNodes.WorkflowManager()._generate_workflow_file_content(
+    content = engine.workflow_manager._generate_workflow_file_content(
         serialized_flow_commands=serialize_result.serialized_flow_commands,
         workflow_metadata=metadata,
     )
     workflow_path.write_text(content)
 
     # Drop the in-process build so the import below starts from a clean parent flow.
-    GriptapeNodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
 
 
 @pytest.mark.skipif(
@@ -115,29 +116,29 @@ def _write_grouped_workflow_file(library_json: Path, workflow_path: Path) -> Non
 )
 @pytest.mark.asyncio
 async def test_import_binds_to_top_level_flow_not_group_body(
-    tmp_path: Path, materialize_library: Callable[..., Path]
+    tmp_path: Path, engine: Engine, materialize_library: Callable[..., Path]
 ) -> None:
     """Importing a group-containing workflow must return the top-level imported flow."""
     library_json = materialize_library(
         tmp_path / "library", template=FIXTURE_LIBRARY_JSON_TEMPLATE, node_file=FIXTURE_NODE_FILE, name=LIBRARY_NAME
     )
     workflow_path = tmp_path / "grouped_inner_workflow.py"
-    _write_grouped_workflow_file(library_json, workflow_path)
+    _write_grouped_workflow_file(engine, library_json, workflow_path)
 
     # Register the workflow file so it can be imported by name.
-    import_workflow_result = await GriptapeNodes.ahandle_request(ImportWorkflowRequest(file_path=str(workflow_path)))
+    import_workflow_result = await engine.ahandle_request(ImportWorkflowRequest(file_path=str(workflow_path)))
     assert isinstance(import_workflow_result, ImportWorkflowResultSuccess), import_workflow_result
     workflow_name = import_workflow_result.workflow_name
 
     # Fresh parent flow to import into.
-    GriptapeNodes.ContextManager().push_workflow(workflow_name="parent_workflow")
-    parent_result = GriptapeNodes.handle_request(
+    engine.context_manager.push_workflow(workflow_name="parent_workflow")
+    parent_result = engine.handle_request(
         CreateFlowRequest(parent_flow_name=None, flow_name="ParentFlow", set_as_new_context=False)
     )
     assert isinstance(parent_result, CreateFlowResultSuccess), parent_result
     parent_flow = parent_result.flow_name
 
-    import_result = await GriptapeNodes.ahandle_request(
+    import_result = await engine.ahandle_request(
         ImportWorkflowAsReferencedSubFlowRequest(workflow_name=workflow_name, flow_name=parent_flow)
     )
     assert isinstance(import_result, ImportWorkflowAsReferencedSubFlowResultSuccess), import_result
@@ -145,7 +146,7 @@ async def test_import_binds_to_top_level_flow_not_group_body(
     # The imported workflow created two flows (its top-level flow + the group's body flow). The
     # returned flow must be the TOP-LEVEL one, i.e. the flow whose parent is the import target.
     # The group's body flow is parented to that top-level flow, so returning it would be the bug.
-    flow_manager = GriptapeNodes.FlowManager()
+    flow_manager = engine.flow_manager
     created_flow = import_result.created_flow_name
     assert flow_manager.get_parent_flow(created_flow) == parent_flow, (
         f"import bound to '{created_flow}' (parent '{flow_manager.get_parent_flow(created_flow)}') "

--- a/tests/e2e/test_workflow_node_execution.py
+++ b/tests/e2e/test_workflow_node_execution.py
@@ -33,10 +33,11 @@ from griptape_nodes.retained_mode.events.library_events import (
     RegisterLibraryFromFileResultSuccess,
 )
 from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from griptape_nodes.retained_mode.engine import Engine
 
 # Timeout with thread dump.
 pytestmark = pytest.mark.timeout(300, method="thread")
@@ -50,7 +51,7 @@ WORKFLOW_NODE_TYPE = "ShoutWorkflow"
 
 
 @pytest.fixture
-def registered_library(tmp_path: Path, materialize_library: Callable[..., Path]) -> Path:
+def registered_library(tmp_path: Path, engine: Engine, materialize_library: Callable[..., Path]) -> Path:
     """Materialize and register the fixture library, returning its JSON path."""
     library_json = materialize_library(
         tmp_path / "library",
@@ -58,7 +59,7 @@ def registered_library(tmp_path: Path, materialize_library: Callable[..., Path])
         node_file=FIXTURE_NODE_FILE,
         extra_files=[FIXTURE_WORKFLOW_FILE],
     )
-    register_result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    register_result = engine.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
     assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
     return library_json
 
@@ -69,22 +70,23 @@ def registered_library(tmp_path: Path, materialize_library: Callable[..., Path])
 )
 def test_workflow_node_registers_with_shape_derived_parameters(
     registered_library: Path,  # noqa: ARG001
+    engine: Engine,
     create_node: Callable[..., str],
 ) -> None:
     """A `workflow_nodes` entry becomes a real node type whose parameters mirror the shape."""
-    list_result = GriptapeNodes.handle_request(ListNodeTypesInLibraryRequest(library=LIBRARY_NAME))
+    list_result = engine.handle_request(ListNodeTypesInLibraryRequest(library=LIBRARY_NAME))
     assert isinstance(list_result, ListNodeTypesInLibraryResultSuccess), list_result
     assert WORKFLOW_NODE_TYPE in list_result.node_types
 
-    GriptapeNodes.ContextManager().push_workflow(workflow_name="workflow_node_e2e_shape")
+    engine.context_manager.push_workflow(workflow_name="workflow_node_e2e_shape")
 
-    flow_result = GriptapeNodes.handle_request(
+    flow_result = engine.handle_request(
         CreateFlowRequest(parent_flow_name=None, flow_name="ParentFlow", set_as_new_context=False)
     )
     assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
 
     create_node(WORKFLOW_NODE_TYPE, "Shout It", flow_result.flow_name, library_name=LIBRARY_NAME)
-    node = GriptapeNodes.NodeManager().get_node_by_name("Shout It")
+    node = engine.node_manager.get_node_by_name("Shout It")
 
     assert isinstance(node, WorkflowNode), f"Expected a workflow-backed node, got {type(node).__name__}"
     # `text` comes from the workflow's Start Flow node, `result` from its End Flow node. Control
@@ -101,24 +103,25 @@ def test_workflow_node_registers_with_shape_derived_parameters(
 @pytest.mark.asyncio
 async def test_workflow_node_runs_its_workflow_and_returns_outputs(
     registered_library: Path,  # noqa: ARG001
+    engine: Engine,
     create_node: Callable[..., str],
 ) -> None:
     """Running the generated node executes the workflow and surfaces its End Flow values."""
-    GriptapeNodes.ContextManager().push_workflow(workflow_name="workflow_node_e2e")
+    engine.context_manager.push_workflow(workflow_name="workflow_node_e2e")
 
-    flow_result = GriptapeNodes.handle_request(
+    flow_result = engine.handle_request(
         CreateFlowRequest(parent_flow_name=None, flow_name="ParentFlow", set_as_new_context=False)
     )
     assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
     parent_flow = flow_result.flow_name
 
     create_node(WORKFLOW_NODE_TYPE, "Shout It", parent_flow, library_name=LIBRARY_NAME)
-    set_result = GriptapeNodes.handle_request(
+    set_result = engine.handle_request(
         SetParameterValueRequest(parameter_name="text", node_name="Shout It", value="hello there")
     )
     assert set_result.succeeded(), set_result
 
-    run_result = await GriptapeNodes.ahandle_request(
+    run_result = await engine.ahandle_request(
         StartFlowRequest(
             flow_name=parent_flow,
             flow_node_name="Shout It",
@@ -128,13 +131,13 @@ async def test_workflow_node_runs_its_workflow_and_returns_outputs(
     )
     assert isinstance(run_result, StartFlowResultSuccess), run_result
 
-    node = GriptapeNodes.NodeManager().get_node_by_name("Shout It")
+    node = engine.node_manager.get_node_by_name("Shout It")
     assert node.state == NodeResolutionState.RESOLVED
     assert node.parameter_output_values.get("result") == "HELLO THERE!"
 
     # The workflow was imported as a child flow of the node's own flow so it can be inspected
     # during the session, and it is tagged transient so a save never bakes it in.
-    subflows_result = GriptapeNodes.handle_request(ListFlowsInFlowRequest(parent_flow_name=parent_flow))
+    subflows_result = engine.handle_request(ListFlowsInFlowRequest(parent_flow_name=parent_flow))
     assert isinstance(subflows_result, ListFlowsInFlowResultSuccess), subflows_result
     assert node.metadata["subflow_name"] in subflows_result.flow_names
 
@@ -146,6 +149,7 @@ async def test_workflow_node_runs_its_workflow_and_returns_outputs(
 @pytest.mark.asyncio
 async def test_two_workflow_nodes_run_independently(
     registered_library: Path,  # noqa: ARG001
+    engine: Engine,
     create_node: Callable[..., str],
     connect: Callable[..., None],
 ) -> None:
@@ -154,9 +158,9 @@ async def test_two_workflow_nodes_run_independently(
     The second import renames the workflow's Start/End nodes (their names are already taken), so
     this covers the path where the saved shape's node names no longer match the live subflow.
     """
-    GriptapeNodes.ContextManager().push_workflow(workflow_name="workflow_node_e2e_pair")
+    engine.context_manager.push_workflow(workflow_name="workflow_node_e2e_pair")
 
-    flow_result = GriptapeNodes.handle_request(
+    flow_result = engine.handle_request(
         CreateFlowRequest(parent_flow_name=None, flow_name="ParentFlow", set_as_new_context=False)
     )
     assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
@@ -167,12 +171,10 @@ async def test_two_workflow_nodes_run_independently(
     connect("First", "exec_out", "Second", "exec_in")
     connect("First", "result", "Second", "text")
 
-    set_result = GriptapeNodes.handle_request(
-        SetParameterValueRequest(parameter_name="text", node_name="First", value="hey")
-    )
+    set_result = engine.handle_request(SetParameterValueRequest(parameter_name="text", node_name="First", value="hey"))
     assert set_result.succeeded(), set_result
 
-    run_result = await GriptapeNodes.ahandle_request(
+    run_result = await engine.ahandle_request(
         StartFlowRequest(
             flow_name=parent_flow,
             flow_node_name="First",
@@ -182,7 +184,7 @@ async def test_two_workflow_nodes_run_independently(
     )
     assert isinstance(run_result, StartFlowResultSuccess), run_result
 
-    node_manager = GriptapeNodes.NodeManager()
+    node_manager = engine.node_manager
     first = node_manager.get_node_by_name("First")
     second = node_manager.get_node_by_name("Second")
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,10 +6,9 @@ from pathlib import Path
 import pytest  # type: ignore[reportMissingImports]
 
 from griptape_nodes.node_library.library_registry import LibraryRegistry
-from griptape_nodes.retained_mode.engine import reset_root_engine
+from griptape_nodes.retained_mode.engine import Engine, current_engine, reset_root_engine
 from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
 from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers import config_manager as config_manager_module
 from griptape_nodes.retained_mode.managers import secrets_manager as secrets_manager_module
 from griptape_nodes.utils import install_file_url_support
@@ -47,16 +46,22 @@ def _isolated_engine_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Ite
 
 
 @pytest.fixture
-def flow() -> CreateFlowResultSuccess:
+def engine() -> Engine:
+    """Provide the engine for this test, building it on first use."""
+    return current_engine()
+
+
+@pytest.fixture
+def flow(engine: Engine) -> CreateFlowResultSuccess:
     """Fixture to create a flow for testing."""
     request = RegisterLibraryFromFileRequest(
         file_path="../griptape-nodes/libraries/griptape_nodes_library/griptape_nodes_library.json"
     )
-    result = GriptapeNodes.handle_request(request)
+    result = engine.handle_request(request)
 
     # Create a canvas (flow with no parents)
     request = CreateFlowRequest(parent_flow_name=None, flow_name="canvas")
-    result = GriptapeNodes.handle_request(request)
+    result = engine.handle_request(request)
 
     assert isinstance(result, CreateFlowResultSuccess)
 

--- a/tests/integration/files/test_files.py
+++ b/tests/integration/files/test_files.py
@@ -1,11 +1,17 @@
 """End-to-end round trips through the real engine for `File` paths."""
 
-from pathlib import Path
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 import pytest
 
 from griptape_nodes.files.file import File
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from griptape_nodes.retained_mode.engine import Engine
 
 
 class TestRelativePathRoundTrip:
@@ -26,7 +32,9 @@ class TestRelativePathRoundTrip:
         "relative_path",
         ["config.json", "data/nested.json", pytest.param("foo%20bar.txt"), pytest.param("report$.txt")],
     )
-    def test_write_then_read_resolves_to_the_workspace(self, relative_path: str, cwd_path: Path) -> None:
+    def test_write_then_read_resolves_to_the_workspace(
+        self, relative_path: str, cwd_path: Path, engine: Engine
+    ) -> None:
         content = f"round trip content for {relative_path}"
 
         written_path = File(relative_path).write_text(content)
@@ -34,5 +42,5 @@ class TestRelativePathRoundTrip:
         assert File(relative_path).read_text() == content
         # Compare against the ConfigManager's own getter, which is `.resolve()`d, so a
         # symlinked temp directory (macOS `/tmp` -> `/private/tmp`) does not fail this.
-        assert written_path == GriptapeNodes.ConfigManager().workspace_path / relative_path
+        assert written_path == engine.config_manager.workspace_path / relative_path
         assert not (cwd_path / relative_path).exists()

--- a/tests/integration/retained_mode/events/test_config_events.py
+++ b/tests/integration/retained_mode/events/test_config_events.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -12,21 +15,23 @@ from griptape_nodes.retained_mode.events.config_events import (
 from griptape_nodes.retained_mode.events.secrets_events import (
     SetSecretValueRequest,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
 
 
 class TestConfigEvents:
     @pytest.mark.xfail(strict=True, reason="Drifted due to not running on CI - see #5237")
-    def test_get_config_value(self) -> None:
-        GriptapeNodes.handle_request(SetSecretValueRequest(key="SECRET_KEY", value="secret foo"))
-        GriptapeNodes.handle_request(SetConfigValueRequest(category_and_key="nodes.foo.bar", value="$SECRET_KEY"))
-        result = GriptapeNodes.handle_request(GetConfigValueRequest(category_and_key="nodes.foo.bar"))
+    def test_get_config_value(self, engine: Engine) -> None:
+        engine.handle_request(SetSecretValueRequest(key="SECRET_KEY", value="secret foo"))
+        engine.handle_request(SetConfigValueRequest(category_and_key="nodes.foo.bar", value="$SECRET_KEY"))
+        result = engine.handle_request(GetConfigValueRequest(category_and_key="nodes.foo.bar"))
 
         assert isinstance(result, GetConfigValueResultSuccess)
         assert result.value == "secret foo"
 
-    def test_get_workspace_returns_absolute_path(self) -> None:
-        result = GriptapeNodes.handle_request(GetWorkspaceRequest())
+    def test_get_workspace_returns_absolute_path(self, engine: Engine) -> None:
+        result = engine.handle_request(GetWorkspaceRequest())
 
         assert isinstance(result, GetWorkspaceResultSuccess)
         assert result.workspace_path

--- a/tests/integration/retained_mode/events/test_lock_nodes.py
+++ b/tests/integration/retained_mode/events/test_lock_nodes.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest  # type: ignore[reportMissingImports]
 
 from griptape_nodes.retained_mode.events.node_events import (
@@ -11,81 +15,79 @@ from griptape_nodes.retained_mode.events.node_events import (
     SetLockNodeStateResultFailure,
     SetLockNodeStateResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
 
 
 class TestLockNodes:
-    def test_lock_without_current_context_returns_failure(self) -> None:
+    def test_lock_without_current_context_returns_failure(self, engine: Engine) -> None:
         # Ensure no current node in context
-        ctx = GriptapeNodes.ContextManager()
+        ctx = engine.context_manager
         while ctx.has_current_node():
             ctx.pop_node()
 
-        res = GriptapeNodes.handle_request(SetLockNodeStateRequest(node_name=None, lock=True))
+        res = engine.handle_request(SetLockNodeStateRequest(node_name=None, lock=True))
         assert isinstance(res, SetLockNodeStateResultFailure)
         assert "Current Context" in str(res.result_details)
 
     @pytest.fixture
-    def create_node(self) -> str:
+    def create_node(self, engine: Engine) -> str:
         """Create a single test node and return its name."""
         request = CreateNodeRequest(node_type="RunAgentNode", override_parent_flow_name="canvas")
-        result = GriptapeNodes.handle_request(request)
+        result = engine.handle_request(request)
         assert hasattr(result, "node_name")
         return result.node_name  # type: ignore[attr-defined]
 
     @pytest.fixture
-    def create_two_nodes(self) -> tuple[str, str]:
+    def create_two_nodes(self, engine: Engine) -> tuple[str, str]:
         """Create two test nodes and return their names."""
-        r1 = GriptapeNodes.handle_request(
-            CreateNodeRequest(node_type="RunAgentNode", override_parent_flow_name="canvas")
-        )
-        r2 = GriptapeNodes.handle_request(
-            CreateNodeRequest(node_type="RunAgentNode", override_parent_flow_name="canvas")
-        )
+        r1 = engine.handle_request(CreateNodeRequest(node_type="RunAgentNode", override_parent_flow_name="canvas"))
+        r2 = engine.handle_request(CreateNodeRequest(node_type="RunAgentNode", override_parent_flow_name="canvas"))
         assert hasattr(r1, "node_name")
         assert hasattr(r2, "node_name")
         return r1.node_name, r2.node_name  # type: ignore[attr-defined]
 
     @pytest.mark.xfail(strict=True, reason="Drifted due to not running on CI - see #5237")
-    def test_lock_single_node_by_name(self, create_node: str) -> None:
+    def test_lock_single_node_by_name(self, create_node: str, engine: Engine) -> None:
         node_name = create_node
         # Lock
         lock_req = SetLockNodeStateRequest(lock=True, node_name=node_name)
-        lock_res = GriptapeNodes.handle_request(lock_req)
+        lock_res = engine.handle_request(lock_req)
         assert isinstance(lock_res, SetLockNodeStateResultSuccess)
         assert lock_res.locked is True
         assert lock_res.node_name == node_name
 
         # Verify via GetAllNodeInfo
-        info_res = GriptapeNodes.handle_request(GetAllNodeInfoRequest(node_name=node_name))
+        info_res = engine.handle_request(GetAllNodeInfoRequest(node_name=node_name))
         assert isinstance(info_res, GetAllNodeInfoResultSuccess)
         assert info_res.locked is True
 
         # Unlock
         unlock_req = SetLockNodeStateRequest(lock=False, node_name=node_name)
-        unlock_res = GriptapeNodes.handle_request(unlock_req)
+        unlock_res = engine.handle_request(unlock_req)
         assert isinstance(unlock_res, SetLockNodeStateResultSuccess)
         assert unlock_res.locked is False
         assert unlock_res.node_name == node_name
 
-        info_res2 = GriptapeNodes.handle_request(GetAllNodeInfoRequest(node_name=node_name))
+        info_res2 = engine.handle_request(GetAllNodeInfoRequest(node_name=node_name))
         assert isinstance(info_res2, GetAllNodeInfoResultSuccess)
         assert info_res2.locked is False
 
     @pytest.mark.xfail(strict=True, reason="Drifted due to not running on CI - see #5237")
-    def test_lock_multiple_nodes(self, create_two_nodes: tuple[str, str]) -> None:
+    def test_lock_multiple_nodes(self, create_two_nodes: tuple[str, str], engine: Engine) -> None:
         node_a, node_b = create_two_nodes
 
         # Lock both (batch)
         lock_req = BatchSetNodeLockStateRequest(lock=True, node_names=[node_a, node_b])
-        lock_res = GriptapeNodes.handle_request(lock_req)
+        lock_res = engine.handle_request(lock_req)
         assert isinstance(lock_res, BatchSetNodeLockStateResultSuccess)
         assert lock_res.updated_nodes == [node_a, node_b]
         assert lock_res.failed_nodes == {}
 
         # Verify both locked
-        info_a = GriptapeNodes.handle_request(GetAllNodeInfoRequest(node_name=node_a))
-        info_b = GriptapeNodes.handle_request(GetAllNodeInfoRequest(node_name=node_b))
+        info_a = engine.handle_request(GetAllNodeInfoRequest(node_name=node_a))
+        info_b = engine.handle_request(GetAllNodeInfoRequest(node_name=node_b))
         assert isinstance(info_a, GetAllNodeInfoResultSuccess)
         assert isinstance(info_b, GetAllNodeInfoResultSuccess)
         assert info_a.locked is True
@@ -93,50 +95,50 @@ class TestLockNodes:
 
         # Unlock both (batch)
         unlock_req = BatchSetNodeLockStateRequest(lock=False, node_names=[node_a, node_b])
-        unlock_res = GriptapeNodes.handle_request(unlock_req)
+        unlock_res = engine.handle_request(unlock_req)
         assert isinstance(unlock_res, BatchSetNodeLockStateResultSuccess)
         assert unlock_res.updated_nodes == [node_a, node_b]
 
-        info_a2 = GriptapeNodes.handle_request(GetAllNodeInfoRequest(node_name=node_a))
-        info_b2 = GriptapeNodes.handle_request(GetAllNodeInfoRequest(node_name=node_b))
+        info_a2 = engine.handle_request(GetAllNodeInfoRequest(node_name=node_a))
+        info_b2 = engine.handle_request(GetAllNodeInfoRequest(node_name=node_b))
         assert isinstance(info_a2, GetAllNodeInfoResultSuccess)
         assert isinstance(info_b2, GetAllNodeInfoResultSuccess)
         assert info_a2.locked is False
         assert info_b2.locked is False
 
     @pytest.mark.xfail(strict=True, reason="Drifted due to not running on CI - see #5237")
-    def test_lock_with_current_context_when_name_missing(self) -> None:
+    def test_lock_with_current_context_when_name_missing(self, engine: Engine) -> None:
         # Create a node and set as current context
         create_req = CreateNodeRequest(
             node_type="RunAgentNode", override_parent_flow_name="canvas", set_as_new_context=True
         )
-        create_res = GriptapeNodes.handle_request(create_req)
+        create_res = engine.handle_request(create_req)
         assert hasattr(create_res, "node_name")
         node_name = create_res.node_name  # type: ignore[attr-defined]
 
         # Lock without specifying node_name
-        lock_res = GriptapeNodes.handle_request(SetLockNodeStateRequest(node_name=None, lock=True))
+        lock_res = engine.handle_request(SetLockNodeStateRequest(node_name=None, lock=True))
         assert isinstance(lock_res, SetLockNodeStateResultSuccess)
         assert lock_res.locked is True
         # In current-context path, node_name should be populated for backward compatibility
         assert lock_res.node_name == node_name
 
-        info_res = GriptapeNodes.handle_request(GetAllNodeInfoRequest(node_name=node_name))
+        info_res = engine.handle_request(GetAllNodeInfoRequest(node_name=node_name))
         assert isinstance(info_res, GetAllNodeInfoResultSuccess)
         assert info_res.locked is True
 
     @pytest.mark.xfail(strict=True, reason="Drifted due to not running on CI - see #5237")
-    def test_lock_multiple_with_missing_node_returns_failure(self, create_node: str) -> None:
+    def test_lock_multiple_with_missing_node_returns_failure(self, create_node: str, engine: Engine) -> None:
         existing = create_node
         missing = "does_not_exist_123"
 
-        res = GriptapeNodes.handle_request(BatchSetNodeLockStateRequest(lock=True, node_names=[existing, missing]))
+        res = engine.handle_request(BatchSetNodeLockStateRequest(lock=True, node_names=[existing, missing]))
         assert isinstance(res, BatchSetNodeLockStateResultFailure)
         # Ensure the error mentions the missing node
         assert missing in str(res.result_details)
 
-    def test_lock_single_missing_node_returns_failure(self) -> None:
+    def test_lock_single_missing_node_returns_failure(self, engine: Engine) -> None:
         missing = "not_here_456"
-        res = GriptapeNodes.handle_request(SetLockNodeStateRequest(lock=True, node_name=missing))
+        res = engine.handle_request(SetLockNodeStateRequest(lock=True, node_name=missing))
         assert isinstance(res, SetLockNodeStateResultFailure)
         assert missing in str(res.result_details)

--- a/tests/integration/retained_mode/events/test_node_events.py
+++ b/tests/integration/retained_mode/events/test_node_events.py
@@ -1,4 +1,6 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 from unittest.mock import ANY
 
 import pytest  # type: ignore[reportMissingImports]
@@ -10,22 +12,24 @@ from griptape_nodes.retained_mode.events.node_events import (
     GetAllNodeInfoRequest,
     GetAllNodeInfoResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
 
 pytestmark = pytest.mark.xfail(strict=True, reason="Drifted due to not running on CI - see #5237")
 
 
 class TestNodeEvents:
     @pytest.fixture
-    def create_node_result(self) -> Any:
+    def create_node_result(self, engine: Engine) -> Any:
         request = CreateNodeRequest(node_type="RunAgentNode", override_parent_flow_name="canvas")
-        result = GriptapeNodes.handle_request(request)
+        result = engine.handle_request(request)
 
         return result
 
-    def test_GetAllNodeInfoResult(self, create_node_result: CreateNodeResultSuccess) -> None:
+    def test_GetAllNodeInfoResult(self, create_node_result: CreateNodeResultSuccess, engine: Engine) -> None:
         request = GetAllNodeInfoRequest(node_name=create_node_result.node_name)
-        result = GriptapeNodes.handle_request(request)
+        result = engine.handle_request(request)
 
         assert isinstance(result, GetAllNodeInfoResultSuccess)
 

--- a/tests/integration/retained_mode/events/test_secret_events.py
+++ b/tests/integration/retained_mode/events/test_secret_events.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from griptape_nodes.retained_mode.events.secrets_events import (
     DeleteSecretValueRequest,
     GetAllSecretValuesRequest,
@@ -7,28 +11,30 @@ from griptape_nodes.retained_mode.events.secrets_events import (
     GetSecretValueResultSuccess,
     SetSecretValueRequest,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
 
 
 class TestSecretEvents:
-    def test_get_set_delete_secret_value_request(self) -> None:
-        GriptapeNodes.handle_request(SetSecretValueRequest(key="SECRET_KEY", value="foo"))
-        result = GriptapeNodes.handle_request(GetSecretValueRequest(key="SECRET_KEY"))
+    def test_get_set_delete_secret_value_request(self, engine: Engine) -> None:
+        engine.handle_request(SetSecretValueRequest(key="SECRET_KEY", value="foo"))
+        result = engine.handle_request(GetSecretValueRequest(key="SECRET_KEY"))
 
         assert isinstance(result, GetSecretValueResultSuccess)
 
         assert result.value == "foo"
 
-        GriptapeNodes.handle_request(DeleteSecretValueRequest(key="SECRET_KEY"))
+        engine.handle_request(DeleteSecretValueRequest(key="SECRET_KEY"))
 
-        result = GriptapeNodes.handle_request(GetSecretValueRequest(key="SECRET_KEY"))
+        result = engine.handle_request(GetSecretValueRequest(key="SECRET_KEY"))
 
         assert isinstance(result, GetSecretValueResultFailure)
 
-    def test_get_all_secret_values_request(self) -> None:
-        GriptapeNodes.handle_request(SetSecretValueRequest(key="SECRET_KEY_1", value="foo"))
-        GriptapeNodes.handle_request(SetSecretValueRequest(key="SECRET_KEY_2", value="foo"))
-        result = GriptapeNodes.handle_request(GetAllSecretValuesRequest())
+    def test_get_all_secret_values_request(self, engine: Engine) -> None:
+        engine.handle_request(SetSecretValueRequest(key="SECRET_KEY_1", value="foo"))
+        engine.handle_request(SetSecretValueRequest(key="SECRET_KEY_2", value="foo"))
+        result = engine.handle_request(GetAllSecretValuesRequest())
 
         assert isinstance(result, GetAllSecretValuesResultSuccess)
 

--- a/tests/unit/common/test_sequences.py
+++ b/tests/unit/common/test_sequences.py
@@ -2,9 +2,9 @@
 
 The intended entry point is the bus request, not the underlying
 `scan_sequences` function. Each test dispatches via
-`GriptapeNodes.ahandle_request(...)` and asserts on the typed result payload.
+`engine.ahandle_request(...)` and asserts on the typed result payload.
 
-Filesystem listings are stubbed by patching `GriptapeNodes.handle_request` so the
+Filesystem listings are stubbed by patching `engine.handle_request` so the
 inner `ListDirectoryRequest` returns canned filenames; this leaves the real
 `OSManager.on_scan_sequences_request` handler in place to exercise the full
 async dispatch path.
@@ -37,7 +37,6 @@ from griptape_nodes.retained_mode.events.project_events import (
     GetPathForMacroRequest,
     GetPathForMacroResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 
 def _stub_listing(directory: str, filenames: list[str]) -> Any:
@@ -121,6 +120,7 @@ def _stub_listing_with_macro(
 
 
 async def _scan(  # noqa: PLR0913
+    engine: Engine,
     directory: str,
     pattern: str,
     *,
@@ -136,7 +136,7 @@ async def _scan(  # noqa: PLR0913
     takes.
     """
     path = f"{directory}/{pattern}" if directory else pattern
-    result = await GriptapeNodes.ahandle_request(
+    result = await engine.ahandle_request(
         ScanSequencesRequest(
             path=path,
             policy=policy,
@@ -156,12 +156,12 @@ async def _scan(  # noqa: PLR0913
 
 class TestBasicScanning:
     @pytest.mark.asyncio
-    async def test_contiguous_sequence_split(self) -> None:
+    async def test_contiguous_sequence_split(self, engine: Engine) -> None:
         """SPLIT on a contiguous sequence yields one sub-sequence."""
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 3, 4, 5]]
-        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            result = await _scan(directory, "render.####.png", policy=MissingItemPolicy.SPLIT)
+        with patch.object(engine, "handle_request", side_effect=_stub_listing(directory, filenames)):
+            result = await _scan(engine, directory, "render.####.png", policy=MissingItemPolicy.SPLIT)
         assert isinstance(result, ScanSequencesResultSuccess)
         assert result.has_entries is True
         assert result.directory_had_matching_files is True
@@ -175,14 +175,14 @@ class TestBasicScanning:
         assert [e.padded_number for e in seqs[0].entries] == ["0001", "0002", "0003", "0004", "0005"]
 
     @pytest.mark.asyncio
-    async def test_no_files_returns_empty_success(self) -> None:
+    async def test_no_files_returns_empty_success(self, engine: Engine) -> None:
         """An empty directory yields a success with no sequences and `has_entries=False`.
 
         The `directory_had_matching_files` flag is False because nothing in
         the listing matched the basename/extension shape.
         """
-        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing("/work/in", [])):
-            result = await _scan("/work/in", "render.####.png")
+        with patch.object(engine, "handle_request", side_effect=_stub_listing("/work/in", [])):
+            result = await _scan(engine, "/work/in", "render.####.png")
         assert isinstance(result, ScanSequencesResultSuccess)
         assert result.sequences == []
         assert result.has_entries is False
@@ -191,7 +191,7 @@ class TestBasicScanning:
         assert result.discovered_last is None
 
     @pytest.mark.asyncio
-    async def test_directory_listing_failure_surfaces_file_io_failure(self) -> None:
+    async def test_directory_listing_failure_surfaces_file_io_failure(self, engine: Engine) -> None:
         """A failed listing propagates the OS-level `FileIOFailureReason` to the caller.
 
         `scan_sequences` raises `DirectoryListingError` when the inner
@@ -201,13 +201,13 @@ class TestBasicScanning:
         folded into empty success.
         """
         # Stub always returns failure for /work/in (only /other is recognized)
-        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing("/other", [])):
-            result = await _scan("/work/in", "render.####.png")
+        with patch.object(engine, "handle_request", side_effect=_stub_listing("/other", [])):
+            result = await _scan(engine, "/work/in", "render.####.png")
         assert isinstance(result, ScanSequencesResultFailure)
         assert result.failure_reason is FileIOFailureReason.FILE_NOT_FOUND
 
     @pytest.mark.asyncio
-    async def test_unrelated_files_filtered_out(self) -> None:
+    async def test_unrelated_files_filtered_out(self, engine: Engine) -> None:
         """Files not matching basename/extension are ignored."""
         directory = "/work/in"
         filenames = [
@@ -217,8 +217,8 @@ class TestBasicScanning:
             "render.0001.exr",  # different extension
             "notes.txt",  # totally unrelated
         ]
-        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            result = await _scan(directory, "render.####.png", policy=MissingItemPolicy.SPLIT)
+        with patch.object(engine, "handle_request", side_effect=_stub_listing(directory, filenames)):
+            result = await _scan(engine, directory, "render.####.png", policy=MissingItemPolicy.SPLIT)
         assert isinstance(result, ScanSequencesResultSuccess)
         seqs = result.sequences
         assert len(seqs) == 1
@@ -230,12 +230,12 @@ class TestBasicScanning:
 
 class TestSplitPolicy:
     @pytest.mark.asyncio
-    async def test_three_runs(self) -> None:
+    async def test_three_runs(self, engine: Engine) -> None:
         """Numbers 1-2, 4, 6-7 split into three sub-sequences."""
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 4, 6, 7]]
-        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            result = await _scan(directory, "render.####.png", policy=MissingItemPolicy.SPLIT)
+        with patch.object(engine, "handle_request", side_effect=_stub_listing(directory, filenames)):
+            result = await _scan(engine, directory, "render.####.png", policy=MissingItemPolicy.SPLIT)
         assert isinstance(result, ScanSequencesResultSuccess)
         seqs = result.sequences
         assert len(seqs) == 3
@@ -244,12 +244,12 @@ class TestSplitPolicy:
         assert (seqs[2].first, seqs[2].last) == (6, 7)
 
     @pytest.mark.asyncio
-    async def test_split_records_discovered_range_on_each(self) -> None:
+    async def test_split_records_discovered_range_on_each(self, engine: Engine) -> None:
         """All sub-sequences carry the same discovered_first/discovered_last."""
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 4, 6, 7]]
-        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            result = await _scan(directory, "render.####.png", policy=MissingItemPolicy.SPLIT)
+        with patch.object(engine, "handle_request", side_effect=_stub_listing(directory, filenames)):
+            result = await _scan(engine, directory, "render.####.png", policy=MissingItemPolicy.SPLIT)
         assert isinstance(result, ScanSequencesResultSuccess)
         for s in result.sequences:
             assert s.discovered_first == 1
@@ -258,12 +258,12 @@ class TestSplitPolicy:
 
 class TestSkipPolicy:
     @pytest.mark.asyncio
-    async def test_skip_omits_gaps(self) -> None:
+    async def test_skip_omits_gaps(self, engine: Engine) -> None:
         """SKIP yields one sequence with only present numbers; gaps absent from entries."""
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 4, 6, 7]]
-        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            result = await _scan(directory, "render.####.png", policy=MissingItemPolicy.SKIP)
+        with patch.object(engine, "handle_request", side_effect=_stub_listing(directory, filenames)):
+            result = await _scan(engine, directory, "render.####.png", policy=MissingItemPolicy.SKIP)
         assert isinstance(result, ScanSequencesResultSuccess)
         seqs = result.sequences
         assert len(seqs) == 1
@@ -273,12 +273,12 @@ class TestSkipPolicy:
 
 class TestFillNearestPolicy:
     @pytest.mark.asyncio
-    async def test_fill_nearest_backward_first(self) -> None:
+    async def test_fill_nearest_backward_first(self, engine: Engine) -> None:
         """FILL_NEAREST fills gaps with the backward-first present number."""
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 4, 6, 7]]
-        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            result = await _scan(directory, "render.####.png", policy=MissingItemPolicy.FILL_NEAREST)
+        with patch.object(engine, "handle_request", side_effect=_stub_listing(directory, filenames)):
+            result = await _scan(engine, directory, "render.####.png", policy=MissingItemPolicy.FILL_NEAREST)
         assert isinstance(result, ScanSequencesResultSuccess)
         s = result.sequences[0]
         # Gap at 3 -> backward to 2
@@ -297,7 +297,7 @@ class TestFillNearestPolicy:
 
 class TestAbortPolicy:
     @pytest.mark.asyncio
-    async def test_abort_surfaces_all_gaps(self) -> None:
+    async def test_abort_surfaces_all_gaps(self, engine: Engine) -> None:
         """ABORT surfaces a ScanSequencesResultFailure listing every gap.
 
         With items 1, 2, 4, 5 on disk, the active range 1..5 has exactly one
@@ -306,14 +306,14 @@ class TestAbortPolicy:
         """
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 4, 5]]
-        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            result = await _scan(directory, "render.####.png", policy=MissingItemPolicy.ABORT)
+        with patch.object(engine, "handle_request", side_effect=_stub_listing(directory, filenames)):
+            result = await _scan(engine, directory, "render.####.png", policy=MissingItemPolicy.ABORT)
         assert isinstance(result, ScanSequencesResultFailure)
         assert result.failure_reason is SequenceScanFailureReason.ABORTED_AT_GAP
         assert result.missing_item_numbers == [3]
 
     @pytest.mark.asyncio
-    async def test_abort_surfaces_multiple_gaps(self) -> None:
+    async def test_abort_surfaces_multiple_gaps(self, engine: Engine) -> None:
         """ABORT collects every gap in one pass, sorted ascending.
 
         Items 1, 2, 5, 7 on disk; active range 1..7. The expected gaps are 3,
@@ -323,8 +323,8 @@ class TestAbortPolicy:
         """
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 5, 7]]
-        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            result = await _scan(directory, "render.####.png", policy=MissingItemPolicy.ABORT)
+        with patch.object(engine, "handle_request", side_effect=_stub_listing(directory, filenames)):
+            result = await _scan(engine, directory, "render.####.png", policy=MissingItemPolicy.ABORT)
         assert isinstance(result, ScanSequencesResultFailure)
         assert result.failure_reason is SequenceScanFailureReason.ABORTED_AT_GAP
         assert result.missing_item_numbers == [3, 4, 6]
@@ -334,7 +334,7 @@ class TestAbortPolicy:
         assert "3, 4, 6" in details
 
     @pytest.mark.asyncio
-    async def test_abort_succeeds_when_dense(self) -> None:
+    async def test_abort_succeeds_when_dense(self, engine: Engine) -> None:
         """ABORT returns one Sequence with all entries when there are no gaps.
 
         The all-gaps pre-pass runs but finds nothing, so the scanner falls
@@ -343,8 +343,8 @@ class TestAbortPolicy:
         """
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 3]]
-        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            result = await _scan(directory, "render.####.png", policy=MissingItemPolicy.ABORT)
+        with patch.object(engine, "handle_request", side_effect=_stub_listing(directory, filenames)):
+            result = await _scan(engine, directory, "render.####.png", policy=MissingItemPolicy.ABORT)
         assert isinstance(result, ScanSequencesResultSuccess)
         seqs = result.sequences
         assert len(seqs) == 1
@@ -356,7 +356,7 @@ class TestAbortPolicy:
 
 class TestNegativeNumbers:
     @pytest.mark.asyncio
-    async def test_negatives_with_different_padding_filter_out_silently(self) -> None:
+    async def test_negatives_with_different_padding_filter_out_silently(self, engine: Engine) -> None:
         """Negative numbers at a different padding width are filtered by the padding match.
 
         When `-0005.png` has 5 total chars (sign + 4 digits), fileseq groups
@@ -365,8 +365,8 @@ class TestNegativeNumbers:
         """
         directory = "/work/in"
         filenames = ["render.-0005.png", "render.0001.png", "render.0002.png"]
-        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            result = await _scan(directory, "render.####.png", policy=MissingItemPolicy.SPLIT)
+        with patch.object(engine, "handle_request", side_effect=_stub_listing(directory, filenames)):
+            result = await _scan(engine, directory, "render.####.png", policy=MissingItemPolicy.SPLIT)
         assert isinstance(result, ScanSequencesResultSuccess)
         seqs = result.sequences
         assert len(seqs) == 1
@@ -375,13 +375,13 @@ class TestNegativeNumbers:
         assert seqs[0].dropped_negative_number_count == 0
 
     @pytest.mark.asyncio
-    async def test_negatives_with_matching_padding_dropped_with_counter(self) -> None:
+    async def test_negatives_with_matching_padding_dropped_with_counter(self, engine: Engine) -> None:
         """When padding matches, negatives DO enter the loop and get filtered out."""
         directory = "/work/in"
         # Width-5 pattern: `-0005` and `00005` both have 5 digits in their slot.
         filenames = ["render.-0005.png", "render.00005.png", "render.00010.png"]
-        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            result = await _scan(directory, "render.#####.png", policy=MissingItemPolicy.SPLIT)
+        with patch.object(engine, "handle_request", side_effect=_stub_listing(directory, filenames)):
+            result = await _scan(engine, directory, "render.#####.png", policy=MissingItemPolicy.SPLIT)
         assert isinstance(result, ScanSequencesResultSuccess)
         seqs = result.sequences
         # The negative is dropped; positives 5 and 10 are in the same sequence
@@ -397,11 +397,11 @@ class TestNegativeNumbers:
 
 class TestSubsetClipping:
     @pytest.mark.asyncio
-    async def test_start_only(self) -> None:
+    async def test_start_only(self, engine: Engine) -> None:
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 3, 4, 5]]
-        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            result = await _scan(directory, "render.####.png", policy=MissingItemPolicy.SPLIT, start_number=3)
+        with patch.object(engine, "handle_request", side_effect=_stub_listing(directory, filenames)):
+            result = await _scan(engine, directory, "render.####.png", policy=MissingItemPolicy.SPLIT, start_number=3)
         assert isinstance(result, ScanSequencesResultSuccess)
         seqs = result.sequences
         assert len(seqs) == 1
@@ -410,11 +410,11 @@ class TestSubsetClipping:
         assert seqs[0].first == 3
 
     @pytest.mark.asyncio
-    async def test_end_only(self) -> None:
+    async def test_end_only(self, engine: Engine) -> None:
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 3, 4, 5]]
-        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            result = await _scan(directory, "render.####.png", policy=MissingItemPolicy.SPLIT, end_number=3)
+        with patch.object(engine, "handle_request", side_effect=_stub_listing(directory, filenames)):
+            result = await _scan(engine, directory, "render.####.png", policy=MissingItemPolicy.SPLIT, end_number=3)
         assert isinstance(result, ScanSequencesResultSuccess)
         seqs = result.sequences
         assert len(seqs) == 1
@@ -423,12 +423,12 @@ class TestSubsetClipping:
         assert seqs[0].last == 3
 
     @pytest.mark.asyncio
-    async def test_start_and_end(self) -> None:
+    async def test_start_and_end(self, engine: Engine) -> None:
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 3, 4, 5]]
-        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
+        with patch.object(engine, "handle_request", side_effect=_stub_listing(directory, filenames)):
             result = await _scan(
-                directory, "render.####.png", policy=MissingItemPolicy.SPLIT, start_number=2, end_number=4
+                engine, directory, "render.####.png", policy=MissingItemPolicy.SPLIT, start_number=2, end_number=4
             )
         assert isinstance(result, ScanSequencesResultSuccess)
         seqs = result.sequences
@@ -436,7 +436,7 @@ class TestSubsetClipping:
         assert [e.number for e in seqs[0].entries] == [2, 3, 4]
 
     @pytest.mark.asyncio
-    async def test_subset_outside_discovered_range_reports_discovered_range(self) -> None:
+    async def test_subset_outside_discovered_range_reports_discovered_range(self, engine: Engine) -> None:
         """Subset clip drops every present item — diagnostic flags expose the on-disk range.
 
         The directory has 1..3 on disk but the caller asked for 10..20.
@@ -446,9 +446,9 @@ class TestSubsetClipping:
         """
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 3]]
-        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
+        with patch.object(engine, "handle_request", side_effect=_stub_listing(directory, filenames)):
             result = await _scan(
-                directory, "render.####.png", policy=MissingItemPolicy.SPLIT, start_number=10, end_number=20
+                engine, directory, "render.####.png", policy=MissingItemPolicy.SPLIT, start_number=10, end_number=20
             )
         assert isinstance(result, ScanSequencesResultSuccess)
         assert result.sequences == []
@@ -458,14 +458,14 @@ class TestSubsetClipping:
         assert result.discovered_last == 3
 
     @pytest.mark.asyncio
-    async def test_negative_start_rejected(self) -> None:
-        result = await _scan("/work/in", "render.####.png", start_number=-1)
+    async def test_negative_start_rejected(self, engine: Engine) -> None:
+        result = await _scan(engine, "/work/in", "render.####.png", start_number=-1)
         assert isinstance(result, ScanSequencesResultFailure)
         assert result.failure_reason is SequenceScanFailureReason.INVALID_BOUNDS
 
     @pytest.mark.asyncio
-    async def test_inverted_bounds_rejected(self) -> None:
-        result = await _scan("/work/in", "render.####.png", start_number=10, end_number=5)
+    async def test_inverted_bounds_rejected(self, engine: Engine) -> None:
+        result = await _scan(engine, "/work/in", "render.####.png", start_number=10, end_number=5)
         assert isinstance(result, ScanSequencesResultFailure)
         assert result.failure_reason is SequenceScanFailureReason.INVALID_BOUNDS
 
@@ -475,19 +475,19 @@ class TestSubsetClipping:
 
 class TestPatternVariants:
     @pytest.mark.asyncio
-    async def test_printf_pattern(self) -> None:
+    async def test_printf_pattern(self, engine: Engine) -> None:
         """%04d works the same as ####."""
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 3]]
-        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            result = await _scan(directory, "render.%04d.png", policy=MissingItemPolicy.SPLIT)
+        with patch.object(engine, "handle_request", side_effect=_stub_listing(directory, filenames)):
+            result = await _scan(engine, directory, "render.%04d.png", policy=MissingItemPolicy.SPLIT)
         assert isinstance(result, ScanSequencesResultSuccess)
         seqs = result.sequences
         assert len(seqs) == 1
         assert [e.number for e in seqs[0].entries] == [1, 2, 3]
 
     @pytest.mark.asyncio
-    async def test_mismatched_padding_reports_files_present(self) -> None:
+    async def test_mismatched_padding_reports_files_present(self, engine: Engine) -> None:
         """Disk has 3-digit numbers; user declared #### (4 digits). No match — empty success.
 
         The basename/extension prefilter accepts these files (so
@@ -498,8 +498,8 @@ class TestPatternVariants:
         """
         directory = "/work/in"
         filenames = [f"render.{n:03d}.png" for n in [1, 2, 3]]
-        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            result = await _scan(directory, "render.####.png", policy=MissingItemPolicy.SPLIT)
+        with patch.object(engine, "handle_request", side_effect=_stub_listing(directory, filenames)):
+            result = await _scan(engine, directory, "render.####.png", policy=MissingItemPolicy.SPLIT)
         assert isinstance(result, ScanSequencesResultSuccess)
         assert result.sequences == []
         assert result.has_entries is False
@@ -508,7 +508,7 @@ class TestPatternVariants:
         assert result.discovered_last is None
 
     @pytest.mark.asyncio
-    async def test_unpadded_printf_round_trip(self) -> None:
+    async def test_unpadded_printf_round_trip(self, engine: Engine) -> None:
         """`%d` matches an unpadded directory and yields bare integer padded_numbers.
 
         fileseq treats `%d` as zfill=1 (same as a single `#`). The Sequence's
@@ -516,8 +516,8 @@ class TestPatternVariants:
         """
         directory = "/work/in"
         filenames = ["render.5.png", "render.42.png", "render.123.png"]
-        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            result = await _scan(directory, "render.%d.png", policy=MissingItemPolicy.SPLIT)
+        with patch.object(engine, "handle_request", side_effect=_stub_listing(directory, filenames)):
+            result = await _scan(engine, directory, "render.%d.png", policy=MissingItemPolicy.SPLIT)
         assert isinstance(result, ScanSequencesResultSuccess)
         seqs = result.sequences
         # 5, 42, 123 aren't contiguous, so SPLIT yields three sequences.
@@ -537,31 +537,31 @@ class TestPatternValidation:
     """Multi-token templates surface as INVALID_TEMPLATE failures."""
 
     @pytest.mark.asyncio
-    async def test_multi_token_dot_separator(self) -> None:
+    async def test_multi_token_dot_separator(self, engine: Engine) -> None:
         """`render.##.##.exr` — fileseq accepts this and silently misparses."""
-        result = await _scan("/work/in", "render.##.##.exr")
+        result = await _scan(engine, "/work/in", "render.##.##.exr")
         assert isinstance(result, ScanSequencesResultFailure)
         assert result.failure_reason is SequenceScanFailureReason.INVALID_TEMPLATE
         assert "2 sequence tokens" in str(result.result_details or "")
 
     @pytest.mark.asyncio
-    async def test_multi_token_underscore_separator(self) -> None:
+    async def test_multi_token_underscore_separator(self, engine: Engine) -> None:
         """`render.####_v####.exr` — two distinct hash tokens."""
-        result = await _scan("/work/in", "render.####_v####.exr")
+        result = await _scan(engine, "/work/in", "render.####_v####.exr")
         assert isinstance(result, ScanSequencesResultFailure)
         assert result.failure_reason is SequenceScanFailureReason.INVALID_TEMPLATE
         assert "2 sequence tokens" in str(result.result_details or "")
 
     @pytest.mark.asyncio
-    async def test_multi_token_mixed_syntax(self) -> None:
+    async def test_multi_token_mixed_syntax(self, engine: Engine) -> None:
         """A printf token AND a hash token in the same template."""
-        result = await _scan("/work/in", "foo_%04d_bar_####.exr")
+        result = await _scan(engine, "/work/in", "foo_%04d_bar_####.exr")
         assert isinstance(result, ScanSequencesResultFailure)
         assert result.failure_reason is SequenceScanFailureReason.INVALID_TEMPLATE
         assert "2 sequence tokens" in str(result.result_details or "")
 
     @pytest.mark.asyncio
-    async def test_zero_token_path_one_item_when_present(self) -> None:
+    async def test_zero_token_path_one_item_when_present(self, engine: Engine) -> None:
         """A token-less path becomes a one-item sequence when the file exists.
 
         The artist pasted in `photo.png` and the file is on disk → produce a
@@ -570,8 +570,8 @@ class TestPatternValidation:
         single-file path.
         """
         directory = "/work/in"
-        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, ["photo.png"])):
-            result = await _scan(directory, "photo.png")
+        with patch.object(engine, "handle_request", side_effect=_stub_listing(directory, ["photo.png"])):
+            result = await _scan(engine, directory, "photo.png")
         assert isinstance(result, ScanSequencesResultSuccess)
         assert result.has_entries is True
         seqs = result.sequences
@@ -585,7 +585,7 @@ class TestPatternValidation:
         assert seqs[0].entries[0].path == "/work/in/photo.png"
 
     @pytest.mark.asyncio
-    async def test_zero_token_path_empty_when_absent(self) -> None:
+    async def test_zero_token_path_empty_when_absent(self, engine: Engine) -> None:
         """A token-less path returns empty success when the file isn't on disk.
 
         The literal filename is the only way a zero-token target can match;
@@ -593,8 +593,8 @@ class TestPatternValidation:
         other miss produces.
         """
         directory = "/work/in"
-        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, ["other.png"])):
-            result = await _scan(directory, "photo.png")
+        with patch.object(engine, "handle_request", side_effect=_stub_listing(directory, ["other.png"])):
+            result = await _scan(engine, directory, "photo.png")
         assert isinstance(result, ScanSequencesResultSuccess)
         assert result.sequences == []
         assert result.has_entries is False
@@ -604,12 +604,12 @@ class TestPatternValidation:
         assert result.directory_had_matching_files is False
 
     @pytest.mark.asyncio
-    async def test_single_token_passes(self) -> None:
+    async def test_single_token_passes(self, engine: Engine) -> None:
         """Sanity: a normal single-token pattern survives the validator."""
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 3]]
-        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            result = await _scan(directory, "render.####.png")
+        with patch.object(engine, "handle_request", side_effect=_stub_listing(directory, filenames)):
+            result = await _scan(engine, directory, "render.####.png")
         assert isinstance(result, ScanSequencesResultSuccess)
         assert len(result.sequences) == 1
 
@@ -626,7 +626,7 @@ class TestPathRoundTrip:
     """
 
     @pytest.mark.asyncio
-    async def test_macro_path_preserves_macro_head(self) -> None:
+    async def test_macro_path_preserves_macro_head(self, engine: Engine) -> None:
         """A macro-form input round-trips with the `{inputs}` head intact.
 
         The handler resolves the macro internally for I/O but rebuilds each
@@ -646,9 +646,7 @@ class TestPathRoundTrip:
                 filenames=filenames,
             ),
         ):
-            result = await GriptapeNodes.ahandle_request(
-                ScanSequencesRequest(path=path, policy=MissingItemPolicy.SPLIT)
-            )
+            result = await engine.ahandle_request(ScanSequencesRequest(path=path, policy=MissingItemPolicy.SPLIT))
         assert isinstance(result, ScanSequencesResultSuccess)
         assert len(result.sequences) == 1
         seq = result.sequences[0]
@@ -661,7 +659,7 @@ class TestPathRoundTrip:
         ]
 
     @pytest.mark.asyncio
-    async def test_absolute_path_round_trips_unchanged(self) -> None:
+    async def test_absolute_path_round_trips_unchanged(self, engine: Engine) -> None:
         """A plain absolute path (no macros) round-trips identically.
 
         The macro-resolver dispatch is skipped entirely — `_build_scan_path_mapping`
@@ -671,8 +669,8 @@ class TestPathRoundTrip:
         """
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2]]
-        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            result = await _scan(directory, "render.####.png")
+        with patch.object(engine, "handle_request", side_effect=_stub_listing(directory, filenames)):
+            result = await _scan(engine, directory, "render.####.png")
         assert isinstance(result, ScanSequencesResultSuccess)
         seq = result.sequences[0]
         assert seq.directory == directory
@@ -695,7 +693,7 @@ class TestNoTokenBehavior:
     """
 
     @pytest.mark.asyncio
-    async def test_single_file_default_ignores_siblings(self) -> None:
+    async def test_single_file_default_ignores_siblings(self, engine: Engine) -> None:
         """SINGLE_FILE: `render.0002.png` returns just that one file.
 
         This is the regression pin for the bug where fileseq's parse of
@@ -706,8 +704,8 @@ class TestNoTokenBehavior:
         directory = "/work/in"
         # Five renders on disk; only the named one should come back.
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 3, 4, 5]]
-        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
-            result = await _scan(directory, "render.0002.png")
+        with patch.object(engine, "handle_request", side_effect=_stub_listing(directory, filenames)):
+            result = await _scan(engine, directory, "render.0002.png")
         assert isinstance(result, ScanSequencesResultSuccess)
         assert result.has_entries is True
         seqs = result.sequences
@@ -722,7 +720,7 @@ class TestNoTokenBehavior:
         assert seqs[0].discovered_last == 1
 
     @pytest.mark.asyncio
-    async def test_explore_sequence_recovers_implicit_grouping(self) -> None:
+    async def test_explore_sequence_recovers_implicit_grouping(self, engine: Engine) -> None:
         """EXPLORE_SEQUENCE: `render.0002.png` walks the full sibling sequence.
 
         Useful when a downstream tool gave the artist one filename but they
@@ -731,8 +729,9 @@ class TestNoTokenBehavior:
         """
         directory = "/work/in"
         filenames = [f"render.{n:04d}.png" for n in [1, 2, 3, 4, 5]]
-        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, filenames)):
+        with patch.object(engine, "handle_request", side_effect=_stub_listing(directory, filenames)):
             result = await _scan(
+                engine,
                 directory,
                 "render.0002.png",
                 policy=MissingItemPolicy.SPLIT,
@@ -748,13 +747,14 @@ class TestNoTokenBehavior:
         assert seqs[0].discovered_last == 5
 
     @pytest.mark.asyncio
-    async def test_reject_fails_with_invalid_template(self) -> None:
+    async def test_reject_fails_with_invalid_template(self, engine: Engine) -> None:
         """REJECT: a token-less path fails fast with INVALID_TEMPLATE.
 
         For workflows that should never silently widen the artist's intent
         (e.g. an automated pipeline that requires an explicit token).
         """
         result = await _scan(
+            engine,
             "/work/in",
             "render.0002.png",
             no_token_behavior=NoTokenBehavior.REJECT,
@@ -765,11 +765,11 @@ class TestNoTokenBehavior:
         assert "no sequence token" in str(result.result_details or "")
 
     @pytest.mark.asyncio
-    async def test_single_file_with_no_digits_still_works(self) -> None:
+    async def test_single_file_with_no_digits_still_works(self, engine: Engine) -> None:
         """SINGLE_FILE on `photo.png` (no digits at all) — sanity check."""
         directory = "/work/in"
-        with patch.object(GriptapeNodes, "handle_request", side_effect=_stub_listing(directory, ["photo.png"])):
-            result = await _scan(directory, "photo.png")
+        with patch.object(engine, "handle_request", side_effect=_stub_listing(directory, ["photo.png"])):
+            result = await _scan(engine, directory, "photo.png")
         assert isinstance(result, ScanSequencesResultSuccess)
         assert result.has_entries is True
         seqs = result.sequences
@@ -777,7 +777,7 @@ class TestNoTokenBehavior:
         assert seqs[0].entries[0].path == "/work/in/photo.png"
 
     @pytest.mark.asyncio
-    async def test_single_file_macro_path_round_trip(self) -> None:
+    async def test_single_file_macro_path_round_trip(self, engine: Engine) -> None:
         """SINGLE_FILE keeps macro paths macro-shaped on the way back out.
 
         Mirrors `test_macro_path_preserves_macro_head` for the literal-file
@@ -798,9 +798,7 @@ class TestNoTokenBehavior:
                 filenames=filenames,
             ),
         ):
-            result = await GriptapeNodes.ahandle_request(
-                ScanSequencesRequest(path=path, policy=MissingItemPolicy.SPLIT)
-            )
+            result = await engine.ahandle_request(ScanSequencesRequest(path=path, policy=MissingItemPolicy.SPLIT))
         assert isinstance(result, ScanSequencesResultSuccess)
         assert len(result.sequences) == 1
         seq = result.sequences[0]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -38,9 +38,3 @@ def isolate_user_config() -> Generator[Path, None, None]:
 def engine() -> Engine:
     """Provide the engine for this test, building it on first use."""
     return current_engine()
-
-
-@pytest.fixture
-def griptape_nodes() -> Engine:
-    """Alias of `engine`, named for the tests written against the old facade."""
-    return current_engine()

--- a/tests/unit/exe_types/node_groups/test_subflow_node_group.py
+++ b/tests/unit/exe_types/node_groups/test_subflow_node_group.py
@@ -7,10 +7,11 @@ from unittest.mock import create_autospec
 
 from griptape_nodes.exe_types.node_groups.subflow_node_group import SubflowNodeGroup
 from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 if TYPE_CHECKING:
     import pytest
+
+    from griptape_nodes.retained_mode.engine import Engine
 
 
 class TestSubflowNodeGroupCreateSubflow:
@@ -18,7 +19,7 @@ class TestSubflowNodeGroupCreateSubflow:
 
     def test_records_deduplicated_flow_name_on_collision(
         self,
-        griptape_nodes: GriptapeNodes,  # noqa: ARG002 - initialises the engine singleton for construction
+        engine: Engine,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """The group records the flow name it got back, not the (colliding) name it requested."""
@@ -26,11 +27,11 @@ class TestSubflowNodeGroupCreateSubflow:
 
         # Simulate the engine deduplicating the requested "G_subflow" (already taken) to "G_subflow_1".
         deduped_result = CreateFlowResultSuccess(flow_name="G_subflow_1", result_details="created")
-        mock_handle = create_autospec(GriptapeNodes.handle_request, return_value=deduped_result)
-        monkeypatch.setattr(GriptapeNodes, "handle_request", mock_handle)
+        mock_handle = create_autospec(engine.handle_request, return_value=deduped_result)
+        monkeypatch.setattr(engine, "handle_request", mock_handle)
 
         # _create_subflow reads the current flow only to parent the request; keep it off engine state.
-        context_manager = GriptapeNodes.ContextManager()
+        context_manager = engine.context_manager
         monkeypatch.setattr(
             context_manager,
             "get_current_flow",
@@ -61,7 +62,7 @@ class TestGetAllNodes:
 
     def test_collects_members_nested_more_than_one_level_deep(
         self,
-        griptape_nodes: GriptapeNodes,  # noqa: ARG002 - initialises the engine singleton for construction
+        engine: Engine,  # noqa: ARG002 - initialises the engine singleton for construction
     ) -> None:
         outer = _MiniSubflowGroup(name="outer")
         middle = _MiniSubflowGroup(name="middle")
@@ -78,7 +79,7 @@ class TestGetAllNodes:
 
     def test_returns_direct_members_when_nothing_is_nested(
         self,
-        griptape_nodes: GriptapeNodes,  # noqa: ARG002 - initialises the engine singleton for construction
+        engine: Engine,  # noqa: ARG002 - initialises the engine singleton for construction
     ) -> None:
         group = _MiniSubflowGroup(name="group")
         group.nodes = {"only": _MiniSubflowGroup(name="only")}

--- a/tests/unit/exe_types/param_components/huggingface/test_huggingface_gating_against_real_catalog.py
+++ b/tests/unit/exe_types/param_components/huggingface/test_huggingface_gating_against_real_catalog.py
@@ -193,13 +193,13 @@ def _deny_denied_provider(checkpoint: AuthorizationCheckpoint) -> CheckpointDeni
 
 
 @pytest.fixture
-def denying_policy(griptape_nodes) -> Iterator[None]:  # noqa: ANN001
+def denying_policy(engine) -> Iterator[None]:  # noqa: ANN001
     """Install the real deny hook for the duration of a test."""
-    griptape_nodes.EventManager().add_authorization_hook(_deny_denied_provider)
+    engine.event_manager.add_authorization_hook(_deny_denied_provider)
     try:
         yield
     finally:
-        griptape_nodes.EventManager().remove_authorization_hook(_deny_denied_provider)
+        engine.event_manager.remove_authorization_hook(_deny_denied_provider)
 
 
 class TestRealCatalogResolution:

--- a/tests/unit/exe_types/param_components/test_model_access_component.py
+++ b/tests/unit/exe_types/param_components/test_model_access_component.py
@@ -460,7 +460,7 @@ class TestEngineFailureIsFailClosedAtRuntime:
 
         self._register_library_without_probe_node()
 
-        with caplog.at_level(logging.WARNING, logger="engine"):
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
             self._build_component_against_unresolved_node()
 
         matches = [r for r in caplog.records if "Could not resolve model access" in r.message]
@@ -473,7 +473,7 @@ class TestEngineFailureIsFailClosedAtRuntime:
 
         self._register_library_without_probe_node()
 
-        with caplog.at_level(logging.WARNING, logger="engine"):
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
             helper = self._build_component_against_unresolved_node()
 
         denial = helper.query_for_denial("alpha")
@@ -489,7 +489,7 @@ class TestEngineFailureIsFailClosedAtRuntime:
 
         self._register_library_without_probe_node()
 
-        with caplog.at_level(logging.WARNING, logger="engine"):
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
             helper = self._build_component_against_unresolved_node()
 
         with pytest.raises(RuntimeError, match="could not be checked against your license"):
@@ -501,7 +501,7 @@ class TestEngineFailureIsFailClosedAtRuntime:
 
         self._register_library_without_probe_node()
 
-        with caplog.at_level(logging.WARNING, logger="engine"):
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
             helper = self._build_component_against_unresolved_node()
 
         # A connected Prompt Model Config driver / Agent replaces the string

--- a/tests/unit/exe_types/param_components/test_model_access_component.py
+++ b/tests/unit/exe_types/param_components/test_model_access_component.py
@@ -29,7 +29,6 @@ from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.exe_types.param_components.model_access_component import ModelAccessComponent
 from griptape_nodes.retained_mode.events.access_events import QueryModelAccessForNodeResultFailure
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.button import Button
 from griptape_nodes.traits.options import Options
 from tests.unit.exe_types.param_components.probe_scope import constructing_under_probe
@@ -186,7 +185,7 @@ class TestPickPermittedDefault:
         )
         assert helper.pick_permitted_default() == "alpha"
 
-    def test_falls_back_to_first_allowed_when_default_denied(self, griptape_nodes) -> None:  # noqa: ANN001
+    def test_falls_back_to_first_allowed_when_default_denied(self, engine) -> None:  # noqa: ANN001
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
@@ -194,7 +193,7 @@ class TestPickPermittedDefault:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Alpha not enabled."),))
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(deny_alpha)
+        engine.event_manager.add_authorization_hook(deny_alpha)
         try:
             _, helper = _install_probe_node_with_helper(
                 model_choices=["alpha", "beta"],
@@ -203,9 +202,9 @@ class TestPickPermittedDefault:
             # Alpha is denied at construction time; beta is the fallback.
             assert helper.pick_permitted_default() == "beta"
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)
+            engine.event_manager.remove_authorization_hook(deny_alpha)
 
-    def test_returns_none_when_every_choice_is_denied(self, griptape_nodes) -> None:  # noqa: ANN001
+    def test_returns_none_when_every_choice_is_denied(self, engine) -> None:  # noqa: ANN001
         """Every declared choice denied -> None. Caller decides what to do next.
 
         The helper does not silently return a denied model as the default -- that
@@ -218,7 +217,7 @@ class TestPickPermittedDefault:
         def deny_all(_checkpoint: object) -> CheckpointDenial:
             return CheckpointDenial(failures=(CheckpointFailure(detail="Nothing enabled."),))
 
-        griptape_nodes.EventManager().add_authorization_hook(deny_all)
+        engine.event_manager.add_authorization_hook(deny_all)
         try:
             _, helper = _install_probe_node_with_helper(
                 model_choices=["alpha", "beta"],
@@ -226,7 +225,7 @@ class TestPickPermittedDefault:
             )
             assert helper.pick_permitted_default() is None
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny_all)
+            engine.event_manager.remove_authorization_hook(deny_all)
 
 
 class TestInstall:
@@ -238,7 +237,7 @@ class TestInstall:
         assert len(param.find_elements_by_type(Options)) == 1
         assert len(param.find_elements_by_type(Button)) == 1
 
-    def test_install_populates_ui_options_with_dropdown_data(self, griptape_nodes) -> None:  # noqa: ANN001
+    def test_install_populates_ui_options_with_dropdown_data(self, engine) -> None:  # noqa: ANN001
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
@@ -246,7 +245,7 @@ class TestInstall:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Alpha not enabled."),))
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(deny_alpha)
+        engine.event_manager.add_authorization_hook(deny_alpha)
         try:
             node, _helper = _install_probe_node_with_helper(model_choices=["alpha", "beta"], default_model="beta")
 
@@ -262,7 +261,7 @@ class TestInstall:
             assert "icon" not in data_by_name["beta"]
             assert "subtitle" not in data_by_name["beta"]
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)
+            engine.event_manager.remove_authorization_hook(deny_alpha)
 
     def test_install_preserves_parameter_identity(self) -> None:
         """Install must not change parameter name / type / tooltip / stored value."""
@@ -281,7 +280,7 @@ class TestInstall:
         # update_ui_options merges; display_name set by the node must survive.
         assert post_param.ui_options.get("display_name") == pre_display_name
 
-    def test_install_applies_initial_badge_when_stored_value_denied(self, griptape_nodes) -> None:  # noqa: ANN001
+    def test_install_applies_initial_badge_when_stored_value_denied(self, engine) -> None:  # noqa: ANN001
         """A node born with a denied stored value shows the badge immediately.
 
         Setup: every choice is denied so ``pick_permitted_default()`` returns
@@ -294,7 +293,7 @@ class TestInstall:
         def deny_everything(_checkpoint: object) -> CheckpointDenial:
             return CheckpointDenial(failures=(CheckpointFailure(detail="Alpha not enabled."),))
 
-        griptape_nodes.EventManager().add_authorization_hook(deny_everything)
+        engine.event_manager.add_authorization_hook(deny_everything)
         try:
             _node, _component, param = _build_probe_node_with_component(
                 model_choices=["alpha", "beta"],
@@ -307,9 +306,9 @@ class TestInstall:
             assert "not permitted" in badge.message.lower()
             assert "Alpha not enabled." in badge.message
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny_everything)
+            engine.event_manager.remove_authorization_hook(deny_everything)
 
-    def test_constructor_relocates_stored_value_off_denied_default(self, griptape_nodes) -> None:  # noqa: ANN001
+    def test_constructor_relocates_stored_value_off_denied_default(self, engine) -> None:  # noqa: ANN001
         """Constructor moves the stored value off a denied default to a permitted alternative.
 
         The parameter's declarative default_value is preserved (unchanged); only
@@ -323,7 +322,7 @@ class TestInstall:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Alpha denied."),))
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(deny_alpha)
+        engine.event_manager.add_authorization_hook(deny_alpha)
         try:
             node, _component, param = _build_probe_node_with_component(
                 model_choices=["alpha", "beta"], default_model="alpha"
@@ -336,7 +335,7 @@ class TestInstall:
             # Declarative default_value on the Parameter is untouched.
             assert param.default_value == "alpha"
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)
+            engine.event_manager.remove_authorization_hook(deny_alpha)
 
 
 class TestConstructorPreconditions:
@@ -461,7 +460,7 @@ class TestEngineFailureIsFailClosedAtRuntime:
 
         self._register_library_without_probe_node()
 
-        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+        with caplog.at_level(logging.WARNING, logger="engine"):
             self._build_component_against_unresolved_node()
 
         matches = [r for r in caplog.records if "Could not resolve model access" in r.message]
@@ -474,7 +473,7 @@ class TestEngineFailureIsFailClosedAtRuntime:
 
         self._register_library_without_probe_node()
 
-        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+        with caplog.at_level(logging.WARNING, logger="engine"):
             helper = self._build_component_against_unresolved_node()
 
         denial = helper.query_for_denial("alpha")
@@ -490,7 +489,7 @@ class TestEngineFailureIsFailClosedAtRuntime:
 
         self._register_library_without_probe_node()
 
-        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+        with caplog.at_level(logging.WARNING, logger="engine"):
             helper = self._build_component_against_unresolved_node()
 
         with pytest.raises(RuntimeError, match="could not be checked against your license"):
@@ -502,7 +501,7 @@ class TestEngineFailureIsFailClosedAtRuntime:
 
         self._register_library_without_probe_node()
 
-        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+        with caplog.at_level(logging.WARNING, logger="engine"):
             helper = self._build_component_against_unresolved_node()
 
         # A connected Prompt Model Config driver / Agent replaces the string
@@ -533,7 +532,7 @@ class TestEngineFailureIsFailClosedAtRuntime:
 
 
 class TestOnValueChanged:
-    def test_sets_badge_when_switching_to_denied_value(self, griptape_nodes) -> None:  # noqa: ANN001
+    def test_sets_badge_when_switching_to_denied_value(self, engine) -> None:  # noqa: ANN001
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
@@ -541,7 +540,7 @@ class TestOnValueChanged:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Alpha not enabled."),))
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(deny_alpha)
+        engine.event_manager.add_authorization_hook(deny_alpha)
         try:
             node, helper = _install_probe_node_with_helper(model_choices=["alpha", "beta"], default_model="beta")
 
@@ -555,9 +554,9 @@ class TestOnValueChanged:
             assert badge is not None
             assert "Alpha not enabled." in badge.message
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)
+            engine.event_manager.remove_authorization_hook(deny_alpha)
 
-    def test_clears_badge_when_switching_to_allowed_value(self, griptape_nodes) -> None:  # noqa: ANN001
+    def test_clears_badge_when_switching_to_allowed_value(self, engine) -> None:  # noqa: ANN001
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
@@ -565,7 +564,7 @@ class TestOnValueChanged:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Alpha not enabled."),))
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(deny_alpha)
+        engine.event_manager.add_authorization_hook(deny_alpha)
         try:
             # default_model="beta" (permitted) so the constructor doesn't auto-move away
             # from a denied initial value. We then simulate the artist manually selecting
@@ -579,7 +578,7 @@ class TestOnValueChanged:
             helper.on_value_changed("beta")
             assert param.get_badge() is None
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)
+            engine.event_manager.remove_authorization_hook(deny_alpha)
 
     def test_clears_badge_on_non_string_value(self) -> None:
         """A driver / Agent connection replaces the string value with an object.
@@ -597,7 +596,7 @@ class TestOnValueChanged:
 
 
 class TestRefreshAndQueryForDenial:
-    def test_query_for_denial_returns_denial_for_denied_model(self, griptape_nodes) -> None:  # noqa: ANN001
+    def test_query_for_denial_returns_denial_for_denied_model(self, engine) -> None:  # noqa: ANN001
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
@@ -605,7 +604,7 @@ class TestRefreshAndQueryForDenial:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Alpha not enabled."),))
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(deny_alpha)
+        engine.event_manager.add_authorization_hook(deny_alpha)
         try:
             _, helper = _install_probe_node_with_helper(model_choices=["alpha", "beta"], default_model="beta")
 
@@ -615,9 +614,9 @@ class TestRefreshAndQueryForDenial:
 
             assert helper.query_for_denial("beta") is None
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)
+            engine.event_manager.remove_authorization_hook(deny_alpha)
 
-    def test_query_for_denial_honors_a_grant_made_since_the_last_refresh(self, griptape_nodes) -> None:  # noqa: ANN001
+    def test_query_for_denial_honors_a_grant_made_since_the_last_refresh(self, engine) -> None:  # noqa: ANN001
         """The run-path re-query must work in BOTH directions, not just allow -> deny.
 
         The snapshot is captured at construction/refresh time. If a cached denial short-circuited
@@ -632,17 +631,17 @@ class TestRefreshAndQueryForDenial:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Alpha not enabled."),))
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(deny_alpha)
+        engine.event_manager.add_authorization_hook(deny_alpha)
         try:
             _, helper = _install_probe_node_with_helper(model_choices=["alpha", "beta"], default_model="beta")
             assert helper.query_for_denial("alpha") is not None
         finally:
             # Policy relaxed. No refresh() -- the run path alone must notice.
-            griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)
+            engine.event_manager.remove_authorization_hook(deny_alpha)
 
         assert helper.query_for_denial("alpha") is None
 
-    def test_an_unanswerable_live_requery_falls_back_to_the_cached_denial(self, griptape_nodes) -> None:  # noqa: ANN001
+    def test_an_unanswerable_live_requery_falls_back_to_the_cached_denial(self, engine) -> None:  # noqa: ANN001
         """A transient lookup failure must not forget a denial we already hold.
 
         The run path re-asks policy live so grants are honored. If that query cannot be answered
@@ -656,20 +655,20 @@ class TestRefreshAndQueryForDenial:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Alpha not enabled."),))
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(deny_alpha)
+        engine.event_manager.add_authorization_hook(deny_alpha)
         try:
             _, helper = _install_probe_node_with_helper(model_choices=["alpha", "beta"], default_model="beta")
             assert helper.query_for_denial("alpha") is not None
 
             # The live re-query now comes back unanswerable.
             with patch.object(
-                GriptapeNodes,
+                engine,
                 "handle_request",
                 return_value=QueryModelAccessForNodeResultFailure(result_details="library unregistered"),
             ):
                 assert helper.query_for_denial("alpha") is not None
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)
+            engine.event_manager.remove_authorization_hook(deny_alpha)
 
     def test_query_for_denial_ignores_non_string_values(self) -> None:
         _, helper = _install_probe_node_with_helper(model_choices=["alpha", "beta"], default_model="alpha")
@@ -689,7 +688,7 @@ class TestRefreshAndQueryForDenial:
 
         assert helper.query_for_denial("never-heard-of-this-model") is None
 
-    def test_refresh_picks_up_hook_change(self, griptape_nodes) -> None:  # noqa: ANN001
+    def test_refresh_picks_up_hook_change(self, engine) -> None:  # noqa: ANN001
         """refresh() re-fetches the denial map so a policy change becomes visible."""
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
@@ -706,7 +705,7 @@ class TestRefreshAndQueryForDenial:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Alpha not enabled."),))
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(deny_alpha)
+        engine.event_manager.add_authorization_hook(deny_alpha)
         try:
             node.set_parameter_value("model", "alpha")
             # on_value_changed uses the STALE cache -- badge should NOT be set yet.
@@ -719,11 +718,11 @@ class TestRefreshAndQueryForDenial:
             assert badge is not None
             assert "Alpha not enabled." in badge.message
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)
+            engine.event_manager.remove_authorization_hook(deny_alpha)
 
 
 class TestRaiseIfDenied:
-    def test_raises_runtimeerror_with_denial_reason(self, griptape_nodes) -> None:  # noqa: ANN001
+    def test_raises_runtimeerror_with_denial_reason(self, engine) -> None:  # noqa: ANN001
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
@@ -731,14 +730,14 @@ class TestRaiseIfDenied:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Alpha not enabled."),))
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(deny_alpha)
+        engine.event_manager.add_authorization_hook(deny_alpha)
         try:
             _, helper = _install_probe_node_with_helper(model_choices=["alpha", "beta"], default_model="beta")
 
             with pytest.raises(RuntimeError, match="Alpha not enabled"):
                 helper.raise_if_denied("alpha")
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)
+            engine.event_manager.remove_authorization_hook(deny_alpha)
 
     def test_does_not_raise_when_allowed(self) -> None:
         _, helper = _install_probe_node_with_helper(model_choices=["alpha", "beta"], default_model="alpha")
@@ -754,7 +753,7 @@ class TestRaiseIfDenied:
 
 
 class TestRefreshButton:
-    def test_refresh_button_click_rebuilds_state(self, griptape_nodes) -> None:  # noqa: ANN001
+    def test_refresh_button_click_rebuilds_state(self, engine) -> None:  # noqa: ANN001
         """The inline Button trait's on_click hook invokes refresh()."""
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
@@ -775,7 +774,7 @@ class TestRefreshButton:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Alpha not enabled."),))
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(deny_alpha)
+        engine.event_manager.add_authorization_hook(deny_alpha)
         try:
             # Call the on_click handler the way the Button trait would.
             assert button.on_click_callback is not None
@@ -785,11 +784,11 @@ class TestRefreshButton:
             assert badge is not None
             assert "Alpha not enabled." in badge.message
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)
+            engine.event_manager.remove_authorization_hook(deny_alpha)
 
 
 class TestSuccessFailureUsagePattern:
-    def test_query_for_denial_supports_early_return_without_raising(self, griptape_nodes) -> None:  # noqa: ANN001
+    def test_query_for_denial_supports_early_return_without_raising(self, engine) -> None:  # noqa: ANN001
         """A SuccessFailure-style caller can inspect the denial and route without an exception.
 
         Verifies that the helper never raises on its own -- the caller decides
@@ -803,7 +802,7 @@ class TestSuccessFailureUsagePattern:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Alpha not enabled."),))
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(deny_alpha)
+        engine.event_manager.add_authorization_hook(deny_alpha)
         try:
             _, helper = _install_probe_node_with_helper(model_choices=["alpha", "beta"], default_model="beta")
 
@@ -819,7 +818,7 @@ class TestSuccessFailureUsagePattern:
             assert routed_to_failure is True
             assert failure_reason == "Alpha not enabled."
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)
+            engine.event_manager.remove_authorization_hook(deny_alpha)
 
 
 class TestModelChoicesProperty:
@@ -836,7 +835,7 @@ class TestModelChoicesProperty:
 
 
 class TestReinstallOptions:
-    def test_reinstall_puts_options_and_decoration_back(self, griptape_nodes) -> None:  # noqa: ANN001
+    def test_reinstall_puts_options_and_decoration_back(self, engine) -> None:  # noqa: ANN001
         """After remove_trait(Options), reinstall_options() re-adds it with decoration + badge."""
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
@@ -845,7 +844,7 @@ class TestReinstallOptions:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Alpha not enabled."),))
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(deny_alpha)
+        engine.event_manager.add_authorization_hook(deny_alpha)
         try:
             # default_model="beta" (permitted) so construction doesn't relocate away
             # from a denied initial value. Then flip the stored value to denied 'alpha'
@@ -873,7 +872,7 @@ class TestReinstallOptions:
             assert badge is not None
             assert "Alpha not enabled." in badge.message
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)
+            engine.event_manager.remove_authorization_hook(deny_alpha)
 
 
 class TestDeprecatedValuesValidation:
@@ -1065,7 +1064,7 @@ class TestSelectionReadingApi:
         node.set_parameter_value(param.name, "beta")
         assert helper.selected_value == "beta"
 
-    def test_selection_denial_gates_the_current_selection(self, griptape_nodes) -> None:  # noqa: ANN001
+    def test_selection_denial_gates_the_current_selection(self, engine) -> None:  # noqa: ANN001
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
@@ -1073,7 +1072,7 @@ class TestSelectionReadingApi:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Alpha not enabled."),))
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(deny_alpha)
+        engine.event_manager.add_authorization_hook(deny_alpha)
         try:
             node, helper, param = _build_probe_node_with_component(
                 model_choices=["alpha", "beta"], default_model="beta"
@@ -1085,9 +1084,9 @@ class TestSelectionReadingApi:
             assert denial is not None
             assert denial.messages() == ["Alpha not enabled."]
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)
+            engine.event_manager.remove_authorization_hook(deny_alpha)
 
-    def test_raise_if_selection_denied_raises_for_the_current_selection(self, griptape_nodes) -> None:  # noqa: ANN001
+    def test_raise_if_selection_denied_raises_for_the_current_selection(self, engine) -> None:  # noqa: ANN001
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
@@ -1095,7 +1094,7 @@ class TestSelectionReadingApi:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Alpha not enabled."),))
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(deny_alpha)
+        engine.event_manager.add_authorization_hook(deny_alpha)
         try:
             node, helper, param = _build_probe_node_with_component(
                 model_choices=["alpha", "beta"], default_model="beta"
@@ -1106,9 +1105,9 @@ class TestSelectionReadingApi:
             with pytest.raises(RuntimeError, match="not permitted"):
                 helper.raise_if_selection_denied()
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)
+            engine.event_manager.remove_authorization_hook(deny_alpha)
 
-    def test_on_value_set_ignores_other_parameters(self, griptape_nodes) -> None:  # noqa: ANN001
+    def test_on_value_set_ignores_other_parameters(self, engine) -> None:  # noqa: ANN001
         """The component filters for its own parameter so nodes can forward unconditionally."""
         from griptape_nodes.exe_types.core_types import Parameter
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
@@ -1118,7 +1117,7 @@ class TestSelectionReadingApi:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Alpha not enabled."),))
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(deny_alpha)
+        engine.event_manager.add_authorization_hook(deny_alpha)
         try:
             node, helper, param = _build_probe_node_with_component(
                 model_choices=["alpha", "beta"], default_model="beta"
@@ -1132,7 +1131,7 @@ class TestSelectionReadingApi:
             helper.on_value_set(param, "alpha")
             assert param.get_badge() is not None
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)
+            engine.event_manager.remove_authorization_hook(deny_alpha)
 
 
 class TestConstructionDeferral:
@@ -1146,7 +1145,7 @@ class TestConstructionDeferral:
     ``TestConstructionWithoutAScopeStillQueries``.
     """
 
-    def test_construction_defers_the_query_and_keeps_the_default(self, griptape_nodes) -> None:  # noqa: ANN001
+    def test_construction_defers_the_query_and_keeps_the_default(self, engine) -> None:  # noqa: ANN001
         from unittest.mock import MagicMock
 
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
@@ -1154,7 +1153,7 @@ class TestConstructionDeferral:
         def deny_all(_checkpoint: object) -> CheckpointDenial:
             return CheckpointDenial(failures=(CheckpointFailure(detail="Nothing enabled."),))
 
-        griptape_nodes.EventManager().add_authorization_hook(deny_all)
+        engine.event_manager.add_authorization_hook(deny_all)
         handle = MagicMock()
         try:
             with (
@@ -1175,9 +1174,9 @@ class TestConstructionDeferral:
             assert all(row.get("icon") != "shield-off" for row in param.ui_options["data"])
             assert param.get_badge() is None
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny_all)
+            engine.event_manager.remove_authorization_hook(deny_all)
 
-    def test_query_for_denial_heals_a_deferred_snapshot(self, griptape_nodes) -> None:  # noqa: ANN001
+    def test_query_for_denial_heals_a_deferred_snapshot(self, engine) -> None:  # noqa: ANN001
         """The enforcement-gap regression: run-time gating must not stay bypassed until a refresh.
 
         This component has no validate_before_node_run equivalent, so if query_for_denial
@@ -1191,7 +1190,7 @@ class TestConstructionDeferral:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Alpha not enabled."),))
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(deny_alpha)
+        engine.event_manager.add_authorization_hook(deny_alpha)
         try:
             with constructing_under_probe():
                 _node, helper, _param = _build_probe_node_with_component(
@@ -1202,9 +1201,9 @@ class TestConstructionDeferral:
             assert helper._snapshot.deferred is False
             assert helper.query_for_denial("beta") is None
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)
+            engine.event_manager.remove_authorization_hook(deny_alpha)
 
-    def test_refresh_heals_decoration(self, griptape_nodes) -> None:  # noqa: ANN001
+    def test_refresh_heals_decoration(self, engine) -> None:  # noqa: ANN001
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
@@ -1212,7 +1211,7 @@ class TestConstructionDeferral:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Alpha not enabled."),))
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(deny_alpha)
+        engine.event_manager.add_authorization_hook(deny_alpha)
         try:
             with constructing_under_probe():
                 _node, helper, param = _build_probe_node_with_component(
@@ -1226,7 +1225,7 @@ class TestConstructionDeferral:
             assert data_by_name["alpha"]["icon"] == "shield-off"
             assert helper._snapshot.deferred is False
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)
+            engine.event_manager.remove_authorization_hook(deny_alpha)
 
 
 class TestConstructionWithoutAScopeStillQueries:
@@ -1237,7 +1236,7 @@ class TestConstructionWithoutAScopeStillQueries:
     artist clicks refresh.
     """
 
-    def test_denial_decoration_and_default_relocation_happen_at_construction(self, griptape_nodes) -> None:  # noqa: ANN001
+    def test_denial_decoration_and_default_relocation_happen_at_construction(self, engine) -> None:  # noqa: ANN001
         from griptape_nodes.node_library.library_registry import LibraryRegistry
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
@@ -1246,7 +1245,7 @@ class TestConstructionWithoutAScopeStillQueries:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Alpha not enabled."),))
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(deny_alpha)
+        engine.event_manager.add_authorization_hook(deny_alpha)
         try:
             with LibraryRegistry.constructing_node():
                 node, helper, param = _build_probe_node_with_component(
@@ -1260,4 +1259,4 @@ class TestConstructionWithoutAScopeStillQueries:
             # __init__ -- construction-time deferral is what suppressed this.
             assert node.get_parameter_value(param.name) == "beta"
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny_alpha)
+            engine.event_manager.remove_authorization_hook(deny_alpha)

--- a/tests/unit/exe_types/test_base_iterative_node_group.py
+++ b/tests/unit/exe_types/test_base_iterative_node_group.py
@@ -17,7 +17,7 @@ from griptape_nodes.exe_types.node_groups.subflow_node_group import (
 )
 
 if TYPE_CHECKING:
-    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+    from griptape_nodes.retained_mode.engine import Engine
 
 
 class MockIterativeGroup(BaseIterativeNodeGroup):
@@ -31,7 +31,7 @@ class MockIterativeGroup(BaseIterativeNodeGroup):
 
 
 @pytest.fixture
-def iterative_group(griptape_nodes: GriptapeNodes) -> MockIterativeGroup:  # noqa: ARG001
+def iterative_group(engine: Engine) -> MockIterativeGroup:  # noqa: ARG001
     """Return a freshly constructed MockIterativeGroup."""
     return MockIterativeGroup(name="test_iterative_group")
 

--- a/tests/unit/exe_types/test_workflow_node.py
+++ b/tests/unit/exe_types/test_workflow_node.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -21,7 +21,9 @@ from griptape_nodes.exe_types.workflow_node import (
 )
 from griptape_nodes.node_library.workflow_registry import WorkflowMetadata, WorkflowRegistry, WorkflowShape
 from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
 
 CONTROL_TYPE = "parametercontroltype"
 
@@ -53,20 +55,20 @@ def _metadata(shape: WorkflowShape | None) -> WorkflowMetadata:
     )
 
 
-def _build_live_subflow() -> str:
+def _build_live_subflow(engine: Engine) -> str:
     """Create a flow standing in for an imported workflow, and return its name.
 
     Mirrors what an import produces for the shape used by `TestResolveLiveRoutes`: a parameterless
     Start Flow node, a Start Flow node exposing `text`, and an End Flow node exposing `result`, all
     renamed because their original names were already taken on the canvas.
     """
-    GriptapeNodes.ContextManager().push_workflow(workflow_name="workflow_node_live_routes")
-    flow_result = GriptapeNodes.handle_request(
+    engine.context_manager.push_workflow(workflow_name="workflow_node_live_routes")
+    flow_result = engine.handle_request(
         CreateFlowRequest(parent_flow_name=None, flow_name="Subflow", set_as_new_context=False)
     )
     assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
 
-    flow = GriptapeNodes.FlowManager().get_flow_by_name(flow_result.flow_name)
+    flow = engine.flow_manager.get_flow_by_name(flow_result.flow_name)
     flow.add_node(StartNode(name="Start Flow_1"))
 
     start_with_text = StartNode(name="Start Flow_2")
@@ -249,7 +251,7 @@ class TestPairShapeNodes:
 class TestResolveLiveRoutes:
     """Routes are re-pointed at the imported copy of the workflow before every run."""
 
-    def test_parameterless_start_node_is_counted_and_skipped(self) -> None:
+    def test_parameterless_start_node_is_counted_and_skipped(self, engine: Engine) -> None:
         """A Start Flow node carrying only control flow contributes no route but still holds a slot.
 
         Pairing is positional, so the parameterless node has to be counted on the declared side or
@@ -268,7 +270,7 @@ class TestResolveLiveRoutes:
             workflow_metadata=_metadata(shape),
         )
         node = node_class(name="Shout It")
-        subflow_name = _build_live_subflow()
+        subflow_name = _build_live_subflow(engine)
 
         live_routes = node._resolve_live_routes(subflow_name)
 

--- a/tests/unit/files/drivers/test_local_file_driver.py
+++ b/tests/unit/files/drivers/test_local_file_driver.py
@@ -4,13 +4,12 @@ import platform
 import sys
 from collections.abc import Iterator
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
 from griptape_nodes.files.drivers.local_file_driver import LocalFileDriver
 from griptape_nodes.files.path_utils import parse_file_uri
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
 
 
@@ -337,19 +336,16 @@ class TestLocalFileDriverRelativePaths:
     def mock_config_manager_accessor(self, mock_config_manager: Mock) -> Iterator[Mock]:
         """Patch the facade accessor the driver uses to reach the ConfigManager.
 
-        Deliberately not `monkeypatch.setattr`: it snapshots `getattr(GriptapeNodes,
-        "ConfigManager")`, which for a classmethod is the *bound* method, and on teardown
-        writes that bound method into `GriptapeNodes.__dict__` instead of the original
-        classmethod descriptor. That permanently mutates a process-global facade class every
-        other test shares. Saving and restoring `__dict__` puts the real descriptor back.
+        Patched by dotted string rather than an imported `GriptapeNodes` reference: the
+        driver (src/griptape_nodes/files/drivers/local_file_driver.py) still calls the
+        facade's `ConfigManager()` classmethod, and `patch()` handles saving and restoring
+        the classmethod descriptor correctly on teardown.
         """
-        original_descriptor = GriptapeNodes.__dict__["ConfigManager"]
-        accessor = Mock(spec=GriptapeNodes.ConfigManager, return_value=mock_config_manager)
-        GriptapeNodes.ConfigManager = accessor  # type: ignore[method-assign]
-        try:
+        with patch(
+            "griptape_nodes.retained_mode.griptape_nodes.GriptapeNodes.ConfigManager",
+            return_value=mock_config_manager,
+        ) as accessor:
             yield accessor
-        finally:
-            GriptapeNodes.ConfigManager = original_descriptor  # type: ignore[method-assign]
 
     @pytest.mark.asyncio
     async def test_read_bare_relative_path_uses_workspace_not_cwd(

--- a/tests/unit/files/test_file.py
+++ b/tests/unit/files/test_file.py
@@ -1,8 +1,11 @@
 """Unit tests for File and FileDestination."""
 
+from __future__ import annotations
+
 import base64
 from io import BytesIO
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
@@ -31,6 +34,9 @@ from griptape_nodes.retained_mode.events.project_events import (
     MacroPath,
     PathResolutionFailureReason,
 )
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
 
 HANDLE_REQUEST_PATH = "griptape_nodes.files.file.GriptapeNodes.handle_request"
 AHANDLE_REQUEST_PATH = "griptape_nodes.files.file.GriptapeNodes.ahandle_request"
@@ -1286,7 +1292,7 @@ def _jpeg_bytes() -> bytes:
 
 
 @pytest.fixture
-def _registered_providers() -> None:
+def _registered_providers(engine: Engine) -> None:
     """Ensure default artifact providers are registered with the ArtifactManager.
 
     Validation goes through ``ArtifactManager.sniff_extension``, which dispatches
@@ -1295,14 +1301,13 @@ def _registered_providers() -> None:
     so we register the default providers manually here.
     """
     from griptape_nodes.retained_mode.events.artifact_events import RegisterArtifactProviderRequest
-    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
     from griptape_nodes.retained_mode.managers.artifact_providers import (
         AudioArtifactProvider,
         ImageArtifactProvider,
         VideoArtifactProvider,
     )
 
-    artifact_manager = GriptapeNodes.ArtifactManager()
+    artifact_manager = engine.artifact_manager
     for provider_class in (ImageArtifactProvider, VideoArtifactProvider, AudioArtifactProvider):
         artifact_manager.on_handle_register_artifact_provider_request(
             RegisterArtifactProviderRequest(provider_class=provider_class)

--- a/tests/unit/machines/test_control_flow.py
+++ b/tests/unit/machines/test_control_flow.py
@@ -25,7 +25,7 @@ from griptape_nodes.machines.dag_builder import DagBuilder, DagNodeCategories
 from griptape_nodes.retained_mode.managers.flow_manager import DagExecutionType, QueueItem
 
 if TYPE_CHECKING:
-    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+    from griptape_nodes.retained_mode.engine import Engine
 
 
 def _engine_with_connections(connections: MagicMock) -> MagicMock:
@@ -52,8 +52,8 @@ def _mock_node(name: str) -> MagicMock:
 class TestDrainGlobalFlowQueue:
     """Tests for ControlFlowMachine._drain_global_flow_queue."""
 
-    def test_buckets_items_by_type_and_empties_queue(self, griptape_nodes: GriptapeNodes) -> None:
-        flow_manager = griptape_nodes.FlowManager()
+    def test_buckets_items_by_type_and_empties_queue(self, engine: Engine) -> None:
+        flow_manager = engine.flow_manager
         flow_manager.global_flow_queue.queue.clear()
 
         start = _mock_node("start")
@@ -71,8 +71,8 @@ class TestDrainGlobalFlowQueue:
         # The queue must be fully drained.
         assert flow_manager.global_flow_queue.empty()
 
-    def test_empty_queue_yields_empty_categories(self, griptape_nodes: GriptapeNodes) -> None:
-        flow_manager = griptape_nodes.FlowManager()
+    def test_empty_queue_yields_empty_categories(self, engine: Engine) -> None:
+        flow_manager = engine.flow_manager
         flow_manager.global_flow_queue.queue.clear()
 
         categories = ControlFlowMachine._drain_global_flow_queue(flow_manager)
@@ -180,7 +180,7 @@ class TestProcessNodesForDagIsolatedScope:
     """
 
     @pytest.mark.asyncio
-    async def test_isolated_scope_keeps_group_children(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_isolated_scope_keeps_group_children(self, engine: Engine) -> None:
         machine = ControlFlowMachine("grp_subflow", is_isolated=True)
         # Swap the fresh DagBuilder for a stub: add_node_with_dependencies becomes a no-op, and the
         # is_isolated check (dag_builder is not the global one) still holds for a MagicMock.
@@ -194,7 +194,7 @@ class TestProcessNodesForDagIsolatedScope:
         subflow = MagicMock()
         subflow.nodes = {"child_a": child_a, "child_b": child_b}
 
-        flow_manager = griptape_nodes.FlowManager()
+        flow_manager = engine.flow_manager
         captured: dict[str, list[BaseNode]] = {}
 
         def fake_classify(nodes: list[BaseNode]) -> DagNodeCategories:

--- a/tests/unit/node_library/test_workflow_registry.py
+++ b/tests/unit/node_library/test_workflow_registry.py
@@ -1,15 +1,20 @@
 """Tests for WorkflowRegistry functionality."""
 
+from __future__ import annotations
+
 import os
 import platform
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from griptape_nodes.files.path_utils import derive_registry_key
 from griptape_nodes.node_library.workflow_registry import Workflow, WorkflowRegistry
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
 
 
 class TestDeriveRegistryKey:
@@ -112,12 +117,12 @@ class TestWorkflowRegistry:
             # On Unix, Windows paths are treated as relative
             assert result.endswith("C:\\Users\\test\\workflow.py")
 
-    def test_get_complete_file_path_with_relative_path(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_get_complete_file_path_with_relative_path(self, engine: Engine) -> None:
         """Test that get_complete_file_path resolves relative paths to workspace."""
         relative_path = "workflows/my_workflow.py"
 
         # Get the actual workspace path from the config manager
-        workspace_path = griptape_nodes.ConfigManager().workspace_path
+        workspace_path = engine.config_manager.workspace_path
 
         result = WorkflowRegistry.get_complete_file_path(relative_path)
 
@@ -140,24 +145,24 @@ class TestWorkflowRegistry:
             # On Unix, ~ is also treated as relative (not expanded)
             assert result.endswith("~/workflows/my_workflow.py")
 
-    def test_get_complete_file_path_with_current_dir_relative(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_get_complete_file_path_with_current_dir_relative(self, engine: Engine) -> None:
         """Test that get_complete_file_path handles current directory relative paths."""
         current_dir_path = "./my_workflow.py"
 
         # Get the actual workspace path from the config manager
-        workspace_path = griptape_nodes.ConfigManager().workspace_path
+        workspace_path = engine.config_manager.workspace_path
 
         result = WorkflowRegistry.get_complete_file_path(current_dir_path)
 
         expected = str(workspace_path / current_dir_path)
         assert result == expected
 
-    def test_get_complete_file_path_with_parent_dir_relative(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_get_complete_file_path_with_parent_dir_relative(self, engine: Engine) -> None:
         """Test that get_complete_file_path handles parent directory relative paths."""
         parent_dir_path = "../external/my_workflow.py"
 
         # Get the actual workspace path from the config manager
-        workspace_path = griptape_nodes.ConfigManager().workspace_path
+        workspace_path = engine.config_manager.workspace_path
 
         result = WorkflowRegistry.get_complete_file_path(parent_dir_path)
 

--- a/tests/unit/retained_mode/managers/artifact_providers/test_prepare_content_for_write.py
+++ b/tests/unit/retained_mode/managers/artifact_providers/test_prepare_content_for_write.py
@@ -5,8 +5,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from griptape_nodes.retained_mode.engine import Engine
 from griptape_nodes.retained_mode.events.artifact_events import RegisterArtifactProviderRequest
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.artifact_providers.image.image_artifact_provider import (
     ImageArtifactProvider,
 )
@@ -70,27 +70,27 @@ class TestImageArtifactProviderPrepareContentForWrite:
 class TestArtifactManagerPrepareContentForWrite:
     """Tests for ArtifactManager.prepare_content_for_write."""
 
-    def test_returns_data_unchanged_for_unknown_extension(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_returns_data_unchanged_for_unknown_extension(self, engine: Engine) -> None:
         """Test that data is returned unchanged when no provider handles the extension."""
-        artifact_manager = griptape_nodes.ArtifactManager()
+        artifact_manager = engine.artifact_manager
         data = b"some binary data"
 
         result = artifact_manager.prepare_content_for_write(data, "archive.xyz_unknown")
 
         assert result is data
 
-    def test_returns_data_unchanged_for_empty_extension(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_returns_data_unchanged_for_empty_extension(self, engine: Engine) -> None:
         """Test that data is returned unchanged when filename has no extension."""
-        artifact_manager = griptape_nodes.ArtifactManager()
+        artifact_manager = engine.artifact_manager
         data = b"some binary data"
 
         result = artifact_manager.prepare_content_for_write(data, "no_extension_file")
 
         assert result is data
 
-    def test_dispatches_to_provider_for_known_extension(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_dispatches_to_provider_for_known_extension(self, engine: Engine) -> None:
         """Test that prepare_content_for_write dispatches to the image provider for .png files."""
-        artifact_manager = griptape_nodes.ArtifactManager()
+        artifact_manager = engine.artifact_manager
         artifact_manager.on_handle_register_artifact_provider_request(
             RegisterArtifactProviderRequest(provider_class=ImageArtifactProvider)
         )

--- a/tests/unit/retained_mode/managers/artifact_providers/video/test_video_artifact_provider_permissions.py
+++ b/tests/unit/retained_mode/managers/artifact_providers/video/test_video_artifact_provider_permissions.py
@@ -17,7 +17,7 @@ from typing import Any
 
 import pytest
 
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.engine import Engine
 from griptape_nodes.retained_mode.managers.artifact_providers.base_artifact_provider import WriteVettingPolicy
 from griptape_nodes.retained_mode.managers.artifact_providers.video.video_artifact_provider import (
     VideoArtifactProvider,
@@ -45,7 +45,7 @@ class TestVideoCheckWriteFormatFromPath:
 
     def test_denies_when_hook_denies_codec(
         self,
-        griptape_nodes: GriptapeNodes,
+        engine: Engine,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
     ) -> None:
@@ -69,11 +69,11 @@ class TestVideoCheckWriteFormatFromPath:
         staged.write_bytes(b"stand-in; ffprobe is mocked")
 
         provider = VideoArtifactProvider(registry=None)  # type: ignore[arg-type]
-        griptape_nodes.EventManager().add_authorization_hook(deny_hevc)
+        engine.event_manager.add_authorization_hook(deny_hevc)
         try:
             denial = provider.check_write_format_from_path(str(staged), "mp4")
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny_hevc)
+            engine.event_manager.remove_authorization_hook(deny_hevc)
 
         assert denial is not None
         # The checkpoint must carry both id (codec) and container_format so a
@@ -82,7 +82,7 @@ class TestVideoCheckWriteFormatFromPath:
 
     def test_allows_when_hook_allows_codec(
         self,
-        griptape_nodes: GriptapeNodes,
+        engine: Engine,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
     ) -> None:
@@ -101,17 +101,17 @@ class TestVideoCheckWriteFormatFromPath:
         staged.write_bytes(b"stand-in; ffprobe is mocked")
 
         provider = VideoArtifactProvider(registry=None)  # type: ignore[arg-type]
-        griptape_nodes.EventManager().add_authorization_hook(deny_hevc)
+        engine.event_manager.add_authorization_hook(deny_hevc)
         try:
             denial = provider.check_write_format_from_path(str(staged), "mp4")
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny_hevc)
+            engine.event_manager.remove_authorization_hook(deny_hevc)
 
         assert denial is None
 
     def test_fails_closed_when_ffprobe_returns_none(
         self,
-        griptape_nodes: GriptapeNodes,
+        engine: Engine,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
     ) -> None:
@@ -131,11 +131,11 @@ class TestVideoCheckWriteFormatFromPath:
         staged.write_bytes(b"unclassifiable")
 
         provider = VideoArtifactProvider(registry=None)  # type: ignore[arg-type]
-        griptape_nodes.EventManager().add_authorization_hook(sentinel_hook)
+        engine.event_manager.add_authorization_hook(sentinel_hook)
         try:
             denial = provider.check_write_format_from_path(str(staged), "mp4")
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(sentinel_hook)
+            engine.event_manager.remove_authorization_hook(sentinel_hook)
 
         assert denial is not None
         # The denial detail is generic -- OSManager wraps it with the caller's
@@ -151,7 +151,7 @@ class TestVideoCheckWriteFormatFromPath:
 
     def test_fails_closed_when_probe_has_no_video_stream(
         self,
-        griptape_nodes: GriptapeNodes,
+        engine: Engine,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
     ) -> None:
@@ -173,11 +173,11 @@ class TestVideoCheckWriteFormatFromPath:
         staged.write_bytes(b"audio-only")
 
         provider = VideoArtifactProvider(registry=None)  # type: ignore[arg-type]
-        griptape_nodes.EventManager().add_authorization_hook(sentinel_hook)
+        engine.event_manager.add_authorization_hook(sentinel_hook)
         try:
             denial = provider.check_write_format_from_path(str(staged), "mp4")
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(sentinel_hook)
+            engine.event_manager.remove_authorization_hook(sentinel_hook)
 
         assert denial is not None
         # Denial detail carries the "probe unavailable or failed -- see server logs"
@@ -189,7 +189,7 @@ class TestVideoCheckWriteFormatFromPath:
 
     def test_denies_when_disallowed_codec_is_on_a_non_first_video_stream(
         self,
-        griptape_nodes: GriptapeNodes,
+        engine: Engine,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
     ) -> None:
@@ -227,11 +227,11 @@ class TestVideoCheckWriteFormatFromPath:
         staged.write_bytes(b"stand-in; ffprobe is mocked")
 
         provider = VideoArtifactProvider(registry=None)  # type: ignore[arg-type]
-        griptape_nodes.EventManager().add_authorization_hook(deny_hevc)
+        engine.event_manager.add_authorization_hook(deny_hevc)
         try:
             denial = provider.check_write_format_from_path(str(staged), "mp4")
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny_hevc)
+            engine.event_manager.remove_authorization_hook(deny_hevc)
 
         assert denial is not None
         # Both codecs must have been offered to the hook, in stream order.
@@ -244,7 +244,7 @@ class TestVideoReadPermission:
     """``check_read_permission`` mirrors the from-path write path (both funnel through _check_codec)."""
 
     def test_denies_when_hook_denies_codec(
-        self, griptape_nodes: GriptapeNodes, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+        self, engine: Engine, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         monkeypatch.setattr(
             VideoArtifactProvider,
@@ -266,17 +266,17 @@ class TestVideoReadPermission:
         source_path.write_bytes(b"stand-in; ffprobe is mocked")
 
         provider = VideoArtifactProvider(registry=None)  # type: ignore[arg-type]
-        griptape_nodes.EventManager().add_authorization_hook(deny_hevc)
+        engine.event_manager.add_authorization_hook(deny_hevc)
         try:
             denial = provider.check_read_permission(str(source_path))
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny_hevc)
+            engine.event_manager.remove_authorization_hook(deny_hevc)
 
         assert denial is not None
         assert seen[-1] == {"id": "hevc", "container_format": "mp4"}
 
     def test_container_format_unknown_when_path_has_no_extension(
-        self, griptape_nodes: GriptapeNodes, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+        self, engine: Engine, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         # A caller can pass a path with no extension (e.g. a temp file). The
         # provider still probes the bytes for codec but tags the checkpoint
@@ -297,16 +297,16 @@ class TestVideoReadPermission:
         source_path.write_bytes(b"stand-in")
 
         provider = VideoArtifactProvider(registry=None)  # type: ignore[arg-type]
-        griptape_nodes.EventManager().add_authorization_hook(record)
+        engine.event_manager.add_authorization_hook(record)
         try:
             provider.check_read_permission(str(source_path))
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(record)
+            engine.event_manager.remove_authorization_hook(record)
 
         assert seen[-1]["container_format"] == "unknown"
 
     def test_fails_closed_when_ffprobe_returns_none(
-        self, griptape_nodes: GriptapeNodes, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+        self, engine: Engine, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         # ffprobe unavailable: read cannot be verified as compliant. Fail
         # closed with a synthetic denial. The provider's denial detail is
@@ -324,11 +324,11 @@ class TestVideoReadPermission:
         source_path.write_bytes(b"stand-in")
 
         provider = VideoArtifactProvider(registry=None)  # type: ignore[arg-type]
-        griptape_nodes.EventManager().add_authorization_hook(sentinel_hook)
+        engine.event_manager.add_authorization_hook(sentinel_hook)
         try:
             denial = provider.check_read_permission(str(source_path))
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(sentinel_hook)
+            engine.event_manager.remove_authorization_hook(sentinel_hook)
 
         assert denial is not None
         # Denial detail carries the "probe unavailable or failed -- see server logs"

--- a/tests/unit/retained_mode/managers/test_access_manager.py
+++ b/tests/unit/retained_mode/managers/test_access_manager.py
@@ -7,12 +7,14 @@ behavior across a per-candidate loop, and failure paths.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from griptape_nodes.exe_types.node_types import BaseNode
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
 
 
 class _ProbeNode(BaseNode):
@@ -97,13 +99,13 @@ class TestAccessManager:
 
     # ---------- Per-node request ----------
 
-    def test_for_node_unknown_node_type_returns_failure(self, griptape_nodes: GriptapeNodes) -> None:  # noqa: ARG002
+    def test_for_node_unknown_node_type_returns_failure(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.access_events import (
             QueryModelAccessForNodeRequest,
             QueryModelAccessForNodeResultFailure,
         )
 
-        result = GriptapeNodes.handle_request(QueryModelAccessForNodeRequest(node_type="Missing"))
+        result = engine.handle_request(QueryModelAccessForNodeRequest(node_type="Missing"))
         assert isinstance(result, QueryModelAccessForNodeResultFailure)
         # Message is clean prose: names the node type, no KeyError quote/tuple repr.
         details = str(result.result_details)
@@ -113,7 +115,7 @@ class TestAccessManager:
 
     def test_for_node_missing_in_specified_library_returns_clean_failure(
         self,
-        griptape_nodes: GriptapeNodes,  # noqa: ARG002
+        engine: Engine,
     ) -> None:
         from griptape_nodes.retained_mode.events.access_events import (
             QueryModelAccessForNodeRequest,
@@ -122,7 +124,7 @@ class TestAccessManager:
 
         self._register()
 
-        result = GriptapeNodes.handle_request(
+        result = engine.handle_request(
             QueryModelAccessForNodeRequest(node_type="NotRegistered", specific_library_name=self._LIBRARY_NAME)
         )
         assert isinstance(result, QueryModelAccessForNodeResultFailure)
@@ -134,7 +136,7 @@ class TestAccessManager:
             f"Failed because it is not registered in library '{self._LIBRARY_NAME}'."
         )
 
-    def test_for_node_no_hook_all_models_allowed(self, griptape_nodes: GriptapeNodes) -> None:  # noqa: ARG002
+    def test_for_node_no_hook_all_models_allowed(self, engine: Engine) -> None:
         from griptape_nodes.node_library.library_declarations import ModelUsageNodeProperty
         from griptape_nodes.retained_mode.events.access_events import (
             QueryModelAccessForNodeRequest,
@@ -146,14 +148,14 @@ class TestAccessManager:
             library_declarations=[self._catalog()],
         )
 
-        result = GriptapeNodes.handle_request(
+        result = engine.handle_request(
             QueryModelAccessForNodeRequest(node_type=_ProbeNode.__name__, specific_library_name=self._LIBRARY_NAME)
         )
         assert isinstance(result, QueryModelAccessForNodeResultSuccess)
         assert [v.model_id for v in result.verdicts] == ["gtc_claude_opus_4_7", "gtc_claude_sonnet_4_6"]
         assert all(v.denial is None for v in result.verdicts)
 
-    def test_for_node_hook_denies_one_model_only(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_for_node_hook_denies_one_model_only(self, engine: Engine) -> None:
         from griptape_nodes.node_library.library_declarations import ModelUsageNodeProperty
         from griptape_nodes.retained_mode.events.access_events import (
             QueryModelAccessForNodeRequest,
@@ -171,13 +173,13 @@ class TestAccessManager:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Opus is not in your plan."),))
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(deny)
+        engine.event_manager.add_authorization_hook(deny)
         try:
-            result = GriptapeNodes.handle_request(
+            result = engine.handle_request(
                 QueryModelAccessForNodeRequest(node_type=_ProbeNode.__name__, specific_library_name=self._LIBRARY_NAME)
             )
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny)
+            engine.event_manager.remove_authorization_hook(deny)
 
         assert isinstance(result, QueryModelAccessForNodeResultSuccess)
         denied = [v for v in result.verdicts if v.denial is not None]
@@ -187,7 +189,7 @@ class TestAccessManager:
         assert denied[0].denial is not None
         assert denied[0].denial.messages() == ["Opus is not in your plan."]
 
-    def test_for_node_verdict_carries_provider_model_id(self, griptape_nodes: GriptapeNodes) -> None:  # noqa: ARG002
+    def test_for_node_verdict_carries_provider_model_id(self, engine: Engine) -> None:
         from griptape_nodes.node_library.library_declarations import ModelUsageNodeProperty
         from griptape_nodes.retained_mode.events.access_events import (
             QueryModelAccessForNodeRequest,
@@ -199,7 +201,7 @@ class TestAccessManager:
             library_declarations=[self._catalog()],
         )
 
-        result = GriptapeNodes.handle_request(
+        result = engine.handle_request(
             QueryModelAccessForNodeRequest(node_type=_ProbeNode.__name__, specific_library_name=self._LIBRARY_NAME)
         )
         assert isinstance(result, QueryModelAccessForNodeResultSuccess)
@@ -207,7 +209,7 @@ class TestAccessManager:
         assert result.verdicts[0].model_id == "gtc_claude_opus_4_7"
         assert result.verdicts[0].provider_model_id == "claude-opus-4-7"
 
-    def test_for_node_unknown_candidate_no_catalog_enrichment(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_for_node_unknown_candidate_no_catalog_enrichment(self, engine: Engine) -> None:
         """Per-node request with an EXPLICIT candidate list including an unknown id.
 
         Verifies the explicit-override path: the engine asks the hook for the id
@@ -225,9 +227,9 @@ class TestAccessManager:
         def record(checkpoint: object) -> None:
             seen_attributes.append(dict(checkpoint.attributes))  # type: ignore[attr-defined]
 
-        griptape_nodes.EventManager().add_authorization_hook(record)
+        engine.event_manager.add_authorization_hook(record)
         try:
-            result = GriptapeNodes.handle_request(
+            result = engine.handle_request(
                 QueryModelAccessForNodeRequest(
                     node_type=_ProbeNode.__name__,
                     candidate_model_ids=["not_in_catalog"],
@@ -235,14 +237,14 @@ class TestAccessManager:
                 )
             )
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(record)
+            engine.event_manager.remove_authorization_hook(record)
 
         assert isinstance(result, QueryModelAccessForNodeResultSuccess)
         assert result.verdicts[0].model_id == "not_in_catalog"
         assert result.verdicts[0].provider_model_id is None
         assert seen_attributes == [{"node_type": _ProbeNode.__name__, "id": "not_in_catalog"}]
 
-    def test_for_node_per_candidate_loop_does_not_trip_recursion_guard(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_for_node_per_candidate_loop_does_not_trip_recursion_guard(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.access_events import (
             QueryModelAccessForNodeRequest,
             QueryModelAccessForNodeResultSuccess,
@@ -255,9 +257,9 @@ class TestAccessManager:
         def record(checkpoint: object) -> None:
             seen_model_ids.append(checkpoint.attributes["id"])  # type: ignore[attr-defined]
 
-        griptape_nodes.EventManager().add_authorization_hook(record)
+        engine.event_manager.add_authorization_hook(record)
         try:
-            result = GriptapeNodes.handle_request(
+            result = engine.handle_request(
                 QueryModelAccessForNodeRequest(
                     node_type=_ProbeNode.__name__,
                     candidate_model_ids=["gtc_claude_opus_4_7", "gtc_claude_sonnet_4_6", "not_in_catalog"],
@@ -265,7 +267,7 @@ class TestAccessManager:
                 )
             )
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(record)
+            engine.event_manager.remove_authorization_hook(record)
 
         assert isinstance(result, QueryModelAccessForNodeResultSuccess)
         # Each candidate produces exactly one verdict and one hook call -- the
@@ -273,7 +275,7 @@ class TestAccessManager:
         assert seen_model_ids == ["gtc_claude_opus_4_7", "gtc_claude_sonnet_4_6", "not_in_catalog"]
         assert [v.model_id for v in result.verdicts] == seen_model_ids
 
-    def test_for_node_action_is_offer_model(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_for_node_action_is_offer_model(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.access_events import QueryModelAccessForNodeRequest
 
         self._register(library_declarations=[self._catalog()])
@@ -283,9 +285,9 @@ class TestAccessManager:
         def record(checkpoint: object) -> None:
             seen_actions.append(checkpoint.action)  # type: ignore[attr-defined]
 
-        griptape_nodes.EventManager().add_authorization_hook(record)
+        engine.event_manager.add_authorization_hook(record)
         try:
-            GriptapeNodes.handle_request(
+            engine.handle_request(
                 QueryModelAccessForNodeRequest(
                     node_type=_ProbeNode.__name__,
                     candidate_model_ids=["gtc_claude_opus_4_7"],
@@ -293,11 +295,11 @@ class TestAccessManager:
                 )
             )
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(record)
+            engine.event_manager.remove_authorization_hook(record)
 
         assert seen_actions == ["OfferModel"]
 
-    def test_for_node_request_derives_model_ids_from_declarations(self, griptape_nodes: GriptapeNodes) -> None:  # noqa: ARG002
+    def test_for_node_request_derives_model_ids_from_declarations(self, engine: Engine) -> None:
         from griptape_nodes.node_library.library_declarations import ModelUsageNodeProperty
         from griptape_nodes.retained_mode.events.access_events import (
             QueryModelAccessForNodeRequest,
@@ -309,13 +311,13 @@ class TestAccessManager:
             library_declarations=[self._catalog()],
         )
 
-        result = GriptapeNodes.handle_request(
+        result = engine.handle_request(
             QueryModelAccessForNodeRequest(node_type=_ProbeNode.__name__, specific_library_name=self._LIBRARY_NAME)
         )
         assert isinstance(result, QueryModelAccessForNodeResultSuccess)
         assert [v.model_id for v in result.verdicts] == ["gtc_claude_opus_4_7"]
 
-    def test_for_node_request_expands_provider_usage(self, griptape_nodes: GriptapeNodes) -> None:  # noqa: ARG002
+    def test_for_node_request_expands_provider_usage(self, engine: Engine) -> None:
         from griptape_nodes.node_library.library_declarations import ModelProviderUsageNodeProperty
         from griptape_nodes.retained_mode.events.access_events import (
             QueryModelAccessForNodeRequest,
@@ -327,7 +329,7 @@ class TestAccessManager:
             library_declarations=[self._catalog()],
         )
 
-        result = GriptapeNodes.handle_request(
+        result = engine.handle_request(
             QueryModelAccessForNodeRequest(node_type=_ProbeNode.__name__, specific_library_name=self._LIBRARY_NAME)
         )
         assert isinstance(result, QueryModelAccessForNodeResultSuccess)
@@ -336,7 +338,7 @@ class TestAccessManager:
 
     def test_for_node_request_with_no_model_declarations_returns_empty_verdicts(
         self,
-        griptape_nodes: GriptapeNodes,  # noqa: ARG002
+        engine: Engine,
     ) -> None:
         from griptape_nodes.retained_mode.events.access_events import (
             QueryModelAccessForNodeRequest,
@@ -345,13 +347,13 @@ class TestAccessManager:
 
         self._register(library_declarations=[self._catalog()])
 
-        result = GriptapeNodes.handle_request(
+        result = engine.handle_request(
             QueryModelAccessForNodeRequest(node_type=_ProbeNode.__name__, specific_library_name=self._LIBRARY_NAME)
         )
         assert isinstance(result, QueryModelAccessForNodeResultSuccess)
         assert result.verdicts == []
 
-    def test_for_node_explicit_candidates_override_declarations(self, griptape_nodes: GriptapeNodes) -> None:  # noqa: ARG002
+    def test_for_node_explicit_candidates_override_declarations(self, engine: Engine) -> None:
         from griptape_nodes.node_library.library_declarations import ModelUsageNodeProperty
         from griptape_nodes.retained_mode.events.access_events import (
             QueryModelAccessForNodeRequest,
@@ -364,7 +366,7 @@ class TestAccessManager:
             library_declarations=[self._catalog()],
         )
 
-        result = GriptapeNodes.handle_request(
+        result = engine.handle_request(
             QueryModelAccessForNodeRequest(
                 node_type=_ProbeNode.__name__,
                 specific_library_name=self._LIBRARY_NAME,
@@ -374,7 +376,7 @@ class TestAccessManager:
         assert isinstance(result, QueryModelAccessForNodeResultSuccess)
         assert [v.model_id for v in result.verdicts] == ["gtc_claude_sonnet_4_6"]
 
-    def test_for_node_preserves_candidate_input_order(self, griptape_nodes: GriptapeNodes) -> None:  # noqa: ARG002
+    def test_for_node_preserves_candidate_input_order(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.access_events import (
             QueryModelAccessForNodeRequest,
             QueryModelAccessForNodeResultSuccess,
@@ -382,7 +384,7 @@ class TestAccessManager:
 
         self._register(library_declarations=[self._catalog()])
 
-        result = GriptapeNodes.handle_request(
+        result = engine.handle_request(
             QueryModelAccessForNodeRequest(
                 node_type=_ProbeNode.__name__,
                 candidate_model_ids=["gtc_claude_sonnet_4_6", "gtc_claude_opus_4_7"],
@@ -392,7 +394,7 @@ class TestAccessManager:
         assert isinstance(result, QueryModelAccessForNodeResultSuccess)
         assert [v.model_id for v in result.verdicts] == ["gtc_claude_sonnet_4_6", "gtc_claude_opus_4_7"]
 
-    def test_for_node_catalog_enrichment_attributes_reach_the_hook(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_for_node_catalog_enrichment_attributes_reach_the_hook(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.access_events import QueryModelAccessForNodeRequest
 
         self._register(library_declarations=[self._catalog()])
@@ -402,9 +404,9 @@ class TestAccessManager:
         def record(checkpoint: object) -> None:
             seen_attributes.append(dict(checkpoint.attributes))  # type: ignore[attr-defined]
 
-        griptape_nodes.EventManager().add_authorization_hook(record)
+        engine.event_manager.add_authorization_hook(record)
         try:
-            GriptapeNodes.handle_request(
+            engine.handle_request(
                 QueryModelAccessForNodeRequest(
                     node_type=_ProbeNode.__name__,
                     candidate_model_ids=["gtc_claude_opus_4_7"],
@@ -412,7 +414,7 @@ class TestAccessManager:
                 )
             )
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(record)
+            engine.event_manager.remove_authorization_hook(record)
 
         assert seen_attributes == [
             {
@@ -425,7 +427,7 @@ class TestAccessManager:
 
     # ---------- Bare request (QueryModelAccessRequest) ----------
 
-    def test_bare_request_no_node_no_catalog_attributes(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_bare_request_no_node_no_catalog_attributes(self, engine: Engine) -> None:
         """Bare request: hook sees `ID` only, even when a library is registered.
 
         The bare form must NOT enrich opportunistically -- it has no library scope
@@ -446,13 +448,13 @@ class TestAccessManager:
         def record(checkpoint: object) -> None:
             seen_attributes.append(dict(checkpoint.attributes))  # type: ignore[attr-defined]
 
-        griptape_nodes.EventManager().add_authorization_hook(record)
+        engine.event_manager.add_authorization_hook(record)
         try:
-            result = GriptapeNodes.handle_request(
+            result = engine.handle_request(
                 QueryModelAccessRequest(candidate_model_ids=["gtc_claude_opus_4_7", "anything"])
             )
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(record)
+            engine.event_manager.remove_authorization_hook(record)
 
         assert isinstance(result, QueryModelAccessResultSuccess)
         # `provider_model_id` is None because the bare form does NOT consult any catalog.
@@ -462,7 +464,7 @@ class TestAccessManager:
             {"id": "anything"},
         ]
 
-    def test_bare_request_hook_can_deny_on_bare_model_id(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_bare_request_hook_can_deny_on_bare_model_id(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.access_events import (
             QueryModelAccessRequest,
             QueryModelAccessResultSuccess,
@@ -474,13 +476,13 @@ class TestAccessManager:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Opus is not in your plan."),))
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(deny)
+        engine.event_manager.add_authorization_hook(deny)
         try:
-            result = GriptapeNodes.handle_request(
+            result = engine.handle_request(
                 QueryModelAccessRequest(candidate_model_ids=["gtc_claude_opus_4_7", "gtc_claude_sonnet_4_6"])
             )
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny)
+            engine.event_manager.remove_authorization_hook(deny)
 
         assert isinstance(result, QueryModelAccessResultSuccess)
         denied = [v for v in result.verdicts if v.denial is not None]
@@ -488,7 +490,7 @@ class TestAccessManager:
 
     # ---------- Catalog-scoped request (QueryModelAccessForCatalogRequest) ----------
 
-    def test_for_catalog_enriches_when_id_resolves(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_for_catalog_enriches_when_id_resolves(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.access_events import QueryModelAccessForCatalogRequest
 
         self._register(library_declarations=[self._catalog()])
@@ -498,16 +500,16 @@ class TestAccessManager:
         def record(checkpoint: object) -> None:
             seen_attributes.append(dict(checkpoint.attributes))  # type: ignore[attr-defined]
 
-        griptape_nodes.EventManager().add_authorization_hook(record)
+        engine.event_manager.add_authorization_hook(record)
         try:
-            GriptapeNodes.handle_request(
+            engine.handle_request(
                 QueryModelAccessForCatalogRequest(
                     library_name=self._LIBRARY_NAME,
                     candidate_model_ids=["gtc_claude_opus_4_7"],
                 )
             )
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(record)
+            engine.event_manager.remove_authorization_hook(record)
 
         # No "node_type" attribute -- catalog-scoped form has no node attribution.
         assert seen_attributes == [
@@ -518,9 +520,7 @@ class TestAccessManager:
             }
         ]
 
-    def test_for_catalog_unknown_library_returns_success_with_bare_verdicts(
-        self, griptape_nodes: GriptapeNodes
-    ) -> None:
+    def test_for_catalog_unknown_library_returns_success_with_bare_verdicts(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.access_events import (
             QueryModelAccessForCatalogRequest,
             QueryModelAccessForCatalogResultSuccess,
@@ -532,16 +532,16 @@ class TestAccessManager:
         def record(checkpoint: object) -> None:
             seen_attributes.append(dict(checkpoint.attributes))  # type: ignore[attr-defined]
 
-        griptape_nodes.EventManager().add_authorization_hook(record)
+        engine.event_manager.add_authorization_hook(record)
         try:
-            result = GriptapeNodes.handle_request(
+            result = engine.handle_request(
                 QueryModelAccessForCatalogRequest(
                     library_name="library-that-does-not-exist",
                     candidate_model_ids=["gtc_claude_opus_4_7"],
                 )
             )
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(record)
+            engine.event_manager.remove_authorization_hook(record)
 
         assert isinstance(result, QueryModelAccessForCatalogResultSuccess)
         assert result.verdicts[0].model_id == "gtc_claude_opus_4_7"
@@ -549,7 +549,7 @@ class TestAccessManager:
         # Hook still got the bare model_id, no enrichment.
         assert seen_attributes == [{"id": "gtc_claude_opus_4_7"}]
 
-    def test_for_catalog_unknown_id_no_enrichment_but_query_still_happens(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_for_catalog_unknown_id_no_enrichment_but_query_still_happens(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.access_events import (
             QueryModelAccessForCatalogRequest,
             QueryModelAccessForCatalogResultSuccess,
@@ -562,16 +562,16 @@ class TestAccessManager:
         def record(checkpoint: object) -> None:
             seen_attributes.append(dict(checkpoint.attributes))  # type: ignore[attr-defined]
 
-        griptape_nodes.EventManager().add_authorization_hook(record)
+        engine.event_manager.add_authorization_hook(record)
         try:
-            result = GriptapeNodes.handle_request(
+            result = engine.handle_request(
                 QueryModelAccessForCatalogRequest(
                     library_name=self._LIBRARY_NAME,
                     candidate_model_ids=["not_in_catalog"],
                 )
             )
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(record)
+            engine.event_manager.remove_authorization_hook(record)
 
         assert isinstance(result, QueryModelAccessForCatalogResultSuccess)
         assert result.verdicts[0].model_id == "not_in_catalog"
@@ -588,7 +588,7 @@ class TestCodecAccess:
     surfaced via a Failure result, not silently defaulted.
     """
 
-    def test_read_direction_uses_read_video_codec_action(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_read_direction_uses_read_video_codec_action(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.access_events import (
             CodecAccessDirection,
             QueryCodecAccessRequest,
@@ -600,18 +600,18 @@ class TestCodecAccess:
         def record(checkpoint: object) -> None:
             seen_actions.append(checkpoint.action)  # type: ignore[attr-defined]
 
-        griptape_nodes.EventManager().add_authorization_hook(record)
+        engine.event_manager.add_authorization_hook(record)
         try:
-            result = GriptapeNodes.handle_request(
+            result = engine.handle_request(
                 QueryCodecAccessRequest(candidate_codecs=["h264"], direction=CodecAccessDirection.READ)
             )
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(record)
+            engine.event_manager.remove_authorization_hook(record)
 
         assert isinstance(result, QueryCodecAccessResultSuccess)
         assert seen_actions == ["ReadVideoCodec"]
 
-    def test_write_direction_uses_write_video_codec_action(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_write_direction_uses_write_video_codec_action(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.access_events import (
             CodecAccessDirection,
             QueryCodecAccessRequest,
@@ -623,18 +623,18 @@ class TestCodecAccess:
         def record(checkpoint: object) -> None:
             seen_actions.append(checkpoint.action)  # type: ignore[attr-defined]
 
-        griptape_nodes.EventManager().add_authorization_hook(record)
+        engine.event_manager.add_authorization_hook(record)
         try:
-            result = GriptapeNodes.handle_request(
+            result = engine.handle_request(
                 QueryCodecAccessRequest(candidate_codecs=["hevc"], direction=CodecAccessDirection.WRITE)
             )
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(record)
+            engine.event_manager.remove_authorization_hook(record)
 
         assert isinstance(result, QueryCodecAccessResultSuccess)
         assert seen_actions == ["WriteVideoCodec"]
 
-    def test_unknown_direction_returns_failure(self, griptape_nodes: GriptapeNodes) -> None:  # noqa: ARG002
+    def test_unknown_direction_returns_failure(self, engine: Engine) -> None:
         # Exercises the runtime `case _:` guard for wire-side stray values --
         # ``direction`` is a StrEnum so pyright catches Python-side typos, but
         # a request deserialized from the WS boundary can still carry any
@@ -645,7 +645,7 @@ class TestCodecAccess:
             QueryCodecAccessResultFailure,
         )
 
-        result = GriptapeNodes.handle_request(
+        result = engine.handle_request(
             QueryCodecAccessRequest(candidate_codecs=["h264"], direction="rewrite")  # type: ignore[arg-type]
         )
 
@@ -655,7 +655,7 @@ class TestCodecAccess:
         assert "read" in details.lower()
         assert "write" in details.lower()
 
-    def test_container_format_threaded_through_checkpoint_attributes(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_container_format_threaded_through_checkpoint_attributes(self, engine: Engine) -> None:
         # A policy that only cares about codec+container pairing (e.g. hevc in
         # mp4 is denied but hevc in mkv is allowed) needs the container to
         # appear on the checkpoint attributes; the request field carries it.
@@ -670,20 +670,20 @@ class TestCodecAccess:
         def record(checkpoint: object) -> None:
             seen_attributes.append(dict(checkpoint.attributes))  # type: ignore[attr-defined]
 
-        griptape_nodes.EventManager().add_authorization_hook(record)
+        engine.event_manager.add_authorization_hook(record)
         try:
-            result = GriptapeNodes.handle_request(
+            result = engine.handle_request(
                 QueryCodecAccessRequest(
                     candidate_codecs=["hevc"], direction=CodecAccessDirection.WRITE, container_format="mp4"
                 )
             )
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(record)
+            engine.event_manager.remove_authorization_hook(record)
 
         assert isinstance(result, QueryCodecAccessResultSuccess)
         assert seen_attributes == [{"id": "hevc", "container_format": "mp4"}]
 
-    def test_container_format_omitted_when_none(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_container_format_omitted_when_none(self, engine: Engine) -> None:
         # When the caller doesn't scope the query to a container, the attribute
         # is not populated -- a policy that requires the pairing key still
         # denies deterministically (missing key), not on a synthesized default.
@@ -697,17 +697,17 @@ class TestCodecAccess:
         def record(checkpoint: object) -> None:
             seen_attributes.append(dict(checkpoint.attributes))  # type: ignore[attr-defined]
 
-        griptape_nodes.EventManager().add_authorization_hook(record)
+        engine.event_manager.add_authorization_hook(record)
         try:
-            GriptapeNodes.handle_request(
+            engine.handle_request(
                 QueryCodecAccessRequest(candidate_codecs=["h264"], direction=CodecAccessDirection.READ)
             )
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(record)
+            engine.event_manager.remove_authorization_hook(record)
 
         assert seen_attributes == [{"id": "h264"}]
 
-    def test_denied_verdict_carries_denial(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_denied_verdict_carries_denial(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.access_events import (
             CodecAccessDirection,
             QueryCodecAccessRequest,
@@ -720,9 +720,9 @@ class TestCodecAccess:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="HEVC write is not in your plan."),))
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(deny_hevc)
+        engine.event_manager.add_authorization_hook(deny_hevc)
         try:
-            result = GriptapeNodes.handle_request(
+            result = engine.handle_request(
                 QueryCodecAccessRequest(
                     candidate_codecs=["h264", "hevc", "vp9"],
                     direction=CodecAccessDirection.WRITE,
@@ -730,7 +730,7 @@ class TestCodecAccess:
                 )
             )
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny_hevc)
+            engine.event_manager.remove_authorization_hook(deny_hevc)
 
         assert isinstance(result, QueryCodecAccessResultSuccess)
         assert [v.codec for v in result.verdicts] == ["h264", "hevc", "vp9"]
@@ -740,7 +740,7 @@ class TestCodecAccess:
         assert all(v.container_format == "mp4" for v in result.verdicts)
 
     def test_id_attribute_parity_between_query_and_enforcement(
-        self, griptape_nodes: GriptapeNodes, monkeypatch: pytest.MonkeyPatch
+        self, engine: Engine, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A single hook keying on attributes["id"] must deny both paths for the same codec.
 
@@ -772,15 +772,15 @@ class TestCodecAccess:
             return None
 
         # --- Query path: QueryCodecAccessRequest ---
-        griptape_nodes.EventManager().add_authorization_hook(deny_hevc_by_id)
+        engine.event_manager.add_authorization_hook(deny_hevc_by_id)
         try:
-            query_result = GriptapeNodes.handle_request(
+            query_result = engine.handle_request(
                 QueryCodecAccessRequest(
                     candidate_codecs=["hevc"], direction=CodecAccessDirection.WRITE, container_format="mp4"
                 )
             )
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny_hevc_by_id)
+            engine.event_manager.remove_authorization_hook(deny_hevc_by_id)
 
         assert isinstance(query_result, QueryCodecAccessResultSuccess)
         assert query_result.verdicts[0].denial is not None
@@ -797,13 +797,13 @@ class TestCodecAccess:
         provider = VideoArtifactProvider(registry=None)  # type: ignore[arg-type]
 
         seen_attributes.clear()
-        griptape_nodes.EventManager().add_authorization_hook(deny_hevc_by_id)
+        engine.event_manager.add_authorization_hook(deny_hevc_by_id)
         try:
             # OSManager stages before calling this; a stand-in path is fine
             # since ffprobe is mocked.
             enforcement_denial = provider.check_write_format_from_path("/tmp/staged.mp4", "mp4")  # noqa: S108
         finally:
-            griptape_nodes.EventManager().remove_authorization_hook(deny_hevc_by_id)
+            engine.event_manager.remove_authorization_hook(deny_hevc_by_id)
 
         # The critical assertion: the enforcement path denies for the SAME
         # hook shape that the query path denies for.

--- a/tests/unit/retained_mode/managers/test_add_nodes_to_group_iterative.py
+++ b/tests/unit/retained_mode/managers/test_add_nodes_to_group_iterative.py
@@ -24,11 +24,11 @@ from griptape_nodes.retained_mode.events.node_events import (
     RemoveNodeFromNodeGroupRequest,
     RemoveNodeFromNodeGroupResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from tests.unit.exe_types.mocks import MockNode
 
 if TYPE_CHECKING:
     from griptape_nodes.exe_types.node_types import AsyncResult, BaseNode
+    from griptape_nodes.retained_mode.engine import Engine
 
 
 # ---------------------------------------------------------------------------
@@ -137,9 +137,9 @@ class _ConcreteSubflowGroup(SubflowNodeGroup):
         pass
 
 
-def _register(obj: BaseNode) -> None:
+def _register(obj: BaseNode, engine: Engine) -> None:
     """Register a node-like object in the ObjectManager so handle_request can find it."""
-    GriptapeNodes.ObjectManager().add_object_by_name(obj.name, obj)
+    engine.object_manager.add_object_by_name(obj.name, obj)
 
 
 # ---------------------------------------------------------------------------
@@ -151,12 +151,13 @@ class TestAddNodesToGroupIterativePath:
     """Verify that AddNodesToNodeGroupRequest auto-includes paired End nodes."""
 
     @pytest.fixture(autouse=True)
-    def _setup_context(self, griptape_nodes: GriptapeNodes) -> None:  # noqa: ARG002
+    def _setup_context(self, engine: Engine) -> None:
         """Push a workflow and flow context so group-operation helpers can find a current flow."""
-        GriptapeNodes.ContextManager().push_workflow(workflow_name="test_workflow")
+        self.engine = engine
+        engine.context_manager.push_workflow(workflow_name="test_workflow")
         flow = ControlFlow(name="test_flow")
-        GriptapeNodes.ObjectManager().add_object_by_name(flow.name, flow)
-        GriptapeNodes.ContextManager().push_flow(flow)
+        engine.object_manager.add_object_by_name(flow.name, flow)
+        engine.context_manager.push_flow(flow)
 
     def _build_paired_nodes(self) -> tuple[_MockIterativeStartNode, _MockIterativeEndNode]:
         """Build a Start/End pair with end_node wired up and both registered."""
@@ -166,14 +167,14 @@ class TestAddNodesToGroupIterativePath:
         # CreateConnectionRequest auto-connects them.
         start.end_node = end
         end.start_node = start
-        _register(start)
-        _register(end)
+        _register(start, self.engine)
+        _register(end, self.engine)
         return start, end
 
     def _build_group(self) -> _ConcreteSubflowGroup:
         """Build a subflow group and register it in the ObjectManager."""
         group = _ConcreteSubflowGroup("TestGroup")
-        _register(group)
+        _register(group, self.engine)
         return group
 
     def test_end_node_is_pulled_into_group_automatically(self) -> None:
@@ -185,7 +186,7 @@ class TestAddNodesToGroupIterativePath:
         start, end = self._build_paired_nodes()
         group = self._build_group()
 
-        result = GriptapeNodes.handle_request(
+        result = self.engine.handle_request(
             AddNodesToNodeGroupRequest(
                 node_names=[start.name],
                 node_group_name=group.name,
@@ -205,7 +206,7 @@ class TestAddNodesToGroupIterativePath:
         start, end = self._build_paired_nodes()
         group = self._build_group()
 
-        result = GriptapeNodes.handle_request(
+        result = self.engine.handle_request(
             AddNodesToNodeGroupRequest(
                 node_names=[end.name],
                 node_group_name=group.name,
@@ -223,8 +224,8 @@ class TestAddNodesToGroupIterativePath:
         """An iterative node with no counterpart wired up must not pull in anything."""
         lone_start = _MockIterativeStartNode("LoneStart")
         lone_end = _MockIterativeEndNode("LoneEnd")
-        _register(lone_start)
-        _register(lone_end)
+        _register(lone_start, self.engine)
+        _register(lone_end, self.engine)
         group = self._build_group()
 
         nodes_added = group.add_nodes_to_group([lone_start, lone_end])
@@ -236,7 +237,7 @@ class TestAddNodesToGroupIterativePath:
         start, end = self._build_paired_nodes()
         group = self._build_group()
 
-        result = GriptapeNodes.handle_request(
+        result = self.engine.handle_request(
             AddNodesToNodeGroupRequest(
                 node_names=[start.name],
                 node_group_name=group.name,
@@ -253,7 +254,7 @@ class TestAddNodesToGroupIterativePath:
         start, end = self._build_paired_nodes()
         group = self._build_group()
 
-        result = GriptapeNodes.handle_request(
+        result = self.engine.handle_request(
             AddNodesToNodeGroupRequest(
                 node_names=[start.name, end.name],
                 node_group_name=group.name,
@@ -272,7 +273,7 @@ class TestAddNodesToGroupIterativePath:
         # Pre-populate the group with the end node only
         group.add_nodes_to_group([end])
 
-        result = GriptapeNodes.handle_request(
+        result = self.engine.handle_request(
             AddNodesToNodeGroupRequest(
                 node_names=[start.name],
                 node_group_name=group.name,
@@ -341,7 +342,7 @@ class TestAddNodesToGroupIterativePath:
         start, end = self._build_paired_nodes()
         group_a = self._build_group()
         group_b = _ConcreteSubflowGroup("TestGroupB")
-        _register(group_b)
+        _register(group_b, self.engine)
         group_a.add_nodes_to_group([start])
 
         nodes_added = group_b.add_nodes_to_group([start])
@@ -355,10 +356,10 @@ class TestAddNodesToGroupIterativePath:
     def test_plain_node_has_no_side_effects(self) -> None:
         """Adding a plain (non-iterative) node does not change the node_names_added list size."""
         plain = MockNode("PlainNode")
-        _register(plain)
+        _register(plain, self.engine)
         group = self._build_group()
 
-        result = GriptapeNodes.handle_request(
+        result = self.engine.handle_request(
             AddNodesToNodeGroupRequest(
                 node_names=[plain.name],
                 node_group_name=group.name,
@@ -374,12 +375,13 @@ class TestRemoveNodesFromGroupIterativePath:
     """Verify that removal is the mirror of addition: the pair leaves the group together."""
 
     @pytest.fixture(autouse=True)
-    def _setup_context(self, griptape_nodes: GriptapeNodes) -> None:  # noqa: ARG002
+    def _setup_context(self, engine: Engine) -> None:
         """Push a workflow and flow context so group-operation helpers can find a current flow."""
-        GriptapeNodes.ContextManager().push_workflow(workflow_name="test_workflow")
+        self.engine = engine
+        engine.context_manager.push_workflow(workflow_name="test_workflow")
         flow = ControlFlow(name="test_flow")
-        GriptapeNodes.ObjectManager().add_object_by_name(flow.name, flow)
-        GriptapeNodes.ContextManager().push_flow(flow)
+        engine.object_manager.add_object_by_name(flow.name, flow)
+        engine.context_manager.push_flow(flow)
 
     def _build_grouped_pair(self) -> tuple[_MockIterativeStartNode, _MockIterativeEndNode, _ConcreteSubflowGroup]:
         """Build a tethered Start/End pair already sitting inside a subflow group."""
@@ -387,10 +389,10 @@ class TestRemoveNodesFromGroupIterativePath:
         end = _MockIterativeEndNode("TestEndNode")
         start.end_node = end
         end.start_node = start
-        _register(start)
-        _register(end)
+        _register(start, self.engine)
+        _register(end, self.engine)
         group = _ConcreteSubflowGroup("TestGroup")
-        _register(group)
+        _register(group, self.engine)
         group.add_nodes_to_group([start])
         return start, end, group
 
@@ -398,7 +400,7 @@ class TestRemoveNodesFromGroupIterativePath:
         """Removing only the Start node must not orphan its End node inside the group."""
         start, end, group = self._build_grouped_pair()
 
-        result = GriptapeNodes.handle_request(
+        result = self.engine.handle_request(
             RemoveNodeFromNodeGroupRequest(
                 node_names=[start.name],
                 node_group_name=group.name,
@@ -417,7 +419,7 @@ class TestRemoveNodesFromGroupIterativePath:
         """Mirror: removing only the End node must also pull its Start node out."""
         start, end, group = self._build_grouped_pair()
 
-        result = GriptapeNodes.handle_request(
+        result = self.engine.handle_request(
             RemoveNodeFromNodeGroupRequest(
                 node_names=[end.name],
                 node_group_name=group.name,
@@ -433,7 +435,7 @@ class TestRemoveNodesFromGroupIterativePath:
         """Naming both halves explicitly removes each exactly once."""
         start, end, group = self._build_grouped_pair()
 
-        result = GriptapeNodes.handle_request(
+        result = self.engine.handle_request(
             RemoveNodeFromNodeGroupRequest(
                 node_names=[start.name, end.name],
                 node_group_name=group.name,
@@ -454,10 +456,10 @@ class TestRemoveNodesFromGroupIterativePath:
         end = _MockIterativeEndNode("TestEndNode")
         start.end_node = end
         end.start_node = start
-        _register(start)
-        _register(end)
+        _register(start, self.engine)
+        _register(end, self.engine)
         group = _ConcreteSubflowGroup("TestGroup")
-        _register(group)
+        _register(group, self.engine)
         group._add_nodes_to_group_dict([start])
 
         nodes_removed = group.remove_nodes_from_group([start])
@@ -469,13 +471,13 @@ class TestRemoveNodesFromGroupIterativePath:
         """Removing a plain (non-iterative) node pulls nothing else out."""
         plain = MockNode("PlainNode")
         other = MockNode("OtherNode")
-        _register(plain)
-        _register(other)
+        _register(plain, self.engine)
+        _register(other, self.engine)
         group = _ConcreteSubflowGroup("TestGroup")
-        _register(group)
+        _register(group, self.engine)
         group.add_nodes_to_group([plain, other])
 
-        result = GriptapeNodes.handle_request(
+        result = self.engine.handle_request(
             RemoveNodeFromNodeGroupRequest(
                 node_names=[plain.name],
                 node_group_name=group.name,
@@ -497,27 +499,28 @@ class TestPlainNodeGroupDoesNotTether:
     """
 
     @pytest.fixture(autouse=True)
-    def _setup_context(self, griptape_nodes: GriptapeNodes) -> None:  # noqa: ARG002
+    def _setup_context(self, engine: Engine) -> None:
         """Push a workflow and flow context so group-operation helpers can find a current flow."""
-        GriptapeNodes.ContextManager().push_workflow(workflow_name="test_workflow")
+        self.engine = engine
+        engine.context_manager.push_workflow(workflow_name="test_workflow")
         flow = ControlFlow(name="test_flow")
-        GriptapeNodes.ObjectManager().add_object_by_name(flow.name, flow)
-        GriptapeNodes.ContextManager().push_flow(flow)
+        engine.object_manager.add_object_by_name(flow.name, flow)
+        engine.context_manager.push_flow(flow)
 
     def _build_paired_nodes(self) -> tuple[_MockIterativeStartNode, _MockIterativeEndNode]:
         start = _MockIterativeStartNode("TestStartNode")
         end = _MockIterativeEndNode("TestEndNode")
         start.end_node = end
         end.start_node = start
-        _register(start)
-        _register(end)
+        _register(start, self.engine)
+        _register(end, self.engine)
         return start, end
 
     def test_plain_group_does_not_pull_in_end_node(self) -> None:
         """Adding a Start node to a plain group leaves its End node alone."""
         start, end = self._build_paired_nodes()
         group = _ConcreteGroup("PlainGroup")
-        _register(group)
+        _register(group, self.engine)
 
         nodes_added = group.add_nodes_to_group([start])
 
@@ -529,7 +532,7 @@ class TestPlainNodeGroupDoesNotTether:
         """Removing a Start node from a plain group leaves its End node in place."""
         start, end = self._build_paired_nodes()
         group = _ConcreteGroup("PlainGroup")
-        _register(group)
+        _register(group, self.engine)
         group.add_nodes_to_group([start, end])
 
         nodes_removed = group.remove_nodes_from_group([start])
@@ -546,9 +549,9 @@ class TestPlainNodeGroupDoesNotTether:
         """
         start, _ = self._build_paired_nodes()
         stranger = MockNode(name="StrangerNode")
-        _register(stranger)
+        _register(stranger, self.engine)
         group = _ConcreteGroup("PlainGroup")
-        _register(group)
+        _register(group, self.engine)
         group.add_nodes_to_group([start])
 
         nodes_removed = group.remove_nodes_from_group([start, stranger])
@@ -565,32 +568,33 @@ class TestCrossGroupMoveKeepsTetheredCompanion:
     """
 
     @pytest.fixture(autouse=True)
-    def _setup_context(self, griptape_nodes: GriptapeNodes) -> None:  # noqa: ARG002
+    def _setup_context(self, engine: Engine) -> None:
         """Push a workflow and flow context so group-operation helpers can find a current flow."""
-        GriptapeNodes.ContextManager().push_workflow(workflow_name="test_workflow")
+        self.engine = engine
+        engine.context_manager.push_workflow(workflow_name="test_workflow")
         flow = ControlFlow(name="test_flow")
-        GriptapeNodes.ObjectManager().add_object_by_name(flow.name, flow)
-        GriptapeNodes.ContextManager().push_flow(flow)
+        engine.object_manager.add_object_by_name(flow.name, flow)
+        engine.context_manager.push_flow(flow)
 
     def _build_paired_nodes(self) -> tuple[_MockIterativeStartNode, _MockIterativeEndNode]:
         start = _MockIterativeStartNode("TestStartNode")
         end = _MockIterativeEndNode("TestEndNode")
         start.end_node = end
         end.start_node = start
-        _register(start)
-        _register(end)
+        _register(start, self.engine)
+        _register(end, self.engine)
         return start, end
 
     def test_plain_destination_absorbs_companion_released_by_subflow_source(self) -> None:
         """A plain group does not tether, but must still keep whatever the source hands it."""
         start, end = self._build_paired_nodes()
         source = _ConcreteSubflowGroup("SourceGroup")
-        _register(source)
+        _register(source, self.engine)
         source.add_nodes_to_group([start])
         assert end.parent_group is source
 
         destination = _ConcreteGroup("DestinationGroup")
-        _register(destination)
+        _register(destination, self.engine)
         nodes_added = destination.add_nodes_to_group([start])
 
         # The companion followed its partner rather than being ejected into no group at all.
@@ -605,11 +609,11 @@ class TestCrossGroupMoveKeepsTetheredCompanion:
         """Same guarantee when both ends are subflow groups, which tether on add as well."""
         start, end = self._build_paired_nodes()
         source = _ConcreteSubflowGroup("SourceGroup")
-        _register(source)
+        _register(source, self.engine)
         source.add_nodes_to_group([start])
 
         destination = _ConcreteSubflowGroup("DestinationGroup")
-        _register(destination)
+        _register(destination, self.engine)
         nodes_added = destination.add_nodes_to_group([start])
 
         assert {n.name for n in nodes_added} == {start.name, end.name}

--- a/tests/unit/retained_mode/managers/test_arbitrary_code_exec_manager.py
+++ b/tests/unit/retained_mode/managers/test_arbitrary_code_exec_manager.py
@@ -1,122 +1,122 @@
+from griptape_nodes.retained_mode.engine import Engine
 from griptape_nodes.retained_mode.events.arbitrary_python_events import (
     RunArbitraryPythonStringRequest,
     RunArbitraryPythonStringResultFailure,
     RunArbitraryPythonStringResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 
 class TestArbitraryCodeExecManager:
-    def test_stdout_captured_as_output(self) -> None:
+    def test_stdout_captured_as_output(self, engine: Engine) -> None:
         """Printed output must be returned as python_output when no variable capture is requested."""
         request = RunArbitraryPythonStringRequest(python_string="print('hello')")
-        result = GriptapeNodes.handle_request(request)
+        result = engine.handle_request(request)
 
         assert isinstance(result, RunArbitraryPythonStringResultSuccess)
         assert result.python_output == "hello\n"
 
-    def test_no_stdout_returns_empty_string(self) -> None:
+    def test_no_stdout_returns_empty_string(self, engine: Engine) -> None:
         """Code that produces no output must yield an empty string, not None or an error."""
         request = RunArbitraryPythonStringRequest(python_string="x = 1 + 1")
-        result = GriptapeNodes.handle_request(request)
+        result = engine.handle_request(request)
 
         assert isinstance(result, RunArbitraryPythonStringResultSuccess)
         assert result.python_output == ""
 
-    def test_ansi_codes_stripped_from_stdout(self) -> None:
+    def test_ansi_codes_stripped_from_stdout(self, engine: Engine) -> None:
         """ANSI codes in printed output must be stripped before returning."""
         ansi_red = "\x1b[31m"
         ansi_reset = "\x1b[0m"
         request = RunArbitraryPythonStringRequest(python_string=f"print('{ansi_red}red{ansi_reset}')")
-        result = GriptapeNodes.handle_request(request)
+        result = engine.handle_request(request)
 
         assert isinstance(result, RunArbitraryPythonStringResultSuccess)
         assert result.python_output == "red\n"
 
-    def test_local_variable_capture_returns_both_stdout_and_value(self) -> None:
+    def test_local_variable_capture_returns_both_stdout_and_value(self, engine: Engine) -> None:
         """When capturing a variable, stdout is still surfaced and the captured value lives in found_variable_values."""
         request = RunArbitraryPythonStringRequest(
             python_string="print('hello')\nresult = 'captured'",
             variable_names_to_capture=["result"],
         )
-        result = GriptapeNodes.handle_request(request)
+        result = engine.handle_request(request)
 
         assert isinstance(result, RunArbitraryPythonStringResultSuccess)
         assert result.python_output == "hello\n"
         assert result.found_variable_values == {"result": "captured"}
         assert result.missing_variables == []
 
-    def test_missing_local_variable_reported_in_missing_variables(self) -> None:
+    def test_missing_local_variable_reported_in_missing_variables(self, engine: Engine) -> None:
         """Requesting a variable that was never set must succeed with the name listed in missing_variables."""
         request = RunArbitraryPythonStringRequest(
             python_string="x = 1",
             variable_names_to_capture=["nonexistent"],
         )
-        result = GriptapeNodes.handle_request(request)
+        result = engine.handle_request(request)
 
         assert isinstance(result, RunArbitraryPythonStringResultSuccess)
         assert result.found_variable_values == {}
         assert result.missing_variables == ["nonexistent"]
 
-    def test_partial_capture_splits_found_and_missing(self) -> None:
+    def test_partial_capture_splits_found_and_missing(self, engine: Engine) -> None:
         """When some requested names exist and others don't, found and missing must split cleanly."""
         request = RunArbitraryPythonStringRequest(
             python_string="a = 1",
             variable_names_to_capture=["a", "missing_a", "missing_b"],
         )
-        result = GriptapeNodes.handle_request(request)
+        result = engine.handle_request(request)
 
         assert isinstance(result, RunArbitraryPythonStringResultSuccess)
         assert result.found_variable_values == {"a": 1}
         assert result.missing_variables == ["missing_a", "missing_b"]
 
-    def test_exec_exception_returns_failure(self) -> None:
+    def test_exec_exception_returns_failure(self, engine: Engine) -> None:
         """An exception raised during exec must return a failure with the error message."""
         request = RunArbitraryPythonStringRequest(python_string="raise ValueError('boom')")
-        result = GriptapeNodes.handle_request(request)
+        result = engine.handle_request(request)
 
         assert isinstance(result, RunArbitraryPythonStringResultFailure)
         assert "ERROR:" in result.python_output
         assert "boom" in result.python_output
 
-    def test_syntax_error_returns_failure(self) -> None:
+    def test_syntax_error_returns_failure(self, engine: Engine) -> None:
         """A syntax error in the submitted code must return a failure, not raise inside the manager."""
         request = RunArbitraryPythonStringRequest(python_string="def bad(: pass")
-        result = GriptapeNodes.handle_request(request)
+        result = engine.handle_request(request)
 
         assert isinstance(result, RunArbitraryPythonStringResultFailure)
         assert "ERROR:" in result.python_output
 
-    def test_recursive_function_works(self) -> None:
+    def test_recursive_function_works(self, engine: Engine) -> None:
         """Recursive functions defined in exec'd code must be able to call themselves."""
         code = "def fact(n): return 1 if n <= 1 else n * fact(n - 1)\nresult = fact(5)"
         request = RunArbitraryPythonStringRequest(
             python_string=code,
             variable_names_to_capture=["result"],
         )
-        result = GriptapeNodes.handle_request(request)
+        result = engine.handle_request(request)
 
         assert isinstance(result, RunArbitraryPythonStringResultSuccess)
         assert result.found_variable_values == {"result": 120}  # 5!
 
-    def test_outer_scope_isolated(self) -> None:
+    def test_outer_scope_isolated(self, engine: Engine) -> None:
         """Exec'd code must not be able to access variables from the calling scope."""
         request = RunArbitraryPythonStringRequest(
             python_string=("try:\n    _ = string_buffer\n    result = False\nexcept NameError:\n    result = True"),
             variable_names_to_capture=["result"],
         )
-        result = GriptapeNodes.handle_request(request)
+        result = engine.handle_request(request)
 
         assert isinstance(result, RunArbitraryPythonStringResultSuccess)
         assert result.found_variable_values == {"result": True}
 
-    def test_multiple_variables_captured_as_dict(self) -> None:
+    def test_multiple_variables_captured_as_dict(self, engine: Engine) -> None:
         """Multiple variable names must return a dict mapping each name to its native value."""
         request = RunArbitraryPythonStringRequest(
             python_string="a = 1\nb = 'hello'\nc = [1, 2, 3]",
             variable_names_to_capture=["a", "b", "c"],
         )
-        result = GriptapeNodes.handle_request(request)
+        result = engine.handle_request(request)
 
         assert isinstance(result, RunArbitraryPythonStringResultSuccess)
         assert result.found_variable_values == {"a": 1, "b": "hello", "c": [1, 2, 3]}

--- a/tests/unit/retained_mode/managers/test_artifact_manager.py
+++ b/tests/unit/retained_mode/managers/test_artifact_manager.py
@@ -36,7 +36,6 @@ from griptape_nodes.retained_mode.events.artifact_events import (
 from griptape_nodes.retained_mode.events.base_events import RequestPayload, ResultPayload
 from griptape_nodes.retained_mode.events.config_events import SetConfigValueResultSuccess
 from griptape_nodes.retained_mode.events.project_events import MacroPath
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.artifact_manager import ArtifactManager, PreviewMetadata
 from griptape_nodes.retained_mode.managers.artifact_providers import (
     BaseArtifactProvider,
@@ -719,14 +718,14 @@ class TestGeneratePreview:
             yield Path(tmpdir)
 
     @pytest.fixture
-    def mock_project(self, temp_dir: Path) -> None:
+    def mock_project(self, temp_dir: Path, engine: Engine) -> None:
         """Set up a real project in ProjectManager with temp_dir as workspace."""
         from griptape_nodes.common.project_templates import ProjectValidationInfo, ProjectValidationStatus
         from griptape_nodes.common.project_templates.default_project_template import DEFAULT_PROJECT_TEMPLATE
         from griptape_nodes.retained_mode.managers.project_manager import ProjectInfo
 
         # Get ProjectManager singleton
-        project_manager = GriptapeNodes.ProjectManager()
+        project_manager = engine.project_manager
 
         # Parse macros for the template
         validation = ProjectValidationInfo(status=ProjectValidationStatus.GOOD)
@@ -770,14 +769,14 @@ class TestGeneratePreview:
         return MacroPath(parsed_macro=parsed_macro, variables={})
 
     @pytest.fixture
-    def artifact_manager(self, mock_project: None, temp_dir: Path) -> ArtifactManager:  # noqa: ARG002
+    def artifact_manager(self, mock_project: None, temp_dir: Path, engine: Engine) -> ArtifactManager:  # noqa: ARG002
         """Create ArtifactManager instance with ImageArtifactProvider registered."""
         manager = ArtifactManager()
         # Register ImageArtifactProvider (no longer auto-registered)
         request = RegisterArtifactProviderRequest(provider_class=ImageArtifactProvider)
         manager.on_handle_register_artifact_provider_request(request)
         # Set workspace_path after provider registration since registration triggers load_configs()
-        GriptapeNodes.ConfigManager().workspace_path = temp_dir
+        engine.config_manager.workspace_path = temp_dir
         return manager
 
     @pytest.mark.asyncio
@@ -1035,13 +1034,13 @@ class TestPreviewMetadataDoesNotCreateSidecar:
             yield Path(tmpdir)
 
     @pytest.fixture
-    def mock_project(self, temp_dir: Path) -> None:
+    def mock_project(self, temp_dir: Path, engine: Engine) -> None:
         """Set up a real project in ProjectManager with temp_dir as workspace."""
         from griptape_nodes.common.project_templates import ProjectValidationInfo, ProjectValidationStatus
         from griptape_nodes.common.project_templates.default_project_template import DEFAULT_PROJECT_TEMPLATE
         from griptape_nodes.retained_mode.managers.project_manager import ProjectInfo
 
-        project_manager = GriptapeNodes.ProjectManager()
+        project_manager = engine.project_manager
 
         validation = ProjectValidationInfo(status=ProjectValidationStatus.GOOD)
         situation_schemas = project_manager._parse_situation_macros(DEFAULT_PROJECT_TEMPLATE.situations, validation)
@@ -1075,12 +1074,12 @@ class TestPreviewMetadataDoesNotCreateSidecar:
         return MacroPath(parsed_macro=parsed_macro, variables={})
 
     @pytest.fixture
-    def artifact_manager(self, mock_project: None, temp_dir: Path) -> ArtifactManager:  # noqa: ARG002
+    def artifact_manager(self, mock_project: None, temp_dir: Path, engine: Engine) -> ArtifactManager:  # noqa: ARG002
         """Create ArtifactManager instance with ImageArtifactProvider registered."""
         manager = ArtifactManager()
         request = RegisterArtifactProviderRequest(provider_class=ImageArtifactProvider)
         manager.on_handle_register_artifact_provider_request(request)
-        GriptapeNodes.ConfigManager().workspace_path = temp_dir
+        engine.config_manager.workspace_path = temp_dir
         return manager
 
     @pytest.mark.asyncio
@@ -1157,14 +1156,14 @@ class TestGetPreviewForArtifact:
             yield Path(tmpdir)
 
     @pytest.fixture
-    def mock_project(self, temp_dir: Path) -> None:
+    def mock_project(self, temp_dir: Path, engine: Engine) -> None:
         """Set up a real project in ProjectManager with temp_dir as workspace."""
         from griptape_nodes.common.project_templates import ProjectValidationInfo, ProjectValidationStatus
         from griptape_nodes.common.project_templates.default_project_template import DEFAULT_PROJECT_TEMPLATE
         from griptape_nodes.retained_mode.managers.project_manager import ProjectInfo
 
         # Get ProjectManager singleton
-        project_manager = GriptapeNodes.ProjectManager()
+        project_manager = engine.project_manager
 
         # Parse macros for the template
         validation = ProjectValidationInfo(status=ProjectValidationStatus.GOOD)
@@ -1204,14 +1203,14 @@ class TestGetPreviewForArtifact:
         return MacroPath(parsed_macro=parsed_macro, variables={})
 
     @pytest.fixture
-    def artifact_manager(self, mock_project: None, temp_dir: Path) -> ArtifactManager:  # noqa: ARG002
+    def artifact_manager(self, mock_project: None, temp_dir: Path, engine: Engine) -> ArtifactManager:  # noqa: ARG002
         """Create ArtifactManager with ImageArtifactProvider registered."""
         manager = ArtifactManager()
         # Register ImageArtifactProvider (no longer auto-registered)
         request = RegisterArtifactProviderRequest(provider_class=ImageArtifactProvider)
         manager.on_handle_register_artifact_provider_request(request)
         # Set workspace_path after provider registration since registration triggers load_configs()
-        GriptapeNodes.ConfigManager().workspace_path = temp_dir
+        engine.config_manager.workspace_path = temp_dir
         return manager
 
     @pytest.fixture
@@ -1700,7 +1699,7 @@ class TestProviderRegistrationConfigLogLevels:
     are expected and should not produce ERROR-level logs that alarm users.
     """
 
-    def test_read_generator_config_uses_debug_failure_log_level(self) -> None:
+    def test_read_generator_config_uses_debug_failure_log_level(self, engine: Engine) -> None:
         """Test that _read_generator_config uses failure_log_level=DEBUG in GetConfigCategoryRequest."""
         import logging
 
@@ -1716,7 +1715,7 @@ class TestProviderRegistrationConfigLogLevels:
 
         def capture_requests(request: RequestPayload) -> ResultPayload:
             captured_requests.append(request)
-            return GriptapeNodes.handle_request(request)
+            return engine.handle_request(request)
 
         manager.engine.handle_request = capture_requests
         manager._read_generator_config(ImageArtifactProvider, PILThumbnailGenerator)
@@ -1725,7 +1724,7 @@ class TestProviderRegistrationConfigLogLevels:
         assert len(category_requests) == 1
         assert category_requests[0].failure_log_level == logging.DEBUG
 
-    def test_validate_and_write_provider_settings_uses_debug_failure_log_level(self) -> None:
+    def test_validate_and_write_provider_settings_uses_debug_failure_log_level(self, engine: Engine) -> None:
         """Test that _validate_and_write_provider_settings uses failure_log_level=DEBUG."""
         import logging
 
@@ -1738,7 +1737,7 @@ class TestProviderRegistrationConfigLogLevels:
 
         def capture_requests(request: RequestPayload) -> ResultPayload:
             captured_requests.append(request)
-            return GriptapeNodes.handle_request(request)
+            return engine.handle_request(request)
 
         manager.engine.handle_request = capture_requests
         manager._validate_and_write_provider_settings(ImageArtifactProvider)

--- a/tests/unit/retained_mode/managers/test_context_manager.py
+++ b/tests/unit/retained_mode/managers/test_context_manager.py
@@ -415,7 +415,7 @@ class TestWorkflowWorkingDirectory:
                 )
                 assert isinstance(result, SetWorkflowContextSuccess)
 
-                with caplog.at_level(logging.WARNING, logger="engine"):
+                with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
                     self._resolve_outputs(engine)
 
                 warnings = [r for r in caplog.records if r.levelno == logging.WARNING]

--- a/tests/unit/retained_mode/managers/test_context_manager.py
+++ b/tests/unit/retained_mode/managers/test_context_manager.py
@@ -26,9 +26,9 @@ from griptape_nodes.retained_mode.events.project_events import (
 class TestPushWorkflow:
     """Tests for ContextManager.push_workflow."""
 
-    def test_push_workflow_with_name(self, griptape_nodes: Engine) -> None:
+    def test_push_workflow_with_name(self, engine: Engine) -> None:
         """workflow_name is used directly as the registry key."""
-        context_manager = griptape_nodes.ContextManager()
+        context_manager = engine.context_manager
         result = context_manager.push_workflow(workflow_name="my_workflow")
 
         assert result == "my_workflow"
@@ -36,10 +36,10 @@ class TestPushWorkflow:
 
         context_manager.pop_workflow()
 
-    def test_push_workflow_with_file_path_inside_workspace(self, griptape_nodes: Engine) -> None:
+    def test_push_workflow_with_file_path_inside_workspace(self, engine: Engine) -> None:
         """file_path inside workspace produces a workspace-relative registry key."""
-        context_manager = griptape_nodes.ContextManager()
-        config_manager = griptape_nodes.ConfigManager()
+        context_manager = engine.context_manager
+        config_manager = engine.config_manager
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             workspace = Path(tmp_dir)
@@ -56,10 +56,10 @@ class TestPushWorkflow:
 
         context_manager.pop_workflow()
 
-    def test_push_workflow_with_file_path_outside_workspace(self, griptape_nodes: Engine) -> None:
+    def test_push_workflow_with_file_path_outside_workspace(self, engine: Engine) -> None:
         """file_path outside workspace uses the absolute path as the registry key."""
-        context_manager = griptape_nodes.ContextManager()
-        config_manager = griptape_nodes.ConfigManager()
+        context_manager = engine.context_manager
+        config_manager = engine.config_manager
 
         with tempfile.TemporaryDirectory() as workspace_dir, tempfile.TemporaryDirectory() as other_dir:
             workspace = Path(workspace_dir)
@@ -77,15 +77,15 @@ class TestPushWorkflow:
 
         context_manager.pop_workflow()
 
-    def test_push_workflow_retains_file_path_independent_of_workspace(self, griptape_nodes: Engine) -> None:
+    def test_push_workflow_retains_file_path_independent_of_workspace(self, engine: Engine) -> None:
         """The pushed file path is retained verbatim and does NOT move with the workspace.
 
         Regression guard: the registry key is derived against whatever workspace is active at
         push time, so switching projects re-registers workflows under a new key and the name
         goes stale. The retained path is what lets `workflow_dir` keep answering afterwards.
         """
-        context_manager = griptape_nodes.ContextManager()
-        config_manager = griptape_nodes.ConfigManager()
+        context_manager = engine.context_manager
+        config_manager = engine.config_manager
 
         with tempfile.TemporaryDirectory() as workspace_dir, tempfile.TemporaryDirectory() as other_dir:
             original = config_manager.workspace_path
@@ -103,14 +103,14 @@ class TestPushWorkflow:
                 config_manager.workspace_path = original
                 context_manager.pop_workflow()
 
-    def test_push_workflow_by_name_captures_path_while_key_is_valid(self, griptape_nodes: Engine) -> None:
+    def test_push_workflow_by_name_captures_path_while_key_is_valid(self, engine: Engine) -> None:
         """Entering by key resolves the path immediately, not lazily at read time.
 
         A key only resolves against the workspace active right now, so deferring the lookup
         would leave nothing to answer with once the workspace changes. An unregistered name
         legitimately has no path.
         """
-        context_manager = griptape_nodes.ContextManager()
+        context_manager = engine.context_manager
 
         context_manager.push_workflow(workflow_name="not_registered_anywhere")
         try:
@@ -118,7 +118,7 @@ class TestPushWorkflow:
         finally:
             context_manager.pop_workflow()
 
-    def test_push_workflow_by_name_resolves_registered_path_and_keeps_it(self, griptape_nodes: Engine) -> None:
+    def test_push_workflow_by_name_resolves_registered_path_and_keeps_it(self, engine: Engine) -> None:
         """A registered workflow entered by key gets its complete path cached, and keeps it.
 
         This is the branch the interactive open-workflow flow takes for every already-saved
@@ -127,8 +127,8 @@ class TestPushWorkflow:
         active right now, so the workspace switch below would otherwise leave nothing to answer
         with.
         """
-        context_manager = griptape_nodes.ContextManager()
-        config_manager = griptape_nodes.ConfigManager()
+        context_manager = engine.context_manager
+        config_manager = engine.config_manager
 
         with tempfile.TemporaryDirectory() as workspace_dir, tempfile.TemporaryDirectory() as other_dir:
             workspace = Path(workspace_dir)
@@ -165,31 +165,31 @@ class TestPushWorkflow:
             finally:
                 config_manager.workspace_path = original
 
-    def test_get_current_workflow_file_path_requires_a_workflow(self, griptape_nodes: Engine) -> None:
+    def test_get_current_workflow_file_path_requires_a_workflow(self, engine: Engine) -> None:
         """Asking outside a workflow context is an error, matching get_current_workflow_name."""
-        context_manager = griptape_nodes.ContextManager()
+        context_manager = engine.context_manager
 
         with pytest.raises(context_manager.NoActiveWorkflowError):
             context_manager.get_current_workflow_file_path()
 
-    def test_push_workflow_raises_when_both_provided(self, griptape_nodes: Engine) -> None:
+    def test_push_workflow_raises_when_both_provided(self, engine: Engine) -> None:
         """Raises ValueError when both workflow_name and file_path are given."""
-        context_manager = griptape_nodes.ContextManager()
+        context_manager = engine.context_manager
 
         with pytest.raises(ValueError, match="not both"):
             context_manager.push_workflow(workflow_name="my_workflow", file_path="/some/path.py")
 
-    def test_push_workflow_raises_when_neither_provided(self, griptape_nodes: Engine) -> None:
+    def test_push_workflow_raises_when_neither_provided(self, engine: Engine) -> None:
         """Raises ValueError when neither workflow_name nor file_path is given."""
-        context_manager = griptape_nodes.ContextManager()
+        context_manager = engine.context_manager
 
         with pytest.raises(ValueError, match="must be provided"):
             context_manager.push_workflow()
 
-    def test_push_workflow_strips_extension(self, griptape_nodes: Engine) -> None:
+    def test_push_workflow_strips_extension(self, engine: Engine) -> None:
         """Registry key derived from file_path has no file extension."""
-        context_manager = griptape_nodes.ContextManager()
-        config_manager = griptape_nodes.ConfigManager()
+        context_manager = engine.context_manager
+        config_manager = engine.config_manager
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             workspace = Path(tmp_dir)
@@ -217,18 +217,18 @@ class TestWorkflowWorkingDirectory:
     the engine can answer with the intended folder in the meantime.
     """
 
-    def _resolve_outputs(self, griptape_nodes: Engine) -> Path:
+    def _resolve_outputs(self, engine: Engine) -> Path:
         """Resolve `{workflow_dir?:/}outputs/img.png` the way a saving node would."""
-        result = griptape_nodes.handle_request(
+        result = engine.handle_request(
             GetPathForMacroRequest(parsed_macro=ParsedMacro("{workflow_dir?:/}outputs/img.png"), variables={})
         )
         assert isinstance(result, GetPathForMacroResultSuccess)
         return result.absolute_path
 
-    def test_unsaved_workflow_outputs_land_in_the_supplied_folder(self, griptape_nodes: Engine) -> None:
+    def test_unsaved_workflow_outputs_land_in_the_supplied_folder(self, engine: Engine) -> None:
         """The whole point: an unsaved workflow's outputs resolve under the folder it was created in."""
-        context_manager = griptape_nodes.ContextManager()
-        config_manager = griptape_nodes.ConfigManager()
+        context_manager = engine.context_manager
+        config_manager = engine.config_manager
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             workspace = Path(tmp_dir).resolve()
@@ -237,7 +237,7 @@ class TestWorkflowWorkingDirectory:
             original = config_manager.workspace_path
             config_manager.workspace_path = workspace
             try:
-                result = griptape_nodes.handle_request(
+                result = engine.handle_request(
                     SetWorkflowContextRequest(display_name="Untitled", working_directory=str(browsed))
                 )
                 assert isinstance(result, SetWorkflowContextSuccess)
@@ -245,73 +245,73 @@ class TestWorkflowWorkingDirectory:
                 assert result.workflow_name.startswith(WorkflowRegistry.UNSAVED_KEY_PREFIX)
                 assert context_manager.get_current_workflow_file_path() is None
 
-                assert self._resolve_outputs(griptape_nodes) == browsed / "outputs" / "img.png"
+                assert self._resolve_outputs(engine) == browsed / "outputs" / "img.png"
             finally:
                 config_manager.workspace_path = original
                 while context_manager.has_current_workflow():
                     context_manager.pop_workflow()
 
-    def test_omitting_the_folder_keeps_the_workspace_root_fallback(self, griptape_nodes: Engine) -> None:
+    def test_omitting_the_folder_keeps_the_workspace_root_fallback(self, engine: Engine) -> None:
         """The field is optional, so the pre-existing behavior has to survive untouched.
 
         Only one of the places the editor creates a workflow has a folder to offer; the others
         pass a display name and nothing else.
         """
-        context_manager = griptape_nodes.ContextManager()
-        config_manager = griptape_nodes.ConfigManager()
+        context_manager = engine.context_manager
+        config_manager = engine.config_manager
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             workspace = Path(tmp_dir).resolve()
             original = config_manager.workspace_path
             config_manager.workspace_path = workspace
             try:
-                result = griptape_nodes.handle_request(SetWorkflowContextRequest(display_name="Untitled"))
+                result = engine.handle_request(SetWorkflowContextRequest(display_name="Untitled"))
                 assert isinstance(result, SetWorkflowContextSuccess)
                 assert context_manager.get_current_workflow_working_directory() is None
 
-                assert self._resolve_outputs(griptape_nodes) == workspace / "outputs" / "img.png"
+                assert self._resolve_outputs(engine) == workspace / "outputs" / "img.png"
             finally:
                 config_manager.workspace_path = original
                 while context_manager.has_current_workflow():
                     context_manager.pop_workflow()
 
-    def test_relative_folder_is_anchored_to_the_workspace(self, griptape_nodes: Engine) -> None:
+    def test_relative_folder_is_anchored_to_the_workspace(self, engine: Engine) -> None:
         """A relative folder resolves against the workspace, not the process working directory.
 
         The path a caller holds is often built from the project base directory, which sits a
         level above the workspace that macro resolution is relative to, so the value is
         normalized on the way in rather than being trusted as-is.
         """
-        context_manager = griptape_nodes.ContextManager()
-        config_manager = griptape_nodes.ConfigManager()
+        context_manager = engine.context_manager
+        config_manager = engine.config_manager
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             workspace = Path(tmp_dir).resolve()
             original = config_manager.workspace_path
             config_manager.workspace_path = workspace
             try:
-                result = griptape_nodes.handle_request(
+                result = engine.handle_request(
                     SetWorkflowContextRequest(display_name="Untitled", working_directory="shots/sh020")
                 )
                 assert isinstance(result, SetWorkflowContextSuccess)
 
                 expected = workspace / "shots" / "sh020"
                 assert context_manager.get_current_workflow_working_directory() == str(expected)
-                assert self._resolve_outputs(griptape_nodes) == expected / "outputs" / "img.png"
+                assert self._resolve_outputs(engine) == expected / "outputs" / "img.png"
             finally:
                 config_manager.workspace_path = original
                 while context_manager.has_current_workflow():
                     context_manager.pop_workflow()
 
-    def test_saved_location_wins_over_the_supplied_folder(self, griptape_nodes: Engine) -> None:
+    def test_saved_location_wins_over_the_supplied_folder(self, engine: Engine) -> None:
         """Saving elsewhere repoints `{workflow_dir}`; the creation folder does not linger.
 
         The folder is only an answer for a workflow with no file of its own. Once there is a
         file -- and the user may well have saved it somewhere other than where they started --
         that file's own directory is the better answer.
         """
-        context_manager = griptape_nodes.ContextManager()
-        config_manager = griptape_nodes.ConfigManager()
+        context_manager = engine.context_manager
+        config_manager = engine.config_manager
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             workspace = Path(tmp_dir).resolve()
@@ -320,31 +320,31 @@ class TestWorkflowWorkingDirectory:
             original = config_manager.workspace_path
             config_manager.workspace_path = workspace
             try:
-                result = griptape_nodes.handle_request(
+                result = engine.handle_request(
                     SetWorkflowContextRequest(display_name="Untitled", working_directory=str(browsed))
                 )
                 assert isinstance(result, SetWorkflowContextSuccess)
-                assert self._resolve_outputs(griptape_nodes) == browsed / "outputs" / "img.png"
+                assert self._resolve_outputs(engine) == browsed / "outputs" / "img.png"
 
                 # What the save path does once the workflow gets a file.
                 saved_to = workspace / "elsewhere" / "my_flow.py"
                 context_manager.set_current_workflow_file_path(str(saved_to))
 
-                assert self._resolve_outputs(griptape_nodes) == saved_to.parent / "outputs" / "img.png"
+                assert self._resolve_outputs(engine) == saved_to.parent / "outputs" / "img.png"
             finally:
                 config_manager.workspace_path = original
                 while context_manager.has_current_workflow():
                     context_manager.pop_workflow()
 
-    def test_supplying_a_file_as_the_folder_is_refused(self, griptape_nodes: Engine) -> None:
+    def test_supplying_a_file_as_the_folder_is_refused(self, engine: Engine) -> None:
         """A file where a folder was meant fails loudly rather than writing beside the file.
 
         The value becomes the parent of everything the workflow writes, so accepting a file
         would silently put outputs next to it -- a plausible location, which is exactly what
         makes it hard to notice.
         """
-        context_manager = griptape_nodes.ContextManager()
-        config_manager = griptape_nodes.ConfigManager()
+        context_manager = engine.context_manager
+        config_manager = engine.config_manager
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             workspace = Path(tmp_dir)
@@ -353,7 +353,7 @@ class TestWorkflowWorkingDirectory:
             original = config_manager.workspace_path
             config_manager.workspace_path = workspace
             try:
-                result = griptape_nodes.handle_request(
+                result = engine.handle_request(
                     SetWorkflowContextRequest(display_name="Untitled", working_directory=str(not_a_folder))
                 )
 
@@ -365,14 +365,14 @@ class TestWorkflowWorkingDirectory:
                 while context_manager.has_current_workflow():
                     context_manager.pop_workflow()
 
-    def test_folder_need_not_exist_yet(self, griptape_nodes: Engine) -> None:
+    def test_folder_need_not_exist_yet(self, engine: Engine) -> None:
         """A folder that has not been created yet is accepted.
 
         Project directories are created on demand at write time, so requiring the folder to
         exist up front would reject the ordinary case of creating a workflow in a new folder.
         """
-        context_manager = griptape_nodes.ContextManager()
-        config_manager = griptape_nodes.ConfigManager()
+        context_manager = engine.context_manager
+        config_manager = engine.config_manager
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             workspace = Path(tmp_dir).resolve()
@@ -380,19 +380,19 @@ class TestWorkflowWorkingDirectory:
             original = config_manager.workspace_path
             config_manager.workspace_path = workspace
             try:
-                result = griptape_nodes.handle_request(
+                result = engine.handle_request(
                     SetWorkflowContextRequest(display_name="Untitled", working_directory=str(not_yet))
                 )
 
                 assert isinstance(result, SetWorkflowContextSuccess)
-                assert self._resolve_outputs(griptape_nodes) == not_yet / "outputs" / "img.png"
+                assert self._resolve_outputs(engine) == not_yet / "outputs" / "img.png"
             finally:
                 config_manager.workspace_path = original
                 while context_manager.has_current_workflow():
                     context_manager.pop_workflow()
 
     def test_folder_silences_the_unresolved_workflow_dir_warning(
-        self, griptape_nodes: Engine, caplog: pytest.LogCaptureFixture
+        self, engine: Engine, caplog: pytest.LogCaptureFixture
     ) -> None:
         """With a folder to answer with, `{workflow_dir?:/}` no longer degrades.
 
@@ -400,8 +400,8 @@ class TestWorkflowWorkingDirectory:
         than an obvious error, so the absence of the warning is the signal that nothing was
         dropped.
         """
-        context_manager = griptape_nodes.ContextManager()
-        config_manager = griptape_nodes.ConfigManager()
+        context_manager = engine.context_manager
+        config_manager = engine.config_manager
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             workspace = Path(tmp_dir)
@@ -410,13 +410,13 @@ class TestWorkflowWorkingDirectory:
             original = config_manager.workspace_path
             config_manager.workspace_path = workspace
             try:
-                result = griptape_nodes.handle_request(
+                result = engine.handle_request(
                     SetWorkflowContextRequest(display_name="Untitled", working_directory=str(browsed))
                 )
                 assert isinstance(result, SetWorkflowContextSuccess)
 
-                with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
-                    self._resolve_outputs(griptape_nodes)
+                with caplog.at_level(logging.WARNING, logger="engine"):
+                    self._resolve_outputs(engine)
 
                 warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
                 assert not warnings, f"Expected no degradation warnings but got: {[r.getMessage() for r in warnings]}"
@@ -425,9 +425,9 @@ class TestWorkflowWorkingDirectory:
                 while context_manager.has_current_workflow():
                     context_manager.pop_workflow()
 
-    def test_get_working_directory_requires_a_workflow(self, griptape_nodes: Engine) -> None:
+    def test_get_working_directory_requires_a_workflow(self, engine: Engine) -> None:
         """Asking outside a workflow context is an error, matching the other context accessors."""
-        context_manager = griptape_nodes.ContextManager()
+        context_manager = engine.context_manager
 
         with pytest.raises(context_manager.NoActiveWorkflowError):
             context_manager.get_current_workflow_working_directory()
@@ -436,11 +436,11 @@ class TestWorkflowWorkingDirectory:
 class TestGeneratedWorkflowCode:
     """Tests that generated workflow code uses push_workflow(file_path=__file__)."""
 
-    def test_generated_code_uses_file_path_not_workflow_name(self, griptape_nodes: Engine) -> None:
+    def test_generated_code_uses_file_path_not_workflow_name(self, engine: Engine) -> None:
         """_generate_workflow_run_prerequisite_code emits push_workflow(file_path=__file__)."""
         from griptape_nodes.retained_mode.managers.workflow_manager import ImportRecorder
 
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         import_recorder = ImportRecorder()
         code_blocks = workflow_manager._generate_workflow_run_prerequisite_code(
             import_recorder=import_recorder,
@@ -459,20 +459,20 @@ class TestGeneratedWorkflowCode:
 class TestEnsureWorkflowAndFlowRequest:
     """Tests for ContextManager.on_ensure_workflow_and_flow_request."""
 
-    def _cleanup(self, griptape_nodes: Engine) -> None:
+    def _cleanup(self, engine: Engine) -> None:
         """Tear down any workflow/flow state left over between tests."""
         from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
 
-        griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
 
-    def test_creates_workflow_and_flow_from_cold_start(self, griptape_nodes: Engine) -> None:
+    def test_creates_workflow_and_flow_from_cold_start(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.context_events import (
             EnsureWorkflowAndFlowRequest,
             EnsureWorkflowAndFlowResultSuccess,
         )
 
-        self._cleanup(griptape_nodes)
-        context_manager = griptape_nodes.ContextManager()
+        self._cleanup(engine)
+        context_manager = engine.context_manager
         assert not context_manager.has_current_workflow()
         assert not context_manager.has_current_flow()
 
@@ -488,16 +488,16 @@ class TestEnsureWorkflowAndFlowRequest:
         assert context_manager.has_current_workflow()
         assert context_manager.has_current_flow()
 
-        self._cleanup(griptape_nodes)
+        self._cleanup(engine)
 
-    def test_reuses_existing_workflow_and_flow(self, griptape_nodes: Engine) -> None:
+    def test_reuses_existing_workflow_and_flow(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.context_events import (
             EnsureWorkflowAndFlowRequest,
             EnsureWorkflowAndFlowResultSuccess,
         )
 
-        self._cleanup(griptape_nodes)
-        context_manager = griptape_nodes.ContextManager()
+        self._cleanup(engine)
+        context_manager = engine.context_manager
 
         # Bootstrap once.
         first = context_manager.on_ensure_workflow_and_flow_request(
@@ -516,17 +516,17 @@ class TestEnsureWorkflowAndFlowRequest:
         assert second.created_workflow is False
         assert second.created_flow is False
 
-        self._cleanup(griptape_nodes)
+        self._cleanup(engine)
 
-    def test_auto_generates_workflow_name_when_none_given(self, griptape_nodes: Engine) -> None:
+    def test_auto_generates_workflow_name_when_none_given(self, engine: Engine) -> None:
         from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
         from griptape_nodes.retained_mode.events.context_events import (
             EnsureWorkflowAndFlowRequest,
             EnsureWorkflowAndFlowResultSuccess,
         )
 
-        self._cleanup(griptape_nodes)
-        context_manager = griptape_nodes.ContextManager()
+        self._cleanup(engine)
+        context_manager = engine.context_manager
 
         result = context_manager.on_ensure_workflow_and_flow_request(EnsureWorkflowAndFlowRequest())
 
@@ -536,4 +536,4 @@ class TestEnsureWorkflowAndFlowRequest:
         assert result.created_workflow is True
         assert result.created_flow is True
 
-        self._cleanup(griptape_nodes)
+        self._cleanup(engine)

--- a/tests/unit/retained_mode/managers/test_create_node_parent_group.py
+++ b/tests/unit/retained_mode/managers/test_create_node_parent_group.py
@@ -3,13 +3,13 @@
 from unittest.mock import MagicMock, patch
 
 from griptape_nodes.exe_types.node_groups.base_node_group import BaseNodeGroup
+from griptape_nodes.retained_mode.engine import Engine
 from griptape_nodes.retained_mode.events.node_events import (
     CreateNodeRequest,
     CreateNodeResultSuccess,
     SerializedNodeCommands,
     SerializeNodeToCommandsResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.node_manager import SerializedGroupResult
 from tests.unit.exe_types.mocks import MockNode
 
@@ -88,6 +88,7 @@ class TestSerializeGroupWithChildren:
         group: _ConcreteGroup,
         group_uuid: str,
         child_uuids: list[str],
+        engine: Engine,
     ) -> SerializedGroupResult:
         """Call _serialize_group_with_children with mocked on_serialize_node_to_commands."""
         group_result = _make_serialize_result(
@@ -100,7 +101,7 @@ class TestSerializeGroupWithChildren:
             _make_serialize_result(node_name=child_name, node_uuid=uuid)
             for child_name, uuid in zip(group.nodes.keys(), child_uuids, strict=True)
         ]
-        manager = GriptapeNodes().NodeManager()
+        manager = engine.node_manager
         with patch.object(
             manager,
             "on_serialize_node_to_commands",
@@ -110,7 +111,7 @@ class TestSerializeGroupWithChildren:
 
             return NodeManager._serialize_group_with_children(manager, group, {}, MagicMock())
 
-    def test_node_names_to_add_cleared_on_group_command(self) -> None:
+    def test_node_names_to_add_cleared_on_group_command(self, engine: Engine) -> None:
         """group_command.create_node_command.node_names_to_add is None after serialization.
 
         This prevents on_create_node_request from calling add_nodes_to_group on the original
@@ -119,12 +120,12 @@ class TestSerializeGroupWithChildren:
         group = _ConcreteGroup("MyGroup")
         group.add_nodes_to_group([MockNode("Child")])
 
-        result = self._run_serialize(group, "group-uuid-1", ["child-uuid-1"])
+        result = self._run_serialize(group, "group-uuid-1", ["child-uuid-1"], engine)
 
         assert result.group_command is not None
         assert result.group_command.create_node_command.node_names_to_add is None
 
-    def test_children_embed_parent_group_uuid_in_metadata(self) -> None:
+    def test_children_embed_parent_group_uuid_in_metadata(self, engine: Engine) -> None:
         """Each child command's metadata contains _parent_group_uuid == group's node_uuid.
 
         This allows on_deserialize_selected_nodes_from_commands to set parent_group_name on each
@@ -135,7 +136,7 @@ class TestSerializeGroupWithChildren:
 
         group_uuid = "group-uuid-abc"
         child_uuids = ["child-uuid-1", "child-uuid-2"]
-        result = self._run_serialize(group, group_uuid, child_uuids)
+        result = self._run_serialize(group, group_uuid, child_uuids, engine)
 
         assert len(result.child_commands) == len(child_uuids)
         for child_cmd in result.child_commands:
@@ -200,36 +201,36 @@ class TestCreateNodeWithUnresolvableParentGroup:
     a result, and the node — already registered — was left orphaned.
     """
 
-    def _bootstrap(self, griptape_nodes: GriptapeNodes) -> None:
+    def _bootstrap(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
 
-        griptape_nodes.ContextManager().push_workflow("parent_group_wf")
-        result = griptape_nodes.handle_request(
+        engine.context_manager.push_workflow("parent_group_wf")
+        result = engine.handle_request(
             CreateFlowRequest(parent_flow_name=None, flow_name="parent_group_flow", set_as_new_context=True)
         )
         assert isinstance(result, CreateFlowResultSuccess)
 
-    def test_missing_parent_group_still_returns_success(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_missing_parent_group_still_returns_success(self, engine: Engine) -> None:
         """A parent_group_name naming nothing is logged and skipped; creation still succeeds."""
-        self._bootstrap(griptape_nodes)
+        self._bootstrap(engine)
 
-        result = griptape_nodes.handle_request(
+        result = engine.handle_request(
             CreateNodeRequest(node_type="Note", node_name="Orphan", parent_group_name="NoSuchGroup")
         )
 
         assert isinstance(result, CreateNodeResultSuccess), result
         assert result.parent_group_name is None
-        node = griptape_nodes.NodeManager().get_node_by_name(result.node_name)
+        node = engine.node_manager.get_node_by_name(result.node_name)
         assert node.parent_group is None
 
-    def test_parent_group_name_that_is_not_a_group_still_returns_success(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_parent_group_name_that_is_not_a_group_still_returns_success(self, engine: Engine) -> None:
         """Pointing parent_group_name at an ordinary node is refused without failing the create."""
-        self._bootstrap(griptape_nodes)
+        self._bootstrap(engine)
 
-        existing = griptape_nodes.handle_request(CreateNodeRequest(node_type="Note", node_name="PlainNode"))
+        existing = engine.handle_request(CreateNodeRequest(node_type="Note", node_name="PlainNode"))
         assert isinstance(existing, CreateNodeResultSuccess)
 
-        result = griptape_nodes.handle_request(
+        result = engine.handle_request(
             CreateNodeRequest(node_type="Note", node_name="Orphan", parent_group_name=existing.node_name)
         )
 

--- a/tests/unit/retained_mode/managers/test_flow_manager.py
+++ b/tests/unit/retained_mode/managers/test_flow_manager.py
@@ -6,7 +6,6 @@ import pickle
 import tempfile
 from collections.abc import Generator
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
 
 import pytest
 from PIL import Image
@@ -16,6 +15,7 @@ from griptape_nodes.exe_types.connections import Connections
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import BaseNode, ControlNode, DataNode, StartNode
 from griptape_nodes.machines.dag_builder import DagNodeCategories
+from griptape_nodes.retained_mode.engine import Engine
 from griptape_nodes.retained_mode.events.flow_events import (
     TRANSIENT_KEY,
     CreateFlowRequest,
@@ -29,10 +29,6 @@ from griptape_nodes.retained_mode.events.flow_events import (
 )
 from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
 from griptape_nodes.retained_mode.file_metadata.workflow_metadata import FLOW_COMMANDS_KEY
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-if TYPE_CHECKING:
-    from griptape_nodes.retained_mode.engine import Engine
 
 
 def _data_parameter(name: str = "value") -> Parameter:
@@ -128,9 +124,9 @@ class TestExtractFlowCommandsFromImageMetadata:
     """Covers the non-error success paths for images that carry no workflow payload."""
 
     def test_returns_success_with_none_when_image_has_no_metadata(
-        self, griptape_nodes: GriptapeNodes, image_without_metadata: str
+        self, engine: Engine, image_without_metadata: str
     ) -> None:
-        flow_manager = griptape_nodes.FlowManager()
+        flow_manager = engine.flow_manager
         request = ExtractFlowCommandsFromImageMetadataRequest(file_url_or_path=image_without_metadata)
 
         result = flow_manager.on_extract_flow_commands_from_image_metadata(request)
@@ -140,9 +136,9 @@ class TestExtractFlowCommandsFromImageMetadata:
         assert result.altered_workflow_state is False
 
     def test_returns_success_with_none_when_flow_commands_key_missing(
-        self, griptape_nodes: GriptapeNodes, image_with_unrelated_metadata: str
+        self, engine: Engine, image_with_unrelated_metadata: str
     ) -> None:
-        flow_manager = griptape_nodes.FlowManager()
+        flow_manager = engine.flow_manager
         request = ExtractFlowCommandsFromImageMetadataRequest(file_url_or_path=image_with_unrelated_metadata)
 
         result = flow_manager.on_extract_flow_commands_from_image_metadata(request)
@@ -151,8 +147,8 @@ class TestExtractFlowCommandsFromImageMetadata:
         assert result.serialized_flow_commands is None
         assert result.altered_workflow_state is False
 
-    def test_returns_failure_when_file_missing(self, griptape_nodes: GriptapeNodes) -> None:
-        flow_manager = griptape_nodes.FlowManager()
+    def test_returns_failure_when_file_missing(self, engine: Engine) -> None:
+        flow_manager = engine.flow_manager
         request = ExtractFlowCommandsFromImageMetadataRequest(file_url_or_path="/does/not/exist.png")
 
         result = flow_manager.on_extract_flow_commands_from_image_metadata(request)
@@ -160,9 +156,9 @@ class TestExtractFlowCommandsFromImageMetadata:
         assert isinstance(result, ExtractFlowCommandsFromImageMetadataResultFailure)
 
     def test_returns_commands_when_flow_commands_key_present(
-        self, griptape_nodes: GriptapeNodes, image_with_flow_commands: str
+        self, engine: Engine, image_with_flow_commands: str
     ) -> None:
-        flow_manager = griptape_nodes.FlowManager()
+        flow_manager = engine.flow_manager
         request = ExtractFlowCommandsFromImageMetadataRequest(file_url_or_path=image_with_flow_commands)
 
         result = flow_manager.on_extract_flow_commands_from_image_metadata(request)
@@ -176,10 +172,10 @@ class TestAwaitFlowCompletion:
     """Tests for FlowManager._await_flow_completion (the wait_for_completion helper)."""
 
     @pytest.mark.asyncio
-    async def test_returns_none_when_flow_finishes_cleanly(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_returns_none_when_flow_finishes_cleanly(self, engine: Engine) -> None:
         from unittest.mock import patch
 
-        flow_manager = griptape_nodes.FlowManager()
+        flow_manager = engine.flow_manager
 
         # No control flow machine -> no error to report; simulate "flow finished" with a single False.
         with patch.object(flow_manager, "check_for_existing_running_flow", return_value=False):
@@ -188,10 +184,10 @@ class TestAwaitFlowCompletion:
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_returns_timeout_string_when_timeout_exceeded(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_returns_timeout_string_when_timeout_exceeded(self, engine: Engine) -> None:
         from unittest.mock import patch
 
-        flow_manager = griptape_nodes.FlowManager()
+        flow_manager = engine.flow_manager
 
         # Keep reporting "still running" so the timeout path fires quickly.
         with patch.object(flow_manager, "check_for_existing_running_flow", return_value=True):
@@ -201,10 +197,10 @@ class TestAwaitFlowCompletion:
         assert "Timed out" in result
 
     @pytest.mark.asyncio
-    async def test_returns_error_message_when_resolution_machine_errored(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_returns_error_message_when_resolution_machine_errored(self, engine: Engine) -> None:
         from unittest.mock import MagicMock, patch
 
-        flow_manager = griptape_nodes.FlowManager()
+        flow_manager = engine.flow_manager
 
         fake_resolution_machine = MagicMock()
         fake_resolution_machine.is_errored.return_value = True
@@ -225,21 +221,21 @@ class TestStartFlowRequestDefaultsToCurrentContext:
     """Tests for StartFlowRequest / StartFlowFromNodeRequest current-context fallback."""
 
     @pytest.mark.asyncio
-    async def test_start_flow_fails_cleanly_when_no_flow_and_no_context(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_start_flow_fails_cleanly_when_no_flow_and_no_context(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.execution_events import (
             StartFlowRequest,
             StartFlowResultFailure,
         )
 
-        flow_manager = griptape_nodes.FlowManager()
-        griptape_nodes.handle_request(
+        flow_manager = engine.flow_manager
+        engine.handle_request(
             __import__(
                 "griptape_nodes.retained_mode.events.object_events",
                 fromlist=["ClearAllObjectStateRequest"],
             ).ClearAllObjectStateRequest(i_know_what_im_doing=True)
         )
 
-        assert not griptape_nodes.ContextManager().has_current_flow()
+        assert not engine.context_manager.has_current_flow()
 
         result = await flow_manager.on_start_flow_request(StartFlowRequest())
 
@@ -248,7 +244,7 @@ class TestStartFlowRequestDefaultsToCurrentContext:
         assert "Current Context" in str(result.result_details)
 
     @pytest.mark.asyncio
-    async def test_start_flow_uses_current_context_flow_when_name_omitted(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_start_flow_uses_current_context_flow_when_name_omitted(self, engine: Engine) -> None:
         from unittest.mock import patch
 
         from griptape_nodes.retained_mode.events.execution_events import (
@@ -258,12 +254,12 @@ class TestStartFlowRequestDefaultsToCurrentContext:
         from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
         from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
 
-        flow_manager = griptape_nodes.FlowManager()
-        griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        flow_manager = engine.flow_manager
+        engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
         # Bootstrap manually via push_workflow + CreateFlowRequest so this test does not
         # depend on any sibling MCP-bootstrap PR landing first.
-        griptape_nodes.ContextManager().push_workflow("wf")
-        create_flow_result = griptape_nodes.handle_request(
+        engine.context_manager.push_workflow("wf")
+        create_flow_result = engine.handle_request(
             CreateFlowRequest(parent_flow_name=None, flow_name="flow_in_ctx", set_as_new_context=True)
         )
         assert isinstance(create_flow_result, CreateFlowResultSuccess)
@@ -278,22 +274,20 @@ class TestStartFlowRequestDefaultsToCurrentContext:
         assert isinstance(result, StartFlowResultFailure)
         get_flow.assert_called_once_with("flow_in_ctx")
 
-        griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
 
     @pytest.mark.asyncio
-    async def test_start_flow_from_node_fails_cleanly_when_no_node_and_no_context(
-        self, griptape_nodes: GriptapeNodes
-    ) -> None:
+    async def test_start_flow_from_node_fails_cleanly_when_no_node_and_no_context(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.execution_events import (
             StartFlowFromNodeRequest,
             StartFlowFromNodeResultFailure,
         )
         from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
 
-        flow_manager = griptape_nodes.FlowManager()
-        griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        flow_manager = engine.flow_manager
+        engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
 
-        assert not griptape_nodes.ContextManager().has_current_node()
+        assert not engine.context_manager.has_current_node()
 
         result = await flow_manager.on_start_flow_from_node_request(StartFlowFromNodeRequest())
 
@@ -301,9 +295,7 @@ class TestStartFlowRequestDefaultsToCurrentContext:
         assert "Current Context" in str(result.result_details)
 
     @pytest.mark.asyncio
-    async def test_start_flow_from_node_uses_current_context_node_and_derives_parent_flow(
-        self, griptape_nodes: GriptapeNodes
-    ) -> None:
+    async def test_start_flow_from_node_uses_current_context_node_and_derives_parent_flow(self, engine: Engine) -> None:
         from unittest.mock import MagicMock, patch
 
         from griptape_nodes.exe_types.node_types import BaseNode
@@ -313,24 +305,24 @@ class TestStartFlowRequestDefaultsToCurrentContext:
         )
         from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
 
-        flow_manager = griptape_nodes.FlowManager()
-        griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        flow_manager = engine.flow_manager
+        engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
 
         # Stand in a current node so the handler can fall back to it. The node itself only
         # needs to expose `.name`; we short-circuit object lookup below.
         fake_node = MagicMock(spec=BaseNode)
         fake_node.name = "node_in_ctx"
-        ctx = griptape_nodes.ContextManager()
+        ctx = engine.context_manager
         with (
             patch.object(ctx, "has_current_node", return_value=True),
             patch.object(ctx, "get_current_node", return_value=fake_node),
             patch.object(
-                griptape_nodes.ObjectManager(),
+                engine.object_manager,
                 "attempt_get_object_by_name_as_type",
                 return_value=fake_node,
             ),
             patch.object(
-                griptape_nodes.NodeManager(),
+                engine.node_manager,
                 "get_node_parent_flow_by_name",
                 return_value="derived_parent_flow",
             ) as get_parent_flow,
@@ -344,14 +336,14 @@ class TestStartFlowRequestDefaultsToCurrentContext:
         get_parent_flow.assert_called_once_with("node_in_ctx")
         get_flow.assert_called_once_with("derived_parent_flow")
 
-        griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
 
 
 class TestStartFlowCancelsOnWaitTimeout:
     """Tests for the wait_for_completion cancel-on-timeout cleanup in on_start_flow_request."""
 
     @pytest.mark.asyncio
-    async def test_cancels_running_flow_when_wait_for_completion_times_out(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_cancels_running_flow_when_wait_for_completion_times_out(self, engine: Engine) -> None:
         from unittest.mock import AsyncMock, MagicMock, patch
 
         from griptape_nodes.retained_mode.events.execution_events import (
@@ -362,7 +354,7 @@ class TestStartFlowCancelsOnWaitTimeout:
             ValidateFlowDependenciesResultSuccess,
         )
 
-        flow_manager = griptape_nodes.FlowManager()
+        flow_manager = engine.flow_manager
 
         fake_flow = MagicMock()
         fake_flow.name = "timeout_flow"
@@ -406,7 +398,7 @@ class TestStartFlowCancelsOnWaitTimeout:
         cancel_mock.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_does_not_cancel_when_flow_already_finished_with_error(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_does_not_cancel_when_flow_already_finished_with_error(self, engine: Engine) -> None:
         from unittest.mock import AsyncMock, MagicMock, patch
 
         from griptape_nodes.retained_mode.events.execution_events import (
@@ -417,7 +409,7 @@ class TestStartFlowCancelsOnWaitTimeout:
             ValidateFlowDependenciesResultSuccess,
         )
 
-        flow_manager = griptape_nodes.FlowManager()
+        flow_manager = engine.flow_manager
 
         fake_flow = MagicMock()
         fake_flow.name = "errored_flow"
@@ -464,32 +456,32 @@ class TestListNodesInFlowRequest:
         fake_flow.nodes = nodes
         return fake_flow
 
-    def _run_request(self, griptape_nodes: GriptapeNodes, flow: object, request: object) -> object:
+    def _run_request(self, engine: Engine, flow: object, request: object) -> object:
         from unittest.mock import patch
 
         from griptape_nodes.retained_mode.managers.flow_manager import ControlFlow
 
-        flow_manager = griptape_nodes.FlowManager()
+        flow_manager = engine.flow_manager
         with patch.object(
-            griptape_nodes.ObjectManager(),
+            engine.object_manager,
             "attempt_get_object_by_name_as_type",
             side_effect=lambda _name, typ: flow if typ is ControlFlow else None,
         ):
             return flow_manager.on_list_nodes_in_flow_request(request)  # type: ignore[arg-type]
 
-    def test_no_filter_returns_all_nodes(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_no_filter_returns_all_nodes(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.flow_events import ListNodesInFlowRequest, ListNodesInFlowResultSuccess
 
         class NoteNode:
             pass
 
         flow = self._make_flow({"Note_1": NoteNode(), "Note_2": NoteNode()})
-        result = self._run_request(griptape_nodes, flow, ListNodesInFlowRequest(flow_name="test_flow"))
+        result = self._run_request(engine, flow, ListNodesInFlowRequest(flow_name="test_flow"))
 
         assert isinstance(result, ListNodesInFlowResultSuccess)
         assert set(result.node_names) == {"Note_1", "Note_2"}
 
-    def test_filter_by_matching_class_name_returns_subset(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_filter_by_matching_class_name_returns_subset(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.flow_events import ListNodesInFlowRequest, ListNodesInFlowResultSuccess
 
         class NoteNode:
@@ -499,14 +491,12 @@ class TestListNodesInFlowRequest:
             pass
 
         flow = self._make_flow({"note_1": NoteNode(), "agent_1": AgentNode(), "note_2": NoteNode()})
-        result = self._run_request(
-            griptape_nodes, flow, ListNodesInFlowRequest(flow_name="test_flow", node_types=["NoteNode"])
-        )
+        result = self._run_request(engine, flow, ListNodesInFlowRequest(flow_name="test_flow", node_types=["NoteNode"]))
 
         assert isinstance(result, ListNodesInFlowResultSuccess)
         assert set(result.node_names) == {"note_1", "note_2"}
 
-    def test_filter_by_nonexistent_class_name_returns_empty(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_filter_by_nonexistent_class_name_returns_empty(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.flow_events import ListNodesInFlowRequest, ListNodesInFlowResultSuccess
 
         class NoteNode:
@@ -514,25 +504,25 @@ class TestListNodesInFlowRequest:
 
         flow = self._make_flow({"note_1": NoteNode()})
         result = self._run_request(
-            griptape_nodes, flow, ListNodesInFlowRequest(flow_name="test_flow", node_types=["NonExistentClass"])
+            engine, flow, ListNodesInFlowRequest(flow_name="test_flow", node_types=["NonExistentClass"])
         )
 
         assert isinstance(result, ListNodesInFlowResultSuccess)
         assert result.node_names == []
 
-    def test_filter_with_empty_list_returns_empty(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_filter_with_empty_list_returns_empty(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.flow_events import ListNodesInFlowRequest, ListNodesInFlowResultSuccess
 
         class NoteNode:
             pass
 
         flow = self._make_flow({"note_1": NoteNode()})
-        result = self._run_request(griptape_nodes, flow, ListNodesInFlowRequest(flow_name="test_flow", node_types=[]))
+        result = self._run_request(engine, flow, ListNodesInFlowRequest(flow_name="test_flow", node_types=[]))
 
         assert isinstance(result, ListNodesInFlowResultSuccess)
         assert result.node_names == []
 
-    def test_filter_with_multiple_types_returns_union(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_filter_with_multiple_types_returns_union(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.flow_events import ListNodesInFlowRequest, ListNodesInFlowResultSuccess
 
         class NoteNode:
@@ -546,7 +536,7 @@ class TestListNodesInFlowRequest:
 
         flow = self._make_flow({"note_1": NoteNode(), "agent_1": AgentNode(), "other_1": OtherNode()})
         result = self._run_request(
-            griptape_nodes,
+            engine,
             flow,
             ListNodesInFlowRequest(flow_name="test_flow", node_types=["NoteNode", "AgentNode"]),
         )
@@ -558,23 +548,23 @@ class TestListNodesInFlowRequest:
 class TestAutoLayoutFlowRequest:
     """Tests for FlowManager.on_auto_layout_flow_request."""
 
-    def _cleanup(self, griptape_nodes: GriptapeNodes) -> None:
+    def _cleanup(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
 
-        griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
 
-    def _bootstrap_workflow_and_flow(self, griptape_nodes: GriptapeNodes, workflow: str, flow: str) -> None:
+    def _bootstrap_workflow_and_flow(self, engine: Engine, workflow: str, flow: str) -> None:
         """Push a workflow + create a flow without depending on any sibling bootstrap PR."""
         from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
 
-        self._cleanup(griptape_nodes)
-        griptape_nodes.ContextManager().push_workflow(workflow)
-        result = griptape_nodes.handle_request(
+        self._cleanup(engine)
+        engine.context_manager.push_workflow(workflow)
+        result = engine.handle_request(
             CreateFlowRequest(parent_flow_name=None, flow_name=flow, set_as_new_context=True)
         )
         assert isinstance(result, CreateFlowResultSuccess)
 
-    def _bootstrap_graph(self, griptape_nodes: GriptapeNodes) -> str:
+    def _bootstrap_graph(self, engine: Engine) -> str:
         """Create a small Workflow + Flow + 3 chained Note nodes (A -> B -> C) for layout tests.
 
         Uses `Note` from the registered Griptape Nodes Library because it has data params that
@@ -583,17 +573,17 @@ class TestAutoLayoutFlowRequest:
         from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
         from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
 
-        self._bootstrap_workflow_and_flow(griptape_nodes, workflow="layout_wf", flow="layout_flow")
+        self._bootstrap_workflow_and_flow(engine, workflow="layout_wf", flow="layout_flow")
 
         names = []
         for desired in ("A", "B", "C"):
-            result = griptape_nodes.handle_request(CreateNodeRequest(node_type="Note", node_name=desired))
+            result = engine.handle_request(CreateNodeRequest(node_type="Note", node_name=desired))
             assert isinstance(result, CreateNodeResultSuccess)
             names.append(result.node_name)
 
         # Wire A -> B -> C on the Note node's text parameter.
         for source, target in itertools.pairwise(names):
-            conn_result = griptape_nodes.handle_request(
+            conn_result = engine.handle_request(
                 CreateConnectionRequest(
                     source_node_name=source,
                     source_parameter_name="note",
@@ -608,28 +598,28 @@ class TestAutoLayoutFlowRequest:
         return "layout_flow"
 
     @pytest.mark.asyncio
-    async def test_fails_cleanly_when_no_flow_in_context_and_no_name(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_fails_cleanly_when_no_flow_in_context_and_no_name(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.flow_events import (
             AutoLayoutFlowRequest,
             AutoLayoutFlowResultFailure,
         )
 
-        self._cleanup(griptape_nodes)
-        flow_manager = griptape_nodes.FlowManager()
+        self._cleanup(engine)
+        flow_manager = engine.flow_manager
 
         result = await flow_manager.on_auto_layout_flow_request(AutoLayoutFlowRequest())
 
         assert isinstance(result, AutoLayoutFlowResultFailure)
 
     @pytest.mark.asyncio
-    async def test_lays_out_linear_chain_into_columns(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_lays_out_linear_chain_into_columns(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.flow_events import (
             AutoLayoutFlowRequest,
             AutoLayoutFlowResultSuccess,
         )
 
-        flow_name = self._bootstrap_graph(griptape_nodes)
-        flow_manager = griptape_nodes.FlowManager()
+        flow_name = self._bootstrap_graph(engine)
+        flow_manager = engine.flow_manager
 
         result = await flow_manager.on_auto_layout_flow_request(
             AutoLayoutFlowRequest(
@@ -654,24 +644,24 @@ class TestAutoLayoutFlowRequest:
         assert flow.nodes["A"].metadata["position"] == {"x": 10.0, "y": 20.0}
         assert flow.nodes["C"].metadata["position"] == {"x": 210.0, "y": 20.0}
 
-        self._cleanup(griptape_nodes)
+        self._cleanup(engine)
 
     @pytest.mark.asyncio
-    async def test_empty_flow_is_handled_gracefully(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_empty_flow_is_handled_gracefully(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.flow_events import (
             AutoLayoutFlowRequest,
             AutoLayoutFlowResultSuccess,
         )
 
-        self._bootstrap_workflow_and_flow(griptape_nodes, workflow="empty_wf", flow="empty_flow")
+        self._bootstrap_workflow_and_flow(engine, workflow="empty_wf", flow="empty_flow")
 
-        flow_manager = griptape_nodes.FlowManager()
+        flow_manager = engine.flow_manager
         result = await flow_manager.on_auto_layout_flow_request(AutoLayoutFlowRequest(flow_name="empty_flow"))
 
         assert isinstance(result, AutoLayoutFlowResultSuccess)
         assert result.positioned_nodes == []
 
-        self._cleanup(griptape_nodes)
+        self._cleanup(engine)
 
 
 class TestExcludeSubflowGroupChildren:
@@ -683,13 +673,13 @@ class TestExcludeSubflowGroupChildren:
     does NOT, because within a group's own subflow those members are exactly what must resolve.
     """
 
-    def test_drops_only_subflow_group_children(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_drops_only_subflow_group_children(self, engine: Engine) -> None:
         from unittest.mock import MagicMock
 
         from griptape_nodes.exe_types.node_groups.subflow_node_group import SubflowNodeGroup
         from griptape_nodes.exe_types.node_types import BaseNode
 
-        flow_manager = griptape_nodes.FlowManager()
+        flow_manager = engine.flow_manager
 
         child = MagicMock(spec=BaseNode)
         child.name = "child"
@@ -708,8 +698,8 @@ class TestExcludeSubflowGroupChildren:
 
         assert [node.name for node in kept] == ["free", "other_group_child"]
 
-    def test_empty_input_returns_empty(self, griptape_nodes: GriptapeNodes) -> None:
-        flow_manager = griptape_nodes.FlowManager()
+    def test_empty_input_returns_empty(self, engine: Engine) -> None:
+        flow_manager = engine.flow_manager
 
         assert flow_manager.exclude_subflow_group_children([]) == []
 
@@ -725,46 +715,46 @@ class TestClassifyNodesForDag:
     """
 
     @staticmethod
-    def _classify(griptape_nodes: GriptapeNodes, nodes: list, connections: Connections) -> DagNodeCategories:
+    def _classify(engine: Engine, nodes: list, connections: Connections) -> DagNodeCategories:
         from unittest.mock import patch
 
-        flow_manager = griptape_nodes.FlowManager()
+        flow_manager = engine.flow_manager
         with patch.object(flow_manager, "get_connections", return_value=connections):
             return flow_manager.classify_nodes_for_dag(nodes)
 
-    def test_start_node_is_a_start_node(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_start_node_is_a_start_node(self, engine: Engine) -> None:
         start = _ClassifyStartNode("Start")
         data = _ClassifyDataNode("Data")
         connections = Connections()
         connections.add_connection(start, _param(start, "value"), data, _param(data, "value"))
 
-        categories = self._classify(griptape_nodes, [start, data], connections)
+        categories = self._classify(engine, [start, data], connections)
 
         assert [node.name for node in categories.start_nodes] == ["Start"]
         # Data has an incoming data connection and no outgoing one, so it is a terminal sink.
         assert [node.name for node in categories.data_sink_nodes] == ["Data"]
         assert categories.control_nodes == []
 
-    def test_data_node_with_external_outgoing_is_not_a_sink(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_data_node_with_external_outgoing_is_not_a_sink(self, engine: Engine) -> None:
         upstream = _ClassifyDataNode("Upstream")
         downstream = _ClassifyDataNode("Downstream")
         connections = Connections()
         connections.add_connection(upstream, _param(upstream, "value"), downstream, _param(downstream, "value"))
 
-        categories = self._classify(griptape_nodes, [upstream, downstream], connections)
+        categories = self._classify(engine, [upstream, downstream], connections)
 
         # Only the leaf (Downstream) is a sink; Upstream feeds a downstream node so it is skipped.
         assert [node.name for node in categories.data_sink_nodes] == ["Downstream"]
         assert categories.start_nodes == []
         assert categories.control_nodes == []
 
-    def test_control_chain_first_node_is_control_entry(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_control_chain_first_node_is_control_entry(self, engine: Engine) -> None:
         first = _ClassifyControlNode("First")
         second = _ClassifyControlNode("Second")
         connections = Connections()
         connections.add_connection(first, _param(first, "exec_out"), second, _param(second, "exec_in"))
 
-        categories = self._classify(griptape_nodes, [first, second], connections)
+        categories = self._classify(engine, [first, second], connections)
 
         # First drives the control flow; Second has an external incoming control edge so the
         # forward control walk reaches it and it is not seeded as an entry node.
@@ -772,13 +762,11 @@ class TestClassifyNodesForDag:
         assert categories.start_nodes == []
         assert categories.data_sink_nodes == []
 
-    def test_control_node_without_control_connections_is_treated_as_data_sink(
-        self, griptape_nodes: GriptapeNodes
-    ) -> None:
+    def test_control_node_without_control_connections_is_treated_as_data_sink(self, engine: Engine) -> None:
         lone = _ClassifyControlNode("Lone")
         connections = Connections()
 
-        categories = self._classify(griptape_nodes, [lone], connections)
+        categories = self._classify(engine, [lone], connections)
 
         # Control params exist but are unused, so the node is a plain data node with no outgoing
         # connection, i.e. a terminal sink.
@@ -786,7 +774,7 @@ class TestClassifyNodesForDag:
         assert categories.control_nodes == []
         assert categories.start_nodes == []
 
-    def test_internal_node_group_outgoing_does_not_disqualify_sink(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_internal_node_group_outgoing_does_not_disqualify_sink(self, engine: Engine) -> None:
         source = _ClassifyDataNode("Source")
         target = _ClassifyDataNode("Target")
         connections = Connections()
@@ -798,14 +786,14 @@ class TestClassifyNodesForDag:
             is_node_group_internal=True,
         )
 
-        categories = self._classify(griptape_nodes, [source, target], connections)
+        categories = self._classify(engine, [source, target], connections)
 
         # Internal NodeGroup connections do not count as external outgoing, so both nodes remain
         # terminal sinks.
         assert sorted(node.name for node in categories.data_sink_nodes) == ["Source", "Target"]
 
-    def test_empty_scope_returns_empty_categories(self, griptape_nodes: GriptapeNodes) -> None:
-        categories = self._classify(griptape_nodes, [], Connections())
+    def test_empty_scope_returns_empty_categories(self, engine: Engine) -> None:
+        categories = self._classify(engine, [], Connections())
 
         assert categories.start_nodes == []
         assert categories.control_nodes == []
@@ -813,16 +801,16 @@ class TestClassifyNodesForDag:
 
 
 @pytest.fixture
-def clean_object_state(griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+def clean_object_state(engine: Engine) -> Generator[None, None, None]:
     """Clear all object state around a test so leftover flows never bleed across tests.
 
     Yield-based so the teardown clear runs even when the test body fails.
     """
-    griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
     try:
         yield
     finally:
-        griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
 
 
 class TestSerializeFlowSkipsTransientChildFlows:
@@ -834,23 +822,23 @@ class TestSerializeFlowSkipsTransientChildFlows:
     """
 
     @pytest.mark.usefixtures("clean_object_state")
-    def test_transient_child_flow_is_not_serialized(self, griptape_nodes: GriptapeNodes) -> None:
-        griptape_nodes.ContextManager().push_workflow("transient_wf")
+    def test_transient_child_flow_is_not_serialized(self, engine: Engine) -> None:
+        engine.context_manager.push_workflow("transient_wf")
 
-        parent = griptape_nodes.handle_request(
+        parent = engine.handle_request(
             CreateFlowRequest(parent_flow_name=None, flow_name="parent", set_as_new_context=True)
         )
         assert isinstance(parent, CreateFlowResultSuccess)
-        keep = griptape_nodes.handle_request(
+        keep = engine.handle_request(
             CreateFlowRequest(parent_flow_name=parent.flow_name, flow_name="child_keep", set_as_new_context=False)
         )
         assert isinstance(keep, CreateFlowResultSuccess)
-        transient = griptape_nodes.handle_request(
+        transient = engine.handle_request(
             CreateFlowRequest(parent_flow_name=parent.flow_name, flow_name="child_transient", set_as_new_context=False)
         )
         assert isinstance(transient, CreateFlowResultSuccess)
 
-        flow_manager = griptape_nodes.FlowManager()
+        flow_manager = engine.flow_manager
         flow_manager.get_flow_by_name(transient.flow_name).metadata[TRANSIENT_KEY] = True
 
         result = flow_manager.on_serialize_flow_to_commands(
@@ -863,9 +851,7 @@ class TestSerializeFlowSkipsTransientChildFlows:
         assert transient.flow_name not in serialized_child_flows
 
     @pytest.mark.usefixtures("clean_object_state")
-    def test_transient_child_flow_internal_connections_do_not_fail_serialization(
-        self, griptape_nodes: GriptapeNodes
-    ) -> None:
+    def test_transient_child_flow_internal_connections_do_not_fail_serialization(self, engine: Engine) -> None:
         """A transient child flow with internal connections must not break the parent save.
 
         Transient flows are skipped by node serialization, so their nodes never enter the UUID map.
@@ -875,28 +861,28 @@ class TestSerializeFlowSkipsTransientChildFlows:
         from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
         from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
 
-        griptape_nodes.ContextManager().push_workflow("transient_conn_wf")
-        parent = griptape_nodes.handle_request(
+        engine.context_manager.push_workflow("transient_conn_wf")
+        parent = engine.handle_request(
             CreateFlowRequest(parent_flow_name=None, flow_name="parent", set_as_new_context=True)
         )
         assert isinstance(parent, CreateFlowResultSuccess)
-        transient = griptape_nodes.handle_request(
+        transient = engine.handle_request(
             CreateFlowRequest(parent_flow_name=parent.flow_name, flow_name="child_transient", set_as_new_context=False)
         )
         assert isinstance(transient, CreateFlowResultSuccess)
 
-        flow_manager = griptape_nodes.FlowManager()
+        flow_manager = engine.flow_manager
         flow_manager.get_flow_by_name(transient.flow_name).metadata[TRANSIENT_KEY] = True
 
         # Two connected Note nodes INSIDE the transient flow (Note has connectable data params
         # and no external deps). This mirrors a per-iteration loop-body flow's internal wiring.
-        with griptape_nodes.ContextManager().flow(transient.flow_name):
+        with engine.context_manager.flow(transient.flow_name):
             node_names = []
             for desired in ("A", "B"):
-                created = griptape_nodes.handle_request(CreateNodeRequest(node_type="Note", node_name=desired))
+                created = engine.handle_request(CreateNodeRequest(node_type="Note", node_name=desired))
                 assert isinstance(created, CreateNodeResultSuccess)
                 node_names.append(created.node_name)
-            griptape_nodes.handle_request(
+            engine.handle_request(
                 CreateConnectionRequest(
                     source_node_name=node_names[0],
                     source_parameter_name="note",
@@ -928,18 +914,16 @@ class TestDeleteIterationFlows:
 
     @pytest.mark.asyncio
     @pytest.mark.usefixtures("clean_object_state")
-    async def test_deletes_all_tracked_flows(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_deletes_all_tracked_flows(self, engine: Engine) -> None:
         from griptape_nodes.common.node_executor import NodeExecutor
 
-        griptape_nodes.ContextManager().push_workflow("cleanup_wf")
-        griptape_nodes.handle_request(
-            CreateFlowRequest(parent_flow_name=None, flow_name="parent", set_as_new_context=True)
-        )
+        engine.context_manager.push_workflow("cleanup_wf")
+        engine.handle_request(CreateFlowRequest(parent_flow_name=None, flow_name="parent", set_as_new_context=True))
 
-        object_manager = griptape_nodes.ObjectManager()
+        object_manager = engine.object_manager
         deserialized_flows: list[tuple[int, str, dict[str, str]]] = []
         for i in range(3):
-            created = griptape_nodes.handle_request(
+            created = engine.handle_request(
                 CreateFlowRequest(parent_flow_name="parent", flow_name=f"iter_{i}", set_as_new_context=False)
             )
             assert isinstance(created, CreateFlowResultSuccess)
@@ -947,11 +931,11 @@ class TestDeleteIterationFlows:
 
         # Delete one flow out from under the helper to prove it tolerates an already-gone flow.
         already_gone = deserialized_flows[1][1]
-        griptape_nodes.handle_request(DeleteFlowRequest(flow_name=already_gone))
+        engine.handle_request(DeleteFlowRequest(flow_name=already_gone))
         assert object_manager.attempt_get_object_by_name(already_gone) is None
 
-        executor = NodeExecutor(engine=cast("Engine", griptape_nodes))
-        await executor._delete_iteration_flows(deserialized_flows, griptape_nodes.EventManager())
+        executor = NodeExecutor(engine=engine)
+        await executor._delete_iteration_flows(deserialized_flows, engine.event_manager)
 
         for _, flow_name, _ in deserialized_flows:
             assert object_manager.attempt_get_object_by_name(flow_name) is None
@@ -966,34 +950,32 @@ class TestReparentFlow:
     """
 
     @pytest.mark.usefixtures("clean_object_state")
-    def test_moves_flow_under_new_parent(self, griptape_nodes: GriptapeNodes) -> None:
-        griptape_nodes.ContextManager().push_workflow("reparent_wf")
-        top = griptape_nodes.handle_request(
-            CreateFlowRequest(parent_flow_name=None, flow_name="top", set_as_new_context=False)
-        )
+    def test_moves_flow_under_new_parent(self, engine: Engine) -> None:
+        engine.context_manager.push_workflow("reparent_wf")
+        top = engine.handle_request(CreateFlowRequest(parent_flow_name=None, flow_name="top", set_as_new_context=False))
         assert isinstance(top, CreateFlowResultSuccess)
-        outer = griptape_nodes.handle_request(
+        outer = engine.handle_request(
             CreateFlowRequest(parent_flow_name=top.flow_name, flow_name="outer", set_as_new_context=False)
         )
         assert isinstance(outer, CreateFlowResultSuccess)
-        inner = griptape_nodes.handle_request(
+        inner = engine.handle_request(
             CreateFlowRequest(parent_flow_name=top.flow_name, flow_name="inner", set_as_new_context=False)
         )
         assert isinstance(inner, CreateFlowResultSuccess)
 
-        flow_manager = griptape_nodes.FlowManager()
+        flow_manager = engine.flow_manager
         flow_manager.reparent_flow(inner.flow_name, outer.flow_name)
 
         assert flow_manager.get_parent_flow(inner.flow_name) == outer.flow_name
 
     @pytest.mark.usefixtures("clean_object_state")
-    def test_rejects_unknown_flows(self, griptape_nodes: GriptapeNodes) -> None:
-        griptape_nodes.ContextManager().push_workflow("reparent_unknown_wf")
-        real = griptape_nodes.handle_request(
+    def test_rejects_unknown_flows(self, engine: Engine) -> None:
+        engine.context_manager.push_workflow("reparent_unknown_wf")
+        real = engine.handle_request(
             CreateFlowRequest(parent_flow_name=None, flow_name="real", set_as_new_context=False)
         )
         assert isinstance(real, CreateFlowResultSuccess)
-        flow_manager = griptape_nodes.FlowManager()
+        flow_manager = engine.flow_manager
 
         with pytest.raises(ValueError, match="doesn't exist"):
             flow_manager.reparent_flow("ghost", real.flow_name)
@@ -1001,30 +983,30 @@ class TestReparentFlow:
             flow_manager.reparent_flow(real.flow_name, "ghost")
 
     @pytest.mark.usefixtures("clean_object_state")
-    def test_rejects_making_a_flow_its_own_parent(self, griptape_nodes: GriptapeNodes) -> None:
-        griptape_nodes.ContextManager().push_workflow("reparent_self_wf")
-        solo = griptape_nodes.handle_request(
+    def test_rejects_making_a_flow_its_own_parent(self, engine: Engine) -> None:
+        engine.context_manager.push_workflow("reparent_self_wf")
+        solo = engine.handle_request(
             CreateFlowRequest(parent_flow_name=None, flow_name="solo", set_as_new_context=False)
         )
         assert isinstance(solo, CreateFlowResultSuccess)
 
         with pytest.raises(ValueError, match="its own parent"):
-            griptape_nodes.FlowManager().reparent_flow(solo.flow_name, solo.flow_name)
+            engine.flow_manager.reparent_flow(solo.flow_name, solo.flow_name)
 
     @pytest.mark.usefixtures("clean_object_state")
-    def test_rejects_moving_a_flow_inside_its_own_descendant(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_rejects_moving_a_flow_inside_its_own_descendant(self, engine: Engine) -> None:
         """That move would detach the branch and leave the ancestor walk with no way out."""
-        griptape_nodes.ContextManager().push_workflow("reparent_cycle_wf")
-        outer = griptape_nodes.handle_request(
+        engine.context_manager.push_workflow("reparent_cycle_wf")
+        outer = engine.handle_request(
             CreateFlowRequest(parent_flow_name=None, flow_name="outer", set_as_new_context=False)
         )
         assert isinstance(outer, CreateFlowResultSuccess)
-        inner = griptape_nodes.handle_request(
+        inner = engine.handle_request(
             CreateFlowRequest(parent_flow_name=outer.flow_name, flow_name="inner", set_as_new_context=False)
         )
         assert isinstance(inner, CreateFlowResultSuccess)
 
-        flow_manager = griptape_nodes.FlowManager()
+        flow_manager = engine.flow_manager
         with pytest.raises(ValueError, match="already inside"):
             flow_manager.reparent_flow(outer.flow_name, inner.flow_name)
 

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -31,6 +31,7 @@ from griptape_nodes.node_library.library_registry import (
     NodeMetadata,
     get_declared_models,
 )
+from griptape_nodes.retained_mode.engine import Engine
 from griptape_nodes.retained_mode.events.base_events import ResultDetails
 from griptape_nodes.retained_mode.events.library_events import (
     DescribeNodeTypeRequest,
@@ -53,7 +54,6 @@ from griptape_nodes.retained_mode.events.library_events import (
     UnloadLibraryFromRegistryRequest,
     UnloadLibraryFromRegistryResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
 from griptape_nodes.retained_mode.managers.library_manager import LibraryManager as _LibraryManager
 from griptape_nodes.retained_mode.managers.library_manager import LibraryVenvInitResult
@@ -135,11 +135,9 @@ class TestLibraryManagerLoadLibraries:
     """Test the load_libraries_request functionality in LibraryManager."""
 
     @pytest.mark.asyncio
-    async def test_libraries_already_loaded_returns_success_without_reloading(
-        self, griptape_nodes: GriptapeNodes
-    ) -> None:
+    async def test_libraries_already_loaded_returns_success_without_reloading(self, engine: Engine) -> None:
         """Test that when libraries are already loaded, returns success without reloading."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         # Mock that libraries are already loaded and discovered libraries match loaded ones
         from griptape_nodes.node_library.library_registry import LibraryRegistry
@@ -174,9 +172,9 @@ class TestLibraryManagerLoadLibraries:
             mock_load_config.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_empty_libraries_loads_from_config_successfully(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_empty_libraries_loads_from_config_successfully(self, engine: Engine) -> None:
         """Test successful library loading from configuration."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         # Mock empty libraries and discovered library that needs loading
         mock_load_config = AsyncMock()
@@ -199,9 +197,9 @@ class TestLibraryManagerLoadLibraries:
             # (the new implementation doesn't call load_all_libraries_from_config anymore)
 
     @pytest.mark.asyncio
-    async def test_library_loading_failure_returns_failure_result(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_library_loading_failure_returns_failure_result(self, engine: Engine) -> None:
         """Test library loading failure returns appropriate error."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         # Mock empty libraries, discovered library, and failed loading
         mock_load_config = AsyncMock(side_effect=Exception("Config error"))
@@ -239,10 +237,10 @@ class TestLibraryManagerDisabledEntries:
 
     @pytest.mark.asyncio
     async def test_discover_library_files_marks_disabled_entries(
-        self, griptape_nodes: GriptapeNodes, lib_files: tuple[Path, Path]
+        self, engine: Engine, lib_files: tuple[Path, Path]
     ) -> None:
         """Object-shaped entries with enabled=False produce disabled register entries."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         enabled_lib, disabled_lib = lib_files
 
         config = [
@@ -250,9 +248,7 @@ class TestLibraryManagerDisabledEntries:
             {"path": str(disabled_lib), "enabled": False},
         ]
 
-        with patch.object(
-            griptape_nodes.ConfigManager(), "get_config_value", side_effect=_register_only_config(config)
-        ):
+        with patch.object(engine.config_manager, "get_config_value", side_effect=_register_only_config(config)):
             result = await library_manager._discover_library_files()
 
         by_path = {
@@ -265,14 +261,14 @@ class TestLibraryManagerDisabledEntries:
 
     @pytest.mark.asyncio
     async def test_discover_library_files_bare_string_defaults_to_enabled(
-        self, griptape_nodes: GriptapeNodes, lib_files: tuple[Path, Path]
+        self, engine: Engine, lib_files: tuple[Path, Path]
     ) -> None:
         """Bare path strings continue to be treated as enabled."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         enabled_lib, _ = lib_files
 
         with patch.object(
-            griptape_nodes.ConfigManager(), "get_config_value", side_effect=_register_only_config([str(enabled_lib)])
+            engine.config_manager, "get_config_value", side_effect=_register_only_config([str(enabled_lib)])
         ):
             result = await library_manager._discover_library_files()
 
@@ -281,22 +277,20 @@ class TestLibraryManagerDisabledEntries:
 
     @pytest.mark.asyncio
     async def test_discover_libraries_request_marks_disabled_lifecycle(
-        self, griptape_nodes: GriptapeNodes, lib_files: tuple[Path, Path]
+        self, engine: Engine, lib_files: tuple[Path, Path]
     ) -> None:
         """discover_libraries_request creates LibraryInfo with DISABLED lifecycle for disabled entries."""
         from griptape_nodes.retained_mode.events.library_events import DiscoverLibrariesRequest
         from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         enabled_lib, disabled_lib = lib_files
 
         config = [str(enabled_lib), {"path": str(disabled_lib), "enabled": False}]
         # Reset tracking so this test does not depend on prior state.
         library_manager._library_file_path_to_info = {}
 
-        with patch.object(
-            griptape_nodes.ConfigManager(), "get_config_value", side_effect=_register_only_config(config)
-        ):
+        with patch.object(engine.config_manager, "get_config_value", side_effect=_register_only_config(config)):
             result = await library_manager.discover_libraries_request(DiscoverLibrariesRequest(include_sandbox=False))
 
         from griptape_nodes.retained_mode.events.library_events import DiscoverLibrariesResultSuccess
@@ -315,15 +309,15 @@ class TestLibraryManagerDisabledEntries:
 
     @pytest.mark.asyncio
     async def test_invalid_entry_is_skipped_with_warning(
-        self, griptape_nodes: GriptapeNodes, caplog: pytest.LogCaptureFixture
+        self, engine: Engine, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Entries that are neither strings nor dicts with a path are skipped."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         config = [42, {"enabled": True}]  # missing 'path', and a bare int
 
         with (
-            patch.object(griptape_nodes.ConfigManager(), "get_config_value", return_value=config),
+            patch.object(engine.config_manager, "get_config_value", return_value=config),
             caplog.at_level(logging.WARNING, logger="griptape_nodes"),
         ):
             result = await library_manager._discover_library_files()
@@ -334,7 +328,7 @@ class TestLibraryManagerDisabledEntries:
 
     @pytest.mark.asyncio
     async def test_rediscovery_reconciles_toggled_enabled_flag(
-        self, griptape_nodes: GriptapeNodes, lib_files: tuple[Path, Path]
+        self, engine: Engine, lib_files: tuple[Path, Path]
     ) -> None:
         """Re-running discovery after a refresh updates lifecycle when the user toggles enabled.
 
@@ -346,16 +340,14 @@ class TestLibraryManagerDisabledEntries:
         from griptape_nodes.retained_mode.events.library_events import DiscoverLibrariesRequest
         from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         first_lib, second_lib = lib_files
         # Reset tracking so this test does not depend on prior state.
         library_manager._library_file_path_to_info = {}
 
         # Initial discovery: first_lib enabled, second_lib disabled.
         initial_config = [str(first_lib), {"path": str(second_lib), "enabled": False}]
-        with patch.object(
-            griptape_nodes.ConfigManager(), "get_config_value", side_effect=_register_only_config(initial_config)
-        ):
+        with patch.object(engine.config_manager, "get_config_value", side_effect=_register_only_config(initial_config)):
             await library_manager.discover_libraries_request(DiscoverLibrariesRequest(include_sandbox=False))
 
         first_state = library_manager._library_file_path_to_info[str(first_lib)].lifecycle_state
@@ -365,9 +357,7 @@ class TestLibraryManagerDisabledEntries:
 
         # User flips the config: first_lib disabled, second_lib enabled, then triggers refresh.
         toggled_config = [{"path": str(first_lib), "enabled": False}, str(second_lib)]
-        with patch.object(
-            griptape_nodes.ConfigManager(), "get_config_value", side_effect=_register_only_config(toggled_config)
-        ):
+        with patch.object(engine.config_manager, "get_config_value", side_effect=_register_only_config(toggled_config)):
             await library_manager.discover_libraries_request(DiscoverLibrariesRequest(include_sandbox=False))
 
         first_state_after = library_manager._library_file_path_to_info[str(first_lib)].lifecycle_state
@@ -379,9 +369,9 @@ class TestLibraryManagerDisabledEntries:
 class TestLibraryManagerMigrateOldXdgPaths:
     """Test the _migrate_old_xdg_library_paths functionality in LibraryManager."""
 
-    def test_removes_old_xdg_paths_and_preserves_valid_paths(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_removes_old_xdg_paths_and_preserves_valid_paths(self, engine: Engine) -> None:
         """Test that old XDG paths are removed while valid paths are preserved."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         # Mock config with one old XDG path and one valid path
         old_xdg_path = "/home/user/.local/share/griptape_nodes/libraries/griptape_nodes_library"
@@ -399,7 +389,7 @@ class TestLibraryManagerMigrateOldXdgPaths:
         )
 
         with (
-            patch.object(griptape_nodes, "_config_manager", mock_config_manager),
+            patch.object(engine, "_config_manager", mock_config_manager),
             patch("griptape_nodes.utils.library_utils.xdg_data_home") as mock_xdg,
         ):
             mock_xdg.return_value = Path("/home/user/.local/share")
@@ -412,9 +402,9 @@ class TestLibraryManagerMigrateOldXdgPaths:
             register_call = next(c for c in calls if "libraries_to_register" in c[0][0])
             assert register_call[0][1] == [valid_path]
 
-    def test_idempotent_with_no_old_paths(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_idempotent_with_no_old_paths(self, engine: Engine) -> None:
         """Test that migration does nothing when config has no old XDG paths."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         # Mock config with only valid paths (no old XDG paths)
         valid_paths = ["/custom/path/library1", "https://github.com/user/library@main"]
@@ -423,7 +413,7 @@ class TestLibraryManagerMigrateOldXdgPaths:
         mock_config_manager.get_config_value.return_value = valid_paths
 
         with (
-            patch.object(griptape_nodes, "_config_manager", mock_config_manager),
+            patch.object(engine, "_config_manager", mock_config_manager),
             patch("griptape_nodes.utils.library_utils.xdg_data_home") as mock_xdg,
         ):
             mock_xdg.return_value = Path("/home/user/.local/share")
@@ -433,35 +423,35 @@ class TestLibraryManagerMigrateOldXdgPaths:
             # Verify config was NOT updated (no old paths to remove)
             mock_config_manager.set_config_value.assert_not_called()
 
-    def test_handles_empty_config_gracefully(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_handles_empty_config_gracefully(self, engine: Engine) -> None:
         """Test that migration returns early when config is empty."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         mock_config_manager = MagicMock()
         mock_config_manager.get_config_value.return_value = []
 
-        with patch.object(griptape_nodes, "_config_manager", mock_config_manager):
+        with patch.object(engine, "_config_manager", mock_config_manager):
             library_manager._migrate_old_xdg_library_paths()
 
             # Verify config was NOT updated (empty config)
             mock_config_manager.set_config_value.assert_not_called()
 
-    def test_handles_none_config_gracefully(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_handles_none_config_gracefully(self, engine: Engine) -> None:
         """Test that migration returns early when config is None."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         mock_config_manager = MagicMock()
         mock_config_manager.get_config_value.return_value = None
 
-        with patch.object(griptape_nodes, "_config_manager", mock_config_manager):
+        with patch.object(engine, "_config_manager", mock_config_manager):
             library_manager._migrate_old_xdg_library_paths()
 
             # Verify config was NOT updated (None config)
             mock_config_manager.set_config_value.assert_not_called()
 
-    def test_removes_all_three_old_library_paths(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_removes_all_three_old_library_paths(self, engine: Engine) -> None:
         """Test that all three old XDG library types are removed."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         # Mock config with all three old XDG library paths
         xdg_base = "/home/user/.local/share/griptape_nodes/libraries"
@@ -484,7 +474,7 @@ class TestLibraryManagerMigrateOldXdgPaths:
         )
 
         with (
-            patch.object(griptape_nodes, "_config_manager", mock_config_manager),
+            patch.object(engine, "_config_manager", mock_config_manager),
             patch("griptape_nodes.utils.library_utils.xdg_data_home") as mock_xdg,
         ):
             mock_xdg.return_value = Path("/home/user/.local/share")
@@ -497,9 +487,9 @@ class TestLibraryManagerMigrateOldXdgPaths:
             register_call = next(c for c in calls if "libraries_to_register" in c[0][0])
             assert register_call[0][1] == [valid_path]
 
-    def test_preserves_custom_paths_and_git_urls(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_preserves_custom_paths_and_git_urls(self, engine: Engine) -> None:
         """Test that custom paths and git URLs are preserved during migration."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         # Mock config with old XDG path, custom path, and git URL
         xdg_base = "/home/user/.local/share/griptape_nodes/libraries"
@@ -519,7 +509,7 @@ class TestLibraryManagerMigrateOldXdgPaths:
         )
 
         with (
-            patch.object(griptape_nodes, "_config_manager", mock_config_manager),
+            patch.object(engine, "_config_manager", mock_config_manager),
             patch("griptape_nodes.utils.library_utils.xdg_data_home") as mock_xdg,
         ):
             mock_xdg.return_value = Path("/home/user/.local/share")
@@ -532,9 +522,9 @@ class TestLibraryManagerMigrateOldXdgPaths:
             register_call = next(c for c in calls if "libraries_to_register" in c[0][0])
             assert register_call[0][1] == [custom_path, git_url]
 
-    def test_adds_git_urls_to_downloads_when_xdg_paths_removed(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_adds_git_urls_to_downloads_when_xdg_paths_removed(self, engine: Engine) -> None:
         """Test that migration adds git URLs to downloads when XDG paths are removed."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         # Mock config with old XDG path in register and empty downloads
         xdg_base = "/home/user/.local/share/griptape_nodes/libraries"
@@ -552,7 +542,7 @@ class TestLibraryManagerMigrateOldXdgPaths:
         )
 
         with (
-            patch.object(griptape_nodes, "_config_manager", mock_config_manager),
+            patch.object(engine, "_config_manager", mock_config_manager),
             patch("griptape_nodes.utils.library_utils.xdg_data_home") as mock_xdg,
         ):
             mock_xdg.return_value = Path("/home/user/.local/share")
@@ -571,9 +561,9 @@ class TestLibraryManagerMigrateOldXdgPaths:
             assert len(download_call[0][1]) == 1  # Git URL added
             assert "griptape-nodes-library-standard" in download_call[0][1][0]
 
-    def test_doesnt_duplicate_existing_git_urls(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_doesnt_duplicate_existing_git_urls(self, engine: Engine) -> None:
         """Test that migration doesn't add URLs already in downloads."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         # Mock config with XDG path in register and corresponding git URL already in downloads
         xdg_base = "/home/user/.local/share/griptape_nodes/libraries"
@@ -591,7 +581,7 @@ class TestLibraryManagerMigrateOldXdgPaths:
         )
 
         with (
-            patch.object(griptape_nodes, "_config_manager", mock_config_manager),
+            patch.object(engine, "_config_manager", mock_config_manager),
             patch("griptape_nodes.utils.library_utils.xdg_data_home") as mock_xdg,
         ):
             mock_xdg.return_value = Path("/home/user/.local/share")
@@ -604,9 +594,9 @@ class TestLibraryManagerMigrateOldXdgPaths:
             assert "libraries_to_register" in call_args[0][0]
             assert call_args[0][1] == []
 
-    def test_handles_multiple_libraries(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_handles_multiple_libraries(self, engine: Engine) -> None:
         """Test migration with all three library types."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         # Mock config with all 3 old XDG paths and empty downloads
         xdg_base = "/home/user/.local/share/griptape_nodes/libraries"
@@ -628,7 +618,7 @@ class TestLibraryManagerMigrateOldXdgPaths:
         )
 
         with (
-            patch.object(griptape_nodes, "_config_manager", mock_config_manager),
+            patch.object(engine, "_config_manager", mock_config_manager),
             patch("griptape_nodes.utils.library_utils.xdg_data_home") as mock_xdg,
         ):
             mock_xdg.return_value = Path("/home/user/.local/share")
@@ -647,9 +637,9 @@ class TestLibraryManagerMigrateOldXdgPaths:
             assert any("griptape-nodes-library-advanced-media" in url for url in download_call[0][1])
             assert any("griptape-nodes-library-griptape-cloud" in url for url in download_call[0][1])
 
-    def test_handles_partial_overlap(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_handles_partial_overlap(self, engine: Engine) -> None:
         """Test when some URLs already exist in downloads."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         # Mock config with 2 XDG paths, 1 git URL already in downloads
         xdg_base = "/home/user/.local/share/griptape_nodes/libraries"
@@ -670,7 +660,7 @@ class TestLibraryManagerMigrateOldXdgPaths:
         )
 
         with (
-            patch.object(griptape_nodes, "_config_manager", mock_config_manager),
+            patch.object(engine, "_config_manager", mock_config_manager),
             patch("griptape_nodes.utils.library_utils.xdg_data_home") as mock_xdg,
         ):
             mock_xdg.return_value = Path("/home/user/.local/share")
@@ -693,9 +683,9 @@ class TestLibraryManagerRegisterLibraryFromFile:
     """Test the register_library_from_file_request functionality in LibraryManager."""
 
     @pytest.mark.asyncio
-    async def test_always_installs_dependencies_even_when_venv_exists(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_always_installs_dependencies_even_when_venv_exists(self, engine: Engine) -> None:
         """Test that dependencies are always installed on library load, even when venv already exists."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         # Mock library schema with pip dependencies
         schema = MagicMock()
@@ -735,9 +725,9 @@ class TestLibraryManagerRegisterLibraryFromFile:
             mock_install.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_dependency_installation_failure_returns_failure(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_dependency_installation_failure_returns_failure(self, engine: Engine) -> None:
         """Test that dependency installation failure returns RegisterLibraryFromFileResultFailure."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         schema = MagicMock()
         schema.name = "lib"
         schema.metadata.library_version = "1.0.0"
@@ -790,9 +780,9 @@ class TestLibraryManagerInstallLibraryDependencies:
         )
 
     @pytest.mark.asyncio
-    async def test_creates_venv_when_pip_dependencies_is_empty(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_creates_venv_when_pip_dependencies_is_empty(self, engine: Engine) -> None:
         """Test that the venv is created even when pip_dependencies is empty."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         schema = MagicMock()
         schema.name = "test_lib"
         schema.metadata.library_version = "1.0.0"
@@ -813,7 +803,7 @@ class TestLibraryManagerInstallLibraryDependencies:
                 "griptape_nodes.retained_mode.managers.library_manager.OSManager.check_available_disk_space",
                 return_value=True,
             ),
-            patch.object(griptape_nodes.ConfigManager(), "get_config_value", return_value=5.0),
+            patch.object(engine.config_manager, "get_config_value", return_value=5.0),
         ):
             result = await mgr.install_library_dependencies_request(
                 InstallLibraryDependenciesRequest(library_file_path="/mock.json")
@@ -824,9 +814,9 @@ class TestLibraryManagerInstallLibraryDependencies:
         assert result.dependencies_installed == 0
 
     @pytest.mark.asyncio
-    async def test_creates_venv_when_dependencies_is_none(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_creates_venv_when_dependencies_is_none(self, engine: Engine) -> None:
         """Test that the venv is created even when the dependencies section is absent."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         schema = MagicMock()
         schema.name = "test_lib"
         schema.metadata.library_version = "1.0.0"
@@ -846,7 +836,7 @@ class TestLibraryManagerInstallLibraryDependencies:
                 "griptape_nodes.retained_mode.managers.library_manager.OSManager.check_available_disk_space",
                 return_value=True,
             ),
-            patch.object(griptape_nodes.ConfigManager(), "get_config_value", return_value=5.0),
+            patch.object(engine.config_manager, "get_config_value", return_value=5.0),
         ):
             result = await mgr.install_library_dependencies_request(
                 InstallLibraryDependenciesRequest(library_file_path="/mock.json")
@@ -857,9 +847,9 @@ class TestLibraryManagerInstallLibraryDependencies:
         assert result.dependencies_installed == 0
 
     @pytest.mark.asyncio
-    async def test_returns_failure_when_venv_creation_fails_with_no_deps(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_returns_failure_when_venv_creation_fails_with_no_deps(self, engine: Engine) -> None:
         """Test that venv creation failure returns failure even when pip_dependencies is empty."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         schema = MagicMock()
         schema.name = "test_lib"
         schema.metadata.library_version = "1.0.0"
@@ -879,9 +869,9 @@ class TestLibraryManagerInstallLibraryDependencies:
         assert "disk full" in str(result.result_details)
 
     @pytest.mark.asyncio
-    async def test_returns_failure_when_venv_unwritable_with_no_deps(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_returns_failure_when_venv_unwritable_with_no_deps(self, engine: Engine) -> None:
         """Test that an unwritable venv returns failure even when pip_dependencies is empty."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         schema = MagicMock()
         schema.name = "test_lib"
         schema.metadata.library_version = "1.0.0"
@@ -906,11 +896,9 @@ class TestLibraryManagerInstallLibraryDependencies:
         assert isinstance(result, InstallLibraryDependenciesResultFailure)
 
     @pytest.mark.asyncio
-    async def test_returns_failure_when_insufficient_disk_space_with_no_deps(
-        self, griptape_nodes: GriptapeNodes
-    ) -> None:
+    async def test_returns_failure_when_insufficient_disk_space_with_no_deps(self, engine: Engine) -> None:
         """Test that insufficient disk space returns failure even when pip_dependencies is empty."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         schema = MagicMock()
         schema.name = "test_lib"
         schema.metadata.library_version = "1.0.0"
@@ -935,7 +923,7 @@ class TestLibraryManagerInstallLibraryDependencies:
                 "griptape_nodes.retained_mode.managers.library_manager.OSManager.format_disk_space_error",
                 return_value="not enough space",
             ),
-            patch.object(griptape_nodes.ConfigManager(), "get_config_value", return_value=5.0),
+            patch.object(engine.config_manager, "get_config_value", return_value=5.0),
         ):
             result = await mgr.install_library_dependencies_request(
                 InstallLibraryDependenciesRequest(library_file_path="/mock.json")
@@ -944,9 +932,9 @@ class TestLibraryManagerInstallLibraryDependencies:
         assert isinstance(result, InstallLibraryDependenciesResultFailure)
 
     @pytest.mark.asyncio
-    async def test_reused_venv_with_successful_install_is_not_rebuilt(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_reused_venv_with_successful_install_is_not_rebuilt(self, engine: Engine) -> None:
         """A reused venv whose first install succeeds must not be rebuilt."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         schema = MagicMock()
         schema.name = "test_lib"
         schema.metadata.library_version = "1.0.0"
@@ -972,7 +960,7 @@ class TestLibraryManagerInstallLibraryDependencies:
                 "griptape_nodes.retained_mode.managers.library_manager.subprocess_run",
                 new_callable=AsyncMock,
             ) as mock_subprocess,
-            patch.object(griptape_nodes.ConfigManager(), "get_config_value", side_effect=_fake_config_value),
+            patch.object(engine.config_manager, "get_config_value", side_effect=_fake_config_value),
         ):
             result = await mgr.install_library_dependencies_request(
                 InstallLibraryDependenciesRequest(library_file_path="/mock.json")
@@ -984,9 +972,9 @@ class TestLibraryManagerInstallLibraryDependencies:
         mock_subprocess.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_rebuilds_reused_venv_and_retries_when_install_fails(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_rebuilds_reused_venv_and_retries_when_install_fails(self, engine: Engine) -> None:
         """A reused venv that fails to install is rebuilt once and the install retried."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         schema = MagicMock()
         schema.name = "test_lib"
         schema.metadata.library_version = "1.0.0"
@@ -1019,7 +1007,7 @@ class TestLibraryManagerInstallLibraryDependencies:
                     MagicMock(),
                 ],
             ) as mock_subprocess,
-            patch.object(griptape_nodes.ConfigManager(), "get_config_value", side_effect=_fake_config_value),
+            patch.object(engine.config_manager, "get_config_value", side_effect=_fake_config_value),
         ):
             result = await mgr.install_library_dependencies_request(
                 InstallLibraryDependenciesRequest(library_file_path="/mock.json")
@@ -1031,9 +1019,9 @@ class TestLibraryManagerInstallLibraryDependencies:
         assert mock_subprocess.await_count == expected_attempts
 
     @pytest.mark.asyncio
-    async def test_does_not_rebuild_freshly_built_venv_on_install_failure(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_does_not_rebuild_freshly_built_venv_on_install_failure(self, engine: Engine) -> None:
         """A freshly built venv that fails to install fails fast without a rebuild."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         schema = MagicMock()
         schema.name = "test_lib"
         schema.metadata.library_version = "1.0.0"
@@ -1060,7 +1048,7 @@ class TestLibraryManagerInstallLibraryDependencies:
                 new_callable=AsyncMock,
                 side_effect=subprocess.CalledProcessError(returncode=2, cmd=["uv"], stderr="bad package"),
             ) as mock_subprocess,
-            patch.object(griptape_nodes.ConfigManager(), "get_config_value", side_effect=_fake_config_value),
+            patch.object(engine.config_manager, "get_config_value", side_effect=_fake_config_value),
         ):
             result = await mgr.install_library_dependencies_request(
                 InstallLibraryDependenciesRequest(library_file_path="/mock.json")
@@ -1071,9 +1059,9 @@ class TestLibraryManagerInstallLibraryDependencies:
         mock_subprocess.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_returns_failure_when_install_fails_after_rebuild(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_returns_failure_when_install_fails_after_rebuild(self, engine: Engine) -> None:
         """If the install still fails after the venv rebuild, the request fails."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         schema = MagicMock()
         schema.name = "test_lib"
         schema.metadata.library_version = "1.0.0"
@@ -1106,7 +1094,7 @@ class TestLibraryManagerInstallLibraryDependencies:
                     subprocess.CalledProcessError(returncode=2, cmd=["uv"], stderr="still broken"),
                 ],
             ) as mock_subprocess,
-            patch.object(griptape_nodes.ConfigManager(), "get_config_value", side_effect=_fake_config_value),
+            patch.object(engine.config_manager, "get_config_value", side_effect=_fake_config_value),
         ):
             result = await mgr.install_library_dependencies_request(
                 InstallLibraryDependenciesRequest(library_file_path="/mock.json")
@@ -1145,10 +1133,8 @@ class TestLibraryManagerVenvHealth:
         return python_path
 
     @pytest.mark.asyncio
-    async def test_init_reuses_functional_venv_without_running_uv(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
-        mgr = griptape_nodes.LibraryManager()
+    async def test_init_reuses_functional_venv_without_running_uv(self, engine: Engine, tmp_path: Path) -> None:
+        mgr = engine.library_manager
         venv_path = tmp_path / ".venv"
         expected_python = self._make_functional_venv(venv_path)
 
@@ -1168,9 +1154,9 @@ class TestLibraryManagerVenvHealth:
         assert (venv_path / "pyvenv.cfg").exists()
 
     @pytest.mark.asyncio
-    async def test_init_recreates_broken_venv(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
+    async def test_init_recreates_broken_venv(self, engine: Engine, tmp_path: Path) -> None:
         """A directory at the venv path that is missing the python executable must be recreated."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         venv_path = tmp_path / ".venv"
         venv_path.mkdir()
         (venv_path / "pyvenv.cfg").write_text("home = /fake\n")
@@ -1197,7 +1183,7 @@ class TestLibraryManagerVenvHealth:
                 "griptape_nodes.retained_mode.managers.library_manager.OSManager.check_available_disk_space",
                 return_value=True,
             ),
-            patch.object(griptape_nodes.ConfigManager(), "get_config_value", side_effect=_fake_config_value),
+            patch.object(engine.config_manager, "get_config_value", side_effect=_fake_config_value),
         ):
             python_path = await mgr._init_library_venv(venv_path)
 
@@ -1207,8 +1193,8 @@ class TestLibraryManagerVenvHealth:
         assert not (venv_path / "stray.txt").exists()
 
     @pytest.mark.asyncio
-    async def test_init_creates_venv_when_directory_absent(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
-        mgr = griptape_nodes.LibraryManager()
+    async def test_init_creates_venv_when_directory_absent(self, engine: Engine, tmp_path: Path) -> None:
+        mgr = engine.library_manager
         venv_path = tmp_path / ".venv"
 
         async def fake_subprocess_run(args: list[str], **_: object) -> MagicMock:
@@ -1228,7 +1214,7 @@ class TestLibraryManagerVenvHealth:
                 "griptape_nodes.retained_mode.managers.library_manager.OSManager.check_available_disk_space",
                 return_value=True,
             ),
-            patch.object(griptape_nodes.ConfigManager(), "get_config_value", side_effect=_fake_config_value),
+            patch.object(engine.config_manager, "get_config_value", side_effect=_fake_config_value),
         ):
             python_path = await mgr._init_library_venv(venv_path)
 
@@ -1238,11 +1224,9 @@ class TestLibraryManagerVenvHealth:
         assert (venv_path / "pyvenv.cfg").exists()
 
     @pytest.mark.asyncio
-    async def test_reset_wipes_functional_venv_and_recreates_it(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
+    async def test_reset_wipes_functional_venv_and_recreates_it(self, engine: Engine, tmp_path: Path) -> None:
         """_reset_and_init_library_venv wipes even a functional venv, unlike _init_library_venv."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         venv_path = tmp_path / ".venv"
         self._make_functional_venv(venv_path)
         # A functional venv would be reused by _init_library_venv; prove reset wipes it anyway.
@@ -1267,7 +1251,7 @@ class TestLibraryManagerVenvHealth:
                 "griptape_nodes.retained_mode.managers.library_manager.OSManager.check_available_disk_space",
                 return_value=True,
             ),
-            patch.object(griptape_nodes.ConfigManager(), "get_config_value", side_effect=_fake_config_value),
+            patch.object(engine.config_manager, "get_config_value", side_effect=_fake_config_value),
         ):
             python_path = await mgr._reset_and_init_library_venv(venv_path)
 
@@ -1276,11 +1260,9 @@ class TestLibraryManagerVenvHealth:
         assert not (venv_path / "stray.txt").exists()
 
     @pytest.mark.asyncio
-    async def test_reset_raises_runtime_error_when_removal_fails(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
+    async def test_reset_raises_runtime_error_when_removal_fails(self, engine: Engine, tmp_path: Path) -> None:
         """A failure to remove the existing venv surfaces as RuntimeError."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         venv_path = tmp_path / ".venv"
         self._make_functional_venv(venv_path)
 
@@ -1298,9 +1280,9 @@ class TestListRegisteredLibraries:
     """Test the on_list_registered_libraries_request functionality in LibraryManager."""
 
     @pytest.mark.asyncio
-    async def test_waits_for_loading_complete_before_returning_libraries(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_waits_for_loading_complete_before_returning_libraries(self, engine: Engine) -> None:
         """Test that the handler blocks until _libraries_loading_complete is set."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         # Ensure the event is not set so the handler will block
         library_manager._libraries_loading_complete.clear()
@@ -1326,9 +1308,9 @@ class TestListRegisteredLibraries:
         assert result.libraries == mock_libraries
 
     @pytest.mark.asyncio
-    async def test_returns_library_list_when_loading_already_complete(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_returns_library_list_when_loading_already_complete(self, engine: Engine) -> None:
         """Test that the handler returns the library list immediately when loading is already done."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         # Simulate loading already finished
         library_manager._libraries_loading_complete.set()
@@ -1343,9 +1325,9 @@ class TestListRegisteredLibraries:
         assert result.libraries == mock_libraries
 
     @pytest.mark.asyncio
-    async def test_returns_copy_of_library_list(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_returns_copy_of_library_list(self, engine: Engine) -> None:
         """Test that the returned library list is a copy and not the original reference."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         library_manager._libraries_loading_complete.set()
 
         mock_libraries = ["LibA"]
@@ -1363,9 +1345,9 @@ class TestListRegisteredLibraries:
 class TestGetAllInfoForAllLibraries:
     """Test the get_all_info_for_all_libraries_request functionality in LibraryManager."""
 
-    def test_calls_library_registry_directly(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_calls_library_registry_directly(self, engine: Engine) -> None:
         """Test that the method reads libraries from LibraryRegistry without going through on_list_registered_libraries_request."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         with (
             patch.object(LibraryRegistry, "list_libraries", return_value=[]) as mock_list,
@@ -1378,9 +1360,9 @@ class TestGetAllInfoForAllLibraries:
         mock_handler.assert_not_called()
         assert isinstance(result, GetAllInfoForAllLibrariesResultSuccess)
 
-    def test_returns_failure_when_individual_library_info_fails(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_returns_failure_when_individual_library_info_fails(self, engine: Engine) -> None:
         """Test that the method returns failure when retrieving info for a library fails."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         mock_failure = MagicMock()
         mock_failure.succeeded.return_value = False
@@ -1400,9 +1382,9 @@ class TestAddLibraryPathsToSysPath:
     """Test the _add_library_paths_to_sys_path helper method."""
 
     @pytest.mark.asyncio
-    async def test_adds_base_dir_to_sys_path(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_adds_base_dir_to_sys_path(self, engine: Engine) -> None:
         """Test that the library base directory is added to sys.path."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         base_dir = Path("/fake/library/dir")
 
         mock_anyio_path = MagicMock()
@@ -1421,9 +1403,9 @@ class TestAddLibraryPathsToSysPath:
             sys.path[:] = original_sys_path
 
     @pytest.mark.asyncio
-    async def test_adds_venv_site_packages_when_venv_exists(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_adds_venv_site_packages_when_venv_exists(self, engine: Engine) -> None:
         """Test that venv site-packages are added to sys.path when the venv exists."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         base_dir = Path("/fake/library/dir")
         venv_path = Path("/fake/library/dir/.venv")
         fake_site_packages = str(Path("/fake/library/dir/.venv/lib/python3.12/site-packages"))
@@ -1449,9 +1431,9 @@ class TestAddLibraryPathsToSysPath:
             sys.path[:] = original_sys_path
 
     @pytest.mark.asyncio
-    async def test_skips_venv_when_venv_does_not_exist(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_skips_venv_when_venv_does_not_exist(self, engine: Engine) -> None:
         """Test that venv site-packages are NOT added when the venv doesn't exist."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         base_dir = Path("/fake/library/dir")
         venv_path = Path("/fake/library/dir/.venv")
 
@@ -1491,7 +1473,7 @@ class TestRegisterSandboxNodeFromSourceRequest:
     @pytest.fixture(autouse=True)
     def _isolate_registry_and_config(
         self,
-        griptape_nodes: GriptapeNodes,
+        engine: Engine,
         tmp_path: Path,
     ) -> Generator[Path, None, None]:
         """Configure a temp sandbox directory + register the Sandbox Library for this test.
@@ -1550,7 +1532,7 @@ class TestRegisterSandboxNodeFromSourceRequest:
         )
         LibraryRegistry.generate_new_library(library_data=sandbox_schema)
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         # Default: return the tmp sandbox. Individual tests that need the "not configured"
         # branch override via their own patch.
         with patch.object(library_manager, "_get_sandbox_directory", return_value=sandbox_dir):
@@ -1561,7 +1543,7 @@ class TestRegisterSandboxNodeFromSourceRequest:
 
     def test_imports_existing_file_and_registers_node_type(
         self,
-        griptape_nodes: GriptapeNodes,
+        engine: Engine,
         _isolate_registry_and_config: Path,  # noqa: PT019 - value is used to locate the source file
     ) -> None:
         from griptape_nodes.retained_mode.events.library_events import (
@@ -1569,7 +1551,7 @@ class TestRegisterSandboxNodeFromSourceRequest:
             RegisterSandboxNodeFromSourceResultSuccess,
         )
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         sandbox_dir = _isolate_registry_and_config
         source_file = sandbox_dir / self._FILE_NAME
         source_file.write_text(self._SOURCE_OK)
@@ -1587,7 +1569,7 @@ class TestRegisterSandboxNodeFromSourceRequest:
 
     def test_accepts_path_relative_to_sandbox_directory(
         self,
-        griptape_nodes: GriptapeNodes,
+        engine: Engine,
         _isolate_registry_and_config: Path,  # noqa: PT019 - value is used to locate the source file
     ) -> None:
         from griptape_nodes.retained_mode.events.library_events import (
@@ -1595,7 +1577,7 @@ class TestRegisterSandboxNodeFromSourceRequest:
             RegisterSandboxNodeFromSourceResultSuccess,
         )
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         sandbox_dir = _isolate_registry_and_config
         (sandbox_dir / self._FILE_NAME).write_text(self._SOURCE_OK)
 
@@ -1609,7 +1591,7 @@ class TestRegisterSandboxNodeFromSourceRequest:
 
     def test_replace_if_exists_swaps_the_old_class(
         self,
-        griptape_nodes: GriptapeNodes,
+        engine: Engine,
         _isolate_registry_and_config: Path,  # noqa: PT019 - value is used to locate the source file
     ) -> None:
         from griptape_nodes.retained_mode.events.library_events import (
@@ -1617,7 +1599,7 @@ class TestRegisterSandboxNodeFromSourceRequest:
             RegisterSandboxNodeFromSourceResultSuccess,
         )
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         sandbox_dir = _isolate_registry_and_config
         source_file = sandbox_dir / self._FILE_NAME
         source_file.write_text(self._SOURCE_OK)
@@ -1638,7 +1620,7 @@ class TestRegisterSandboxNodeFromSourceRequest:
 
     def test_fails_when_sandbox_directory_is_not_configured(
         self,
-        griptape_nodes: GriptapeNodes,
+        engine: Engine,
         _isolate_registry_and_config: Path,  # noqa: PT019 - fixture installs the default sandbox stub we override here
     ) -> None:
         from unittest.mock import patch
@@ -1648,7 +1630,7 @@ class TestRegisterSandboxNodeFromSourceRequest:
             RegisterSandboxNodeFromSourceResultFailure,
         )
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         # Override the fixture's default stub so the resolver returns None, simulating the
         # "no sandbox configured" case.
         with patch.object(library_manager, "_get_sandbox_directory", return_value=None):
@@ -1661,7 +1643,7 @@ class TestRegisterSandboxNodeFromSourceRequest:
 
     def test_rejects_paths_outside_sandbox_or_with_wrong_extension(
         self,
-        griptape_nodes: GriptapeNodes,
+        engine: Engine,
         _isolate_registry_and_config: Path,  # noqa: PT019 - value is used to seed source files
         tmp_path: Path,
     ) -> None:
@@ -1670,7 +1652,7 @@ class TestRegisterSandboxNodeFromSourceRequest:
             RegisterSandboxNodeFromSourceResultFailure,
         )
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         sandbox_dir = _isolate_registry_and_config
 
         # Create a real file outside the sandbox so the failure is about containment, not
@@ -1696,7 +1678,7 @@ class TestRegisterSandboxNodeFromSourceRequest:
 
     def test_fails_when_file_does_not_exist(
         self,
-        griptape_nodes: GriptapeNodes,
+        engine: Engine,
         _isolate_registry_and_config: Path,  # noqa: PT019 - fixture installs the sandbox stub
     ) -> None:
         from griptape_nodes.retained_mode.events.library_events import (
@@ -1704,7 +1686,7 @@ class TestRegisterSandboxNodeFromSourceRequest:
             RegisterSandboxNodeFromSourceResultFailure,
         )
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         result = library_manager.register_sandbox_node_from_source_request(
             RegisterSandboxNodeFromSourceRequest(file_path="never_written.py")
@@ -1715,7 +1697,7 @@ class TestRegisterSandboxNodeFromSourceRequest:
 
     def test_fails_when_source_has_no_base_node_subclass(
         self,
-        griptape_nodes: GriptapeNodes,
+        engine: Engine,
         _isolate_registry_and_config: Path,  # noqa: PT019 - value is used to locate the source file
     ) -> None:
         from griptape_nodes.retained_mode.events.library_events import (
@@ -1723,7 +1705,7 @@ class TestRegisterSandboxNodeFromSourceRequest:
             RegisterSandboxNodeFromSourceResultFailure,
         )
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         sandbox_dir = _isolate_registry_and_config
         no_node_file = sandbox_dir / "no_node.py"
         no_node_file.write_text("x = 1\n")
@@ -1833,11 +1815,11 @@ class TestDescribeNodeTypeRequest:
             ),
         )
 
-    def test_probe_resolves_library_model_catalog(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_probe_resolves_library_model_catalog(self, engine: Engine) -> None:
         # The probe must be constructed with the node's library/type so __init__
         # logic that resolves against the model_catalog (get_declared_models)
         # works -- otherwise the catalog is invisible and the roster is empty.
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         schema = LibrarySchema(
             name=self._LIBRARY_NAME,
             library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
@@ -1887,8 +1869,8 @@ class TestDescribeNodeTypeRequest:
         # Resolved from the catalog -> non-empty. Without library context it would be "".
         assert by_name["resolved_models"].default_value == "acme-m1"
 
-    def test_returns_parameter_schema_without_touching_object_manager(self, griptape_nodes: GriptapeNodes) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    def test_returns_parameter_schema_without_touching_object_manager(self, engine: Engine) -> None:
+        library_manager = engine.library_manager
         self._register_probe_library()
 
         request = DescribeNodeTypeRequest(
@@ -1925,14 +1907,14 @@ class TestDescribeNodeTypeRequest:
 
         # Probe node must not leak into the ObjectManager.
         assert (
-            griptape_nodes.ObjectManager().attempt_get_object_by_name(
+            engine.object_manager.attempt_get_object_by_name(
                 f"__describe_node_type_probe__{_DescribeNodeTypeProbe.__name__}"
             )
             is None
         )
 
-    def test_resolves_library_when_node_type_is_unambiguous(self, griptape_nodes: GriptapeNodes) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    def test_resolves_library_when_node_type_is_unambiguous(self, engine: Engine) -> None:
+        library_manager = engine.library_manager
         self._register_probe_library()
 
         request = DescribeNodeTypeRequest(node_type=_DescribeNodeTypeProbe.__name__)
@@ -1942,8 +1924,8 @@ class TestDescribeNodeTypeRequest:
         assert isinstance(result, DescribeNodeTypeResultSuccess)
         assert result.library == self._LIBRARY_NAME
 
-    def test_returns_failure_when_node_type_missing(self, griptape_nodes: GriptapeNodes) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    def test_returns_failure_when_node_type_missing(self, engine: Engine) -> None:
+        library_manager = engine.library_manager
         self._register_probe_library()
 
         request = DescribeNodeTypeRequest(node_type="NotARealNode", library=self._LIBRARY_NAME)
@@ -1952,9 +1934,9 @@ class TestDescribeNodeTypeRequest:
 
         assert isinstance(result, DescribeNodeTypeResultFailure)
 
-    def test_returns_success_with_warning_detail_when_init_raises(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_returns_success_with_warning_detail_when_init_raises(self, engine: Engine) -> None:
         """Nodes whose __init__ performs I/O can raise (e.g. auth). We still want the node-level metadata."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         schema = LibrarySchema(
             name=self._LIBRARY_NAME,
@@ -2108,18 +2090,18 @@ class TestLibraryManagerEngineVersionCheck:
         config_manager.get_config_value.return_value = spec
         return config_manager
 
-    def test_satisfied_returns_none(self, griptape_nodes: GriptapeNodes) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    def test_satisfied_returns_none(self, engine: Engine) -> None:
+        library_manager = engine.library_manager
         with (
-            patch.object(griptape_nodes, "_config_manager", self._config_manager_returning(">=0.5,<1.0")),
+            patch.object(engine, "_config_manager", self._config_manager_returning(">=0.5,<1.0")),
             patch("griptape_nodes.utils.version_utils.engine_version", "0.5.3"),
         ):
             assert library_manager._check_engine_version() is None
 
-    def test_unsatisfied_returns_detail_naming_running_version(self, griptape_nodes: GriptapeNodes) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    def test_unsatisfied_returns_detail_naming_running_version(self, engine: Engine) -> None:
+        library_manager = engine.library_manager
         with (
-            patch.object(griptape_nodes, "_config_manager", self._config_manager_returning(">=2.0,<3.0")),
+            patch.object(engine, "_config_manager", self._config_manager_returning(">=2.0,<3.0")),
             patch("griptape_nodes.utils.version_utils.engine_version", "0.5.3"),
         ):
             detail = library_manager._check_engine_version()
@@ -2127,10 +2109,10 @@ class TestLibraryManagerEngineVersionCheck:
         assert detail is not None
         assert "0.5.3" in detail
 
-    def test_malformed_specifier_returns_detail(self, griptape_nodes: GriptapeNodes) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    def test_malformed_specifier_returns_detail(self, engine: Engine) -> None:
+        library_manager = engine.library_manager
         with (
-            patch.object(griptape_nodes, "_config_manager", self._config_manager_returning("not-a-specifier")),
+            patch.object(engine, "_config_manager", self._config_manager_returning("not-a-specifier")),
             patch("griptape_nodes.utils.version_utils.engine_version", "0.5.3"),
         ):
             detail = library_manager._check_engine_version()
@@ -2138,9 +2120,9 @@ class TestLibraryManagerEngineVersionCheck:
         assert detail is not None
         assert "not a valid" in detail.lower()
 
-    def test_no_key_returns_none(self, griptape_nodes: GriptapeNodes) -> None:
-        library_manager = griptape_nodes.LibraryManager()
-        with patch.object(griptape_nodes, "_config_manager", self._config_manager_returning(None)):
+    def test_no_key_returns_none(self, engine: Engine) -> None:
+        library_manager = engine.library_manager
+        with patch.object(engine, "_config_manager", self._config_manager_returning(None)):
             assert library_manager._check_engine_version() is None
 
 
@@ -2148,10 +2130,10 @@ class TestLibraryManagerProvisioningPlan:
     """`_plan_one_library_provisioning` is a pure decision the preview and execution share."""
 
     @pytest.mark.asyncio
-    async def test_satisfied_git_entry_plans_skip(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_satisfied_git_entry_plans_skip(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.library_events import LibraryProvisioningActionKind
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         download = LibraryDownload(name="git-lib", version=">=2.0,<3", git_url="griptape-ai/git-lib@v2")
         with patch.object(library_manager, "_installed_download_version", new=AsyncMock(return_value="2.1.0")):
             action = await library_manager._plan_one_library_provisioning(download)
@@ -2160,10 +2142,10 @@ class TestLibraryManagerProvisioningPlan:
         assert action.destructive is False
 
     @pytest.mark.asyncio
-    async def test_missing_git_entry_plans_install(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_missing_git_entry_plans_install(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.library_events import LibraryProvisioningActionKind
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         download = LibraryDownload(name="git-lib", version=">=2.0", git_url="griptape-ai/git-lib@v2.0")
         with patch.object(library_manager, "_installed_download_version", new=AsyncMock(return_value=None)):
             action = await library_manager._plan_one_library_provisioning(download)
@@ -2172,10 +2154,10 @@ class TestLibraryManagerProvisioningPlan:
         assert action.destructive is False
 
     @pytest.mark.asyncio
-    async def test_wrong_git_version_plans_destructive_overwrite(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_wrong_git_version_plans_destructive_overwrite(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.library_events import LibraryProvisioningActionKind
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         download = LibraryDownload(name="git-lib", version=">=2.0", git_url="griptape-ai/git-lib@v2.0")
         with patch.object(library_manager, "_installed_download_version", new=AsyncMock(return_value="1.0.0")):
             action = await library_manager._plan_one_library_provisioning(download)
@@ -2185,15 +2167,13 @@ class TestLibraryManagerProvisioningPlan:
         assert action.destructive is True
 
     @pytest.mark.asyncio
-    async def test_version_pin_without_name_uses_repo_name_for_action_label(
-        self, griptape_nodes: GriptapeNodes
-    ) -> None:
+    async def test_version_pin_without_name_uses_repo_name_for_action_label(self, engine: Engine) -> None:
         # A {git_url, version} entry with no `name` still enforces its pin: the installed
         # copy is found by its repo-name directory, so a wrong version plans OVERWRITE
         # rather than silently no-opping. The action's library_name falls back to the repo name.
         from griptape_nodes.retained_mode.events.library_events import LibraryProvisioningActionKind
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         download = LibraryDownload(version=">=2.0", git_url="griptape-ai/git-lib@v2.0")
         with patch.object(library_manager, "_installed_download_version", new=AsyncMock(return_value="1.0.0")):
             action = await library_manager._plan_one_library_provisioning(download)
@@ -2218,42 +2198,40 @@ class TestInstalledLibraryVersion:
         config_manager = MagicMock()
         config_manager.resolved_libraries_root.return_value = libraries_dir
         # find_files_recursive resolves `discovery_max_depth` through this same
-        # config manager (via GriptapeNodes.ConfigManager()), so it needs a real
+        # config manager (via engine.config_manager), so it needs a real
         # int here or the recursive walk's depth comparison blows up on a MagicMock.
         config_manager.get_config_value.return_value = DEFAULT_MAX_SEARCH_DEPTH
         return config_manager
 
     @pytest.mark.asyncio
-    async def test_returns_version_from_matching_manifest(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    async def test_returns_version_from_matching_manifest(self, engine: Engine, tmp_path: Path) -> None:
+        library_manager = engine.library_manager
         libraries_dir = tmp_path / "libraries"
         self._write_manifest(libraries_dir / "git-lib", "Griptape Nodes Library", "0.78.0")
-        with patch.object(griptape_nodes, "_config_manager", self._config_manager_for(libraries_dir)):
+        with patch.object(engine, "_config_manager", self._config_manager_for(libraries_dir)):
             assert await library_manager._installed_library_version("Griptape Nodes Library", libraries_dir) == "0.78.0"
 
     @pytest.mark.asyncio
-    async def test_returns_none_when_no_manifest_matches(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    async def test_returns_none_when_no_manifest_matches(self, engine: Engine, tmp_path: Path) -> None:
+        library_manager = engine.library_manager
         libraries_dir = tmp_path / "libraries"
         self._write_manifest(libraries_dir / "other", "Some Other Library", "1.0.0")
-        with patch.object(griptape_nodes, "_config_manager", self._config_manager_for(libraries_dir)):
+        with patch.object(engine, "_config_manager", self._config_manager_for(libraries_dir)):
             assert await library_manager._installed_library_version("Griptape Nodes Library", libraries_dir) is None
 
     @pytest.mark.asyncio
-    async def test_returns_none_when_libraries_root_empty(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    async def test_returns_none_when_libraries_root_empty(self, engine: Engine, tmp_path: Path) -> None:
+        library_manager = engine.library_manager
         libraries_dir = tmp_path / "empty-libraries"
-        with patch.object(griptape_nodes, "_config_manager", self._config_manager_for(libraries_dir)):
+        with patch.object(engine, "_config_manager", self._config_manager_for(libraries_dir)):
             assert await library_manager._installed_library_version("Griptape Nodes Library", libraries_dir) is None
 
     @pytest.mark.asyncio
-    async def test_returns_none_when_manifest_has_no_version(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    async def test_returns_none_when_manifest_has_no_version(self, engine: Engine, tmp_path: Path) -> None:
+        library_manager = engine.library_manager
         libraries_dir = tmp_path / "libraries"
         self._write_manifest(libraries_dir / "git-lib", "Griptape Nodes Library", None)
-        with patch.object(griptape_nodes, "_config_manager", self._config_manager_for(libraries_dir)):
+        with patch.object(engine, "_config_manager", self._config_manager_for(libraries_dir)):
             assert await library_manager._installed_library_version("Griptape Nodes Library", libraries_dir) is None
 
 
@@ -2266,34 +2244,30 @@ class TestInstalledLibraryManifestPath:
     """
 
     @pytest.mark.asyncio
-    async def test_returns_manifest_path_for_matching_name(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    async def test_returns_manifest_path_for_matching_name(self, engine: Engine, tmp_path: Path) -> None:
+        library_manager = engine.library_manager
         libraries_dir = tmp_path / "libraries"
         TestInstalledLibraryVersion._write_manifest(libraries_dir / "git-lib", "Griptape Nodes Library", "0.78.0")
-        with patch.object(
-            griptape_nodes, "_config_manager", TestInstalledLibraryVersion._config_manager_for(libraries_dir)
-        ):
+        with patch.object(engine, "_config_manager", TestInstalledLibraryVersion._config_manager_for(libraries_dir)):
             result = await library_manager._installed_library_manifest_path("Griptape Nodes Library", libraries_dir)
         assert result == libraries_dir / "git-lib" / "griptape_nodes_library.json"
 
     @pytest.mark.asyncio
-    async def test_returns_none_when_no_manifest_matches(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    async def test_returns_none_when_no_manifest_matches(self, engine: Engine, tmp_path: Path) -> None:
+        library_manager = engine.library_manager
         libraries_dir = tmp_path / "libraries"
         TestInstalledLibraryVersion._write_manifest(libraries_dir / "other", "Some Other Library", "1.0.0")
-        with patch.object(
-            griptape_nodes, "_config_manager", TestInstalledLibraryVersion._config_manager_for(libraries_dir)
-        ):
+        with patch.object(engine, "_config_manager", TestInstalledLibraryVersion._config_manager_for(libraries_dir)):
             assert (
                 await library_manager._installed_library_manifest_path("Griptape Nodes Library", libraries_dir) is None
             )
 
     @pytest.mark.asyncio
-    async def test_returns_none_when_libraries_root_empty(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    async def test_returns_none_when_libraries_root_empty(self, engine: Engine, tmp_path: Path) -> None:
+        library_manager = engine.library_manager
         libraries_dir = tmp_path / "empty-libraries"
         with patch.object(
-            griptape_nodes,
+            engine,
             "_config_manager",
             TestInstalledLibraryVersion._config_manager_for(libraries_dir),
         ):
@@ -2312,63 +2286,53 @@ class TestInstalledDownloadVersion:
     """
 
     @pytest.mark.asyncio
-    async def test_resolves_by_repo_name_directory_when_name_absent(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
+    async def test_resolves_by_repo_name_directory_when_name_absent(self, engine: Engine, tmp_path: Path) -> None:
         # The clone dir is the repo name from the git URL, while the manifest's own
         # `name` differs; the lookup must key off the directory, not the manifest name.
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         libraries_dir = tmp_path / "libraries"
         TestInstalledLibraryVersion._write_manifest(libraries_dir / "git-lib", "Griptape Nodes Library", "1.2.3")
         download = LibraryDownload(git_url="griptape-ai/git-lib@v2.0", version=">=1.0")
-        with patch.object(
-            griptape_nodes, "_config_manager", TestInstalledLibraryVersion._config_manager_for(libraries_dir)
-        ):
+        with patch.object(engine, "_config_manager", TestInstalledLibraryVersion._config_manager_for(libraries_dir)):
             assert await library_manager._installed_download_version(download, libraries_dir) == "1.2.3"
 
     @pytest.mark.asyncio
-    async def test_returns_none_when_repo_directory_absent(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    async def test_returns_none_when_repo_directory_absent(self, engine: Engine, tmp_path: Path) -> None:
+        library_manager = engine.library_manager
         libraries_dir = tmp_path / "libraries"
         TestInstalledLibraryVersion._write_manifest(libraries_dir / "other-lib", "Other", "1.0.0")
         download = LibraryDownload(git_url="griptape-ai/git-lib@v2.0", version=">=1.0")
-        with patch.object(
-            griptape_nodes, "_config_manager", TestInstalledLibraryVersion._config_manager_for(libraries_dir)
-        ):
+        with patch.object(engine, "_config_manager", TestInstalledLibraryVersion._config_manager_for(libraries_dir)):
             assert await library_manager._installed_download_version(download, libraries_dir) is None
 
     @pytest.mark.asyncio
-    async def test_name_overrides_directory_match(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
+    async def test_name_overrides_directory_match(self, engine: Engine, tmp_path: Path) -> None:
         # With an explicit `name`, resolve by manifest name even when the library lives
         # under a directory that does not match the repo name (e.g. legacy XDG layout).
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         libraries_dir = tmp_path / "libraries"
         TestInstalledLibraryVersion._write_manifest(libraries_dir / "legacy-dir", "Griptape Nodes Library", "0.9.0")
         download = LibraryDownload(git_url="griptape-ai/git-lib@v2.0", version=">=1.0", name="Griptape Nodes Library")
-        with patch.object(
-            griptape_nodes, "_config_manager", TestInstalledLibraryVersion._config_manager_for(libraries_dir)
-        ):
+        with patch.object(engine, "_config_manager", TestInstalledLibraryVersion._config_manager_for(libraries_dir)):
             assert await library_manager._installed_download_version(download, libraries_dir) == "0.9.0"
 
     @pytest.mark.asyncio
-    async def test_returns_none_when_libraries_root_empty(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    async def test_returns_none_when_libraries_root_empty(self, engine: Engine, tmp_path: Path) -> None:
+        library_manager = engine.library_manager
         download = LibraryDownload(git_url="griptape-ai/git-lib@v2.0", version=">=1.0")
         libraries_dir = tmp_path / "empty-libraries"
         with patch.object(
-            griptape_nodes,
+            engine,
             "_config_manager",
             TestInstalledLibraryVersion._config_manager_for(libraries_dir),
         ):
             assert await library_manager._installed_download_version(download, libraries_dir) is None
 
     @pytest.mark.asyncio
-    async def test_explicit_libraries_path_probes_target_not_live(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
+    async def test_explicit_libraries_path_probes_target_not_live(self, engine: Engine, tmp_path: Path) -> None:
         # The preview passes the TARGET project's libraries dir. The probe must read it,
         # not the live config, so it never falls back to the active workspace.
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         target_libs = tmp_path / "target" / "libraries"
         TestInstalledLibraryVersion._write_manifest(target_libs / "git-lib", "Griptape Nodes Library", "3.3.0")
         download = LibraryDownload(git_url="griptape-ai/git-lib@v2.0", version=">=1.0")
@@ -2377,7 +2341,7 @@ class TestInstalledDownloadVersion:
         # libraries_directory must never be read.
         live_config.get_config_value.return_value = str(tmp_path / "live" / "libraries")
         live_config.workspace_path = str(tmp_path / "live")
-        with patch.object(griptape_nodes, "_config_manager", live_config):
+        with patch.object(engine, "_config_manager", live_config):
             assert await library_manager._installed_download_version(download, target_libs) == "3.3.0"
         live_config.get_config_value.assert_not_called()
 
@@ -2393,8 +2357,8 @@ class TestDiscoverProvisionedManifestPaths:
     """
 
     @pytest.mark.asyncio
-    async def test_provisioned_manifest_path_is_discovered(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    async def test_provisioned_manifest_path_is_discovered(self, engine: Engine, tmp_path: Path) -> None:
+        library_manager = engine.library_manager
         libraries_dir = tmp_path / "libraries"
         manifest_dir = libraries_dir / "griptape-nodes-library-standard"
         TestInstalledLibraryVersion._write_manifest(manifest_dir, "Griptape Nodes Library", "0.78.0")
@@ -2406,15 +2370,15 @@ class TestDiscoverProvisionedManifestPaths:
 
         config_manager = TestInstalledLibraryVersion._config_manager_for(libraries_dir)
         config_manager.get_config_value.side_effect = _config_value_dispatcher(libraries_dir, config)
-        with patch.object(griptape_nodes, "_config_manager", config_manager):
+        with patch.object(engine, "_config_manager", config_manager):
             result = await library_manager._discover_library_files()
 
         discovered_paths = [Path(entry.registration.path) for entry in result if entry.registration.path is not None]
         assert expected_manifest in discovered_paths
 
     @pytest.mark.asyncio
-    async def test_missing_register_path_is_skipped(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    async def test_missing_register_path_is_skipped(self, engine: Engine, tmp_path: Path) -> None:
+        library_manager = engine.library_manager
         libraries_dir = tmp_path / "libraries"
         libraries_dir.mkdir(parents=True, exist_ok=True)
 
@@ -2423,7 +2387,7 @@ class TestDiscoverProvisionedManifestPaths:
 
         config_manager = TestInstalledLibraryVersion._config_manager_for(libraries_dir)
         config_manager.get_config_value.side_effect = _config_value_dispatcher(libraries_dir, config)
-        with patch.object(griptape_nodes, "_config_manager", config_manager):
+        with patch.object(engine, "_config_manager", config_manager):
             result = await library_manager._discover_library_files()
 
         assert result == []
@@ -2476,8 +2440,8 @@ class TestReconcileLibrariesFromConfig:
         return config_manager
 
     @pytest.mark.asyncio
-    async def test_engine_version_failure_blocks_provisioning(self, griptape_nodes: GriptapeNodes) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    async def test_engine_version_failure_blocks_provisioning(self, engine: Engine) -> None:
+        library_manager = engine.library_manager
         with (
             patch.object(library_manager, "_check_engine_version", return_value="engine too old"),
             patch.object(library_manager, "_provision_one_library", new=AsyncMock()) as mock_provision,
@@ -2489,8 +2453,8 @@ class TestReconcileLibrariesFromConfig:
         mock_provision.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_only_download_entries_are_provisioned(self, griptape_nodes: GriptapeNodes) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    async def test_only_download_entries_are_provisioned(self, engine: Engine) -> None:
+        library_manager = engine.library_manager
         # Both shapes of a download entry: a bare git-URL string and the object form.
         download_config = [
             "griptape-ai/bare-lib@v2",
@@ -2500,7 +2464,7 @@ class TestReconcileLibrariesFromConfig:
         register_config = ["griptape_nodes_library.json", {"path": "../shared/lib"}]
         config_manager = self._config_manager_for_keys(downloads=download_config, register=register_config)
         with (
-            patch.object(griptape_nodes, "_config_manager", config_manager),
+            patch.object(engine, "_config_manager", config_manager),
             patch.object(library_manager, "_check_engine_version", return_value=None),
             patch.object(library_manager, "_provision_one_library", new=AsyncMock(return_value=None)) as mock_provision,
         ):
@@ -2511,12 +2475,12 @@ class TestReconcileLibrariesFromConfig:
         assert mock_provision.await_count == 2  # noqa: PLR2004
 
     @pytest.mark.asyncio
-    async def test_provision_failure_is_collected(self, griptape_nodes: GriptapeNodes) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    async def test_provision_failure_is_collected(self, engine: Engine) -> None:
+        library_manager = engine.library_manager
         download_config = [{"name": "git-lib", "git_url": "griptape-ai/git-lib@v2", "version": ">=2.0"}]
         config_manager = self._config_manager_for_keys(downloads=download_config)
         with (
-            patch.object(griptape_nodes, "_config_manager", config_manager),
+            patch.object(engine, "_config_manager", config_manager),
             patch.object(library_manager, "_check_engine_version", return_value=None),
             patch.object(library_manager, "_provision_one_library", new=AsyncMock(return_value="clone failed")),
         ):
@@ -2560,7 +2524,7 @@ class TestPreviewProjectProvisioning:
     @staticmethod
     @contextlib.contextmanager
     def _patch_managers(
-        griptape_nodes: GriptapeNodes, *, dirs: object, merged: object, libraries_root: object = None
+        engine: Engine, *, dirs: object, merged: object, libraries_root: object = None
     ) -> Generator[tuple[MagicMock, MagicMock], None, None]:
         """Wire the mocked ProjectManager/ConfigManager the new handler calls.
 
@@ -2577,8 +2541,8 @@ class TestPreviewProjectProvisioning:
         mock_config_manager.compute_project_provisioning_config.return_value = merged
         TestPreviewProjectProvisioning._use_real_libraries_root_formula(mock_config_manager)
         with (
-            patch.object(griptape_nodes, "_project_manager", mock_project_manager),
-            patch.object(griptape_nodes, "_config_manager", mock_config_manager),
+            patch.object(engine, "_project_manager", mock_project_manager),
+            patch.object(engine, "_config_manager", mock_config_manager),
         ):
             yield mock_project_manager, mock_config_manager
 
@@ -2596,9 +2560,7 @@ class TestPreviewProjectProvisioning:
 
     @staticmethod
     @contextlib.contextmanager
-    def _patch_system_defaults(
-        griptape_nodes: GriptapeNodes, *, merged: object
-    ) -> Generator[tuple[MagicMock, MagicMock], None, None]:
+    def _patch_system_defaults(engine: Engine, *, merged: object) -> Generator[tuple[MagicMock, MagicMock], None, None]:
         """Wire the mocked ConfigManager for the system-defaults branch.
 
         System defaults reads its merged config from compute_system_defaults_provisioning_config
@@ -2609,22 +2571,22 @@ class TestPreviewProjectProvisioning:
         mock_config_manager = MagicMock()
         mock_config_manager.compute_system_defaults_provisioning_config.return_value = merged
         with (
-            patch.object(griptape_nodes, "_project_manager", mock_project_manager),
-            patch.object(griptape_nodes, "_config_manager", mock_config_manager),
+            patch.object(engine, "_project_manager", mock_project_manager),
+            patch.object(engine, "_config_manager", mock_config_manager),
         ):
             yield mock_project_manager, mock_config_manager
 
     @pytest.mark.asyncio
-    async def test_not_loaded_project_is_failure(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_not_loaded_project_is_failure(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.library_events import (
             PreviewProjectProvisioningRequest,
             PreviewProjectProvisioningResultFailure,
         )
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         mock_project_manager = MagicMock()
         mock_project_manager.resolve_provisioning_config_dirs = AsyncMock(return_value=None)
-        with patch.object(griptape_nodes, "_project_manager", mock_project_manager):
+        with patch.object(engine, "_project_manager", mock_project_manager):
             result = await library_manager.on_preview_project_provisioning_request(
                 PreviewProjectProvisioningRequest(project_id="/nope/project.yml")
             )
@@ -2632,15 +2594,15 @@ class TestPreviewProjectProvisioning:
         assert isinstance(result, PreviewProjectProvisioningResultFailure)
 
     @pytest.mark.asyncio
-    async def test_no_download_entries_is_empty_success(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
+    async def test_no_download_entries_is_empty_success(self, engine: Engine, tmp_path: Path) -> None:
         from griptape_nodes.retained_mode.events.library_events import (
             PreviewProjectProvisioningRequest,
             PreviewProjectProvisioningResultSuccess,
         )
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         merged = self._merged_config([])
-        with self._patch_managers(griptape_nodes, dirs=MagicMock(), merged=merged):
+        with self._patch_managers(engine, dirs=MagicMock(), merged=merged):
             result = await library_manager.on_preview_project_provisioning_request(
                 PreviewProjectProvisioningRequest(project_id=str(tmp_path / "project.yml"))
             )
@@ -2650,16 +2612,14 @@ class TestPreviewProjectProvisioning:
         assert result.engine_version_failure is None
 
     @pytest.mark.asyncio
-    async def test_download_entries_preserve_order_and_flags(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
+    async def test_download_entries_preserve_order_and_flags(self, engine: Engine, tmp_path: Path) -> None:
         from griptape_nodes.retained_mode.events.library_events import (
             LibraryProvisioningActionKind,
             PreviewProjectProvisioningRequest,
             PreviewProjectProvisioningResultSuccess,
         )
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         merged = self._merged_config(
             [
                 {"name": "skip-lib", "git_url": "griptape-ai/skip-lib@v2", "version": ">=2.0"},
@@ -2669,7 +2629,7 @@ class TestPreviewProjectProvisioning:
         )
         installed = {"skip-lib": "2.1.0", "install-lib": None, "overwrite-lib": "1.0.0"}
         with (
-            self._patch_managers(griptape_nodes, dirs=MagicMock(), merged=merged),
+            self._patch_managers(engine, dirs=MagicMock(), merged=merged),
             patch.object(
                 library_manager,
                 "_installed_download_version",
@@ -2691,9 +2651,7 @@ class TestPreviewProjectProvisioning:
         assert [a.destructive for a in result.actions] == [False, False, True]
 
     @pytest.mark.asyncio
-    async def test_plan_reads_merged_config_for_resolved_dirs(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
+    async def test_plan_reads_merged_config_for_resolved_dirs(self, engine: Engine, tmp_path: Path) -> None:
         """The preview plans from the merged config (not the project-adjacent file).
 
         Guards defect #2: when a higher-priority layer supplies
@@ -2707,7 +2665,7 @@ class TestPreviewProjectProvisioning:
             PreviewProjectProvisioningResultSuccess,
         )
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         dirs = MagicMock()
         dirs.project_dir = tmp_path / "proj"
         dirs.workspace_dir = tmp_path / "ws"
@@ -2715,7 +2673,7 @@ class TestPreviewProjectProvisioning:
         # project-adjacent file alone would carry; the plan must reflect this entry.
         merged = self._merged_config([{"name": "merged-lib", "git_url": "griptape-ai/merged-lib@v2", "version": ">=2"}])
         with (
-            self._patch_managers(griptape_nodes, dirs=dirs, merged=merged) as (
+            self._patch_managers(engine, dirs=dirs, merged=merged) as (
                 _mock_project_manager,
                 mock_config_manager,
             ),
@@ -2732,9 +2690,7 @@ class TestPreviewProjectProvisioning:
         assert result.actions[0].kind == LibraryProvisioningActionKind.INSTALL
 
     @pytest.mark.asyncio
-    async def test_probes_global_workspace_for_unset_libraries_fallback(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
+    async def test_probes_global_workspace_for_unset_libraries_fallback(self, engine: Engine, tmp_path: Path) -> None:
         """The unset-libraries_dir probe reads the GLOBAL workspace's libraries dir.
 
         With no own/inherited libraries_dir, the preview fallback resolves libraries_directory against
@@ -2750,7 +2706,7 @@ class TestPreviewProjectProvisioning:
             PreviewProjectProvisioningResultSuccess,
         )
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         global_ws = tmp_path / "global"
         TestInstalledLibraryVersion._write_manifest(global_ws / "libraries" / "git-lib", "git-lib", "1.0.0")
         merged = self._merged_config(
@@ -2773,8 +2729,8 @@ class TestPreviewProjectProvisioning:
         # activation-mirroring gate to the fallback probe under test.
         mock_project_manager.unresolvable_declared_path_messages.return_value = []
         with (
-            patch.object(griptape_nodes, "_project_manager", mock_project_manager),
-            patch.object(griptape_nodes, "_config_manager", live_config),
+            patch.object(engine, "_project_manager", mock_project_manager),
+            patch.object(engine, "_config_manager", live_config),
         ):
             result = await library_manager.on_preview_project_provisioning_request(
                 PreviewProjectProvisioningRequest(project_id=str(tmp_path / "project.yml"))
@@ -2787,7 +2743,7 @@ class TestPreviewProjectProvisioning:
 
     @pytest.mark.asyncio
     async def test_probes_offline_resolved_libraries_root_over_workspace_default(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
+        self, engine: Engine, tmp_path: Path
     ) -> None:
         """A non-None libraries_root from the offline resolver overrides the workspace-relative default.
 
@@ -2803,7 +2759,7 @@ class TestPreviewProjectProvisioning:
             PreviewProjectProvisioningResultSuccess,
         )
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         resolved_root = tmp_path / "shared-libs"
         TestInstalledLibraryVersion._write_manifest(resolved_root / "git-lib", "git-lib", "1.0.0")
         # The merged workspace-relative default points at an empty dir; probing it would miss the
@@ -2813,7 +2769,7 @@ class TestPreviewProjectProvisioning:
             workspace_directory=str(tmp_path / "ws"),
             libraries_directory="libraries",
         )
-        with self._patch_managers(griptape_nodes, dirs=MagicMock(), merged=merged, libraries_root=resolved_root):
+        with self._patch_managers(engine, dirs=MagicMock(), merged=merged, libraries_root=resolved_root):
             result = await library_manager.on_preview_project_provisioning_request(
                 PreviewProjectProvisioningRequest(project_id=str(tmp_path / "project.yml"))
             )
@@ -2824,18 +2780,16 @@ class TestPreviewProjectProvisioning:
         assert result.actions[0].installed_version == "1.0.0"
 
     @pytest.mark.asyncio
-    async def test_unsatisfiable_engine_version_populates_failure(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
+    async def test_unsatisfiable_engine_version_populates_failure(self, engine: Engine, tmp_path: Path) -> None:
         from griptape_nodes.retained_mode.events.library_events import (
             PreviewProjectProvisioningRequest,
             PreviewProjectProvisioningResultSuccess,
         )
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         merged = self._merged_config([], engine_version=">=2.0,<3.0")
         with (
-            self._patch_managers(griptape_nodes, dirs=MagicMock(), merged=merged),
+            self._patch_managers(engine, dirs=MagicMock(), merged=merged),
             patch("griptape_nodes.utils.version_utils.engine_version", "0.5.3"),
         ):
             result = await library_manager.on_preview_project_provisioning_request(
@@ -2848,18 +2802,16 @@ class TestPreviewProjectProvisioning:
         assert "0.5.3" in result.engine_version_failure
 
     @pytest.mark.asyncio
-    async def test_satisfiable_engine_version_leaves_failure_none(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
+    async def test_satisfiable_engine_version_leaves_failure_none(self, engine: Engine, tmp_path: Path) -> None:
         from griptape_nodes.retained_mode.events.library_events import (
             PreviewProjectProvisioningRequest,
             PreviewProjectProvisioningResultSuccess,
         )
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         merged = self._merged_config([], engine_version=">=0.5,<1.0")
         with (
-            self._patch_managers(griptape_nodes, dirs=MagicMock(), merged=merged),
+            self._patch_managers(engine, dirs=MagicMock(), merged=merged),
             patch("griptape_nodes.utils.version_utils.engine_version", "0.5.3"),
         ):
             result = await library_manager.on_preview_project_provisioning_request(
@@ -2870,9 +2822,7 @@ class TestPreviewProjectProvisioning:
         assert result.engine_version_failure is None
 
     @pytest.mark.asyncio
-    async def test_system_defaults_plans_from_user_layer_without_resolving_dirs(
-        self, griptape_nodes: GriptapeNodes
-    ) -> None:
+    async def test_system_defaults_plans_from_user_layer_without_resolving_dirs(self, engine: Engine) -> None:
         """System defaults is previewable: it plans from the defaults->user->env merge.
 
         Switching to system defaults activates that merge (no project-adjacent or
@@ -2887,10 +2837,10 @@ class TestPreviewProjectProvisioning:
             PreviewProjectProvisioningResultSuccess,
         )
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         merged = self._merged_config([{"name": "user-pin", "git_url": "griptape-ai/user-pin@v2", "version": "==2.0.0"}])
         with (
-            self._patch_system_defaults(griptape_nodes, merged=merged) as (mock_project_manager, _mock_config_manager),
+            self._patch_system_defaults(engine, merged=merged) as (mock_project_manager, _mock_config_manager),
             patch.object(library_manager, "_installed_download_version", new=AsyncMock(return_value="1.0.0")),
         ):
             result = await library_manager.on_preview_project_provisioning_request(
@@ -2904,19 +2854,17 @@ class TestPreviewProjectProvisioning:
         assert result.actions[0].destructive is True
 
     @pytest.mark.asyncio
-    async def test_system_defaults_unsatisfiable_engine_version_populates_failure(
-        self, griptape_nodes: GriptapeNodes
-    ) -> None:
+    async def test_system_defaults_unsatisfiable_engine_version_populates_failure(self, engine: Engine) -> None:
         """A user-config engine_version pin gates the system-defaults switch too."""
         from griptape_nodes.retained_mode.events.library_events import (
             PreviewProjectProvisioningRequest,
             PreviewProjectProvisioningResultSuccess,
         )
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         merged = self._merged_config([], engine_version=">=2.0,<3.0")
         with (
-            self._patch_system_defaults(griptape_nodes, merged=merged),
+            self._patch_system_defaults(engine, merged=merged),
             patch("griptape_nodes.utils.version_utils.engine_version", "0.5.3"),
         ):
             result = await library_manager.on_preview_project_provisioning_request(
@@ -2928,16 +2876,16 @@ class TestPreviewProjectProvisioning:
         assert "0.5.3" in result.engine_version_failure
 
     @pytest.mark.asyncio
-    async def test_system_defaults_no_pins_is_empty_success(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_system_defaults_no_pins_is_empty_success(self, engine: Engine) -> None:
         """No user-config pins means nothing to provision: empty plan, no modal."""
         from griptape_nodes.retained_mode.events.library_events import (
             PreviewProjectProvisioningRequest,
             PreviewProjectProvisioningResultSuccess,
         )
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         merged = self._merged_config([])
-        with self._patch_system_defaults(griptape_nodes, merged=merged):
+        with self._patch_system_defaults(engine, merged=merged):
             result = await library_manager.on_preview_project_provisioning_request(
                 PreviewProjectProvisioningRequest(project_id=SYSTEM_DEFAULTS_KEY)
             )
@@ -2951,9 +2899,7 @@ class TestProvisionGitLibraryOverwriteDir:
     """`_provision_git_library` aims the destructive overwrite at the installed dir."""
 
     @pytest.mark.asyncio
-    async def test_overwrite_targets_installed_manifest_dir(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
+    async def test_overwrite_targets_installed_manifest_dir(self, engine: Engine, tmp_path: Path) -> None:
         """Defect #3: the overwrite deletes the manifest's dir, not libraries_path/<repo-name>.
 
         When the installed dir name != git repo name, `_provision_git_library` resolves the
@@ -2965,7 +2911,7 @@ class TestProvisionGitLibraryOverwriteDir:
             DownloadLibraryResultSuccess,
         )
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         download = LibraryDownload(name="my-lib", version=">=2.0", git_url="griptape-ai/repo-name@v2.0")
         # Installed under a directory whose name ("custom-install-dir") differs from the
         # git repo name ("repo-name") the handler would otherwise guess.
@@ -2977,7 +2923,7 @@ class TestProvisionGitLibraryOverwriteDir:
         success = MagicMock(spec=DownloadLibraryResultSuccess)
         ahandle = AsyncMock(return_value=success)
         with (
-            patch.object(griptape_nodes, "ahandle_request", ahandle),
+            patch.object(engine, "ahandle_request", ahandle),
             patch.object(
                 library_manager, "_installed_library_manifest_path", new=AsyncMock(return_value=manifest_path)
             ),
@@ -2997,7 +2943,7 @@ class TestProvisionGitLibraryOverwriteDir:
         assert sent_request.target_directory_name == installed_dir.name
 
     @pytest.mark.asyncio
-    async def test_fresh_install_leaves_dir_hints_none(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_fresh_install_leaves_dir_hints_none(self, engine: Engine) -> None:
         """A fresh install passes no dir hints, keeping the handler's repo-name default.
 
         When installed_version is None there is nothing to overwrite, so the manifest is
@@ -3008,13 +2954,13 @@ class TestProvisionGitLibraryOverwriteDir:
             DownloadLibraryResultSuccess,
         )
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         download = LibraryDownload(name="my-lib", version=">=2.0", git_url="griptape-ai/repo-name@v2.0")
 
         success = MagicMock(spec=DownloadLibraryResultSuccess)
         ahandle = AsyncMock(return_value=success)
         with (
-            patch.object(griptape_nodes, "ahandle_request", ahandle),
+            patch.object(engine, "ahandle_request", ahandle),
             patch.object(library_manager, "_installed_library_manifest_path", new=AsyncMock()) as mock_resolve,
         ):
             failure = await library_manager._provision_git_library(
@@ -3034,20 +2980,18 @@ class TestProvisionGitLibraryOverwriteDir:
 class TestLibraryManagerInitializationFlag:
     """Test the is_initializing flag reported on the engine heartbeat."""
 
-    def test_not_initializing_by_default(self, griptape_nodes: GriptapeNodes) -> None:
-        assert griptape_nodes.LibraryManager().is_initializing() is False
+    def test_not_initializing_by_default(self, engine: Engine) -> None:
+        assert engine.library_manager.is_initializing() is False
 
     @pytest.mark.asyncio
-    async def test_reload_brackets_is_initializing(
-        self, griptape_nodes: GriptapeNodes, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_reload_brackets_is_initializing(self, engine: Engine, monkeypatch: pytest.MonkeyPatch) -> None:
         """is_initializing() is True for the duration of the reload and False once it returns."""
         from griptape_nodes.retained_mode.events.library_events import (
             ReloadAllLibrariesRequest,
             ReloadAllLibrariesResultSuccess,
         )
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         observed: dict[str, bool] = {}
 
         async def fake_run(_request: ReloadAllLibrariesRequest) -> ReloadAllLibrariesResultSuccess:
@@ -3063,12 +3007,12 @@ class TestLibraryManagerInitializationFlag:
 
     @pytest.mark.asyncio
     async def test_reload_clears_is_initializing_on_exception(
-        self, griptape_nodes: GriptapeNodes, monkeypatch: pytest.MonkeyPatch
+        self, engine: Engine, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A failure during reload still clears the flag (finally), so the GUI doesn't hang."""
         from griptape_nodes.retained_mode.events.library_events import ReloadAllLibrariesRequest
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         async def boom(_request: ReloadAllLibrariesRequest) -> None:
             msg = "boom"
@@ -3105,17 +3049,15 @@ class TestDownloadLibraryRegisterPersistence:
         return fake_clone
 
     @pytest.mark.asyncio
-    async def test_reconcile_download_does_not_persist_to_global_config(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
+    async def test_reconcile_download_does_not_persist_to_global_config(self, engine: Engine, tmp_path: Path) -> None:
         """auto_register=False (the reconcile/provisioning path) leaves global libraries_to_register untouched."""
         from griptape_nodes.retained_mode.events.library_events import (
             DownloadLibraryRequest,
             DownloadLibraryResultSuccess,
         )
 
-        library_manager = griptape_nodes.LibraryManager()
-        config_mgr = griptape_nodes.ConfigManager()
+        library_manager = engine.library_manager
+        config_mgr = engine.config_manager
         before = config_mgr.get_config_value(LIBRARIES_TO_REGISTER_KEY, default=[])
 
         with patch(
@@ -3136,9 +3078,7 @@ class TestDownloadLibraryRegisterPersistence:
         assert result.library_path not in {extract_library_path(entry) for entry in after}
 
     @pytest.mark.asyncio
-    async def test_explicit_download_persists_to_global_config(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
+    async def test_explicit_download_persists_to_global_config(self, engine: Engine, tmp_path: Path) -> None:
         """auto_register=True (the explicit CLI download) appends the clone path to global libraries_to_register."""
         from griptape_nodes.retained_mode.events.library_events import (
             DownloadLibraryRequest,
@@ -3146,8 +3086,8 @@ class TestDownloadLibraryRegisterPersistence:
             RegisterLibraryFromFileResultSuccess,
         )
 
-        library_manager = griptape_nodes.LibraryManager()
-        config_mgr = griptape_nodes.ConfigManager()
+        library_manager = engine.library_manager
+        config_mgr = engine.config_manager
 
         # download_library_request routes registration through the engine's ahandle_request;
         # the minimal fake manifest can't pass full LibrarySchema validation, so mock the
@@ -3162,7 +3102,7 @@ class TestDownloadLibraryRegisterPersistence:
                 side_effect=self._make_clone("explicit_lib"),
             ),
             patch.object(
-                griptape_nodes,
+                engine,
                 "ahandle_request",
                 new=AsyncMock(return_value=mock_register_result),
             ),
@@ -3201,14 +3141,12 @@ class TestDiscoverDownloadedLibraries:
         return manifest_path
 
     @pytest.mark.asyncio
-    async def test_download_only_library_is_discovered_from_workspace(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
+    async def test_download_only_library_is_discovered_from_workspace(self, engine: Engine, tmp_path: Path) -> None:
         """A libraries_to_download entry with no libraries_to_register row is still discovered."""
         from griptape_nodes.retained_mode.managers.settings import LIBRARIES_TO_DOWNLOAD_KEY
 
-        library_manager = griptape_nodes.LibraryManager()
-        config_mgr = griptape_nodes.ConfigManager()
+        library_manager = engine.library_manager
+        config_mgr = engine.config_manager
 
         libraries_dir = tmp_path / "libraries"
         manifest_path = self._install_manifest(libraries_dir, "remote_lib", "remote_lib")
@@ -3267,11 +3205,11 @@ class TestPersistLibrarySettings:
         )
 
     def test_persist_does_not_leak_project_download_pin_to_global(
-        self, griptape_nodes: GriptapeNodes, isolate_user_config: Path, tmp_path: Path
+        self, engine: Engine, isolate_user_config: Path, tmp_path: Path
     ) -> None:
         """A project-layer libraries_to_download pin must NOT be written into the global user config."""
-        library_manager = griptape_nodes.LibraryManager()
-        config_mgr = griptape_nodes.ConfigManager()
+        library_manager = engine.library_manager
+        config_mgr = engine.config_manager
 
         # Prime a project-adjacent config carrying a download pin, then load it as
         # the project layer so the MERGED config sees the pin but the global user
@@ -3307,9 +3245,9 @@ class TestPersistLibrarySettings:
         # ...but the project-layer download pin did NOT leak into the global config.
         assert "libraries_to_download" not in init
 
-    def test_persist_creates_missing_category(self, griptape_nodes: GriptapeNodes, isolate_user_config: Path) -> None:
+    def test_persist_creates_missing_category(self, engine: Engine, isolate_user_config: Path) -> None:
         """A library declaring a brand-new category writes its contents verbatim to global."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         library = self._library_with_settings(
             "my_library_category",
@@ -3473,12 +3411,10 @@ class TestLibraryManagerMetadataLoadFailureSurfacing:
     """
 
     @pytest.mark.asyncio
-    async def test_schema_validation_failure_surfaces_on_library_info(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
+    async def test_schema_validation_failure_surfaces_on_library_info(self, engine: Engine, tmp_path: Path) -> None:
         from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         # A library JSON with a usable name and version but a schema-violating body (missing
         # required categories/nodes), mirroring the user's "settings.0.category" failure.
@@ -3517,10 +3453,10 @@ class TestLibraryManagerMetadataLoadFailureSurfacing:
         assert library_manager.collate_problems_for_lib_info(stored) is not None
 
     @pytest.mark.asyncio
-    async def test_missing_file_surfaces_missing_fitness(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
+    async def test_missing_file_surfaces_missing_fitness(self, engine: Engine, tmp_path: Path) -> None:
         from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         file_path = str(tmp_path / "does_not_exist" / "griptape_nodes_library.json")
         library_info = LibraryManager.LibraryInfo(
@@ -3546,10 +3482,10 @@ class TestLibraryManagerMetadataLoadFailureSurfacing:
 class TestCollectLibraryLoadStatuses:
     """_collect_library_load_statuses turns LibraryInfo into serializable status data."""
 
-    def test_maps_fields_and_disabled_state(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_maps_fields_and_disabled_state(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
 
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         good = LibraryManager.LibraryInfo(
             lifecycle_state=LibraryManager.LibraryLifecycleState.LOADED,
@@ -3587,8 +3523,8 @@ class TestCollectLibraryLoadStatuses:
         assert disabled_status.disabled is True
         assert disabled_status.library_version is None
 
-    def test_empty_when_no_libraries(self, griptape_nodes: GriptapeNodes) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    def test_empty_when_no_libraries(self, engine: Engine) -> None:
+        library_manager = engine.library_manager
         library_manager._library_file_path_to_info = {}
 
         assert library_manager._collect_library_load_statuses() == []
@@ -3622,7 +3558,7 @@ class TestLibraryFitnessAuthorizationCheckpoint:
             nodes=[],
         )
 
-    def test_denied_library_is_unusable_with_permission_problem(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_denied_library_is_unusable_with_permission_problem(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.library_events import (
             EvaluateLibraryFitnessRequest,
             EvaluateLibraryFitnessResultFailure,
@@ -3643,12 +3579,12 @@ class TestLibraryFitnessAuthorizationCheckpoint:
                 failures=(CheckpointFailure(detail="Ask your admin to enable Labs libraries.", capability="lib:labs"),)
             )
 
-        griptape_nodes.EventManager().add_authorization_hook(deny)
+        engine.event_manager.add_authorization_hook(deny)
         with patch(
             "griptape_nodes.retained_mode.managers.version_compatibility_manager.VersionCompatibilityManager.check_library_version_compatibility",
             return_value=[],
         ):
-            result = griptape_nodes.LibraryManager().evaluate_library_fitness_request(
+            result = engine.library_manager.evaluate_library_fitness_request(
                 EvaluateLibraryFitnessRequest(schema=self._schema("blocked-lib", LifecycleStage.LABS))
             )
 
@@ -3659,7 +3595,7 @@ class TestLibraryFitnessAuthorizationCheckpoint:
         assert len(problems) == 1
         assert "Ask your admin to enable Labs libraries." in problems[0].collate_problems_for_display(problems)
 
-    def test_allowed_library_passes(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_allowed_library_passes(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.library_events import (
             EvaluateLibraryFitnessRequest,
             EvaluateLibraryFitnessResultSuccess,
@@ -3670,12 +3606,12 @@ class TestLibraryFitnessAuthorizationCheckpoint:
             "griptape_nodes.retained_mode.managers.version_compatibility_manager.VersionCompatibilityManager.check_library_version_compatibility",
             return_value=[],
         ):
-            result = griptape_nodes.LibraryManager().evaluate_library_fitness_request(
+            result = engine.library_manager.evaluate_library_fitness_request(
                 EvaluateLibraryFitnessRequest(schema=self._schema("ok-lib"))
             )
         assert isinstance(result, EvaluateLibraryFitnessResultSuccess)
 
-    def test_denied_node_is_a_library_problem_but_library_stays_usable(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_denied_node_is_a_library_problem_but_library_stays_usable(self, engine: Engine) -> None:
         from griptape_nodes.node_library.library_declarations import LifecycleStage, LifecycleStageNodeProperty
         from griptape_nodes.node_library.library_registry import NodeDefinition, NodeMetadata
         from griptape_nodes.retained_mode.events.library_events import (
@@ -3705,12 +3641,12 @@ class TestLibraryFitnessAuthorizationCheckpoint:
             )
         )
 
-        griptape_nodes.EventManager().add_authorization_hook(deny)
+        engine.event_manager.add_authorization_hook(deny)
         with patch(
             "griptape_nodes.retained_mode.managers.version_compatibility_manager.VersionCompatibilityManager.check_library_version_compatibility",
             return_value=[],
         ):
-            result = griptape_nodes.LibraryManager().evaluate_library_fitness_request(
+            result = engine.library_manager.evaluate_library_fitness_request(
                 EvaluateLibraryFitnessRequest(schema=schema)
             )
 
@@ -3750,9 +3686,9 @@ class TestLibraryManagerDuplicateEntryHygiene:
             problems=[],
         )
 
-    def test_unload_removes_all_entries_for_library_name(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_unload_removes_all_entries_for_library_name(self, engine: Engine) -> None:
         """Unload must drop every entry for the name, not just the first, so no stale copy lingers."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         # Two on-disk copies registered under one name: one on `main`, one on `stable`. Both
         # report the same version but live at different paths (the #5039 scenario).
@@ -3780,13 +3716,13 @@ class TestLibraryManagerDuplicateEntryHygiene:
         assert remaining == []
         assert entries == {}
 
-    def test_reload_collapses_duplicate_entries_to_one(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_reload_collapses_duplicate_entries_to_one(self, engine: Engine) -> None:
         """Reload must collapse duplicate entries to one.
 
         It must not leave a pre-operation entry alongside the reloaded one when the git operation
         resolves the JSON under a different filename.
         """
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         # Pre-operation entry keyed under the dashed filename.
         old_path = "/libs/copy/griptape-nodes-library.json"
@@ -3800,7 +3736,7 @@ class TestLibraryManagerDuplicateEntryHygiene:
         with (
             patch.object(library_manager, "_library_file_path_to_info", entries),
             patch.object(
-                griptape_nodes,
+                engine,
                 "handle_request",
                 return_value=UnloadLibraryFromRegistryResultSuccess(result_details="ok"),
             ),
@@ -3809,7 +3745,7 @@ class TestLibraryManagerDuplicateEntryHygiene:
                 return_value=Path(new_path),
             ),
             patch.object(
-                griptape_nodes,
+                engine,
                 "ahandle_request",
                 AsyncMock(return_value=RegisterLibraryFromFileResultSuccess(library_name="MyLib", result_details="ok")),
             ),
@@ -3830,7 +3766,7 @@ class TestLibraryManagerDuplicateEntryHygiene:
         mylib_paths = [path for path, info in entries.items() if info.library_name == "MyLib"]
         assert mylib_paths == [str(Path(new_path))]
 
-    def test_resolver_prefers_loaded_copy_over_failed_duplicate(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_resolver_prefers_loaded_copy_over_failed_duplicate(self, engine: Engine) -> None:
         """The resolver must return the LOADED copy, not a dead duplicate.
 
         A duplicate install keeps a second entry marked FAILURE (DuplicateLibraryProblem) in the
@@ -3839,7 +3775,7 @@ class TestLibraryManagerDuplicateEntryHygiene:
         version, producing a permanent "update available" loop (issue #5039). Preferring the LOADED
         entry keeps path resolution consistent with the copy whose version the check reads.
         """
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         # The FAILURE duplicate is inserted first, so first-match would pick it.
         entries = {
@@ -3863,9 +3799,9 @@ class TestLibraryManagerDuplicateEntryHygiene:
         assert info is not None
         assert info.library_path == "/libs/loaded/griptape_nodes_library.json"
 
-    def test_resolver_falls_back_to_first_match_when_none_loaded(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_resolver_falls_back_to_first_match_when_none_loaded(self, engine: Engine) -> None:
         """With no LOADED copy (e.g. discovery / worker-pending), the resolver keeps first-match."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         entries = {
             "/libs/copyA/griptape_nodes_library.json": self._lib_info(

--- a/tests/unit/retained_mode/managers/test_library_manager_age_gate.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_age_gate.py
@@ -38,7 +38,7 @@ from griptape_nodes.utils.git_utils import GitError
 from griptape_nodes.utils.library_utils import LibraryVersionInfo
 
 if TYPE_CHECKING:
-    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+    from griptape_nodes.retained_mode.engine import Engine
 
 LIBRARY_MANAGER_MODULE = "griptape_nodes.retained_mode.managers.library_manager"
 MIN_AGE_HOURS = 24.0
@@ -60,21 +60,21 @@ def _config_manager(*, minimum_release_age_hours: float) -> MagicMock:
 class TestEvaluateUpdateAgeGate:
     """Test the pure age-gate decision helper."""
 
-    def test_disabled_never_gates(self, griptape_nodes: GriptapeNodes) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    def test_disabled_never_gates(self, engine: Engine) -> None:
+        library_manager = engine.library_manager
         young_commit = datetime.now(tz=UTC) - timedelta(hours=1)
 
-        with patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=0.0)):
+        with patch.object(engine, "_config_manager", _config_manager(minimum_release_age_hours=0.0)):
             decision = library_manager._evaluate_update_age_gate(young_commit)
 
         assert decision.enabled is False
         assert decision.gated is False
 
-    def test_enabled_gates_commit_younger_than_threshold(self, griptape_nodes: GriptapeNodes) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    def test_enabled_gates_commit_younger_than_threshold(self, engine: Engine) -> None:
+        library_manager = engine.library_manager
         young_commit = datetime.now(tz=UTC) - timedelta(hours=1)
 
-        with patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)):
+        with patch.object(engine, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)):
             decision = library_manager._evaluate_update_age_gate(young_commit)
 
         assert decision.enabled is True
@@ -83,11 +83,11 @@ class TestEvaluateUpdateAgeGate:
         assert decision.age_hours == pytest.approx(1.0, abs=0.1)
         assert decision.minimum_release_age_hours == MIN_AGE_HOURS
 
-    def test_enabled_allows_commit_older_than_threshold(self, griptape_nodes: GriptapeNodes) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    def test_enabled_allows_commit_older_than_threshold(self, engine: Engine) -> None:
+        library_manager = engine.library_manager
         old_commit = datetime.now(tz=UTC) - timedelta(hours=48)
 
-        with patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)):
+        with patch.object(engine, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)):
             decision = library_manager._evaluate_update_age_gate(old_commit)
 
         assert decision.enabled is True
@@ -95,33 +95,33 @@ class TestEvaluateUpdateAgeGate:
         assert decision.age_hours is not None
         assert decision.age_hours == pytest.approx(48.0, abs=0.1)
 
-    def test_enabled_allows_when_commit_datetime_unknown(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_enabled_allows_when_commit_datetime_unknown(self, engine: Engine) -> None:
         """A missing commit timestamp cannot be verified, so the update is allowed (not wedged)."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
-        with patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)):
+        with patch.object(engine, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)):
             decision = library_manager._evaluate_update_age_gate(None)
 
         assert decision.enabled is True
         assert decision.gated is False
         assert decision.age_hours is None
 
-    def test_naive_commit_datetime_is_treated_as_utc(self, griptape_nodes: GriptapeNodes) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    def test_naive_commit_datetime_is_treated_as_utc(self, engine: Engine) -> None:
+        library_manager = engine.library_manager
         naive_young_commit = datetime.now(tz=UTC).replace(tzinfo=None) - timedelta(hours=1)
 
-        with patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)):
+        with patch.object(engine, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)):
             decision = library_manager._evaluate_update_age_gate(naive_young_commit)
 
         assert decision.gated is True
 
     def test_enabled_unknown_timestamp_logs_fail_open_warning(
-        self, griptape_nodes: GriptapeNodes, caplog: pytest.LogCaptureFixture
+        self, engine: Engine, caplog: pytest.LogCaptureFixture
     ) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         with (
-            patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)),
+            patch.object(engine, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)),
             caplog.at_level("WARNING"),
         ):
             decision = library_manager._evaluate_update_age_gate(None)
@@ -129,13 +129,11 @@ class TestEvaluateUpdateAgeGate:
         assert decision.gated is False
         assert any("could not be determined" in message for message in caplog.messages)
 
-    def test_disabled_unknown_timestamp_does_not_warn(
-        self, griptape_nodes: GriptapeNodes, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    def test_disabled_unknown_timestamp_does_not_warn(self, engine: Engine, caplog: pytest.LogCaptureFixture) -> None:
+        library_manager = engine.library_manager
 
         with (
-            patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=0.0)),
+            patch.object(engine, "_config_manager", _config_manager(minimum_release_age_hours=0.0)),
             caplog.at_level("WARNING"),
         ):
             decision = library_manager._evaluate_update_age_gate(None)
@@ -143,13 +141,13 @@ class TestEvaluateUpdateAgeGate:
         assert decision.enabled is False
         assert not any("could not be determined" in message for message in caplog.messages)
 
-    def test_explicit_config_is_not_re_read_from_config_manager(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_explicit_config_is_not_re_read_from_config_manager(self, engine: Engine) -> None:
         """Passing a pre-read config skips the ConfigManager lookup entirely."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         config_mgr = _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)
         old_commit = datetime.now(tz=UTC) - timedelta(hours=48)
 
-        with patch.object(griptape_nodes, "_config_manager", config_mgr):
+        with patch.object(engine, "_config_manager", config_mgr):
             decision = library_manager._evaluate_update_age_gate(
                 old_commit, config=MinimumReleaseAgeConfig(hours=MIN_AGE_HOURS)
             )
@@ -162,35 +160,35 @@ class TestEvaluateUpdateAgeGate:
 class TestReadMinimumReleaseAgeConfig:
     """Test the config-reading helper that both the check and update paths share."""
 
-    def test_reads_configured_hours(self, griptape_nodes: GriptapeNodes) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    def test_reads_configured_hours(self, engine: Engine) -> None:
+        library_manager = engine.library_manager
 
-        with patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=12.0)):
+        with patch.object(engine, "_config_manager", _config_manager(minimum_release_age_hours=12.0)):
             config = library_manager._read_minimum_release_age_config()
 
         assert config == MinimumReleaseAgeConfig(hours=12.0)
         assert config.enabled is True
 
-    def test_zero_hours_disables_the_gate(self, griptape_nodes: GriptapeNodes) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    def test_zero_hours_disables_the_gate(self, engine: Engine) -> None:
+        library_manager = engine.library_manager
 
-        with patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=0.0)):
+        with patch.object(engine, "_config_manager", _config_manager(minimum_release_age_hours=0.0)):
             config = library_manager._read_minimum_release_age_config()
 
         assert config == MinimumReleaseAgeConfig(hours=0.0)
         assert config.enabled is False
 
-    def test_explicit_null_override_falls_back_to_default(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_explicit_null_override_falls_back_to_default(self, engine: Engine) -> None:
         """An explicit ``null`` in config resolves to None (bypassing cast_type); coalesce to the default.
 
         Reading the config must never raise (e.g. ``float(None)``), otherwise a malformed config
         would wedge every update instead of failing open.
         """
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         null_config_mgr = MagicMock()
         null_config_mgr.get_config_value.return_value = None
 
-        with patch.object(griptape_nodes, "_config_manager", null_config_mgr):
+        with patch.object(engine, "_config_manager", null_config_mgr):
             config = library_manager._read_minimum_release_age_config()
 
         assert config == MinimumReleaseAgeConfig(hours=0.0)
@@ -209,9 +207,9 @@ class TestUpdateLibraryRequestAgeGate:
         )
 
     @pytest.mark.asyncio
-    async def test_young_target_commit_blocks_update(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_young_target_commit_blocks_update(self, engine: Engine) -> None:
         """A target commit younger than the minimum age blocks the update without touching git."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         library_dir = Path("/var/lib/test_lib")
         young_commit = datetime.now(tz=UTC) - timedelta(hours=2)
 
@@ -222,7 +220,7 @@ class TestUpdateLibraryRequestAgeGate:
                 new=AsyncMock(return_value=self._validation_context(library_dir)),
             ),
             patch(f"{LIBRARY_MANAGER_MODULE}.is_monorepo", return_value=False),
-            patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)),
+            patch.object(engine, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)),
             patch.object(
                 library_manager,
                 "_get_remote_target_commit_datetime",
@@ -239,9 +237,9 @@ class TestUpdateLibraryRequestAgeGate:
         mock_update_git.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_old_target_commit_allows_update(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_old_target_commit_allows_update(self, engine: Engine) -> None:
         """A target commit older than the minimum age is allowed through to the git update."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         library_dir = Path("/var/lib/test_lib")
         old_commit = datetime.now(tz=UTC) - timedelta(hours=48)
 
@@ -252,7 +250,7 @@ class TestUpdateLibraryRequestAgeGate:
                 new=AsyncMock(return_value=self._validation_context(library_dir)),
             ),
             patch(f"{LIBRARY_MANAGER_MODULE}.is_monorepo", return_value=False),
-            patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)),
+            patch.object(engine, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)),
             patch.object(
                 library_manager,
                 "_get_remote_target_commit_datetime",
@@ -275,9 +273,9 @@ class TestUpdateLibraryRequestAgeGate:
         mock_update_git.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_disabled_skips_remote_age_lookup(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_disabled_skips_remote_age_lookup(self, engine: Engine) -> None:
         """When gating is disabled, the update path never pays for the remote age round-trip."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         library_dir = Path("/var/lib/test_lib")
 
         with (
@@ -287,7 +285,7 @@ class TestUpdateLibraryRequestAgeGate:
                 new=AsyncMock(return_value=self._validation_context(library_dir)),
             ),
             patch(f"{LIBRARY_MANAGER_MODULE}.is_monorepo", return_value=False),
-            patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=0.0)),
+            patch.object(engine, "_config_manager", _config_manager(minimum_release_age_hours=0.0)),
             patch.object(
                 library_manager,
                 "_get_remote_target_commit_datetime",
@@ -309,9 +307,9 @@ class TestUpdateLibraryRequestAgeGate:
         mock_remote_age.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_unknown_target_commit_allows_update(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_unknown_target_commit_allows_update(self, engine: Engine) -> None:
         """Fail-open: when the target commit timestamp cannot be read, the update still proceeds."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         library_dir = Path("/var/lib/test_lib")
 
         with (
@@ -321,7 +319,7 @@ class TestUpdateLibraryRequestAgeGate:
                 new=AsyncMock(return_value=self._validation_context(library_dir)),
             ),
             patch(f"{LIBRARY_MANAGER_MODULE}.is_monorepo", return_value=False),
-            patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)),
+            patch.object(engine, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)),
             patch.object(
                 library_manager,
                 "_get_remote_target_commit_datetime",
@@ -347,9 +345,9 @@ class TestGetRemoteTargetCommitDatetime:
     """Test the remote target-commit timestamp helper that feeds the update-path age gate."""
 
     @pytest.mark.asyncio
-    async def test_returns_none_when_no_remote(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_returns_none_when_no_remote(self, engine: Engine) -> None:
         """A library with no git remote cannot be age-checked, so the helper returns None."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         with (
             patch(f"{LIBRARY_MANAGER_MODULE}.get_git_remote", return_value=None),
@@ -361,9 +359,9 @@ class TestGetRemoteTargetCommitDatetime:
         mock_clone.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_returns_none_on_git_error(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_returns_none_on_git_error(self, engine: Engine) -> None:
         """A git failure while reading the remote commit degrades to None (fail-open)."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         with (
             patch(f"{LIBRARY_MANAGER_MODULE}.get_git_remote", return_value="https://example.com/repo.git"),
@@ -384,7 +382,7 @@ class TestCheckLibraryUpdateRequestAgeGate:
     async def _run_check(
         self,
         library_manager: LibraryManager,
-        griptape_nodes: GriptapeNodes,
+        engine: Engine,
         *,
         commit_datetime: datetime | None,
         enabled: bool,
@@ -423,7 +421,7 @@ class TestCheckLibraryUpdateRequestAgeGate:
             patch(f"{LIBRARY_MANAGER_MODULE}.clone_and_get_library_version", return_value=version_info),
             patch.object(library_manager, "_check_engine_version_compatibility", return_value=(True, "1.0.0")),
             patch.object(
-                griptape_nodes,
+                engine,
                 "_config_manager",
                 _config_manager(minimum_release_age_hours=minimum_release_age_hours),
             ),
@@ -436,12 +434,12 @@ class TestCheckLibraryUpdateRequestAgeGate:
         return result
 
     @pytest.mark.asyncio
-    async def test_gated_update_reports_age_fields(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_gated_update_reports_age_fields(self, engine: Engine) -> None:
         """A young target commit yields has_update=True with update_gated_by_age=True and the age/min fields."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         young_commit = datetime.now(tz=UTC) - timedelta(hours=2)
 
-        result = await self._run_check(library_manager, griptape_nodes, commit_datetime=young_commit, enabled=True)
+        result = await self._run_check(library_manager, engine, commit_datetime=young_commit, enabled=True)
 
         assert result.has_update is True
         assert result.update_gated_by_age is True
@@ -450,12 +448,12 @@ class TestCheckLibraryUpdateRequestAgeGate:
         assert result.minimum_release_age_hours == MIN_AGE_HOURS
 
     @pytest.mark.asyncio
-    async def test_ungated_update_reports_age_fields(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_ungated_update_reports_age_fields(self, engine: Engine) -> None:
         """An old target commit is not gated, but the age and min fields are still populated when enabled."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         old_commit = datetime.now(tz=UTC) - timedelta(hours=48)
 
-        result = await self._run_check(library_manager, griptape_nodes, commit_datetime=old_commit, enabled=True)
+        result = await self._run_check(library_manager, engine, commit_datetime=old_commit, enabled=True)
 
         assert result.has_update is True
         assert result.update_gated_by_age is False
@@ -464,26 +462,26 @@ class TestCheckLibraryUpdateRequestAgeGate:
         assert result.minimum_release_age_hours == MIN_AGE_HOURS
 
     @pytest.mark.asyncio
-    async def test_disabled_leaves_min_age_none(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_disabled_leaves_min_age_none(self, engine: Engine) -> None:
         """With gating disabled, an available update is never gated and reports no configured minimum."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         young_commit = datetime.now(tz=UTC) - timedelta(hours=2)
 
-        result = await self._run_check(library_manager, griptape_nodes, commit_datetime=young_commit, enabled=False)
+        result = await self._run_check(library_manager, engine, commit_datetime=young_commit, enabled=False)
 
         assert result.has_update is True
         assert result.update_gated_by_age is False
         assert result.minimum_release_age_hours is None
 
     @pytest.mark.asyncio
-    async def test_no_update_leaves_age_fields_default(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_no_update_leaves_age_fields_default(self, engine: Engine) -> None:
         """When there is no update, the age gate is not evaluated and its fields stay at defaults."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         young_commit = datetime.now(tz=UTC) - timedelta(hours=2)
 
         result = await self._run_check(
             library_manager,
-            griptape_nodes,
+            engine,
             commit_datetime=young_commit,
             enabled=True,
             has_update=False,
@@ -517,9 +515,9 @@ class TestSyncLibrariesRequestAgeGate:
         )
 
     @pytest.mark.asyncio
-    async def test_deferred_library_counted_and_not_updated(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_deferred_library_counted_and_not_updated(self, engine: Engine) -> None:
         """A gated library is counted in libraries_deferred, summarized, and skipped by the update pass."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         check_results = {
             "up_to_date": self._check_result(has_update=False),
             "gated": self._check_result(has_update=True, gated=True, latest_version="2.0.0"),
@@ -541,8 +539,8 @@ class TestSyncLibrariesRequestAgeGate:
             raise AssertionError(error)
 
         with (
-            patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)),
-            patch.object(griptape_nodes, "ahandle_request", AsyncMock(side_effect=dispatch)),
+            patch.object(engine, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)),
+            patch.object(engine, "ahandle_request", AsyncMock(side_effect=dispatch)),
         ):
             result = await library_manager.sync_libraries_request(SyncLibrariesRequest())
 
@@ -562,13 +560,13 @@ class TestSyncLibrariesRequestAgeGate:
         assert "up_to_date" not in result.update_summary
 
     @pytest.mark.asyncio
-    async def test_update_pass_age_gate_refusal_counts_as_deferred(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_update_pass_age_gate_refusal_counts_as_deferred(self, engine: Engine) -> None:
         """A library that passes the check but is refused by the update pass age gate is deferred, not failed.
 
         This models a newer commit landing on the remote between the check and update passes: the
         update request comes back as UpdateLibraryResultFailure(age_gated=True) rather than success.
         """
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         check_results = {
             "raced": self._check_result(has_update=True, gated=False),
         }
@@ -586,8 +584,8 @@ class TestSyncLibrariesRequestAgeGate:
             raise AssertionError(error)
 
         with (
-            patch.object(griptape_nodes, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)),
-            patch.object(griptape_nodes, "ahandle_request", AsyncMock(side_effect=dispatch)),
+            patch.object(engine, "_config_manager", _config_manager(minimum_release_age_hours=MIN_AGE_HOURS)),
+            patch.object(engine, "ahandle_request", AsyncMock(side_effect=dispatch)),
         ):
             result = await library_manager.sync_libraries_request(SyncLibrariesRequest())
 

--- a/tests/unit/retained_mode/managers/test_library_manager_deps.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_deps.py
@@ -14,6 +14,7 @@ from griptape_nodes.node_library.library_registry import (
     LibraryNameAndVersion,
     LibrarySchema,
 )
+from griptape_nodes.retained_mode.engine import Engine
 from griptape_nodes.retained_mode.events.base_events import ResultDetails
 from griptape_nodes.retained_mode.events.library_events import (
     DownloadLibraryRequest,
@@ -24,7 +25,6 @@ from griptape_nodes.retained_mode.events.library_events import (
     RegisterLibraryFromFileRequest,
     RegisterLibraryFromFileResultFailure,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.fitness_problems.libraries import LibraryDependencyProblem
 from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
 from griptape_nodes.retained_mode.managers.settings import LibraryDependencyInstallBehavior
@@ -146,9 +146,9 @@ class TestLibraryDependencyResolution:
     """
 
     @pytest.mark.asyncio
-    async def test_no_library_dependencies_skips_download(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_no_library_dependencies_skips_download(self, engine: Engine) -> None:
         """A library with no library_dependencies does not call download_library_request."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         lib_info = _make_lib_info()
 
         with (
@@ -168,9 +168,9 @@ class TestLibraryDependencyResolution:
         mock_download.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_empty_library_dependencies_skips_download(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_empty_library_dependencies_skips_download(self, engine: Engine) -> None:
         """A library with library_dependencies=[] does not call download_library_request."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         lib_info = _make_lib_info()
 
         with (
@@ -190,9 +190,9 @@ class TestLibraryDependencyResolution:
         mock_download.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_already_tracked_dependency_skips_download(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_already_tracked_dependency_skips_download(self, engine: Engine) -> None:
         """If the dep repo name appears in an existing tracked path with healthy state, download is skipped."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         lib_info = _make_lib_info()
         schema = _make_schema_mock(["griptape-ai/griptape-nodes-library-opencolorio@v1.2.0"])
 
@@ -225,9 +225,9 @@ class TestLibraryDependencyResolution:
         mock_download.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_missing_dependency_triggers_download(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_missing_dependency_triggers_download(self, engine: Engine) -> None:
         """A dep not yet tracked causes download_library_request to be called with correct args."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         lib_info = _make_lib_info()
         schema = _make_schema_mock(["griptape-ai/nodes-dep@v1.0.0"])
 
@@ -260,9 +260,9 @@ class TestLibraryDependencyResolution:
         assert req.auto_register is True
 
     @pytest.mark.asyncio
-    async def test_dependency_failure_marks_library_unusable(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_dependency_failure_marks_library_unusable(self, engine: Engine) -> None:
         """When a dependency download fails, the library gets LibraryDependencyProblem and UNUSABLE fitness."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         lib_info = _make_lib_info()
         schema = _make_schema_mock(["griptape-ai/nodes-bad@v1.0.0"])
 
@@ -291,9 +291,9 @@ class TestLibraryDependencyResolution:
         assert "griptape-ai/nodes-bad@v1.0.0" in dep_problems[0].dependency_name
 
     @pytest.mark.asyncio
-    async def test_dependency_resolved_before_pip_install(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_dependency_resolved_before_pip_install(self, engine: Engine) -> None:
         """Library dependency download happens before pip package installation."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         lib_info = _make_lib_info()
         schema = _make_schema_mock(["griptape-ai/nodes-dep@v1.0.0"])
 
@@ -328,9 +328,9 @@ class TestLibraryDependencyResolution:
         assert call_order.index("download") < call_order.index("install")
 
     @pytest.mark.asyncio
-    async def test_never_behavior_skips_required_dep_and_marks_flawed(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_never_behavior_skips_required_dep_and_marks_flawed(self, engine: Engine) -> None:
         """When install behavior is 'never', required deps are skipped and library is FLAWED."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         lib_info = _make_lib_info()
         schema = _make_schema_mock(["griptape-ai/nodes-dep@v1.0.0"])
 
@@ -342,7 +342,7 @@ class TestLibraryDependencyResolution:
             patch.object(mgr, "install_library_dependencies_request", return_value=_INSTALL_STOP),
             patch.object(mgr, "download_library_request") as mock_download,
             patch.object(mgr, "_library_file_path_to_info", {"/mock.json": lib_info}),
-            patch.object(griptape_nodes, "_config_manager", config_mock),
+            patch.object(engine, "_config_manager", config_mock),
         ):
             await mgr._progress_library_through_lifecycle(
                 library_info=lib_info,
@@ -357,9 +357,9 @@ class TestLibraryDependencyResolution:
         assert "nodes-dep" in dep_problems[0].dependency_name
 
     @pytest.mark.asyncio
-    async def test_never_behavior_skips_optional_dep_without_problem(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_never_behavior_skips_optional_dep_without_problem(self, engine: Engine) -> None:
         """When install behavior is 'never', optional deps are silently skipped."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         lib_info = _make_lib_info()
         schema = _make_schema_mock(["griptape-ai/nodes-dep@v1.0.0"], optional=True)
 
@@ -371,7 +371,7 @@ class TestLibraryDependencyResolution:
             patch.object(mgr, "install_library_dependencies_request", return_value=_INSTALL_STOP),
             patch.object(mgr, "download_library_request") as mock_download,
             patch.object(mgr, "_library_file_path_to_info", {"/mock.json": lib_info}),
-            patch.object(griptape_nodes, "_config_manager", config_mock),
+            patch.object(engine, "_config_manager", config_mock),
         ):
             await mgr._progress_library_through_lifecycle(
                 library_info=lib_info,
@@ -385,14 +385,14 @@ class TestLibraryDependencyResolution:
         assert len(dep_problems) == 0
 
     @pytest.mark.asyncio
-    async def test_optional_dep_failure_does_not_fail_registration(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_optional_dep_failure_does_not_fail_registration(self, engine: Engine) -> None:
         """When an optional dep download fails, the lifecycle continues past the dep block.
 
         Unlike a required dep failure (which returns early before pip install), an optional
         dep failure only logs a warning. The lifecycle proceeds to install_library_dependencies,
         so mock_install must be called and no LibraryDependencyProblem must be recorded.
         """
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         lib_info = _make_lib_info()
         schema = _make_schema_mock(["griptape-ai/nodes-optional@v1.0.0"], optional=True)
 
@@ -420,11 +420,9 @@ class TestLibraryDependencyResolution:
         assert len(dep_problems) == 0
 
     @pytest.mark.asyncio
-    async def test_registration_failure_after_download_marks_library_unusable(
-        self, griptape_nodes: GriptapeNodes
-    ) -> None:
+    async def test_registration_failure_after_download_marks_library_unusable(self, engine: Engine) -> None:
         """When download_library_request returns failure, the dependent library is marked UNUSABLE and install is not reached."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         lib_info = _make_lib_info()
         schema = _make_schema_mock(["griptape-ai/nodes-dep@v1.0.0"])
 
@@ -454,9 +452,9 @@ class TestLibraryDependencyResolution:
         assert len(dep_problems) == 1
 
     @pytest.mark.asyncio
-    async def test_failed_dep_already_in_tracker_triggers_download(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_failed_dep_already_in_tracker_triggers_download(self, engine: Engine) -> None:
         """A dep in _library_file_path_to_info but in FAILURE state is not treated as satisfied — download must still be attempted."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         lib_info = _make_lib_info()
         schema = _make_schema_mock(["griptape-ai/griptape-nodes-library-opencolorio@v1.2.0"])
 
@@ -498,9 +496,9 @@ class TestLibraryDependencyResolution:
         mock_download.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_dep_recognized_by_library_name_skips_download(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_dep_recognized_by_library_name_skips_download(self, engine: Engine) -> None:
         """A dep whose library_name matches repo name skips download even when its path has no matching component."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         lib_info = _make_lib_info()
         schema = _make_schema_mock(["griptape-ai/griptape-nodes-library-opencolorio@v1.2.0"])
 
@@ -558,9 +556,9 @@ def _make_lib_registry_mock(
 class TestResolveTransitiveLibraryDeps:
     """Tests for LibraryManager.resolve_transitive_library_deps()."""
 
-    def test_no_deps_returns_initial(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_no_deps_returns_initial(self, engine: Engine) -> None:
         """A library with no library_dependencies returns just the initial set."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         lib_a = _make_lib_registry_mock(library_dependencies=None)
 
         with patch(
@@ -571,9 +569,9 @@ class TestResolveTransitiveLibraryDeps:
 
         assert [r.library_name for r in result] == ["lib-a"]
 
-    def test_direct_dep_added(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_direct_dep_added(self, engine: Engine) -> None:
         """Library A declaring a library_dependency on Library B includes B in the result."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         dep_b = LibraryDependencyDeclaration(url="griptape-ai/lib-b@v1.0.0", required=True)
         lib_a = _make_lib_registry_mock(library_dependencies=[dep_b])
         lib_b = _make_lib_registry_mock(library_dependencies=None)
@@ -594,9 +592,9 @@ class TestResolveTransitiveLibraryDeps:
         assert "lib-a" in names
         assert "lib-b" in names
 
-    def test_transitive_dep_added(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_transitive_dep_added(self, engine: Engine) -> None:
         """A→B→C chain results in all three libraries being included."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         dep_b = LibraryDependencyDeclaration(url="griptape-ai/lib-b@v1.0.0", required=True)
         dep_c = LibraryDependencyDeclaration(url="griptape-ai/lib-c@v1.0.0", required=True)
         lib_a = _make_lib_registry_mock(library_dependencies=[dep_b])
@@ -616,9 +614,9 @@ class TestResolveTransitiveLibraryDeps:
 
         assert {r.library_name for r in result} == {"lib-a", "lib-b", "lib-c"}
 
-    def test_cycle_does_not_loop(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_cycle_does_not_loop(self, engine: Engine) -> None:
         """A→B→A cycle terminates and includes both libraries exactly once."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         dep_b = LibraryDependencyDeclaration(url="griptape-ai/lib-b@v1.0.0", required=True)
         dep_a = LibraryDependencyDeclaration(url="griptape-ai/lib-a@v1.0.0", required=True)
         lib_a = _make_lib_registry_mock(library_dependencies=[dep_b])
@@ -637,9 +635,9 @@ class TestResolveTransitiveLibraryDeps:
 
         assert {r.library_name for r in result} == {"lib-a", "lib-b"}
 
-    def test_unregistered_dep_skipped(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_unregistered_dep_skipped(self, engine: Engine) -> None:
         """A dep that has no LibraryInfo is skipped without raising."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         dep_missing = LibraryDependencyDeclaration(url="griptape-ai/lib-missing@v1.0.0", required=True)
         lib_a = _make_lib_registry_mock(library_dependencies=[dep_missing])
 
@@ -664,7 +662,7 @@ class TestDownloadLibraryRequestAutoRegister:
     """
 
     @pytest.mark.asyncio
-    async def test_auto_register_failure_returns_download_failure(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_auto_register_failure_returns_download_failure(self, engine: Engine) -> None:
         """When RegisterLibraryFromFileRequest fails, download_library_request must return DownloadLibraryResultFailure.
 
         Regression guard: old code only logged a warning on registration failure and fell through to
@@ -673,7 +671,7 @@ class TestDownloadLibraryRequestAutoRegister:
         import json as _json
         import tempfile
 
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         tracked: dict = {}
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -696,7 +694,7 @@ class TestDownloadLibraryRequestAutoRegister:
                     return_value=fake_json_path,
                 ),
                 patch.object(
-                    griptape_nodes,
+                    engine,
                     "ahandle_request",
                     new_callable=AsyncMock,
                     return_value=RegisterLibraryFromFileResultFailure(result_details="schema validation error"),
@@ -750,10 +748,8 @@ class TestWorkerDelegatedAdvancedLibrarySkip:
         )
 
     @pytest.mark.asyncio
-    async def test_orchestrator_skips_advanced_module_for_worker_delegated_library(
-        self, griptape_nodes: GriptapeNodes
-    ) -> None:
-        mgr = griptape_nodes.LibraryManager()
+    async def test_orchestrator_skips_advanced_module_for_worker_delegated_library(self, engine: Engine) -> None:
+        mgr = engine.library_manager
         lib_info = self._make_lib_info(
             state=LibraryManager.LibraryLifecycleState.WORKER_DELEGATED, requires_worker=True
         )
@@ -783,9 +779,9 @@ class TestWorkerDelegatedAdvancedLibrarySkip:
         assert lib_info.lifecycle_state is LibraryManager.LibraryLifecycleState.WORKER_PENDING
 
     @pytest.mark.asyncio
-    async def test_in_process_library_still_loads_the_advanced_module(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_in_process_library_still_loads_the_advanced_module(self, engine: Engine) -> None:
         """Pins the non-worker path: the skip must key on worker delegation, not fire always."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         lib_info = self._make_lib_info(
             state=LibraryManager.LibraryLifecycleState.DEPENDENCIES_INSTALLED, requires_worker=False
         )
@@ -835,14 +831,14 @@ class TestRequiresWorkerResolvedOnFilePathRegistration:
         return RegisterLibraryFromFileRequest(file_path="/mock.json", perform_discovery_if_not_found=False)
 
     @pytest.mark.asyncio
-    async def test_an_existing_library_info_is_updated_in_place(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_an_existing_library_info_is_updated_in_place(self, engine: Engine) -> None:
         """Discovered-but-unnamed LibraryInfo: the stale requires_worker must be overwritten.
 
         `_library_file_path_to_info` can already hold an entry from discovery that never got a
         library_name (so it defaulted requires_worker to False). Updating every other field
         while leaving that one stale is how a worker library ends up loading in-process.
         """
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         lib_info = LibraryManager.LibraryInfo(
             lifecycle_state=LibraryManager.LibraryLifecycleState.DISCOVERED,
             library_path="/mock.json",
@@ -869,9 +865,9 @@ class TestRequiresWorkerResolvedOnFilePathRegistration:
         assert lib_info.lifecycle_state is LibraryManager.LibraryLifecycleState.METADATA_LOADED
 
     @pytest.mark.asyncio
-    async def test_a_new_library_info_is_created_with_it(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_a_new_library_info_is_created_with_it(self, engine: Engine) -> None:
         """Nothing discovered yet -- the freshly built LibraryInfo carries the resolved value."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
 
         with (
             patch.object(
@@ -888,9 +884,9 @@ class TestRequiresWorkerResolvedOnFilePathRegistration:
         assert result.library_info.lifecycle_state is LibraryManager.LibraryLifecycleState.METADATA_LOADED
 
     @pytest.mark.asyncio
-    async def test_a_library_with_no_worker_declaration_stays_in_process(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_a_library_with_no_worker_declaration_stays_in_process(self, engine: Engine) -> None:
         """The resolution must read the manifest, not default to worker mode for everyone."""
-        mgr = griptape_nodes.LibraryManager()
+        mgr = engine.library_manager
         schema = self._worker_mode_schema()
         schema.metadata.declarations = []
 

--- a/tests/unit/retained_mode/managers/test_library_manager_directory_paths.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_directory_paths.py
@@ -6,12 +6,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from griptape_nodes.retained_mode.engine import Engine
 from griptape_nodes.retained_mode.events.library_events import (
     DownloadLibraryResultFailure,
     UpdateLibraryRequest,
     UpdateLibraryResultFailure,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.library_manager import LibraryGitOperationContext
 from griptape_nodes.utils.git_utils import GitCloneError, GitPullError
 
@@ -19,15 +19,15 @@ from griptape_nodes.utils.git_utils import GitCloneError, GitPullError
 class TestGetSandboxDirectory:
     """Test _get_sandbox_directory resolves absolute and relative paths."""
 
-    def test_relative_path(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_relative_path(self, engine: Engine) -> None:
         """A relative sandbox_library_directory is resolved against the workspace."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         config_mgr = MagicMock()
         config_mgr.get_config_value.return_value = "sandbox_library"
         config_mgr.workspace_path = Path("/workspace")
 
         with (
-            patch.object(griptape_nodes, "_config_manager", config_mgr),
+            patch.object(engine, "_config_manager", config_mgr),
             patch(
                 "griptape_nodes.retained_mode.managers.library_manager.resolve_workspace_path",
                 return_value=Path("/workspace/sandbox_library"),
@@ -39,15 +39,15 @@ class TestGetSandboxDirectory:
         mock_resolve.assert_called_once_with(Path("sandbox_library"), Path("/workspace"))
         assert result == Path("/workspace/sandbox_library")
 
-    def test_absolute_path(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_absolute_path(self, engine: Engine) -> None:
         """An absolute sandbox_library_directory is used as-is."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         config_mgr = MagicMock()
         config_mgr.get_config_value.return_value = "/opt/sandbox"
         config_mgr.workspace_path = Path("/workspace")
 
         with (
-            patch.object(griptape_nodes, "_config_manager", config_mgr),
+            patch.object(engine, "_config_manager", config_mgr),
             patch(
                 "griptape_nodes.retained_mode.managers.library_manager.resolve_workspace_path",
                 return_value=Path("/opt/sandbox"),
@@ -59,27 +59,27 @@ class TestGetSandboxDirectory:
         mock_resolve.assert_called_once_with(Path("/opt/sandbox"), Path("/workspace"))
         assert result == Path("/opt/sandbox")
 
-    def test_not_configured_returns_none(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_not_configured_returns_none(self, engine: Engine) -> None:
         """When sandbox_library_directory is empty, returns None without resolving."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         config_mgr = MagicMock()
         config_mgr.get_config_value.return_value = ""
         config_mgr.workspace_path = Path("/workspace")
 
-        with patch.object(griptape_nodes, "_config_manager", config_mgr):
+        with patch.object(engine, "_config_manager", config_mgr):
             result = library_manager._get_sandbox_directory()
 
         assert result is None
 
-    def test_nonexistent_directory_returns_none(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_nonexistent_directory_returns_none(self, engine: Engine) -> None:
         """When the resolved directory does not exist, returns None."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         config_mgr = MagicMock()
         config_mgr.get_config_value.return_value = "sandbox_library"
         config_mgr.workspace_path = Path("/workspace")
 
         with (
-            patch.object(griptape_nodes, "_config_manager", config_mgr),
+            patch.object(engine, "_config_manager", config_mgr),
             patch(
                 "griptape_nodes.retained_mode.managers.library_manager.resolve_workspace_path",
                 return_value=Path("/workspace/sandbox_library"),
@@ -95,13 +95,13 @@ class TestDownloadLibrariesFromGitUrlsPath:
     """Test _download_libraries_from_git_urls resolves absolute and relative paths."""
 
     @pytest.mark.asyncio
-    async def test_uses_resolved_libraries_root(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_uses_resolved_libraries_root(self, engine: Engine) -> None:
         """The download root comes from ConfigManager.resolved_libraries_root (own/inherited or default)."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         config_mgr = MagicMock()
         config_mgr.resolved_libraries_root.return_value = Path("/workspace/libraries")
 
-        with patch.object(griptape_nodes, "_config_manager", config_mgr):
+        with patch.object(engine, "_config_manager", config_mgr):
             result = await library_manager._download_libraries_from_git_urls([])
 
         config_mgr.resolved_libraries_root.assert_called_once_with()
@@ -112,9 +112,9 @@ class TestDownloadLibraryRequestPath:
     """Test download_library_request resolves absolute and relative paths."""
 
     @pytest.mark.asyncio
-    async def test_uses_resolved_libraries_root(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_uses_resolved_libraries_root(self, engine: Engine) -> None:
         """The download root comes from ConfigManager.resolved_libraries_root."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         config_mgr = MagicMock()
         config_mgr.resolved_libraries_root.return_value = Path("/workspace/libraries")
 
@@ -125,7 +125,7 @@ class TestDownloadLibraryRequestPath:
         request.download_directory = None
 
         with (
-            patch.object(griptape_nodes, "_config_manager", config_mgr),
+            patch.object(engine, "_config_manager", config_mgr),
             patch(
                 "griptape_nodes.retained_mode.managers.library_manager.normalize_github_url",
                 return_value="https://github.com/user/repo.git",
@@ -140,9 +140,9 @@ class TestDownloadLibraryRequestPath:
         assert isinstance(result, DownloadLibraryResultFailure)
 
     @pytest.mark.asyncio
-    async def test_custom_download_directory_skips_config(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_custom_download_directory_skips_config(self, engine: Engine) -> None:
         """When download_directory is provided, it is used directly without resolving config."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         config_mgr = MagicMock()
         config_mgr.workspace_path = Path("/workspace")
 
@@ -153,7 +153,7 @@ class TestDownloadLibraryRequestPath:
         request.download_directory = "/custom/dir"
 
         with (
-            patch.object(griptape_nodes, "_config_manager", config_mgr),
+            patch.object(engine, "_config_manager", config_mgr),
             patch(
                 "griptape_nodes.retained_mode.managers.library_manager.normalize_github_url",
                 return_value="https://github.com/user/repo.git",
@@ -167,7 +167,7 @@ class TestDownloadLibraryRequestPath:
         config_mgr.resolved_libraries_root.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_existing_target_dir_sets_existing_path(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_existing_target_dir_sets_existing_path(self, engine: Engine) -> None:
         """Existing target directory failure carries the path in ``existing_path``.
 
         When the target directory already exists and fail_on_exists is True, the failure
@@ -175,7 +175,7 @@ class TestDownloadLibraryRequestPath:
         can render it without having to parse the human-readable error message (which is
         unreliable for paths containing ``:``, e.g. Windows drive letters).
         """
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         config_mgr = MagicMock()
         config_mgr.resolved_libraries_root.return_value = Path("/opt/libraries")
 
@@ -188,7 +188,7 @@ class TestDownloadLibraryRequestPath:
         request.fail_on_exists = True
 
         with (
-            patch.object(griptape_nodes, "_config_manager", config_mgr),
+            patch.object(engine, "_config_manager", config_mgr),
             patch(
                 "griptape_nodes.retained_mode.managers.library_manager.normalize_github_url",
                 return_value="https://github.com/user/repo.git",
@@ -207,14 +207,14 @@ class TestUpdateLibraryRequestExistingPath:
     """Test update_library_request reports the dirty library directory in ``existing_path``."""
 
     @pytest.mark.asyncio
-    async def test_uncommitted_changes_sets_existing_path(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_uncommitted_changes_sets_existing_path(self, engine: Engine) -> None:
         """Uncommitted-changes update failure carries the library directory in ``existing_path``.
 
         Without this, clients on Windows cannot recover the path from the error message because
         the drive-letter colon collides with the ``<path>: <reason>`` separator in the
         human-readable message.
         """
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         library_dir = Path("/var/lib/test_lib")
 
         validation_context = LibraryGitOperationContext(

--- a/tests/unit/retained_mode/managers/test_library_manager_git_failures.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_git_failures.py
@@ -26,7 +26,7 @@ from griptape_nodes.retained_mode.managers.library_manager import (
 from griptape_nodes.utils.git_utils import GitError, GitNotFoundError
 
 if TYPE_CHECKING:
-    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+    from griptape_nodes.retained_mode.engine import Engine
 
 LIBRARY_MANAGER_MODULE = "griptape_nodes.retained_mode.managers.library_manager"
 LIBRARY_DIR = Path("/var/lib/test_lib")
@@ -60,9 +60,9 @@ class TestCheckLibraryUpdateRequestGitFailures:
     """Test check_library_update_request when a git call fails."""
 
     @pytest.mark.asyncio
-    async def test_monorepo_check_failure_returns_failure(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_monorepo_check_failure_returns_failure(self, engine: Engine) -> None:
         """A git failure while reading the repository layout fails the check instead of escaping."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         with (
             patch(f"{LIBRARY_MANAGER_MODULE}.LibraryRegistry.get_library", return_value=_library()),
@@ -77,9 +77,9 @@ class TestCheckLibraryUpdateRequestGitFailures:
         assert "test_lib" in str(result.result_details)
 
     @pytest.mark.asyncio
-    async def test_local_commit_failure_returns_failure(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_local_commit_failure_returns_failure(self, engine: Engine) -> None:
         """A git failure while reading the local commit fails the check instead of escaping."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         with (
             patch(f"{LIBRARY_MANAGER_MODULE}.LibraryRegistry.get_library", return_value=_library()),
@@ -97,13 +97,13 @@ class TestCheckLibraryUpdateRequestGitFailures:
         assert "test_lib" in str(result.result_details)
 
     @pytest.mark.asyncio
-    async def test_monorepo_reports_no_update_without_git_details(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_monorepo_reports_no_update_without_git_details(self, engine: Engine) -> None:
         """A monorepo library still reports "no update, manage manually" when git details are unavailable.
 
         The remote and ref in that response are informational, so their absence must not turn a
         successful answer into a failure.
         """
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         with (
             patch(f"{LIBRARY_MANAGER_MODULE}.LibraryRegistry.get_library", return_value=_library()),
@@ -125,9 +125,9 @@ class TestUpdateLibraryRequestGitFailures:
     """Test update_library_request when a git call fails."""
 
     @pytest.mark.asyncio
-    async def test_monorepo_check_failure_returns_failure(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_monorepo_check_failure_returns_failure(self, engine: Engine) -> None:
         """A git failure while reading the repository layout fails the update before the working tree is touched."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         with (
             patch.object(

--- a/tests/unit/retained_mode/managers/test_library_manager_lazy_loading.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_lazy_loading.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from pathlib import Path
 
-    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+    from griptape_nodes.retained_mode.engine import Engine
 
 _GOOD_NODE_SOURCE = """
 from griptape_nodes.exe_types.node_types import BaseNode
@@ -145,8 +145,8 @@ class TestLazyNodeLoadingDefault:
 
 
 class TestEagerLoading:
-    def test_broken_node_is_reported_at_load(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
-        manager = griptape_nodes.LibraryManager()
+    def test_broken_node_is_reported_at_load(self, engine: Engine, tmp_path: Path) -> None:
+        manager = engine.library_manager
         schema = _write_library(tmp_path)
         library = LibraryRegistry.generate_new_library(library_data=schema)
         info = _library_info(schema, tmp_path)
@@ -164,8 +164,8 @@ class TestEagerLoading:
 
 
 class TestLazyLoading:
-    def test_broken_node_is_not_reported_until_used(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
-        manager = griptape_nodes.LibraryManager()
+    def test_broken_node_is_not_reported_until_used(self, engine: Engine, tmp_path: Path) -> None:
+        manager = engine.library_manager
         schema = _write_library(tmp_path)
         library = LibraryRegistry.generate_new_library(library_data=schema)
         info = _library_info(schema, tmp_path)
@@ -187,9 +187,9 @@ class TestLazyLoading:
 
 
 class TestShouldLazyLoadNodes:
-    def test_worker_always_eager(self, griptape_nodes: GriptapeNodes) -> None:
-        manager = griptape_nodes.LibraryManager()
-        config_mgr = griptape_nodes.ConfigManager()
+    def test_worker_always_eager(self, engine: Engine) -> None:
+        manager = engine.library_manager
+        config_mgr = engine.config_manager
         # Even with the setting on, a worker loads eagerly.
         with (
             patch.object(manager, "_is_worker", True),
@@ -197,18 +197,18 @@ class TestShouldLazyLoadNodes:
         ):
             assert manager._should_lazy_load_nodes() is False
 
-    def test_orchestrator_honors_setting_enabled(self, griptape_nodes: GriptapeNodes) -> None:
-        manager = griptape_nodes.LibraryManager()
-        config_mgr = griptape_nodes.ConfigManager()
+    def test_orchestrator_honors_setting_enabled(self, engine: Engine) -> None:
+        manager = engine.library_manager
+        config_mgr = engine.config_manager
         with (
             patch.object(manager, "_is_worker", False),
             patch.object(config_mgr, "get_config_value", return_value=True),
         ):
             assert manager._should_lazy_load_nodes() is True
 
-    def test_orchestrator_honors_setting_disabled(self, griptape_nodes: GriptapeNodes) -> None:
-        manager = griptape_nodes.LibraryManager()
-        config_mgr = griptape_nodes.ConfigManager()
+    def test_orchestrator_honors_setting_disabled(self, engine: Engine) -> None:
+        manager = engine.library_manager
+        config_mgr = engine.config_manager
         with (
             patch.object(manager, "_is_worker", False),
             patch.object(config_mgr, "get_config_value", return_value=False),
@@ -217,8 +217,8 @@ class TestShouldLazyLoadNodes:
 
 
 class TestMultipleNodesPerFile:
-    def test_sibling_classes_share_a_single_module_import(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
-        manager = griptape_nodes.LibraryManager()
+    def test_sibling_classes_share_a_single_module_import(self, engine: Engine, tmp_path: Path) -> None:
+        manager = engine.library_manager
         marker = tmp_path / "import_count.txt"
         (tmp_path / "siblings.py").write_text(_SIBLINGS_SOURCE.format(marker=str(marker)))
         schema = _schema(
@@ -250,10 +250,8 @@ class TestMultipleNodesPerFile:
 
 
 class TestDescribeNodeTypeWithLazyImportFailure:
-    def test_describe_returns_metadata_only_when_lazy_import_fails(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
-        manager = griptape_nodes.LibraryManager()
+    def test_describe_returns_metadata_only_when_lazy_import_fails(self, engine: Engine, tmp_path: Path) -> None:
+        manager = engine.library_manager
         schema = _write_library(tmp_path)
         library = LibraryRegistry.generate_new_library(library_data=schema)
         info = _library_info(schema, tmp_path)
@@ -298,10 +296,8 @@ class TestStableNamespaceImportUnderLazyLoading:
             ):
                 del sys.modules[module_name]
 
-    def _register_lazy_library(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> tuple[LibraryManager, LibrarySchema]:
-        manager = griptape_nodes.LibraryManager()
+    def _register_lazy_library(self, engine: Engine, tmp_path: Path) -> tuple[LibraryManager, LibrarySchema]:
+        manager = engine.library_manager
         schema = _write_library(tmp_path)
         library = LibraryRegistry.generate_new_library(library_data=schema)
         info = _library_info(schema, tmp_path)
@@ -310,10 +306,8 @@ class TestStableNamespaceImportUnderLazyLoading:
         )
         return manager, schema
 
-    def test_stable_namespace_imports_before_any_class_resolution(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
-        self._register_lazy_library(griptape_nodes, tmp_path)
+    def test_stable_namespace_imports_before_any_class_resolution(self, engine: Engine, tmp_path: Path) -> None:
+        self._register_lazy_library(engine, tmp_path)
         assert self.GOOD_STABLE_NAMESPACE not in sys.modules
 
         module = importlib.import_module(self.GOOD_STABLE_NAMESPACE)
@@ -324,8 +318,8 @@ class TestStableNamespaceImportUnderLazyLoading:
         library = LibraryRegistry.get_library("Lazy Flag Test Library")
         assert library.get_node_class("GoodNode") is module.GoodNode
 
-    def test_unpickle_resolves_stable_namespace_reference(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
-        self._register_lazy_library(griptape_nodes, tmp_path)
+    def test_unpickle_resolves_stable_namespace_reference(self, engine: Engine, tmp_path: Path) -> None:
+        self._register_lazy_library(engine, tmp_path)
         assert self.GOOD_STABLE_NAMESPACE not in sys.modules
 
         # A GLOBAL-opcode pickle referencing the stable namespace, as found inside saved
@@ -335,8 +329,8 @@ class TestStableNamespaceImportUnderLazyLoading:
 
         assert node_class.__name__ == "GoodNode"
 
-    def test_parent_packages_resolve_as_namespace_packages(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
-        self._register_lazy_library(griptape_nodes, tmp_path)
+    def test_parent_packages_resolve_as_namespace_packages(self, engine: Engine, tmp_path: Path) -> None:
+        self._register_lazy_library(engine, tmp_path)
 
         root_package = importlib.import_module("griptape_nodes.node_libraries")
         library_package = importlib.import_module("griptape_nodes.node_libraries.lazy_flag_test_library")
@@ -344,24 +338,22 @@ class TestStableNamespaceImportUnderLazyLoading:
         assert root_package.__path__ is not None
         assert library_package.__path__ is not None
 
-    def test_broken_module_import_raises_import_error(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
-        self._register_lazy_library(griptape_nodes, tmp_path)
+    def test_broken_module_import_raises_import_error(self, engine: Engine, tmp_path: Path) -> None:
+        self._register_lazy_library(engine, tmp_path)
 
         with pytest.raises(ImportError):
             importlib.import_module(self.BROKEN_STABLE_NAMESPACE)
 
-    def test_unregistered_library_is_no_longer_importable(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
-        manager, schema = self._register_lazy_library(griptape_nodes, tmp_path)
+    def test_unregistered_library_is_no_longer_importable(self, engine: Engine, tmp_path: Path) -> None:
+        manager, schema = self._register_lazy_library(engine, tmp_path)
 
         manager._unregister_all_stable_module_aliases_for_library(schema.name)
 
         with pytest.raises(ModuleNotFoundError):
             importlib.import_module(self.GOOD_STABLE_NAMESPACE)
 
-    def test_loaded_module_import_is_not_reexecuted_by_class_resolution(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
-        manager = griptape_nodes.LibraryManager()
+    def test_loaded_module_import_is_not_reexecuted_by_class_resolution(self, engine: Engine, tmp_path: Path) -> None:
+        manager = engine.library_manager
         marker = tmp_path / "import_count.txt"
         (tmp_path / "siblings.py").write_text(_SIBLINGS_SOURCE.format(marker=str(marker)))
         schema = _schema(

--- a/tests/unit/retained_mode/managers/test_library_manager_ordering.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_ordering.py
@@ -17,7 +17,7 @@ from griptape_nodes.retained_mode.events.library_events import (
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator
 
-    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+    from griptape_nodes.retained_mode.engine import Engine
 
 
 def _register_only_config(libraries: object) -> Callable[..., object]:
@@ -54,11 +54,9 @@ class TestLibraryManagerDeterministicOrdering:
             yield Path(tmpdir).resolve()
 
     @pytest.mark.asyncio
-    async def test_discover_library_files_preserves_config_order(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    async def test_discover_library_files_preserves_config_order(self, engine: Engine, temp_dir: Path) -> None:
         """Test that _discover_library_files preserves the order from libraries_to_register."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         # Create library files in different directories (to have distinct paths)
         lib_z = temp_dir / "z_lib" / "griptape_nodes_library.json"
@@ -74,9 +72,7 @@ class TestLibraryManagerDeterministicOrdering:
         # Mock config to return libraries in specific order (z, a, m)
         config_order = [str(lib_z), str(lib_a), str(lib_m)]
 
-        with patch.object(
-            griptape_nodes.ConfigManager(), "get_config_value", side_effect=_register_only_config(config_order)
-        ):
+        with patch.object(engine.config_manager, "get_config_value", side_effect=_register_only_config(config_order)):
             result = await library_manager._discover_library_files()
 
             # Should preserve config order, not alphabetical
@@ -89,10 +85,10 @@ class TestLibraryManagerDeterministicOrdering:
 
     @pytest.mark.asyncio
     async def test_discover_library_files_handles_directories_deterministically(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
+        self, engine: Engine, temp_dir: Path
     ) -> None:
         """Test that files discovered from directories are sorted deterministically."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         # Create subdirectories with library files (each needs the standard library filename)
         lib_dir = temp_dir / "libraries"
@@ -111,9 +107,7 @@ class TestLibraryManagerDeterministicOrdering:
         lib_b.write_text("{}")
 
         # Mock config to point to the parent directory
-        with patch.object(
-            griptape_nodes.ConfigManager(), "get_config_value", side_effect=_register_only_config([str(lib_dir)])
-        ):
+        with patch.object(engine.config_manager, "get_config_value", side_effect=_register_only_config([str(lib_dir)])):
             result = await library_manager._discover_library_files()
 
             # Files from directory should be sorted alphabetically by path
@@ -125,10 +119,10 @@ class TestLibraryManagerDeterministicOrdering:
 
     @pytest.mark.asyncio
     async def test_discover_library_files_mixed_files_and_directories_preserves_order(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
+        self, engine: Engine, temp_dir: Path
     ) -> None:
         """Test that mixing direct files and directories preserves config order."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         # Create direct library file in its own directory
         direct_dir = temp_dir / "direct"
@@ -156,9 +150,7 @@ class TestLibraryManagerDeterministicOrdering:
         # Config order: direct file, directory, another direct file
         config_order = [str(direct_lib), str(lib_dir), str(another_direct)]
 
-        with patch.object(
-            griptape_nodes.ConfigManager(), "get_config_value", side_effect=_register_only_config(config_order)
-        ):
+        with patch.object(engine.config_manager, "get_config_value", side_effect=_register_only_config(config_order)):
             result = await library_manager._discover_library_files()
 
             # Should be: direct_lib, dir_lib_a, dir_lib_b, another_direct
@@ -172,10 +164,10 @@ class TestLibraryManagerDeterministicOrdering:
 
     @pytest.mark.asyncio
     async def test_discover_library_files_deduplicates_preserving_first_occurrence(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
+        self, engine: Engine, temp_dir: Path
     ) -> None:
         """Test that duplicate libraries are removed, preserving first occurrence."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         # Create library file
         lib_dir = temp_dir / "mylib"
@@ -186,9 +178,7 @@ class TestLibraryManagerDeterministicOrdering:
         # Config lists same library twice
         config_order = [str(lib), str(lib)]
 
-        with patch.object(
-            griptape_nodes.ConfigManager(), "get_config_value", side_effect=_register_only_config(config_order)
-        ):
+        with patch.object(engine.config_manager, "get_config_value", side_effect=_register_only_config(config_order)):
             result = await library_manager._discover_library_files()
 
             # Should only appear once
@@ -196,11 +186,9 @@ class TestLibraryManagerDeterministicOrdering:
             assert len(result) == 1
 
     @pytest.mark.asyncio
-    async def test_discover_libraries_request_returns_list_in_order(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    async def test_discover_libraries_request_returns_list_in_order(self, engine: Engine, temp_dir: Path) -> None:
         """Test that discover_libraries_request returns libraries as a list in order."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         # Create library files in separate directories
         z_dir = temp_dir / "z_lib"
@@ -215,9 +203,7 @@ class TestLibraryManagerDeterministicOrdering:
         # Mock config to return libraries in specific order
         config_order = [str(lib1), str(lib2)]
 
-        with patch.object(
-            griptape_nodes.ConfigManager(), "get_config_value", side_effect=_register_only_config(config_order)
-        ):
+        with patch.object(engine.config_manager, "get_config_value", side_effect=_register_only_config(config_order)):
             request = DiscoverLibrariesRequest(include_sandbox=False)
             result = await library_manager.discover_libraries_request(request)
 
@@ -229,11 +215,9 @@ class TestLibraryManagerDeterministicOrdering:
             assert discovered_paths == [lib1, lib2]
 
     @pytest.mark.asyncio
-    async def test_discover_libraries_request_deterministic_across_calls(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    async def test_discover_libraries_request_deterministic_across_calls(self, engine: Engine, temp_dir: Path) -> None:
         """Test that multiple calls return the same order."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
 
         # Create multiple library files with random-ish names in separate directories
         libs = []
@@ -244,7 +228,7 @@ class TestLibraryManagerDeterministicOrdering:
             lib.write_text("{}")
             libs.append(str(lib))
 
-        with patch.object(griptape_nodes.ConfigManager(), "get_config_value", side_effect=_register_only_config(libs)):
+        with patch.object(engine.config_manager, "get_config_value", side_effect=_register_only_config(libs)):
             request = DiscoverLibrariesRequest(include_sandbox=False)
 
             result1 = await library_manager.discover_libraries_request(request)

--- a/tests/unit/retained_mode/managers/test_library_manager_post_dispatch_hooks.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_post_dispatch_hooks.py
@@ -17,7 +17,7 @@ from griptape_nodes.retained_mode.managers.fitness_problems.libraries import (
 from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
 
 if TYPE_CHECKING:
-    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+    from griptape_nodes.retained_mode.engine import Engine
 
 
 @dataclass
@@ -61,7 +61,7 @@ def _load(lm: LibraryManager, library: Library, library_info: LibraryManager.Lib
 
 
 class TestPostDispatchHookRegistration:
-    def test_hooks_registered_via_event_manager(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_hooks_registered_via_event_manager(self, engine: Engine) -> None:
         """get_post_dispatch_hooks() pairs should be registered with EventManager."""
 
         class MyLib(AdvancedNodeLibrary):
@@ -71,14 +71,14 @@ class TestPostDispatchHookRegistration:
         library = _make_library(advanced_library=MyLib())
         library_info = _make_library_info()
 
-        lm = griptape_nodes.LibraryManager()
+        lm = engine.library_manager
         event_manager = MagicMock()
-        with patch.object(griptape_nodes, "_event_manager", event_manager):
+        with patch.object(engine, "_event_manager", event_manager):
             _load(lm, library, library_info)
 
         event_manager.add_post_dispatch_hook.assert_called_once_with(_TestRequest, _hook)
 
-    def test_hook_pairs_recorded_on_library(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_hook_pairs_recorded_on_library(self, engine: Engine) -> None:
         """The request type is tracked alongside the callback, because removal needs both."""
 
         class MyLib(AdvancedNodeLibrary):
@@ -88,14 +88,14 @@ class TestPostDispatchHookRegistration:
         library = _make_library(advanced_library=MyLib())
         library_info = _make_library_info()
 
-        lm = griptape_nodes.LibraryManager()
+        lm = engine.library_manager
         event_manager = MagicMock()
-        with patch.object(griptape_nodes, "_event_manager", event_manager):
+        with patch.object(engine, "_event_manager", event_manager):
             _load(lm, library, library_info)
 
         assert library.get_registered_post_dispatch_hooks() == [(_TestRequest, _hook)]
 
-    def test_exception_in_get_post_dispatch_hooks_appends_problem(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_exception_in_get_post_dispatch_hooks_appends_problem(self, engine: Engine) -> None:
         """An exception from get_post_dispatch_hooks() should append PostDispatchHookRegistrationProblem."""
 
         class BoomLib(AdvancedNodeLibrary):
@@ -106,15 +106,15 @@ class TestPostDispatchHookRegistration:
         library = _make_library(advanced_library=BoomLib())
         library_info = _make_library_info()
 
-        lm = griptape_nodes.LibraryManager()
+        lm = engine.library_manager
         event_manager = MagicMock()
-        with patch.object(griptape_nodes, "_event_manager", event_manager):
+        with patch.object(engine, "_event_manager", event_manager):
             _load(lm, library, library_info)
 
         problem_types = [type(p) for p in library_info.problems]
         assert PostDispatchHookRegistrationProblem in problem_types
 
-    def test_non_callable_hook_appends_problem(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_non_callable_hook_appends_problem(self, engine: Engine) -> None:
         """Library code is untyped at this boundary, so a bad pair must fail loudly here."""
 
         class BadLib(AdvancedNodeLibrary):
@@ -124,9 +124,9 @@ class TestPostDispatchHookRegistration:
         library = _make_library(advanced_library=BadLib())
         library_info = _make_library_info()
 
-        lm = griptape_nodes.LibraryManager()
+        lm = engine.library_manager
         event_manager = MagicMock()
-        with patch.object(griptape_nodes, "_event_manager", event_manager):
+        with patch.object(engine, "_event_manager", event_manager):
             _load(lm, library, library_info)
 
         problem_types = [type(p) for p in library_info.problems]
@@ -134,9 +134,7 @@ class TestPostDispatchHookRegistration:
         event_manager.add_post_dispatch_hook.assert_not_called()
         assert library.get_registered_post_dispatch_hooks() == []
 
-    def test_a_bad_pair_stops_registration_but_leaves_earlier_pairs_tracked(
-        self, griptape_nodes: GriptapeNodes
-    ) -> None:
+    def test_a_bad_pair_stops_registration_but_leaves_earlier_pairs_tracked(self, engine: Engine) -> None:
         """A bad pair abandons the rest of the list, so what did register must still be tracked.
 
         Registration aborts on the first bad entry, matching the request-handler block
@@ -159,9 +157,9 @@ class TestPostDispatchHookRegistration:
         library = _make_library(advanced_library=PartlyBadLib())
         library_info = _make_library_info()
 
-        lm = griptape_nodes.LibraryManager()
+        lm = engine.library_manager
         event_manager = MagicMock()
-        with patch.object(griptape_nodes, "_event_manager", event_manager):
+        with patch.object(engine, "_event_manager", event_manager):
             _load(lm, library, library_info)
 
         problem_types = [type(p) for p in library_info.problems]
@@ -171,7 +169,7 @@ class TestPostDispatchHookRegistration:
         assert registered == [first_hook]
         assert library.get_registered_post_dispatch_hooks() == [(_TestRequest, first_hook)]
 
-    def test_non_type_request_key_appends_problem(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_non_type_request_key_appends_problem(self, engine: Engine) -> None:
         """A key that is not a class would register and then never fire, silently.
 
         `_fire_post_dispatch_hooks` looks the callbacks up by `type(request)`, so a key
@@ -186,9 +184,9 @@ class TestPostDispatchHookRegistration:
         library = _make_library(advanced_library=BadKeyLib())
         library_info = _make_library_info()
 
-        lm = griptape_nodes.LibraryManager()
+        lm = engine.library_manager
         event_manager = MagicMock()
-        with patch.object(griptape_nodes, "_event_manager", event_manager):
+        with patch.object(engine, "_event_manager", event_manager):
             _load(lm, library, library_info)
 
         problem_types = [type(p) for p in library_info.problems]
@@ -196,19 +194,19 @@ class TestPostDispatchHookRegistration:
         event_manager.add_post_dispatch_hook.assert_not_called()
         assert library.get_registered_post_dispatch_hooks() == []
 
-    def test_no_advanced_library_does_nothing(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_no_advanced_library_does_nothing(self, engine: Engine) -> None:
         """A library with no advanced library should not touch EventManager at all."""
         library = _make_library(advanced_library=None)
         library_info = _make_library_info()
 
-        lm = griptape_nodes.LibraryManager()
+        lm = engine.library_manager
         event_manager = MagicMock()
-        with patch.object(griptape_nodes, "_event_manager", event_manager):
+        with patch.object(engine, "_event_manager", event_manager):
             _load(lm, library, library_info)
 
         event_manager.add_post_dispatch_hook.assert_not_called()
 
-    def test_empty_get_post_dispatch_hooks_does_nothing(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_empty_get_post_dispatch_hooks_does_nothing(self, engine: Engine) -> None:
         """A library returning [] should not register any hooks."""
 
         class EmptyLib(AdvancedNodeLibrary):
@@ -217,14 +215,14 @@ class TestPostDispatchHookRegistration:
         library = _make_library(advanced_library=EmptyLib())
         library_info = _make_library_info()
 
-        lm = griptape_nodes.LibraryManager()
+        lm = engine.library_manager
         event_manager = MagicMock()
-        with patch.object(griptape_nodes, "_event_manager", event_manager):
+        with patch.object(engine, "_event_manager", event_manager):
             _load(lm, library, library_info)
 
         event_manager.add_post_dispatch_hook.assert_not_called()
 
-    def test_worker_mode_library_with_hooks_appends_incompatible_problem(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_worker_mode_library_with_hooks_appends_incompatible_problem(self, engine: Engine) -> None:
         """Hooks registered in a worker process never see requests the orchestrator handles."""
 
         class WorkerLib(AdvancedNodeLibrary):
@@ -235,15 +233,15 @@ class TestPostDispatchHookRegistration:
         library_info = _make_library_info()
         library_info.requires_worker = True
 
-        lm = griptape_nodes.LibraryManager()
+        lm = engine.library_manager
         event_manager = MagicMock()
-        with patch.object(griptape_nodes, "_event_manager", event_manager):
+        with patch.object(engine, "_event_manager", event_manager):
             _load(lm, library, library_info)
 
         problem_types = [type(p) for p in library_info.problems]
         assert PostDispatchHooksWorkerIncompatibleProblem in problem_types
 
-    def test_non_worker_library_with_hooks_no_incompatible_problem(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_non_worker_library_with_hooks_no_incompatible_problem(self, engine: Engine) -> None:
         """A non-worker library with hooks is the supported case and must load clean."""
 
         class OrchestratorLib(AdvancedNodeLibrary):
@@ -254,9 +252,9 @@ class TestPostDispatchHookRegistration:
         library_info = _make_library_info()
         library_info.requires_worker = False
 
-        lm = griptape_nodes.LibraryManager()
+        lm = engine.library_manager
         event_manager = MagicMock()
-        with patch.object(griptape_nodes, "_event_manager", event_manager):
+        with patch.object(engine, "_event_manager", event_manager):
             _load(lm, library, library_info)
 
         problem_types = [type(p) for p in library_info.problems]

--- a/tests/unit/retained_mode/managers/test_library_manager_request_handlers.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_request_handlers.py
@@ -17,7 +17,7 @@ from griptape_nodes.retained_mode.managers.fitness_problems.libraries import (
 from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
 
 if TYPE_CHECKING:
-    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+    from griptape_nodes.retained_mode.engine import Engine
 
 
 @dataclass
@@ -58,7 +58,7 @@ def _make_library(advanced_library: AdvancedNodeLibrary | None = None) -> Librar
 
 
 class TestRequestHandlerRegistration:
-    def test_handlers_registered_via_event_manager(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_handlers_registered_via_event_manager(self, engine: Engine) -> None:
         """get_request_handlers() pairs should be registered with EventManager."""
 
         class MyLib(AdvancedNodeLibrary):
@@ -68,9 +68,9 @@ class TestRequestHandlerRegistration:
         library = _make_library(advanced_library=MyLib())
         library_info = _make_library_info()
 
-        lm = griptape_nodes.LibraryManager()
+        lm = engine.library_manager
         event_manager = MagicMock()
-        with patch.object(griptape_nodes, "_event_manager", event_manager):
+        with patch.object(engine, "_event_manager", event_manager):
             lm._attempt_load_nodes_from_library(
                 library_data=library._library_data,
                 library=library,
@@ -80,7 +80,7 @@ class TestRequestHandlerRegistration:
 
         event_manager.assign_manager_to_request_type.assert_called_once_with(_TestRequest, _handler)
 
-    def test_handler_types_recorded_on_library(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_handler_types_recorded_on_library(self, engine: Engine) -> None:
         """Registered handler types must be stored in library._registered_request_handler_types."""
 
         class MyLib(AdvancedNodeLibrary):
@@ -90,9 +90,9 @@ class TestRequestHandlerRegistration:
         library = _make_library(advanced_library=MyLib())
         library_info = _make_library_info()
 
-        lm = griptape_nodes.LibraryManager()
+        lm = engine.library_manager
         event_manager = MagicMock()
-        with patch.object(griptape_nodes, "_event_manager", event_manager):
+        with patch.object(engine, "_event_manager", event_manager):
             lm._attempt_load_nodes_from_library(
                 library_data=library._library_data,
                 library=library,
@@ -102,7 +102,7 @@ class TestRequestHandlerRegistration:
 
         assert _TestRequest in library._registered_request_handler_types
 
-    def test_exception_in_get_request_handlers_appends_problem(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_exception_in_get_request_handlers_appends_problem(self, engine: Engine) -> None:
         """An exception from get_request_handlers() should append RequestHandlerRegistrationProblem."""
 
         class BoomLib(AdvancedNodeLibrary):
@@ -115,9 +115,9 @@ class TestRequestHandlerRegistration:
         # Add a dummy node so the library isn't marked UNUSABLE (any_nodes_loaded_successfully=False)
         library_info.problems = []
 
-        lm = griptape_nodes.LibraryManager()
+        lm = engine.library_manager
         event_manager = MagicMock()
-        with patch.object(griptape_nodes, "_event_manager", event_manager):
+        with patch.object(engine, "_event_manager", event_manager):
             lm._attempt_load_nodes_from_library(
                 library_data=library._library_data,
                 library=library,
@@ -128,14 +128,14 @@ class TestRequestHandlerRegistration:
         problem_types = [type(p) for p in library_info.problems]
         assert RequestHandlerRegistrationProblem in problem_types
 
-    def test_no_advanced_library_does_nothing(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_no_advanced_library_does_nothing(self, engine: Engine) -> None:
         """A library with no advanced library should not touch EventManager at all."""
         library = _make_library(advanced_library=None)
         library_info = _make_library_info()
 
-        lm = griptape_nodes.LibraryManager()
+        lm = engine.library_manager
         event_manager = MagicMock()
-        with patch.object(griptape_nodes, "_event_manager", event_manager):
+        with patch.object(engine, "_event_manager", event_manager):
             lm._attempt_load_nodes_from_library(
                 library_data=library._library_data,
                 library=library,
@@ -145,7 +145,7 @@ class TestRequestHandlerRegistration:
 
         event_manager.assign_manager_to_request_type.assert_not_called()
 
-    def test_empty_get_request_handlers_does_nothing(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_empty_get_request_handlers_does_nothing(self, engine: Engine) -> None:
         """A library returning [] from get_request_handlers() should not register any handlers."""
 
         class EmptyLib(AdvancedNodeLibrary):
@@ -154,9 +154,9 @@ class TestRequestHandlerRegistration:
         library = _make_library(advanced_library=EmptyLib())
         library_info = _make_library_info()
 
-        lm = griptape_nodes.LibraryManager()
+        lm = engine.library_manager
         event_manager = MagicMock()
-        with patch.object(griptape_nodes, "_event_manager", event_manager):
+        with patch.object(engine, "_event_manager", event_manager):
             lm._attempt_load_nodes_from_library(
                 library_data=library._library_data,
                 library=library,
@@ -166,9 +166,7 @@ class TestRequestHandlerRegistration:
 
         event_manager.assign_manager_to_request_type.assert_not_called()
 
-    def test_worker_mode_library_with_handlers_appends_incompatible_problem(
-        self, griptape_nodes: GriptapeNodes
-    ) -> None:
+    def test_worker_mode_library_with_handlers_appends_incompatible_problem(self, engine: Engine) -> None:
         """A library requiring worker mode that declares handlers should surface RequestHandlersWorkerIncompatibleProblem."""
 
         class WorkerLib(AdvancedNodeLibrary):
@@ -179,9 +177,9 @@ class TestRequestHandlerRegistration:
         library_info = _make_library_info()
         library_info.requires_worker = True
 
-        lm = griptape_nodes.LibraryManager()
+        lm = engine.library_manager
         event_manager = MagicMock()
-        with patch.object(griptape_nodes, "_event_manager", event_manager):
+        with patch.object(engine, "_event_manager", event_manager):
             lm._attempt_load_nodes_from_library(
                 library_data=library._library_data,
                 library=library,
@@ -192,7 +190,7 @@ class TestRequestHandlerRegistration:
         problem_types = [type(p) for p in library_info.problems]
         assert RequestHandlersWorkerIncompatibleProblem in problem_types
 
-    def test_non_worker_library_with_handlers_no_incompatible_problem(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_non_worker_library_with_handlers_no_incompatible_problem(self, engine: Engine) -> None:
         """A non-worker library with handlers should NOT get RequestHandlersWorkerIncompatibleProblem."""
 
         class OrchestratorLib(AdvancedNodeLibrary):
@@ -203,9 +201,9 @@ class TestRequestHandlerRegistration:
         library_info = _make_library_info()
         library_info.requires_worker = False
 
-        lm = griptape_nodes.LibraryManager()
+        lm = engine.library_manager
         event_manager = MagicMock()
-        with patch.object(griptape_nodes, "_event_manager", event_manager):
+        with patch.object(engine, "_event_manager", event_manager):
             lm._attempt_load_nodes_from_library(
                 library_data=library._library_data,
                 library=library,

--- a/tests/unit/retained_mode/managers/test_library_manager_source_info.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_source_info.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
+from griptape_nodes.retained_mode.engine import Engine
 from griptape_nodes.retained_mode.events.library_events import (
     GetEngineSourceInfoRequest,
     GetEngineSourceInfoResultFailure,
@@ -13,7 +14,6 @@ from griptape_nodes.retained_mode.events.library_events import (
     GetLibrarySourceInfoResultFailure,
     GetLibrarySourceInfoResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
 
 # Compute the filesystem root once at import time so async test bodies don't
@@ -23,8 +23,8 @@ _FS_ROOT = Path("/").resolve()
 
 class TestGetLibrarySourceInfoRequest:
     @pytest.mark.asyncio
-    async def test_returns_success_with_correct_paths(self, griptape_nodes: GriptapeNodes) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    async def test_returns_success_with_correct_paths(self, engine: Engine) -> None:
+        library_manager = engine.library_manager
 
         root = _FS_ROOT
         json_path = str(root / "some" / "dir" / "griptape_nodes_library.json")
@@ -51,8 +51,8 @@ class TestGetLibrarySourceInfoRequest:
         assert result.library_directory == dir_path
 
     @pytest.mark.asyncio
-    async def test_library_directory_is_parent_of_json_path(self, griptape_nodes: GriptapeNodes) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    async def test_library_directory_is_parent_of_json_path(self, engine: Engine) -> None:
+        library_manager = engine.library_manager
 
         root = _FS_ROOT
         json_path = str(root / "libs" / "my_lib" / "griptape_nodes_library.json")
@@ -76,8 +76,8 @@ class TestGetLibrarySourceInfoRequest:
         assert Path(result.library_directory) == Path(result.library_json_path).parent
 
     @pytest.mark.asyncio
-    async def test_returns_failure_when_library_not_found(self, griptape_nodes: GriptapeNodes) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    async def test_returns_failure_when_library_not_found(self, engine: Engine) -> None:
+        library_manager = engine.library_manager
 
         with patch.object(
             library_manager, "get_library_info_by_library_name", return_value=None, autospec=True
@@ -89,8 +89,8 @@ class TestGetLibrarySourceInfoRequest:
         assert isinstance(result, GetLibrarySourceInfoResultFailure)
 
     @pytest.mark.asyncio
-    async def test_waits_for_libraries_loading_complete(self, griptape_nodes: GriptapeNodes) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    async def test_waits_for_libraries_loading_complete(self, engine: Engine) -> None:
+        library_manager = engine.library_manager
 
         loading_event = asyncio.Event()
         root = _FS_ROOT
@@ -126,8 +126,8 @@ class TestGetLibrarySourceInfoRequest:
 
 
 class TestGetEngineSourceInfoRequest:
-    def test_returns_success_with_valid_directory(self, griptape_nodes: GriptapeNodes) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    def test_returns_success_with_valid_directory(self, engine: Engine) -> None:
+        library_manager = engine.library_manager
 
         request = GetEngineSourceInfoRequest()
         result = library_manager.on_get_engine_source_info_request(request)
@@ -135,8 +135,8 @@ class TestGetEngineSourceInfoRequest:
         assert isinstance(result, GetEngineSourceInfoResultSuccess)
         assert Path(result.package_directory).is_dir()
 
-    def test_package_directory_contains_init(self, griptape_nodes: GriptapeNodes) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    def test_package_directory_contains_init(self, engine: Engine) -> None:
+        library_manager = engine.library_manager
 
         request = GetEngineSourceInfoRequest()
         result = library_manager.on_get_engine_source_info_request(request)
@@ -144,8 +144,8 @@ class TestGetEngineSourceInfoRequest:
         assert isinstance(result, GetEngineSourceInfoResultSuccess)
         assert (Path(result.package_directory) / "__init__.py").exists()
 
-    def test_package_directory_contains_exe_types(self, griptape_nodes: GriptapeNodes) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    def test_package_directory_contains_exe_types(self, engine: Engine) -> None:
+        library_manager = engine.library_manager
 
         request = GetEngineSourceInfoRequest()
         result = library_manager.on_get_engine_source_info_request(request)
@@ -153,8 +153,8 @@ class TestGetEngineSourceInfoRequest:
         assert isinstance(result, GetEngineSourceInfoResultSuccess)
         assert (Path(result.package_directory) / "exe_types" / "node_types.py").exists()
 
-    def test_returns_failure_when_spec_not_found(self, griptape_nodes: GriptapeNodes) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    def test_returns_failure_when_spec_not_found(self, engine: Engine) -> None:
+        library_manager = engine.library_manager
 
         with patch("importlib.util.find_spec", return_value=None):
             request = GetEngineSourceInfoRequest()
@@ -162,8 +162,8 @@ class TestGetEngineSourceInfoRequest:
 
         assert isinstance(result, GetEngineSourceInfoResultFailure)
 
-    def test_returns_failure_when_spec_origin_is_none(self, griptape_nodes: GriptapeNodes) -> None:
-        library_manager = griptape_nodes.LibraryManager()
+    def test_returns_failure_when_spec_origin_is_none(self, engine: Engine) -> None:
+        library_manager = engine.library_manager
 
         spec_without_origin = ModuleSpec(name="griptape_nodes", loader=None, origin=None)
 

--- a/tests/unit/retained_mode/managers/test_library_manager_stale_modules.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_stale_modules.py
@@ -28,8 +28,8 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from pathlib import Path
 
+    from griptape_nodes.retained_mode.engine import Engine
     from griptape_nodes.retained_mode.events.base_events import ResultPayload
-    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 LIBRARY_NAME = "Stale Module Test Library"
 STABLE_NAMESPACE = "griptape_nodes.node_libraries.stale_module_test_library.some_node"
@@ -91,10 +91,8 @@ def _unload(manager: LibraryManager) -> None:
 
 
 class TestStaleModuleDetection:
-    def test_a_library_that_never_loaded_a_module_needs_no_restart(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
-        manager = griptape_nodes.LibraryManager()
+    def test_a_library_that_never_loaded_a_module_needs_no_restart(self, engine: Engine, tmp_path: Path) -> None:
+        manager = engine.library_manager
         _register_library(manager, tmp_path)
 
         _unload(manager)
@@ -103,8 +101,8 @@ class TestStaleModuleDetection:
         assert manager._was_reloaded_after_its_modules_were_imported(LIBRARY_NAME) is False
         assert manager.explain_stale_module_failure(LIBRARY_NAME) is None
 
-    def test_reloading_after_a_module_loaded_is_remembered(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
-        manager = griptape_nodes.LibraryManager()
+    def test_reloading_after_a_module_loaded_is_remembered(self, engine: Engine, tmp_path: Path) -> None:
+        manager = engine.library_manager
         _register_library(manager, tmp_path)
         _pretend_a_node_module_loaded(manager)
 
@@ -116,8 +114,8 @@ class TestStaleModuleDetection:
         assert "Restart the engine" in explanation
         assert LIBRARY_NAME in explanation
 
-    def test_the_marker_survives_a_successful_re_register(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
-        manager = griptape_nodes.LibraryManager()
+    def test_the_marker_survives_a_successful_re_register(self, engine: Engine, tmp_path: Path) -> None:
+        manager = engine.library_manager
         _register_library(manager, tmp_path)
         _pretend_a_node_module_loaded(manager)
         _unload(manager)
@@ -126,23 +124,23 @@ class TestStaleModuleDetection:
         # Only restarting the process clears cached modules, so re-registering must not clear it.
         assert manager._was_reloaded_after_its_modules_were_imported(LIBRARY_NAME) is True
 
-    def test_an_untouched_library_is_never_blamed(self, griptape_nodes: GriptapeNodes) -> None:
-        manager = griptape_nodes.LibraryManager()
+    def test_an_untouched_library_is_never_blamed(self, engine: Engine) -> None:
+        manager = engine.library_manager
 
         assert manager._was_reloaded_after_its_modules_were_imported("Some Other Library") is False
         assert manager.explain_stale_module_failure("Some Other Library") is None
 
 
 class TestNodeImportProblemReporting:
-    def test_no_problems_recorded(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
-        manager = griptape_nodes.LibraryManager()
+    def test_no_problems_recorded(self, engine: Engine, tmp_path: Path) -> None:
+        manager = engine.library_manager
         _register_library(manager, tmp_path)
 
         assert manager._library_has_node_import_problems(LIBRARY_NAME) is False
         assert manager.get_library_name_for_node_type("SomeNode") is None
 
-    def test_import_problems_are_found_and_attributed(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
-        manager = griptape_nodes.LibraryManager()
+    def test_import_problems_are_found_and_attributed(self, engine: Engine, tmp_path: Path) -> None:
+        manager = engine.library_manager
         _register_library(
             manager,
             tmp_path,
@@ -159,8 +157,8 @@ class TestNodeImportProblemReporting:
 class TestReloadResultsReportRestart:
     """Every path that reloads a library in place has to report the restart, not just updates."""
 
-    def test_a_clean_reload_reports_no_restart(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
-        manager = griptape_nodes.LibraryManager()
+    def test_a_clean_reload_reports_no_restart(self, engine: Engine, tmp_path: Path) -> None:
+        manager = engine.library_manager
         _register_library(manager, tmp_path)
         _pretend_a_node_module_loaded(manager)
         _unload(manager)
@@ -181,9 +179,9 @@ class TestReloadResultsReportRestart:
         assert switch_result.restart_required is False
 
     def test_a_stale_reload_reports_a_restart_for_updates_and_ref_switches(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
+        self, engine: Engine, tmp_path: Path
     ) -> None:
-        manager = griptape_nodes.LibraryManager()
+        manager = engine.library_manager
         _register_library(manager, tmp_path)
         _pretend_a_node_module_loaded(manager)
         _unload(manager)
@@ -204,10 +202,8 @@ class TestReloadResultsReportRestart:
         assert "Restart the engine" in _first_detail_message(switch_result)
         assert switch_result.new_ref == "dev"
 
-    def test_an_import_failure_without_a_reload_asks_for_no_restart(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
-        manager = griptape_nodes.LibraryManager()
+    def test_an_import_failure_without_a_reload_asks_for_no_restart(self, engine: Engine, tmp_path: Path) -> None:
+        manager = engine.library_manager
         _register_library(manager, tmp_path, problems=[_import_problem()])
 
         # The library is simply broken: it was never reloaded on top of imported modules, so a

--- a/tests/unit/retained_mode/managers/test_library_manager_strict_mode.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_strict_mode.py
@@ -18,12 +18,13 @@ from griptape_nodes.common.strict_mode import STRICT_MODE
 from griptape_nodes.exe_types.core_types import Parameter, Trait
 from griptape_nodes.exe_types.param_components.huggingface.huggingface_repo_parameter import HuggingFaceRepoParameter
 from griptape_nodes.node_library.library_registry import LibraryRegistry
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from tests.unit.exe_types.mocks import MockNode
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
     from contextlib import AbstractContextManager
+
+    from griptape_nodes.retained_mode.engine import Engine
 
 
 @pytest.fixture
@@ -91,8 +92,10 @@ class _ViolatingProbe:
 
 class TestSerializeSchemasStrictMode:
     @pytest.mark.asyncio
-    async def test_clean_class_is_included(self, patched_registry: Callable[[dict[str, type]], Any]) -> None:
-        manager = GriptapeNodes.LibraryManager()
+    async def test_clean_class_is_included(
+        self, engine: Engine, patched_registry: Callable[[dict[str, type]], Any]
+    ) -> None:
+        manager = engine.library_manager
         with patched_registry({"Clean": _CleanProbe}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
@@ -100,10 +103,10 @@ class TestSerializeSchemasStrictMode:
 
     @pytest.mark.asyncio
     async def test_violating_class_is_skipped(
-        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+        self, engine: Engine, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.DEBUG, logger="griptape_nodes.strict_mode")
-        manager = GriptapeNodes.LibraryManager()
+        manager = engine.library_manager
         with patched_registry({"Violator": _ViolatingProbe, "Clean": _CleanProbe}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
@@ -133,7 +136,7 @@ class _ProbeWithHuggingFaceRepoParam(MockNode):
 class TestHuggingFaceRepoParameterSurvivesTheProbe:
     @pytest.mark.asyncio
     async def test_hf_param_node_is_included_and_issues_no_bus_requests(
-        self, patched_registry: Callable[[dict[str, type]], Any]
+        self, engine: Engine, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         module = "griptape_nodes.exe_types.param_components.huggingface"
 
@@ -141,7 +144,7 @@ class TestHuggingFaceRepoParameterSurvivesTheProbe:
             msg = f"bus request issued during probe construction: {type(request).__name__}"
             raise AssertionError(msg)
 
-        manager = GriptapeNodes.LibraryManager()
+        manager = engine.library_manager
         with (
             patch(f"{module}.huggingface_repo_parameter.list_repo_revisions_in_cache", return_value=[]),
             patch(f"{module}.huggingface_model_parameter.GriptapeNodes.handle_request", side_effect=_refuse_bus),
@@ -205,10 +208,10 @@ class TestParameterBehaviorsDropped:
 
     @pytest.mark.asyncio
     async def test_clean_parameters_produce_no_violation(
-        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+        self, engine: Engine, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
-        manager = GriptapeNodes.LibraryManager()
+        manager = engine.library_manager
         with patched_registry({"Clean": _ProbeWithCleanParams}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
@@ -217,10 +220,10 @@ class TestParameterBehaviorsDropped:
 
     @pytest.mark.asyncio
     async def test_parameter_with_converter_reports_warning_but_keeps_schema(
-        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+        self, engine: Engine, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
-        manager = GriptapeNodes.LibraryManager()
+        manager = engine.library_manager
         with patched_registry({"WithBehavior": _ProbeWithConverterParam}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
@@ -234,10 +237,10 @@ class TestParameterBehaviorsDropped:
 
     @pytest.mark.asyncio
     async def test_parameter_with_validator_reports_warning_but_keeps_schema(
-        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+        self, engine: Engine, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
-        manager = GriptapeNodes.LibraryManager()
+        manager = engine.library_manager
         with patched_registry({"WithValidator": _ProbeWithValidatorParam}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
@@ -248,10 +251,10 @@ class TestParameterBehaviorsDropped:
 
     @pytest.mark.asyncio
     async def test_parameter_with_trait_reports_warning_but_keeps_schema(
-        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+        self, engine: Engine, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
-        manager = GriptapeNodes.LibraryManager()
+        manager = engine.library_manager
         with patched_registry({"WithTrait": _ProbeWithTraitParam}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
@@ -311,10 +314,10 @@ class TestInertWorkerHooks:
 
     @pytest.mark.asyncio
     async def test_connection_hook_override_reports_warning_but_keeps_schema(
-        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+        self, engine: Engine, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
-        manager = GriptapeNodes.LibraryManager()
+        manager = engine.library_manager
         with patched_registry({"WithConnHook": _ProbeWithConnectionHook}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
@@ -328,10 +331,10 @@ class TestInertWorkerHooks:
 
     @pytest.mark.asyncio
     async def test_value_hook_override_reports_warning_but_keeps_schema(
-        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+        self, engine: Engine, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
-        manager = GriptapeNodes.LibraryManager()
+        manager = engine.library_manager
         with patched_registry({"WithValueHook": _ProbeWithValueHook}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
@@ -344,13 +347,13 @@ class TestInertWorkerHooks:
 
     @pytest.mark.asyncio
     async def test_engine_owned_hook_override_is_not_reported(
-        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+        self, engine: Engine, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         # A hook implemented by an engine-owned base/component (module under
         # griptape_nodes.) is not the author's code; flagging it would nag on
         # something the library author cannot remediate.
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
-        manager = GriptapeNodes.LibraryManager()
+        manager = engine.library_manager
         with patched_registry({"EngineHook": _ProbeInheritingEngineHook}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
@@ -359,10 +362,10 @@ class TestInertWorkerHooks:
 
     @pytest.mark.asyncio
     async def test_hookless_class_produces_no_hook_violation(
-        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+        self, engine: Engine, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
-        manager = GriptapeNodes.LibraryManager()
+        manager = engine.library_manager
         with patched_registry({"Clean": _CleanProbe}):
             schemas = await manager._serialize_library_node_schemas("libA")
 

--- a/tests/unit/retained_mode/managers/test_library_manager_workflow_nodes.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_workflow_nodes.py
@@ -88,12 +88,12 @@ def _write_workflow(tmp_path: Path, *, shape: dict[str, Any] | None) -> Path:
 
 
 class TestRegisterWorkflowNode:
-    def test_registers_generated_node_type(self, griptape_nodes: Engine, tmp_path: Path) -> None:
+    def test_registers_generated_node_type(self, engine: Engine, tmp_path: Path) -> None:
         workflow_path = _write_workflow(tmp_path, shape=_SHAPE)
         library = _library([_definition(workflow_path.name)])
         library_info = _library_info()
 
-        registered = griptape_nodes.library_manager._register_workflow_node(
+        registered = engine.library_manager._register_workflow_node(
             library.get_library_data().workflow_nodes[0],  # type: ignore[index]
             tmp_path,
             library,
@@ -107,11 +107,11 @@ class TestRegisterWorkflowNode:
         assert issubclass(node_class, WorkflowNode)
         assert node_class.workflow_file_path == workflow_path
 
-    def test_metadata_from_the_json_wins(self, griptape_nodes: Engine, tmp_path: Path) -> None:
+    def test_metadata_from_the_json_wins(self, engine: Engine, tmp_path: Path) -> None:
         workflow_path = _write_workflow(tmp_path, shape=_SHAPE)
         library = _library([_definition(workflow_path.name)])
 
-        griptape_nodes.library_manager._register_workflow_node(
+        engine.library_manager._register_workflow_node(
             library.get_library_data().workflow_nodes[0],  # type: ignore[index]
             tmp_path,
             library,
@@ -120,11 +120,11 @@ class TestRegisterWorkflowNode:
 
         assert library.get_node_metadata(NODE_TYPE).display_name == "Shout Workflow"
 
-    def test_missing_workflow_file_records_problem(self, griptape_nodes: Engine, tmp_path: Path) -> None:
+    def test_missing_workflow_file_records_problem(self, engine: Engine, tmp_path: Path) -> None:
         library = _library([_definition("absent_workflow.py")])
         library_info = _library_info()
 
-        registered = griptape_nodes.library_manager._register_workflow_node(
+        registered = engine.library_manager._register_workflow_node(
             library.get_library_data().workflow_nodes[0],  # type: ignore[index]
             tmp_path,
             library,
@@ -135,12 +135,12 @@ class TestRegisterWorkflowNode:
         assert not library.has_node_type(NODE_TYPE)
         assert [type(problem) for problem in library_info.problems] == [WorkflowNodeLoadProblem]
 
-    def test_workflow_without_shape_records_problem(self, griptape_nodes: Engine, tmp_path: Path) -> None:
+    def test_workflow_without_shape_records_problem(self, engine: Engine, tmp_path: Path) -> None:
         workflow_path = _write_workflow(tmp_path, shape=None)
         library = _library([_definition(workflow_path.name)])
         library_info = _library_info()
 
-        registered = griptape_nodes.library_manager._register_workflow_node(
+        registered = engine.library_manager._register_workflow_node(
             library.get_library_data().workflow_nodes[0],  # type: ignore[index]
             tmp_path,
             library,
@@ -178,7 +178,7 @@ class TestWorkflowNodeLoadProblemDisplay:
         assert "Encountered 2 workflow-backed node failures" in message
 
 
-@pytest.mark.usefixtures("griptape_nodes")
+@pytest.mark.usefixtures("engine")
 class TestSchemaDefaults:
     def test_workflow_nodes_defaults_to_none(self) -> None:
         schema = LibrarySchema(

--- a/tests/unit/retained_mode/managers/test_model_manager.py
+++ b/tests/unit/retained_mode/managers/test_model_manager.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from griptape_nodes.exe_types.node_types import BaseNode
+from griptape_nodes.retained_mode.engine import Engine
 from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
 from griptape_nodes.retained_mode.events.base_events import RequestPayload
 from griptape_nodes.retained_mode.events.model_events import (
@@ -28,7 +29,6 @@ from griptape_nodes.retained_mode.events.model_events import (
     SearchModelsResultFailure,
     SearchModelsResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 from griptape_nodes.retained_mode.managers.model_manager import DownloadParams, ModelManager
 
@@ -233,12 +233,11 @@ class TestOnHandleDeclareModelInvocationRequest:
         assert isinstance(allowed.result, DeclareModelInvocationResultSuccess)
         assert allowed.result.model_id == "gtc_gpt_5"
 
-    def test_authorization_checkpoint_denial_blocks_invocation(self) -> None:
+    def test_authorization_checkpoint_denial_blocks_invocation(self, engine: Engine) -> None:
         # The InvokeModel checkpoint gates the declared invocation: a denial from
         # a registered authorization hook turns into a failure so the node does
         # not invoke the model. The handler passes the stable catalog key; the app
         # resolves the provider and family from it.
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
             AuthorizationCheckpoint,
             CheckpointDenial,
@@ -255,7 +254,7 @@ class TestOnHandleDeclareModelInvocationRequest:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Anthropic models are not enabled."),))
             return None
 
-        GriptapeNodes.EventManager().add_authorization_hook(deny)
+        engine.event_manager.add_authorization_hook(deny)
         manager = ModelManager()
 
         denied = manager.on_handle_declare_model_invocation_request(
@@ -270,10 +269,9 @@ class TestOnHandleDeclareModelInvocationRequest:
         )
         assert isinstance(allowed, DeclareModelInvocationResultSuccess)
 
-    def test_empty_failure_denial_still_yields_a_reason(self) -> None:
+    def test_empty_failure_denial_still_yields_a_reason(self, engine: Engine) -> None:
         # A hook that misuses the contract by returning a denial with no failures
         # (it should return None to allow) must not produce a reason-less message.
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
             AuthorizationCheckpoint,
             CheckpointDenial,
@@ -282,7 +280,7 @@ class TestOnHandleDeclareModelInvocationRequest:
         def deny(_checkpoint: AuthorizationCheckpoint) -> CheckpointDenial:
             return CheckpointDenial(failures=())
 
-        GriptapeNodes.EventManager().add_authorization_hook(deny)
+        engine.event_manager.add_authorization_hook(deny)
         manager = ModelManager()
 
         denied = manager.on_handle_declare_model_invocation_request(
@@ -344,7 +342,7 @@ class TestDeclareModelInvocationCatalogEnrichment:
             }
         )
 
-    def _register_node(self, node_name: str) -> None:
+    def _register_node(self, node_name: str, engine: Engine) -> None:
         """Register a library + probe node type, then a node instance the handler can resolve."""
         from griptape_nodes.node_library.library_declarations import ModelUsageNodeProperty
         from griptape_nodes.node_library.library_registry import (
@@ -382,25 +380,25 @@ class TestDeclareModelInvocationCatalogEnrichment:
             name=node_name,
             metadata={"library": _CATALOG_LIBRARY_NAME, "node_type": _ProbeModelNode.__name__},
         )
-        GriptapeNodes.ObjectManager().add_object_by_name(node_name, node)
+        engine.object_manager.add_object_by_name(node_name, node)
 
     def test_checkpoint_carries_family_and_provider_for_declared_model(
         self,
-        griptape_nodes: GriptapeNodes,
+        engine: Engine,
     ) -> None:
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
             AuthorizationCheckpoint,
             CheckpointDenial,
         )
 
-        self._register_node("Probe_1")
+        self._register_node("Probe_1", engine)
         seen: dict[str, object] = {}
 
         def capture(checkpoint: AuthorizationCheckpoint) -> CheckpointDenial | None:
             seen["attributes"] = dict(checkpoint.attributes)
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(capture)
+        engine.event_manager.add_authorization_hook(capture)
         manager = ModelManager()
 
         result = manager.on_handle_declare_model_invocation_request(
@@ -416,7 +414,7 @@ class TestDeclareModelInvocationCatalogEnrichment:
             "model_families": ["GPT Image"],
         }
 
-    def test_family_scoped_hook_blocks_the_invocation(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_family_scoped_hook_blocks_the_invocation(self, engine: Engine) -> None:
         # Mirrors a license policy that forbids a family via the attribute form
         # `resource.model_families.contains(...)`: with the family now on the
         # InvokeModel checkpoint, that forbid fires at invocation time, not only
@@ -427,14 +425,14 @@ class TestDeclareModelInvocationCatalogEnrichment:
             CheckpointFailure,
         )
 
-        self._register_node("Probe_1")
+        self._register_node("Probe_1", engine)
 
         def deny(checkpoint: AuthorizationCheckpoint) -> CheckpointDenial | None:
             if "GPT Image" in (checkpoint.attributes.get("model_families") or []):
                 return CheckpointDenial(failures=(CheckpointFailure(detail="GPT Image family is not in your plan."),))
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(deny)
+        engine.event_manager.add_authorization_hook(deny)
         manager = ModelManager()
 
         result = manager.on_handle_declare_model_invocation_request(
@@ -444,7 +442,7 @@ class TestDeclareModelInvocationCatalogEnrichment:
         assert isinstance(result, DeclareModelInvocationResultFailure)
         assert "GPT Image family is not in your plan." in str(result.result_details)
 
-    def test_key_absent_from_node_models_falls_back_to_bare_id(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_key_absent_from_node_models_falls_back_to_bare_id(self, engine: Engine) -> None:
         # A key the node does not declare cannot be enriched; the checkpoint
         # carries only the bare id, so a family/provider rule cannot match but a
         # bare-id rule still can.
@@ -453,14 +451,14 @@ class TestDeclareModelInvocationCatalogEnrichment:
             CheckpointDenial,
         )
 
-        self._register_node("Probe_1")
+        self._register_node("Probe_1", engine)
         seen: dict[str, object] = {}
 
         def capture(checkpoint: AuthorizationCheckpoint) -> CheckpointDenial | None:
             seen["attributes"] = dict(checkpoint.attributes)
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(capture)
+        engine.event_manager.add_authorization_hook(capture)
         manager = ModelManager()
 
         manager.on_handle_declare_model_invocation_request(
@@ -469,7 +467,7 @@ class TestDeclareModelInvocationCatalogEnrichment:
 
         assert seen["attributes"] == {"id": "gtc_not_declared"}
 
-    def test_missing_node_name_falls_back_to_bare_id(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_missing_node_name_falls_back_to_bare_id(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
             AuthorizationCheckpoint,
             CheckpointDenial,
@@ -481,7 +479,7 @@ class TestDeclareModelInvocationCatalogEnrichment:
             seen["attributes"] = dict(checkpoint.attributes)
             return None
 
-        griptape_nodes.EventManager().add_authorization_hook(capture)
+        engine.event_manager.add_authorization_hook(capture)
         manager = ModelManager()
 
         manager.on_handle_declare_model_invocation_request(

--- a/tests/unit/retained_mode/managers/test_node_manager.py
+++ b/tests/unit/retained_mode/managers/test_node_manager.py
@@ -18,26 +18,25 @@ from griptape_nodes.retained_mode.events.node_events import (
     UnresolveNodeResultSuccess,
 )
 from griptape_nodes.retained_mode.events.parameter_events import AlterParameterDetailsRequest
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 
 class TestNodeManagerBatchSetNodeMetadata:
     """Test the batch_set_node_metadata functionality in NodeManager."""
 
-    def test_batch_set_node_metadata_empty_request_succeeds(self) -> None:
+    def test_batch_set_node_metadata_empty_request_succeeds(self, engine: Engine) -> None:
         """Test that an empty batch request succeeds without errors."""
         # Create an empty batch request
         request = BatchSetNodeMetadataRequest(node_metadata_updates={})
 
-        # Execute the batch update through GriptapeNodes
-        result = GriptapeNodes.handle_request(request)
+        # Execute the batch update through the engine
+        result = engine.handle_request(request)
 
         # Should succeed even with no updates
         assert isinstance(result, BatchSetNodeMetadataResultSuccess)
         assert result.updated_nodes == []
         assert result.failed_nodes == {}
 
-    def test_batch_set_node_metadata_all_nodes_not_found_fails(self) -> None:
+    def test_batch_set_node_metadata_all_nodes_not_found_fails(self, engine: Engine) -> None:
         """Test that batch update fails when all nodes are not found."""
         # Create request with non-existent nodes
         request = BatchSetNodeMetadataRequest(
@@ -47,8 +46,8 @@ class TestNodeManagerBatchSetNodeMetadata:
             }
         )
 
-        # Execute the batch update through GriptapeNodes
-        result = GriptapeNodes.handle_request(request)
+        # Execute the batch update through the engine
+        result = engine.handle_request(request)
 
         # Should fail because all nodes failed to be found
         assert isinstance(result, BatchSetNodeMetadataResultFailure)
@@ -174,7 +173,7 @@ class TestNodeManagerResolutionStateSerialization:
         mock_tracker.get_tracker_state.return_value = SerializedParameterValueTracker.TrackerState.NOT_IN_TRACKER
 
         caplog.clear()
-        caplog.set_level(logging.WARNING, logger="griptape_nodes")
+        caplog.set_level(logging.WARNING, logger="engine")
 
         NodeManager.handle_parameter_value_saving(
             parameter=mock_parameter,
@@ -216,7 +215,7 @@ class TestNodeManagerResolutionStateSerialization:
         mock_tracker.get_tracker_state.return_value = SerializedParameterValueTracker.TrackerState.NOT_SERIALIZABLE
 
         caplog.clear()
-        caplog.set_level(logging.WARNING, logger="griptape_nodes")
+        caplog.set_level(logging.WARNING, logger="engine")
 
         NodeManager.handle_parameter_value_saving(
             parameter=mock_parameter,
@@ -265,7 +264,7 @@ class TestSerializeNodeWithoutLibraryMetadata:
         assert node.metadata["library"] == "Original Library"
         assert node.metadata["node_type"] == "OriginalType"
 
-    def test_serialize_node_without_library_metadata_does_not_crash(self, griptape_nodes: Engine) -> None:
+    def test_serialize_node_without_library_metadata_does_not_crash(self, engine: Engine) -> None:
         """Regression for griptape-ai/griptape-nodes-app#154: a missing 'library' key must not raise."""
         from griptape_nodes.exe_types.node_types import ErrorProxyNode
         from griptape_nodes.retained_mode.events.context_events import EnsureWorkflowAndFlowRequest
@@ -275,10 +274,8 @@ class TestSerializeNodeWithoutLibraryMetadata:
         )
         from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
 
-        griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
-        griptape_nodes.handle_request(
-            EnsureWorkflowAndFlowRequest(workflow_name="proxy_workflow", flow_name="proxy_flow")
-        )
+        engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        engine.handle_request(EnsureWorkflowAndFlowRequest(workflow_name="proxy_workflow", flow_name="proxy_flow"))
 
         node = ErrorProxyNode(
             name="Execute Python",
@@ -292,46 +289,44 @@ class TestSerializeNodeWithoutLibraryMetadata:
         node.metadata.pop("library", None)
         assert "library" not in node.metadata
 
-        GriptapeNodes.ObjectManager().add_object_by_name(node.name, node)
+        engine.object_manager.add_object_by_name(node.name, node)
 
-        result = griptape_nodes.NodeManager().on_serialize_node_to_commands(
-            SerializeNodeToCommandsRequest(node_name=node.name)
-        )
+        result = engine.node_manager.on_serialize_node_to_commands(SerializeNodeToCommandsRequest(node_name=node.name))
 
         assert isinstance(result, SerializeNodeToCommandsResultSuccess)
         create_command = result.serialized_node_commands.create_node_command
         assert create_command.node_type == "ExecutePython"
         assert create_command.specific_library_name == "Missing Library"
 
-        griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
 
 
 class TestUnresolveNodeRequest:
     """Tests for the on_unresolve_node_request handler."""
 
-    def test_node_not_found_returns_failure(self) -> None:
-        result = GriptapeNodes.handle_request(UnresolveNodeRequest(node_name="nonexistent_node"))
+    def test_node_not_found_returns_failure(self, engine: Engine) -> None:
+        result = engine.handle_request(UnresolveNodeRequest(node_name="nonexistent_node"))
         assert isinstance(result, UnresolveNodeResultFailure)
         assert "nonexistent_node" in str(result.result_details)
 
-    def test_resolving_node_returns_failure_without_side_effects(self) -> None:
+    def test_resolving_node_returns_failure_without_side_effects(self, engine: Engine) -> None:
         mock_node = MagicMock(spec=BaseNode)
         mock_node.name = "test_node"
         mock_node.state = NodeResolutionState.RESOLVING
         mock_node.parameter_output_values = MagicMock()
         with patch.object(
-            GriptapeNodes.ObjectManager(),
+            engine.object_manager,
             "attempt_get_object_by_name_as_type",
             return_value=mock_node,
         ):
-            result = GriptapeNodes.handle_request(UnresolveNodeRequest(node_name="test_node"))
+            result = engine.handle_request(UnresolveNodeRequest(node_name="test_node"))
 
         assert isinstance(result, UnresolveNodeResultFailure)
         assert "test_node" in str(result.result_details)
         mock_node.make_node_unresolved.assert_not_called()
         mock_node.parameter_output_values.clear.assert_not_called()
 
-    def test_resolved_node_unresolves_and_cascades_downstream(self) -> None:
+    def test_resolved_node_unresolves_and_cascades_downstream(self, engine: Engine) -> None:
         mock_node = MagicMock(spec=BaseNode)
         mock_node.name = "test_node"
         mock_node.state = NodeResolutionState.RESOLVED
@@ -339,17 +334,17 @@ class TestUnresolveNodeRequest:
         mock_connections = MagicMock()
         with (
             patch.object(
-                GriptapeNodes.ObjectManager(),
+                engine.object_manager,
                 "attempt_get_object_by_name_as_type",
                 return_value=mock_node,
             ),
             patch.object(
-                GriptapeNodes.FlowManager(),
+                engine.flow_manager,
                 "get_connections",
                 return_value=mock_connections,
             ),
         ):
-            result = GriptapeNodes.handle_request(UnresolveNodeRequest(node_name="test_node"))
+            result = engine.handle_request(UnresolveNodeRequest(node_name="test_node"))
 
         assert isinstance(result, UnresolveNodeResultSuccess)
         mock_node.make_node_unresolved.assert_called_once_with(
@@ -358,7 +353,7 @@ class TestUnresolveNodeRequest:
         mock_node.parameter_output_values.silent_clear.assert_not_called()
         mock_connections.unresolve_future_nodes.assert_called_once_with(mock_node)
 
-    def test_unresolved_node_still_cascades_downstream(self) -> None:
+    def test_unresolved_node_still_cascades_downstream(self, engine: Engine) -> None:
         mock_node = MagicMock(spec=BaseNode)
         mock_node.name = "test_node"
         mock_node.state = NodeResolutionState.UNRESOLVED
@@ -366,17 +361,17 @@ class TestUnresolveNodeRequest:
         mock_connections = MagicMock()
         with (
             patch.object(
-                GriptapeNodes.ObjectManager(),
+                engine.object_manager,
                 "attempt_get_object_by_name_as_type",
                 return_value=mock_node,
             ),
             patch.object(
-                GriptapeNodes.FlowManager(),
+                engine.flow_manager,
                 "get_connections",
                 return_value=mock_connections,
             ),
         ):
-            result = GriptapeNodes.handle_request(UnresolveNodeRequest(node_name="test_node"))
+            result = engine.handle_request(UnresolveNodeRequest(node_name="test_node"))
 
         assert isinstance(result, UnresolveNodeResultSuccess)
         mock_node.parameter_output_values.silent_clear.assert_not_called()
@@ -387,7 +382,7 @@ class TestNodeManagerAlterParameterDetailsClearDefaultValue:
     """Test AlterParameterDetailsRequest behavior when clear_default_value and default_value are both set."""
 
     def test_clear_default_value_with_default_value_logs_warning_and_clears(
-        self, griptape_nodes: Engine, caplog: pytest.LogCaptureFixture
+        self, engine: Engine, caplog: pytest.LogCaptureFixture
     ) -> None:
         """When both clear_default_value and default_value are provided, default is cleared and a warning is logged."""
         parameter = Parameter(name="test_param", default_value="original_value")
@@ -401,7 +396,7 @@ class TestNodeManagerAlterParameterDetailsClearDefaultValue:
         caplog.clear()
         caplog.set_level(logging.WARNING)
 
-        griptape_nodes.NodeManager().modify_key_parameter_fields(request, parameter)
+        engine.node_manager.modify_key_parameter_fields(request, parameter)
 
         assert parameter.default_value is None
         assert len(caplog.records) == 1
@@ -415,7 +410,7 @@ class TestNodeManagerAlterParameterDetailsClearDefaultValue:
 class TestGetParameterValueOutputPriority:
     """Output values must take priority over input/property values in GetParameterValueRequest."""
 
-    def test_output_value_takes_priority_over_parameter_value(self, griptape_nodes: Engine) -> None:
+    def test_output_value_takes_priority_over_parameter_value(self, engine: Engine) -> None:
         """When both parameter_values and parameter_output_values contain a key, the output value wins."""
         from unittest.mock import MagicMock
 
@@ -436,17 +431,17 @@ class TestGetParameterValueOutputPriority:
         mock_node.parameter_output_values = {"result": output_value}
         mock_node.get_parameter_by_name.return_value = param
 
-        obj_mgr = griptape_nodes.ObjectManager()
+        obj_mgr = engine.object_manager
         obj_mgr.add_object_by_name("test_node", mock_node)
 
-        node_manager = griptape_nodes.NodeManager()
+        node_manager = engine.node_manager
         request = GetParameterValueRequest(parameter_name="result", node_name="test_node")
         result = node_manager.on_get_parameter_value_request(request)
 
         assert isinstance(result, GetParameterValueResultSuccess)
         assert result.value == output_value
 
-    def test_falls_back_to_parameter_value_when_no_output(self, griptape_nodes: Engine) -> None:
+    def test_falls_back_to_parameter_value_when_no_output(self, engine: Engine) -> None:
         """When parameter_output_values is empty, parameter_values is used."""
         from unittest.mock import MagicMock
 
@@ -466,17 +461,17 @@ class TestGetParameterValueOutputPriority:
         mock_node.parameter_output_values = {}
         mock_node.get_parameter_by_name.return_value = param
 
-        obj_mgr = griptape_nodes.ObjectManager()
+        obj_mgr = engine.object_manager
         obj_mgr.add_object_by_name("test_node", mock_node)
 
-        node_manager = griptape_nodes.NodeManager()
+        node_manager = engine.node_manager
         request = GetParameterValueRequest(parameter_name="a", node_name="test_node")
         result = node_manager.on_get_parameter_value_request(request)
 
         assert isinstance(result, GetParameterValueResultSuccess)
         assert result.value == input_value
 
-    def test_falls_back_to_default_when_no_values(self, griptape_nodes: Engine) -> None:
+    def test_falls_back_to_default_when_no_values(self, engine: Engine) -> None:
         """When neither dict contains the key, the parameter default is returned."""
         from unittest.mock import MagicMock
 
@@ -496,10 +491,10 @@ class TestGetParameterValueOutputPriority:
         mock_node.parameter_output_values = {}
         mock_node.get_parameter_by_name.return_value = param
 
-        obj_mgr = griptape_nodes.ObjectManager()
+        obj_mgr = engine.object_manager
         obj_mgr.add_object_by_name("test_node", mock_node)
 
-        node_manager = griptape_nodes.NodeManager()
+        node_manager = engine.node_manager
         request = GetParameterValueRequest(parameter_name="x", node_name="test_node")
         result = node_manager.on_get_parameter_value_request(request)
 
@@ -511,14 +506,14 @@ class TestNodeManagerCancelExecuteNode:
     """Tests for the CancelExecuteNodeRequest handler and cancel_worker_execution dispatch."""
 
     @pytest.mark.asyncio
-    async def test_handler_no_inflight_returns_success(self, griptape_nodes: Engine) -> None:
+    async def test_handler_no_inflight_returns_success(self, engine: Engine) -> None:
         """Cancelling a request_id that isn't tracked is idempotent success."""
         from griptape_nodes.retained_mode.events.execution_events import (
             CancelExecuteNodeRequest,
             CancelExecuteNodeResultSuccess,
         )
 
-        node_manager = griptape_nodes.NodeManager()
+        node_manager = engine.node_manager
         request = CancelExecuteNodeRequest(target_request_id="not-tracked")
 
         result = await node_manager.on_cancel_execute_node_request(request)
@@ -526,7 +521,7 @@ class TestNodeManagerCancelExecuteNode:
         assert isinstance(result, CancelExecuteNodeResultSuccess)
 
     @pytest.mark.asyncio
-    async def test_handler_cancels_tracked_task_and_sets_flag(self, griptape_nodes: Engine) -> None:
+    async def test_handler_cancels_tracked_task_and_sets_flag(self, engine: Engine) -> None:
         """With an in-flight task registered, the handler sets the node's cancel flag and cancels the task."""
         import asyncio
 
@@ -536,7 +531,7 @@ class TestNodeManagerCancelExecuteNode:
             CancelExecuteNodeResultSuccess,
         )
 
-        node_manager = griptape_nodes.NodeManager()
+        node_manager = engine.node_manager
 
         cancellation_seen = {"value": False}
 
@@ -572,9 +567,9 @@ class TestNodeManagerCancelExecuteNode:
                 task.cancel()
 
     @pytest.mark.asyncio
-    async def test_cancel_worker_execution_noop_when_not_tracked(self, griptape_nodes: Engine) -> None:
+    async def test_cancel_worker_execution_noop_when_not_tracked(self, engine: Engine) -> None:
         """cancel_worker_execution is a no-op when the node isn't routed to a worker."""
-        node_manager = griptape_nodes.NodeManager()
+        node_manager = engine.node_manager
 
         # Should not raise; there is no entry for "ghost_node" and
         # WorkerManager.forward_event_to_worker should not be invoked.
@@ -756,7 +751,7 @@ class TestNodeInstantiationAuthorizationCheckpoint:
         )
         assert self._attrs(library)["executes_arbitrary_code"] is True
 
-    def test_enforce_raises_on_denial(self, griptape_nodes: Engine) -> None:
+    def test_enforce_raises_on_denial(self, engine: Engine) -> None:
         from griptape_nodes.node_library.library_declarations import LifecycleStage, LifecycleStageNodeProperty
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
         from griptape_nodes.retained_mode.managers.node_manager import NodeManager, _NodeInstantiationDeniedError
@@ -770,16 +765,16 @@ class TestNodeInstantiationAuthorizationCheckpoint:
             seen["stage"] = checkpoint.attributes.get("lifecycle_stage")  # type: ignore[attr-defined]
             return CheckpointDenial(failures=(CheckpointFailure(detail="Ask your admin to enable Labs nodes."),))
 
-        griptape_nodes.event_manager.add_authorization_hook(deny)
+        engine.event_manager.add_authorization_hook(deny)
         with pytest.raises(_NodeInstantiationDeniedError, match="Ask your admin to enable Labs nodes"):
             NodeManager._enforce_instantiation_checkpoint(
                 node_type=_GateProbe.__name__,
                 specific_library_name=self._LIBRARY_NAME,
-                event_manager=griptape_nodes.event_manager,
+                event_manager=engine.event_manager,
             )
         assert seen == {"action": "InstantiateNode", "stage": "LABS"}
 
-    def test_enforce_allows_without_hook(self, griptape_nodes: Engine) -> None:
+    def test_enforce_allows_without_hook(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.managers.node_manager import NodeManager
 
         self._register()
@@ -787,10 +782,10 @@ class TestNodeInstantiationAuthorizationCheckpoint:
         NodeManager._enforce_instantiation_checkpoint(
             node_type=_GateProbe.__name__,
             specific_library_name=self._LIBRARY_NAME,
-            event_manager=griptape_nodes.event_manager,
+            event_manager=engine.event_manager,
         )
 
-    def test_worker_materialize_denied_returns_failure(self, griptape_nodes: Engine) -> None:
+    def test_worker_materialize_denied_returns_failure(self, engine: Engine) -> None:
         """Worker-side construction from caller-supplied metadata is gated by the same checkpoint."""
         from griptape_nodes.node_library.library_declarations import LifecycleStage, LifecycleStageNodeProperty
         from griptape_nodes.retained_mode.events.execution_events import (
@@ -806,16 +801,16 @@ class TestNodeInstantiationAuthorizationCheckpoint:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Labs nodes are disabled."),))
             return None
 
-        griptape_nodes.event_manager.add_authorization_hook(deny)
+        engine.event_manager.add_authorization_hook(deny)
         request = ExecuteNodeRequest(
             node_name="probe-1",
             node_metadata={"node_type": _GateProbe.__name__, "library": self._LIBRARY_NAME},
         )
-        result = griptape_nodes.NodeManager()._materialize_transient_node_from_metadata(request)
+        result = engine.node_manager._materialize_transient_node_from_metadata(request)
         assert isinstance(result, ExecuteNodeResultFailure)
         assert "Labs nodes are disabled." in str(result.result_details)
 
-    def test_worker_materialize_allows_without_hook(self, griptape_nodes: Engine) -> None:
+    def test_worker_materialize_allows_without_hook(self, engine: Engine) -> None:
         """With no policy hook the worker path builds the node, matching the no-denial contract."""
         from griptape_nodes.exe_types.node_types import BaseNode
         from griptape_nodes.retained_mode.events.execution_events import ExecuteNodeRequest
@@ -825,11 +820,11 @@ class TestNodeInstantiationAuthorizationCheckpoint:
             node_name="probe-1",
             node_metadata={"node_type": _GateProbe.__name__, "library": self._LIBRARY_NAME},
         )
-        result = griptape_nodes.NodeManager()._materialize_transient_node_from_metadata(request)
+        result = engine.node_manager._materialize_transient_node_from_metadata(request)
         assert isinstance(result, BaseNode)
         assert result.name == "probe-1"
 
-    def test_schema_preview_returns_denied_node_types(self, griptape_nodes: Engine) -> None:
+    def test_schema_preview_returns_denied_node_types(self, engine: Engine) -> None:
         from griptape_nodes.node_library.library_declarations import LifecycleStage, LifecycleStageNodeProperty
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
         from griptape_nodes.retained_mode.managers.node_manager import NodeManager
@@ -841,20 +836,18 @@ class TestNodeInstantiationAuthorizationCheckpoint:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Labs nodes are disabled."),))
             return None
 
-        griptape_nodes.event_manager.add_authorization_hook(deny)
-        denials = NodeManager.evaluate_schema_node_instantiation_denials(
-            schema, event_manager=griptape_nodes.event_manager
-        )
+        engine.event_manager.add_authorization_hook(deny)
+        denials = NodeManager.evaluate_schema_node_instantiation_denials(schema, event_manager=engine.event_manager)
         assert set(denials) == {_GateProbe.__name__}
         assert denials[_GateProbe.__name__].messages() == ["Labs nodes are disabled."]
 
-    def test_schema_preview_empty_without_hook(self, griptape_nodes: Engine) -> None:
+    def test_schema_preview_empty_without_hook(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.managers.node_manager import NodeManager
 
         # No hook -> nothing denied.
         assert (
             NodeManager.evaluate_schema_node_instantiation_denials(
-                self._schema_with_node(), event_manager=griptape_nodes.event_manager
+                self._schema_with_node(), event_manager=engine.event_manager
             )
             == {}
         )
@@ -911,7 +904,7 @@ class TestNodeInstantiationAuthorizationCheckpoint:
         assert "provider_ids" not in attrs
         assert "model_families" not in attrs
 
-    def test_model_facts_reach_the_checkpoint_and_can_be_denied(self, griptape_nodes: Engine) -> None:
+    def test_model_facts_reach_the_checkpoint_and_can_be_denied(self, engine: Engine) -> None:
         from griptape_nodes.node_library.library_declarations import ModelUsageNodeProperty
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
         from griptape_nodes.retained_mode.managers.node_manager import NodeManager
@@ -930,10 +923,8 @@ class TestNodeInstantiationAuthorizationCheckpoint:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Anthropic is not enabled."),))
             return None
 
-        griptape_nodes.event_manager.add_authorization_hook(deny)
-        denials = NodeManager.evaluate_schema_node_instantiation_denials(
-            schema, event_manager=griptape_nodes.event_manager
-        )
+        engine.event_manager.add_authorization_hook(deny)
+        denials = NodeManager.evaluate_schema_node_instantiation_denials(schema, event_manager=engine.event_manager)
         assert seen == {"provider_ids": ["anthropic"], "model_families": ["Claude 4"]}
         assert set(denials) == {_GateProbe.__name__}
         assert denials[_GateProbe.__name__].messages() == ["Anthropic is not enabled."]
@@ -1009,7 +1000,7 @@ class TestNodeCreationFailureDescription:
         yield
         LibraryRegistry._clear()
 
-    def _record_flawed_library(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
+    def _record_flawed_library(self, engine: Engine, tmp_path: Path) -> None:
         """Track a LOADED-but-FLAWED library whose Agent node module failed to import."""
         from griptape_nodes.retained_mode.managers.fitness_problems.libraries.node_module_import_problem import (
             NodeModuleImportProblem,
@@ -1017,7 +1008,7 @@ class TestNodeCreationFailureDescription:
         from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
 
         library_file_path = str(tmp_path / "griptape_nodes_library.json")
-        griptape_nodes.LibraryManager()._library_file_path_to_info[library_file_path] = LibraryManager.LibraryInfo(
+        engine.library_manager._library_file_path_to_info[library_file_path] = LibraryManager.LibraryInfo(
             lifecycle_state=LibraryManager.LibraryLifecycleState.LOADED,
             library_path=library_file_path,
             is_sandbox=False,
@@ -1055,10 +1046,10 @@ class TestNodeCreationFailureDescription:
         library = LibraryRegistry.generate_new_library(library_data=schema)
         library.register_new_node_type(_GateProbe, NodeMetadata(category="t", description="d", display_name="Probe"))
 
-    def test_description_appends_the_library_problems(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
-        self._record_flawed_library(griptape_nodes, tmp_path)
+    def test_description_appends_the_library_problems(self, engine: Engine, tmp_path: Path) -> None:
+        self._record_flawed_library(engine, tmp_path)
 
-        description = griptape_nodes.NodeManager()._describe_node_creation_failure(
+        description = engine.node_manager._describe_node_creation_failure(
             LibraryRegistryError(f"Node type 'Agent' not found in library '{self._LIBRARY_NAME}'"),
             node_type="Agent",
             library_name=self._LIBRARY_NAME,
@@ -1069,15 +1060,13 @@ class TestNodeCreationFailureDescription:
         assert description.startswith(f"Node type 'Agent' not found in library '{self._LIBRARY_NAME}'")
         assert "require_model_invocation_sync" in description
 
-    def test_description_finds_the_library_by_node_type_when_unnamed(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
+    def test_description_finds_the_library_by_node_type_when_unnamed(self, engine: Engine, tmp_path: Path) -> None:
         # Creating a node from the node palette names no library, so the failure path has to
         # resolve the owning library itself to report its problems.
         self._register_library_providing_probe()
-        self._record_flawed_library(griptape_nodes, tmp_path)
+        self._record_flawed_library(engine, tmp_path)
 
-        description = griptape_nodes.NodeManager()._describe_node_creation_failure(
+        description = engine.node_manager._describe_node_creation_failure(
             ImportError("cannot import name 'require_model_invocation_sync'"),
             node_type=_GateProbe.__name__,
             library_name=None,
@@ -1086,14 +1075,12 @@ class TestNodeCreationFailureDescription:
         assert "require_model_invocation_sync" in description
         assert self._LIBRARY_NAME in description
 
-    def test_description_finds_the_library_by_recorded_import_failure(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
+    def test_description_finds_the_library_by_recorded_import_failure(self, engine: Engine, tmp_path: Path) -> None:
         # An eagerly-loaded node whose module failed to import registers nothing, so no library
         # provides the type; the recorded failure is what names the library.
-        self._record_flawed_library(griptape_nodes, tmp_path)
+        self._record_flawed_library(engine, tmp_path)
 
-        description = griptape_nodes.NodeManager()._describe_node_creation_failure(
+        description = engine.node_manager._describe_node_creation_failure(
             LibraryRegistryError("No node type 'Agent' could be found in any of the libraries registered."),
             node_type="Agent",
             library_name=None,
@@ -1102,18 +1089,18 @@ class TestNodeCreationFailureDescription:
         assert "require_model_invocation_sync" in description
         assert self._LIBRARY_NAME in description
 
-    def test_description_is_just_the_message_when_the_library_is_healthy(self, griptape_nodes: GriptapeNodes) -> None:
-        description = griptape_nodes.NodeManager()._describe_node_creation_failure(
+    def test_description_is_just_the_message_when_the_library_is_healthy(self, engine: Engine) -> None:
+        description = engine.node_manager._describe_node_creation_failure(
             ValueError("node __init__ blew up"), node_type="Whatever", library_name="library-with-no-problems"
         )
 
         assert description == "node __init__ blew up"
 
-    def test_description_unquotes_a_sentence_raised_as_a_key_error(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_description_unquotes_a_sentence_raised_as_a_key_error(self, engine: Engine) -> None:
         # A node's __init__ lives in a separately versioned library and can raise a sentence as a
         # bare KeyError (`BaseNode.set_parameter_value` does). str() would repr that sentence, so
         # the artist would read their error wrapped in quotes.
-        description = griptape_nodes.NodeManager()._describe_node_creation_failure(
+        description = engine.node_manager._describe_node_creation_failure(
             KeyError("Attempted to set value for Parameter 'prompt' but no such Parameter could be found."),
             node_type="Whatever",
             library_name="library-with-no-problems",
@@ -1122,14 +1109,14 @@ class TestNodeCreationFailureDescription:
         assert description == "Attempted to set value for Parameter 'prompt' but no such Parameter could be found."
 
     def test_description_tells_the_artist_to_restart_after_a_mid_session_reload(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
+        self, engine: Engine, tmp_path: Path
     ) -> None:
-        self._record_flawed_library(griptape_nodes, tmp_path)
+        self._record_flawed_library(engine, tmp_path)
         # The library was reloaded after its node modules had already imported, so this engine is
         # stuck with the old code no matter how the library is re-registered.
-        griptape_nodes.LibraryManager()._libraries_reloaded_after_import.add(self._LIBRARY_NAME)
+        engine.library_manager._libraries_reloaded_after_import.add(self._LIBRARY_NAME)
 
-        description = griptape_nodes.NodeManager()._describe_node_creation_failure(
+        description = engine.node_manager._describe_node_creation_failure(
             ImportError("cannot import name 'require_model_invocation_sync'"),
             node_type="Agent",
             library_name=self._LIBRARY_NAME,
@@ -1139,12 +1126,10 @@ class TestNodeCreationFailureDescription:
         assert "cannot import name 'require_model_invocation_sync'" in description
         assert "Restart the engine" in description
 
-    def test_description_omits_the_restart_hint_for_a_library_loaded_once(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
-        self._record_flawed_library(griptape_nodes, tmp_path)
+    def test_description_omits_the_restart_hint_for_a_library_loaded_once(self, engine: Engine, tmp_path: Path) -> None:
+        self._record_flawed_library(engine, tmp_path)
 
-        description = griptape_nodes.NodeManager()._describe_node_creation_failure(
+        description = engine.node_manager._describe_node_creation_failure(
             ImportError("no module named 'torch'"),
             node_type="Agent",
             library_name=self._LIBRARY_NAME,
@@ -1154,10 +1139,8 @@ class TestNodeCreationFailureDescription:
         # would not help. Saying otherwise would send the artist on a goose chase.
         assert "Restart the engine" not in description
 
-    def test_description_is_just_the_message_when_the_node_type_has_no_library(
-        self, griptape_nodes: GriptapeNodes
-    ) -> None:
-        description = griptape_nodes.NodeManager()._describe_node_creation_failure(
+    def test_description_is_just_the_message_when_the_node_type_has_no_library(self, engine: Engine) -> None:
+        description = engine.node_manager._describe_node_creation_failure(
             ValueError("boom"), node_type="UnknownEverywhere", library_name=None
         )
 

--- a/tests/unit/retained_mode/managers/test_node_manager.py
+++ b/tests/unit/retained_mode/managers/test_node_manager.py
@@ -173,7 +173,7 @@ class TestNodeManagerResolutionStateSerialization:
         mock_tracker.get_tracker_state.return_value = SerializedParameterValueTracker.TrackerState.NOT_IN_TRACKER
 
         caplog.clear()
-        caplog.set_level(logging.WARNING, logger="engine")
+        caplog.set_level(logging.WARNING, logger="griptape_nodes")
 
         NodeManager.handle_parameter_value_saving(
             parameter=mock_parameter,
@@ -215,7 +215,7 @@ class TestNodeManagerResolutionStateSerialization:
         mock_tracker.get_tracker_state.return_value = SerializedParameterValueTracker.TrackerState.NOT_SERIALIZABLE
 
         caplog.clear()
-        caplog.set_level(logging.WARNING, logger="engine")
+        caplog.set_level(logging.WARNING, logger="griptape_nodes")
 
         NodeManager.handle_parameter_value_saving(
             parameter=mock_parameter,

--- a/tests/unit/retained_mode/managers/test_os_manager.py
+++ b/tests/unit/retained_mode/managers/test_os_manager.py
@@ -12,6 +12,7 @@ import send2trash
 from griptape_nodes.common.macro_parser import ParsedMacro
 from griptape_nodes.common.sequences import MissingItemPolicy, NoTokenBehavior, SequenceScanOptions
 from griptape_nodes.files.path_utils import normalize_path_for_platform, resolve_path_safely
+from griptape_nodes.retained_mode.engine import Engine
 from griptape_nodes.retained_mode.events.base_events import ResultDetails
 from griptape_nodes.retained_mode.events.os_events import (
     CreateFileRequest,
@@ -56,7 +57,6 @@ from griptape_nodes.retained_mode.events.os_events import (
     WriteFileResultSuccess,
 )
 from griptape_nodes.retained_mode.events.project_events import MacroPath
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.os_manager import OSManager, WindowsSpecialFolderError
 from griptape_nodes.retained_mode.managers.resource_types.os_resource import Platform
 
@@ -74,16 +74,16 @@ class TestWriteFileRequest:
             yield Path(tmpdir)
 
     @pytest.fixture(autouse=True)
-    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+    def setup_workspace(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
         """Automatically set workspace to temp_dir for all tests."""
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        original_workspace = engine.config_manager.workspace_path
+        engine.config_manager.workspace_path = temp_dir
         yield
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.config_manager.workspace_path = original_workspace
 
-    def test_write_text_file_success(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_write_text_file_success(self, engine: Engine, temp_dir: Path) -> None:
         """Test successfully writing a text file."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "test.txt"
         request = WriteFileRequest(file_path=str(file_path), content="Hello, World!")
 
@@ -95,9 +95,9 @@ class TestWriteFileRequest:
         assert result.bytes_written > 0
         assert file_path.read_text() == "Hello, World!"
 
-    def test_write_binary_file_success(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_write_binary_file_success(self, engine: Engine, temp_dir: Path) -> None:
         """Test successfully writing a binary file."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "test.bin"
         content = b"\x00\x01\x02\x03"
         request = WriteFileRequest(file_path=str(file_path), content=content)
@@ -110,9 +110,9 @@ class TestWriteFileRequest:
         assert result.bytes_written == len(content)
         assert file_path.read_bytes() == content
 
-    def test_write_file_append_mode(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_write_file_append_mode(self, engine: Engine, temp_dir: Path) -> None:
         """Test appending to an existing file."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "test.txt"
         file_path.write_text("Initial content\n")
 
@@ -122,9 +122,9 @@ class TestWriteFileRequest:
         assert isinstance(result, WriteFileResultSuccess)
         assert file_path.read_text() == "Initial content\nAppended content\n"
 
-    def test_write_file_overwrite_policy(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_write_file_overwrite_policy(self, engine: Engine, temp_dir: Path) -> None:
         """Test overwriting an existing file with OVERWRITE policy."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "test.txt"
         file_path.write_text("Old content")
 
@@ -136,9 +136,9 @@ class TestWriteFileRequest:
         assert isinstance(result, WriteFileResultSuccess)
         assert file_path.read_text() == "New content"
 
-    def test_write_file_fail_policy(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_write_file_fail_policy(self, engine: Engine, temp_dir: Path) -> None:
         """Test FAIL policy when file exists."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "test.txt"
         file_path.write_text("Existing content")
 
@@ -153,9 +153,9 @@ class TestWriteFileRequest:
         assert isinstance(result.result_details, ResultDetails)
         assert "exists" in result.result_details.result_details[0].message.lower()
 
-    def test_write_file_create_parents_true(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_write_file_create_parents_true(self, engine: Engine, temp_dir: Path) -> None:
         """Test creating parent directories when create_parents=True."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "subdir" / "nested" / "test.txt"
         request = WriteFileRequest(file_path=str(file_path), content="Content", create_parents=True)
 
@@ -165,9 +165,9 @@ class TestWriteFileRequest:
         assert file_path.exists()
         assert file_path.read_text() == "Content"
 
-    def test_write_file_create_parents_false(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_write_file_create_parents_false(self, engine: Engine, temp_dir: Path) -> None:
         """Test failure when parent directory missing and create_parents=False."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "nonexistent" / "test.txt"
         request = WriteFileRequest(file_path=str(file_path), content="Content", create_parents=False)
 
@@ -176,9 +176,9 @@ class TestWriteFileRequest:
         assert isinstance(result, WriteFileResultFailure)
         assert result.failure_reason == FileIOFailureReason.POLICY_NO_CREATE_PARENT_DIRS
 
-    def test_write_file_invalid_path(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_write_file_invalid_path(self, engine: Engine, temp_dir: Path) -> None:
         """Test invalid path handling - attempting to write to a directory."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         # Create a directory and try to write to it as if it were a file
         dir_path = temp_dir / "test_directory"
         dir_path.mkdir()
@@ -198,9 +198,9 @@ class TestWriteFileRequest:
         else:
             assert result.failure_reason == FileIOFailureReason.IS_DIRECTORY
 
-    def test_write_file_permission_denied(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_write_file_permission_denied(self, engine: Engine, temp_dir: Path) -> None:
         """Test permission denied error."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "test.txt"
         request = WriteFileRequest(file_path=str(file_path), content="Content")
 
@@ -221,48 +221,48 @@ class TestReadFileRequest:
             yield Path(tmpdir)
 
     @pytest.fixture(autouse=True)
-    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+    def setup_workspace(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
         """Automatically set workspace to temp_dir for all tests."""
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        original_workspace = engine.config_manager.workspace_path
+        engine.config_manager.workspace_path = temp_dir
         yield
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.config_manager.workspace_path = original_workspace
 
-    def test_read_text_file_success(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_read_text_file_success(self, engine: Engine, temp_dir: Path) -> None:
         """Test successfully reading a text file."""
         file_path = temp_dir / "test.txt"
         file_path.write_text("Test content")
 
         request = ReadFileRequest(file_path=str(file_path))
-        result = griptape_nodes.handle_request(request)
+        result = engine.handle_request(request)
 
         assert isinstance(result, ReadFileResultSuccess)
         assert result.content == "Test content"
         assert result.encoding == "utf-8"
 
-    def test_read_binary_file_success(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_read_binary_file_success(self, engine: Engine, temp_dir: Path) -> None:
         """Test successfully reading a binary file."""
         file_path = temp_dir / "test.bin"
         content = b"\x00\x01\x02\x03"
         file_path.write_bytes(content)
 
         request = ReadFileRequest(file_path=str(file_path))
-        result = griptape_nodes.handle_request(request)
+        result = engine.handle_request(request)
 
         assert isinstance(result, ReadFileResultSuccess)
         # Binary files might be returned as base64 or bytes
         assert result.content is not None
 
-    def test_read_file_not_found(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_read_file_not_found(self, engine: Engine, temp_dir: Path) -> None:
         """Test reading non-existent file returns FILE_NOT_FOUND."""
         request = ReadFileRequest(file_path=str(temp_dir / "nonexistent.txt"))
 
-        result = griptape_nodes.handle_request(request)
+        result = engine.handle_request(request)
 
         assert isinstance(result, ReadFileResultFailure)
         assert result.failure_reason == FileIOFailureReason.FILE_NOT_FOUND
 
-    def test_read_file_permission_denied(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_read_file_permission_denied(self, engine: Engine, temp_dir: Path) -> None:
         """Test reading file without permission."""
         file_path = temp_dir / "test.txt"
         file_path.write_text("Content")
@@ -271,17 +271,17 @@ class TestReadFileRequest:
 
         # Mock the file operation to raise PermissionError
         with patch.object(Path, "open", side_effect=PermissionError("Permission denied")):
-            result = griptape_nodes.handle_request(request)
+            result = engine.handle_request(request)
 
         assert isinstance(result, ReadFileResultFailure)
         assert result.failure_reason == FileIOFailureReason.PERMISSION_DENIED
 
-    def test_read_file_invalid_path(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_read_file_invalid_path(self, engine: Engine) -> None:
         """Test reading with invalid path - empty path."""
         # Empty path is invalid
         request = ReadFileRequest(file_path="")
 
-        result = griptape_nodes.handle_request(request)
+        result = engine.handle_request(request)
 
         assert isinstance(result, ReadFileResultFailure)
         # INVALID_PATH is returned for empty path
@@ -298,16 +298,16 @@ class TestCreateFileRequest:
             yield Path(tmpdir)
 
     @pytest.fixture(autouse=True)
-    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+    def setup_workspace(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
         """Automatically set workspace to temp_dir for all tests."""
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        original_workspace = engine.config_manager.workspace_path
+        engine.config_manager.workspace_path = temp_dir
         yield
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.config_manager.workspace_path = original_workspace
 
-    def test_create_empty_file_success(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_create_empty_file_success(self, engine: Engine, temp_dir: Path) -> None:
         """Test creating an empty file."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         request = CreateFileRequest(path=str(temp_dir / "test.txt"), workspace_only=False)
 
         result = os_manager.on_create_file_request(request)
@@ -315,9 +315,9 @@ class TestCreateFileRequest:
         assert isinstance(result, CreateFileResultSuccess)
         assert (temp_dir / "test.txt").exists()
 
-    def test_create_file_with_content(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_create_file_with_content(self, engine: Engine, temp_dir: Path) -> None:
         """Test creating a file with initial content."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         request = CreateFileRequest(path=str(temp_dir / "test.txt"), content="Initial content", workspace_only=False)
 
         result = os_manager.on_create_file_request(request)
@@ -325,9 +325,9 @@ class TestCreateFileRequest:
         assert isinstance(result, CreateFileResultSuccess)
         assert (temp_dir / "test.txt").read_text() == "Initial content"
 
-    def test_create_directory_success(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_create_directory_success(self, engine: Engine, temp_dir: Path) -> None:
         """Test creating a directory."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         request = CreateFileRequest(path=str(temp_dir / "testdir"), is_directory=True, workspace_only=False)
 
         result = os_manager.on_create_file_request(request)
@@ -335,9 +335,9 @@ class TestCreateFileRequest:
         assert isinstance(result, CreateFileResultSuccess)
         assert (temp_dir / "testdir").is_dir()
 
-    def test_create_file_already_exists(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_create_file_already_exists(self, engine: Engine, temp_dir: Path) -> None:
         """Test creating file that already exists returns success with warning."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "test.txt"
         file_path.write_text("Existing")
 
@@ -350,9 +350,9 @@ class TestCreateFileRequest:
         assert isinstance(result.result_details, ResultDetails)
         assert "exists" in result.result_details.result_details[0].message.lower()
 
-    def test_create_file_permission_denied(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_create_file_permission_denied(self, engine: Engine, temp_dir: Path) -> None:
         """Test permission denied when creating file."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         request = CreateFileRequest(path=str(temp_dir / "test.txt"), workspace_only=False)
 
         # CreateFile uses Path.touch() for empty files, not Path.open()
@@ -373,16 +373,16 @@ class TestRenameFileRequest:
             yield Path(tmpdir)
 
     @pytest.fixture(autouse=True)
-    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+    def setup_workspace(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
         """Automatically set workspace to temp_dir for all tests."""
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        original_workspace = engine.config_manager.workspace_path
+        engine.config_manager.workspace_path = temp_dir
         yield
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.config_manager.workspace_path = original_workspace
 
-    def test_rename_file_success(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_rename_file_success(self, engine: Engine, temp_dir: Path) -> None:
         """Test successfully renaming a file."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         old_path = temp_dir / "old.txt"
         new_path = temp_dir / "new.txt"
         old_path.write_text("Content")
@@ -395,9 +395,9 @@ class TestRenameFileRequest:
         assert new_path.exists()
         assert new_path.read_text() == "Content"
 
-    def test_rename_file_source_not_found(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_rename_file_source_not_found(self, engine: Engine, temp_dir: Path) -> None:
         """Test renaming non-existent file."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         request = RenameFileRequest(
             old_path=str(temp_dir / "nonexistent.txt"), new_path=str(temp_dir / "new.txt"), workspace_only=False
         )
@@ -407,9 +407,9 @@ class TestRenameFileRequest:
         assert isinstance(result, RenameFileResultFailure)
         assert result.failure_reason == FileIOFailureReason.FILE_NOT_FOUND
 
-    def test_rename_file_destination_exists(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_rename_file_destination_exists(self, engine: Engine, temp_dir: Path) -> None:
         """Test renaming when destination already exists."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         old_path = temp_dir / "old.txt"
         new_path = temp_dir / "new.txt"
         old_path.write_text("Old content")
@@ -421,9 +421,9 @@ class TestRenameFileRequest:
         assert isinstance(result, RenameFileResultFailure)
         assert result.failure_reason == FileIOFailureReason.INVALID_PATH
 
-    def test_rename_file_permission_denied(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_rename_file_permission_denied(self, engine: Engine, temp_dir: Path) -> None:
         """Test permission denied when renaming."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         old_path = temp_dir / "old.txt"
         new_path = temp_dir / "new.txt"
         old_path.write_text("Content")
@@ -447,16 +447,16 @@ class TestListDirectoryRequest:
             yield Path(tmpdir)
 
     @pytest.fixture(autouse=True)
-    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+    def setup_workspace(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
         """Automatically set workspace to temp_dir for all tests."""
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        original_workspace = engine.config_manager.workspace_path
+        engine.config_manager.workspace_path = temp_dir
         yield
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.config_manager.workspace_path = original_workspace
 
-    def test_list_directory_success(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_list_directory_success(self, engine: Engine, temp_dir: Path) -> None:
         """Test successfully listing a directory with sequence grouping disabled."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         # Create some test files
         (temp_dir / "file1.txt").write_text("Content 1")
         (temp_dir / "file2.txt").write_text("Content 2")
@@ -471,16 +471,14 @@ class TestListDirectoryRequest:
         assert names == {"file1.txt", "file2.txt", "subdir"}
         assert result.sequences == []
 
-    def test_bounds_clip_entire_sequence_files_stay_in_entries(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    def test_bounds_clip_entire_sequence_files_stay_in_entries(self, engine: Engine, temp_dir: Path) -> None:
         """Files fully clipped by start_number/end_number remain in entries.
 
         Regression: consumed_filenames must not be updated before the active-range
         check — otherwise listing removes sequence-member files from entries even
         though no Sequence is returned for them.
         """
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         (temp_dir / "render.0001.exr").write_text("f1")
         (temp_dir / "render.0002.exr").write_text("f2")
 
@@ -498,9 +496,7 @@ class TestListDirectoryRequest:
         assert "render.0001.exr" in entry_names
         assert "render.0002.exr" in entry_names
 
-    def test_bounds_partial_clip_out_of_range_files_stay_in_entries(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    def test_bounds_partial_clip_out_of_range_files_stay_in_entries(self, engine: Engine, temp_dir: Path) -> None:
         """Files outside the active range remain in entries even when a Sequence is returned.
 
         Regression: consumed_filenames was populated from the full bare_names set
@@ -508,7 +504,7 @@ class TestListDirectoryRequest:
         [active.first, active.last]. Files clipped by start_number/end_number were
         silently dropped from entries despite never appearing in any Sequence.
         """
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         for i in range(1, 6):
             (temp_dir / f"render.{i:04d}.exr").write_text(f"f{i}")
 
@@ -528,9 +524,9 @@ class TestListDirectoryRequest:
         # Frame 1 is outside the active range — it must not be consumed
         assert "render.0001.exr" in entry_names
 
-    def test_list_directory_groups_sequences(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_list_directory_groups_sequences(self, engine: Engine, temp_dir: Path) -> None:
         """Test that numbered files are grouped into Sequence objects by default."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         (temp_dir / "render.0001.exr").write_text("frame 1")
         (temp_dir / "render.0002.exr").write_text("frame 2")
         (temp_dir / "render.0003.exr").write_text("frame 3")
@@ -552,9 +548,9 @@ class TestListDirectoryRequest:
         assert seq.first == 1
         assert seq.last == 3  # noqa: PLR2004
 
-    def test_single_sequence_file_stays_in_entries(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_single_sequence_file_stays_in_entries(self, engine: Engine, temp_dir: Path) -> None:
         """A lone file that looks like a sequence pattern must not be grouped into a Sequence."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         (temp_dir / "render.0001.exr").write_text("frame 1")
         (temp_dir / "readme.txt").write_text("notes")
 
@@ -567,9 +563,9 @@ class TestListDirectoryRequest:
         assert "render.0001.exr" in entry_names
         assert "readme.txt" in entry_names
 
-    def test_list_directory_hidden_files(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_list_directory_hidden_files(self, engine: Engine, temp_dir: Path) -> None:
         """Test listing directory with hidden files."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         (temp_dir / "visible.txt").write_text("Content")
         (temp_dir / ".hidden").write_text("Hidden")
 
@@ -588,9 +584,9 @@ class TestListDirectoryRequest:
         assert isinstance(result, ListDirectoryResultSuccess)
         assert len(result.entries) == 2  # noqa: PLR2004
 
-    def test_list_directory_not_found(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_list_directory_not_found(self, engine: Engine, temp_dir: Path) -> None:
         """Test listing non-existent directory."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         request = ListDirectoryRequest(directory_path=str(temp_dir / "nonexistent"), workspace_only=False)
 
         result = os_manager.on_list_directory_request(request)
@@ -598,9 +594,9 @@ class TestListDirectoryRequest:
         assert isinstance(result, ListDirectoryResultFailure)
         assert result.failure_reason == FileIOFailureReason.FILE_NOT_FOUND
 
-    def test_list_directory_not_a_directory(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_list_directory_not_a_directory(self, engine: Engine, temp_dir: Path) -> None:
         """Test listing a file instead of directory."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "file.txt"
         file_path.write_text("Content")
 
@@ -610,9 +606,9 @@ class TestListDirectoryRequest:
         assert isinstance(result, ListDirectoryResultFailure)
         assert result.failure_reason == FileIOFailureReason.INVALID_PATH
 
-    def test_list_directory_permission_denied(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_list_directory_permission_denied(self, engine: Engine, temp_dir: Path) -> None:
         """Test permission denied when listing directory."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         request = ListDirectoryRequest(directory_path=str(temp_dir), workspace_only=False)
 
         # Mock os.scandir() instead of Path.iterdir() since we now use os.scandir() for better performance
@@ -626,11 +622,9 @@ class TestListDirectoryRequest:
         assert isinstance(result, ListDirectoryResultFailure)
         assert result.failure_reason == FileIOFailureReason.PERMISSION_DENIED
 
-    def test_list_directory_symlink_to_file_preserves_symlink_path(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    def test_list_directory_symlink_to_file_preserves_symlink_path(self, engine: Engine, temp_dir: Path) -> None:
         """Symlink-to-file entries return the symlink path, not the resolved target."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         target_file = temp_dir / "target.txt"
         target_file.write_text("content")
         symlink_file = temp_dir / "link.txt"
@@ -653,11 +647,9 @@ class TestListDirectoryRequest:
         assert symlink_path.resolve() == target_file.resolve()
         assert str(symlink_path) == str(symlink_file.absolute())
 
-    def test_list_directory_symlink_to_directory_preserves_symlink_path(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    def test_list_directory_symlink_to_directory_preserves_symlink_path(self, engine: Engine, temp_dir: Path) -> None:
         """Symlink-to-directory entries return the symlink path, not the resolved target."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         target_dir = temp_dir / "target_dir"
         target_dir.mkdir()
         (target_dir / "nested.txt").write_text("nested")
@@ -691,15 +683,15 @@ class TestListDirectorySequencesRequest:
             yield Path(tmpdir)
 
     @pytest.fixture(autouse=True)
-    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+    def setup_workspace(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
+        original_workspace = engine.config_manager.workspace_path
+        engine.config_manager.workspace_path = temp_dir
         yield
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.config_manager.workspace_path = original_workspace
 
-    def test_returns_only_sequences(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_returns_only_sequences(self, engine: Engine, temp_dir: Path) -> None:
         """Non-sequence files are absent from the result; sequences are present."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         (temp_dir / "render.0001.exr").write_text("f1")
         (temp_dir / "render.0002.exr").write_text("f2")
         (temp_dir / "readme.txt").write_text("notes")
@@ -714,11 +706,9 @@ class TestListDirectorySequencesRequest:
         assert seq.first == 1
         assert seq.last == 2  # noqa: PLR2004
 
-    def test_empty_directory_returns_success_with_no_sequences(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    def test_empty_directory_returns_success_with_no_sequences(self, engine: Engine, temp_dir: Path) -> None:
         """A directory with no sequences returns an empty success, not a failure."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         (temp_dir / "readme.txt").write_text("notes")
 
         request = ListDirectorySequencesRequest(directory_path=str(temp_dir), workspace_only=False)
@@ -727,9 +717,9 @@ class TestListDirectorySequencesRequest:
         assert isinstance(result, ListDirectorySequencesResultSuccess)
         assert result.sequences == []
 
-    def test_padding_filter_excludes_mismatched_sequences(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_padding_filter_excludes_mismatched_sequences(self, engine: Engine, temp_dir: Path) -> None:
         """sequence_options.padding=4 keeps only #### sequences; ### sequences are excluded."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         (temp_dir / "hi.0001.exr").write_text("f1")  # 4-digit
         (temp_dir / "hi.0002.exr").write_text("f2")
         (temp_dir / "lo.001.exr").write_text("f1")  # 3-digit
@@ -746,9 +736,9 @@ class TestListDirectorySequencesRequest:
         assert len(result.sequences) == 1
         assert result.sequences[0].padding == 4  # noqa: PLR2004
 
-    def test_delegates_failure_from_inner_request(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_delegates_failure_from_inner_request(self, engine: Engine, temp_dir: Path) -> None:
         """A bad directory path surfaces as a failure result."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         request = ListDirectorySequencesRequest(directory_path=str(temp_dir / "nonexistent"), workspace_only=False)
         from griptape_nodes.retained_mode.events.os_events import ListDirectorySequencesResultFailure
 
@@ -767,11 +757,11 @@ class TestDeduceSequencesFromFileListRequest:
             yield Path(tmpdir)
 
     @pytest.fixture(autouse=True)
-    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+    def setup_workspace(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
+        original_workspace = engine.config_manager.workspace_path
+        engine.config_manager.workspace_path = temp_dir
         yield
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.config_manager.workspace_path = original_workspace
 
     def _write_frames(self, directory: Path, basename: str, ext: str, frames: list[int]) -> list[str]:
         paths = []
@@ -781,9 +771,9 @@ class TestDeduceSequencesFromFileListRequest:
             paths.append(str(p))
         return paths
 
-    def test_detects_sequence_from_absolute_paths(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_detects_sequence_from_absolute_paths(self, engine: Engine, temp_dir: Path) -> None:
         """A list of absolute file paths is grouped into a Sequence."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         paths = self._write_frames(temp_dir, "render", "exr", [1, 2, 3])
 
         request = DeduceSequencesFromFileListRequest(file_paths=paths)
@@ -796,23 +786,23 @@ class TestDeduceSequencesFromFileListRequest:
         assert seq.last == 3  # noqa: PLR2004
         assert len(seq.entries) == 3  # noqa: PLR2004
 
-    def test_empty_file_list_returns_empty_success(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_empty_file_list_returns_empty_success(self, engine: Engine) -> None:
         """An empty file list returns success with no sequences."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         request = DeduceSequencesFromFileListRequest(file_paths=[])
         result = os_manager.on_deduce_sequences_from_file_list_request(request)
 
         assert isinstance(result, DeduceSequencesFromFileListResultSuccess)
         assert result.sequences == []
 
-    def test_bare_filenames_yield_empty_directory(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_bare_filenames_yield_empty_directory(self, engine: Engine) -> None:
         """Bare filenames (no directory component) produce Sequence.directory == ''.
 
         Path('render.0001.exr').parent is '.', which must be normalised to ''
         so that Sequence.directory and entry paths match the documented contract
         rather than emitting './render.0001.exr'.
         """
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         request = DeduceSequencesFromFileListRequest(
             file_paths=["render.0001.exr", "render.0002.exr"],
         )
@@ -824,9 +814,9 @@ class TestDeduceSequencesFromFileListRequest:
         assert seq.directory == ""
         assert not any(e.path.startswith("./") for e in seq.entries)
 
-    def test_non_sequence_names_do_not_produce_sequences(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_non_sequence_names_do_not_produce_sequences(self, engine: Engine, temp_dir: Path) -> None:
         """Plain names without numeric tokens produce no sequences (callers filter directories)."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         paths = self._write_frames(temp_dir, "frame", "exr", [1, 2])
         paths.append(str(temp_dir / "subdir"))  # bare name with no sequence token
 
@@ -836,9 +826,9 @@ class TestDeduceSequencesFromFileListRequest:
         assert isinstance(result, DeduceSequencesFromFileListResultSuccess)
         assert len(result.sequences) == 1  # subdir produces no sequence
 
-    def test_files_from_multiple_directories(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_files_from_multiple_directories(self, engine: Engine, temp_dir: Path) -> None:
         """Files from different parent directories are grouped independently."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         dir_a = temp_dir / "a"
         dir_b = temp_dir / "b"
         dir_a.mkdir()
@@ -852,9 +842,9 @@ class TestDeduceSequencesFromFileListRequest:
         assert isinstance(result, DeduceSequencesFromFileListResultSuccess)
         assert len(result.sequences) == 2  # noqa: PLR2004
 
-    def test_no_sequence_files_returns_empty_success(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_no_sequence_files_returns_empty_success(self, engine: Engine, temp_dir: Path) -> None:
         """Files with no sequence tokens return success with an empty sequences list."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         p = temp_dir / "readme.txt"
         p.write_text("notes")
 
@@ -864,9 +854,9 @@ class TestDeduceSequencesFromFileListRequest:
         assert isinstance(result, DeduceSequencesFromFileListResultSuccess)
         assert result.sequences == []
 
-    def test_padding_filter(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_padding_filter(self, engine: Engine, temp_dir: Path) -> None:
         """sequence_options.padding filters to only matching zero-fill width."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         paths_4 = self._write_frames(temp_dir, "hi", "exr", [1, 2])  # 4-digit
         paths_3 = [str(temp_dir / f"lo.{n:03d}.exr") for n in [1, 2]]
         for p in paths_3:
@@ -882,9 +872,9 @@ class TestDeduceSequencesFromFileListRequest:
         assert len(result.sequences) == 1
         assert result.sequences[0].padding == 4  # noqa: PLR2004
 
-    def test_frame_bounds(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_frame_bounds(self, engine: Engine, temp_dir: Path) -> None:
         """start_number / end_number clip the active range."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         paths = self._write_frames(temp_dir, "render", "exr", [1, 2, 3, 4, 5])
 
         request = DeduceSequencesFromFileListRequest(
@@ -904,16 +894,14 @@ class TestDeduceSequencesFromFileListRequest:
         assert seq.last == 4  # noqa: PLR2004
         assert [e.number for e in seq.entries] == [2, 3, 4]
 
-    def test_bounds_clip_entire_sequence_files_stay_in_entries(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    def test_bounds_clip_entire_sequence_files_stay_in_entries(self, engine: Engine, temp_dir: Path) -> None:
         """Files whose sequence is fully clipped by bounds are NOT removed from the result.
 
         Regression: consumed_filenames must not be updated before the active-range
         check, otherwise files that produce no Sequence (because start_number >
         discovered_last) are silently consumed and callers lose them.
         """
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         paths = self._write_frames(temp_dir, "render", "exr", [1, 2, 3])
 
         # Ask for frames 100+, which clips the entire on-disk range out.
@@ -926,9 +914,9 @@ class TestDeduceSequencesFromFileListRequest:
         assert isinstance(result, DeduceSequencesFromFileListResultSuccess)
         assert result.sequences == []
 
-    def test_invalid_bounds_returns_failure(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_invalid_bounds_returns_failure(self, engine: Engine, temp_dir: Path) -> None:
         """A negative start_number surfaces as INVALID_BOUNDS failure."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         paths = self._write_frames(temp_dir, "render", "exr", [1, 2, 3])
 
         request = DeduceSequencesFromFileListRequest(
@@ -940,9 +928,9 @@ class TestDeduceSequencesFromFileListRequest:
         assert isinstance(result, DeduceSequencesFromFileListResultFailure)
         assert result.failure_reason == SequenceScanFailureReason.INVALID_BOUNDS
 
-    def test_abort_policy_with_single_gap_returns_failure(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_abort_policy_with_single_gap_returns_failure(self, engine: Engine, temp_dir: Path) -> None:
         """ABORT policy with exactly one gap returns ABORTED_AT_GAP with a single-gap message."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         paths = self._write_frames(temp_dir, "render", "exr", [1, 3])  # gap at 2
 
         request = DeduceSequencesFromFileListRequest(
@@ -956,11 +944,9 @@ class TestDeduceSequencesFromFileListRequest:
         assert isinstance(result.result_details, ResultDetails)
         assert "gap at item 2" in result.result_details.result_details[0].message
 
-    def test_abort_policy_with_multiple_gaps_returns_failure(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    def test_abort_policy_with_multiple_gaps_returns_failure(self, engine: Engine, temp_dir: Path) -> None:
         """ABORT policy with multiple gaps lists all gap positions in the message."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         paths = self._write_frames(temp_dir, "render", "exr", [1, 3, 5])  # gaps at 2, 4
 
         request = DeduceSequencesFromFileListRequest(
@@ -974,9 +960,9 @@ class TestDeduceSequencesFromFileListRequest:
         assert isinstance(result.result_details, ResultDetails)
         assert "2 gaps" in result.result_details.result_details[0].message
 
-    def test_abort_policy_with_many_gaps_truncates_preview(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_abort_policy_with_many_gaps_truncates_preview(self, engine: Engine, temp_dir: Path) -> None:
         """ABORT with more gaps than ABORTED_AT_GAP_PREVIEW_COUNT appends a '+ N more' suffix."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         # 6 gaps: missing 2, 4, 6, 8, 10, 12 — exceeds the preview count of 5
         paths = self._write_frames(temp_dir, "render", "exr", [1, 3, 5, 7, 9, 11, 13])
 
@@ -991,9 +977,9 @@ class TestDeduceSequencesFromFileListRequest:
         assert isinstance(result.result_details, ResultDetails)
         assert "more" in result.result_details.result_details[0].message
 
-    def test_unexpected_exception_returns_unknown_failure(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_unexpected_exception_returns_unknown_failure(self, engine: Engine) -> None:
         """An unexpected exception from the scan is caught and returned as UNKNOWN failure."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
 
         request = DeduceSequencesFromFileListRequest(file_paths=["render.0001.exr"])
         with patch(
@@ -1007,9 +993,9 @@ class TestDeduceSequencesFromFileListRequest:
         assert isinstance(result.result_details, ResultDetails)
         assert "boom" in result.result_details.result_details[0].message
 
-    def test_single_frame_sequence_not_returned(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_single_frame_sequence_not_returned(self, engine: Engine, temp_dir: Path) -> None:
         """A sequence with only one present frame is not included in the result."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         paths = self._write_frames(temp_dir, "render", "exr", [1])
 
         request = DeduceSequencesFromFileListRequest(file_paths=paths)
@@ -1018,11 +1004,9 @@ class TestDeduceSequencesFromFileListRequest:
         assert isinstance(result, DeduceSequencesFromFileListResultSuccess)
         assert result.sequences == []
 
-    def test_reject_no_token_behavior_skips_token_less_sequences(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    def test_reject_no_token_behavior_skips_token_less_sequences(self, engine: Engine, temp_dir: Path) -> None:
         """NoTokenBehavior.REJECT causes token-less files to be silently skipped."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         paths = self._write_frames(temp_dir, "render", "exr", [1, 2])
 
         request = DeduceSequencesFromFileListRequest(
@@ -1105,21 +1089,21 @@ class TestNormalizePathPartsForSpecialFolder:
 class TestTryResolveWindowsSpecialFolder:
     """Test try_resolve_windows_special_folder helper."""
 
-    def test_unknown_folder_returns_none(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_unknown_folder_returns_none(self, engine: Engine) -> None:
         """Unknown first part returns None."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         result = os_manager.try_resolve_windows_special_folder(["unknown", "sub"])
         assert result is None
 
-    def test_empty_parts_returns_none(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_empty_parts_returns_none(self, engine: Engine) -> None:
         """Empty parts returns None."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         result = os_manager.try_resolve_windows_special_folder([])
         assert result is None
 
-    def test_downloads_resolved_returns_path_and_empty_remaining(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_downloads_resolved_returns_path_and_empty_remaining(self, engine: Engine) -> None:
         """Known folder with no remaining parts."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         mock_path = Path("/mock/Downloads")
 
         def mock_get(csidl: int) -> Path:
@@ -1132,9 +1116,9 @@ class TestTryResolveWindowsSpecialFolder:
         assert result.special_path == mock_path
         assert result.remaining_parts == []
 
-    def test_desktop_with_remaining_parts(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_desktop_with_remaining_parts(self, engine: Engine) -> None:
         """Known folder with remaining parts."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         mock_path = Path("/mock/Desktop")
 
         def mock_get(csidl: int) -> Path:
@@ -1147,9 +1131,9 @@ class TestTryResolveWindowsSpecialFolder:
         assert result.special_path == mock_path
         assert result.remaining_parts == ["sub", "file.txt"]
 
-    def test_get_folder_raises_returns_none(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_get_folder_raises_returns_none(self, engine: Engine) -> None:
         """When _get_windows_special_folder_path raises WindowsSpecialFolderError, result is None."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         with patch.object(
             os_manager, "_get_windows_special_folder_path", side_effect=WindowsSpecialFolderError("mock")
         ):
@@ -1167,27 +1151,27 @@ class TestExpandPath:
             yield Path(tmpdir)
 
     @pytest.fixture(autouse=True)
-    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+    def setup_workspace(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
         """Set workspace to temp_dir for tests."""
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        original_workspace = engine.config_manager.workspace_path
+        engine.config_manager.workspace_path = temp_dir
         yield
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.config_manager.workspace_path = original_workspace
 
     def test_expand_path_relative_anchored_on_workspace(
         self,
-        griptape_nodes: GriptapeNodes,
+        engine: Engine,
         temp_dir: Path,  # noqa: ARG002
     ) -> None:
         """A path that is still relative after expansion is anchored on the workspace directory."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         result = os_manager._expand_path("subdir")
-        expected = griptape_nodes.ConfigManager().workspace_path / "subdir"
+        expected = engine.config_manager.workspace_path / "subdir"
         assert result == expected
 
-    def test_expand_path_expands_vars_and_tilde(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_expand_path_expands_vars_and_tilde(self, engine: Engine, temp_dir: Path) -> None:
         """Expandvars and expanduser are applied when not a Windows special folder."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         # Use a path that won't match Windows special folder logic on this platform
         result = os_manager._expand_path(str(temp_dir))
         assert result == temp_dir or result.resolve() == temp_dir.resolve()
@@ -1195,11 +1179,11 @@ class TestExpandPath:
     @pytest.mark.skipif(platform.system() != "Windows", reason="Windows-specific special folder test")
     def test_expand_path_windows_special_folder_mocked(
         self,
-        griptape_nodes: GriptapeNodes,
+        engine: Engine,
         temp_dir: Path,  # noqa: ARG002
     ) -> None:
         """On Windows, special folder is resolved via Shell API when path is ~/Downloads."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         mock_downloads = Path("C:/mock/Downloads")
 
         with patch.object(os_manager, "_get_windows_special_folder_path", return_value=mock_downloads) as mock_get:
@@ -1209,13 +1193,13 @@ class TestExpandPath:
 
     def test_expand_path_non_windows_uses_expanduser(
         self,
-        griptape_nodes: GriptapeNodes,
+        engine: Engine,
         temp_dir: Path,  # noqa: ARG002
     ) -> None:
         """On non-Windows, ~/path uses expanduser (no special folder logic)."""
         if platform.system() == "Windows":
             pytest.skip("Non-Windows test")
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         result = os_manager._expand_path("~/Downloads")
         expected = resolve_path_safely(Path.home() / "Downloads")
         assert result == expected
@@ -1233,12 +1217,12 @@ class TestResolveFilePath:
             yield Path(tmpdir)
 
     @pytest.fixture(autouse=True)
-    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+    def setup_workspace(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
         """Set workspace to temp_dir for tests."""
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        original_workspace = engine.config_manager.workspace_path
+        engine.config_manager.workspace_path = temp_dir
         yield
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.config_manager.workspace_path = original_workspace
 
     @pytest.mark.parametrize(
         "path_str",
@@ -1249,37 +1233,35 @@ class TestResolveFilePath:
             "data/nested.json",
         ],
     )
-    def test_relative_path_anchored_on_workspace(self, griptape_nodes: GriptapeNodes, path_str: str) -> None:
+    def test_relative_path_anchored_on_workspace(self, engine: Engine, path_str: str) -> None:
         """Relative paths resolve against the workspace directory, not the process CWD."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         result = os_manager._resolve_file_path(path_str)
-        expected = griptape_nodes.ConfigManager().workspace_path / path_str
+        expected = engine.config_manager.workspace_path / path_str
         assert result == expected
 
-    def test_unresolvable_variable_anchored_on_workspace(
-        self, griptape_nodes: GriptapeNodes, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_unresolvable_variable_anchored_on_workspace(self, engine: Engine, monkeypatch: pytest.MonkeyPatch) -> None:
         """A path naming an undefined variable stays literal and is anchored on the workspace."""
         monkeypatch.delenv(self.UNSET_VAR_NAME, raising=False)
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         result = os_manager._resolve_file_path(f"${self.UNSET_VAR_NAME}/sub")
-        expected = griptape_nodes.ConfigManager().workspace_path / f"${self.UNSET_VAR_NAME}" / "sub"
+        expected = engine.config_manager.workspace_path / f"${self.UNSET_VAR_NAME}" / "sub"
         assert result == expected
 
-    def test_tilde_path_not_anchored_on_workspace(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_tilde_path_not_anchored_on_workspace(self, engine: Engine) -> None:
         """A ~ path expands to the user's home directory rather than the workspace."""
         if platform.system() == "Windows":
             pytest.skip("Windows resolves ~/Downloads through the Shell API special folder path")
-        os_manager = griptape_nodes.OSManager()
-        workspace_path = griptape_nodes.ConfigManager().workspace_path
+        os_manager = engine.os_manager
+        workspace_path = engine.config_manager.workspace_path
         result = os_manager._resolve_file_path("~/Downloads")
         assert result == resolve_path_safely(Path.home() / "Downloads")
         assert not result.is_relative_to(workspace_path)
 
-    def test_absolute_path_not_anchored_on_workspace(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
+    def test_absolute_path_not_anchored_on_workspace(self, engine: Engine, tmp_path: Path) -> None:
         """An absolute path is returned unchanged rather than being joined onto the workspace."""
-        os_manager = griptape_nodes.OSManager()
-        workspace_path = griptape_nodes.ConfigManager().workspace_path
+        os_manager = engine.os_manager
+        workspace_path = engine.config_manager.workspace_path
         absolute_path = resolve_path_safely(tmp_path / "elsewhere" / "file.txt")
         result = os_manager._resolve_file_path(str(absolute_path))
         assert result == absolute_path
@@ -1296,12 +1278,12 @@ class TestWindowsLongPathHandling:
             yield Path(tmpdir)
 
     @pytest.fixture(autouse=True)
-    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+    def setup_workspace(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
         """Automatically set workspace to temp_dir for all tests."""
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        original_workspace = engine.config_manager.workspace_path
+        engine.config_manager.workspace_path = temp_dir
         yield
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.config_manager.workspace_path = original_workspace
 
     @pytest.fixture
     def long_path(self, temp_dir: Path) -> Path:
@@ -1311,7 +1293,7 @@ class TestWindowsLongPathHandling:
         path_parts = [temp_dir] + [long_component] * 6  # Will exceed 260 chars
         return Path(*path_parts)
 
-    def test_normalize_path_short_path(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:  # noqa: ARG002
+    def test_normalize_path_short_path(self, engine: Engine, temp_dir: Path) -> None:  # noqa: ARG002
         r"""Short paths get the \\?\ prefix on Windows, none elsewhere.
 
         The prefix is applied unconditionally on Windows (not gated on length):
@@ -1327,7 +1309,7 @@ class TestWindowsLongPathHandling:
             assert not result.startswith("\\\\?\\")
 
     @pytest.mark.skipif(platform.system() != "Windows", reason="Windows-specific test")
-    def test_normalize_path_long_path_windows(self, griptape_nodes: GriptapeNodes, long_path: Path) -> None:  # noqa: ARG002
+    def test_normalize_path_long_path_windows(self, engine: Engine, long_path: Path) -> None:  # noqa: ARG002
         r"""Test that long paths on Windows get \\?\ prefix."""
         result = normalize_path_for_platform(long_path)
 
@@ -1336,16 +1318,16 @@ class TestWindowsLongPathHandling:
             assert result.startswith("\\\\?\\")
 
     @pytest.mark.skipif(platform.system() == "Windows", reason="Non-Windows test")
-    def test_normalize_path_long_path_non_windows(self, griptape_nodes: GriptapeNodes, long_path: Path) -> None:  # noqa: ARG002
+    def test_normalize_path_long_path_non_windows(self, engine: Engine, long_path: Path) -> None:  # noqa: ARG002
         """Test that long paths on non-Windows don't get prefix."""
         result = normalize_path_for_platform(long_path)
 
         # On non-Windows, no prefix should be added
         assert not result.startswith("\\\\?\\")
 
-    def test_write_file_with_long_path(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_write_file_with_long_path(self, engine: Engine, temp_dir: Path) -> None:
         """Test writing file with long path works correctly."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         # Create a moderately long path (not exceeding OS limits)
         subdir = temp_dir / ("a" * 30) / ("b" * 30) / ("c" * 30)
         file_path = subdir / "test.txt"
@@ -1370,17 +1352,17 @@ class TestDeleteFileRequest:
             yield Path(tmpdir)
 
     @pytest.fixture(autouse=True)
-    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+    def setup_workspace(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
         """Automatically set workspace to temp_dir for all tests."""
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        original_workspace = engine.config_manager.workspace_path
+        engine.config_manager.workspace_path = temp_dir
         yield
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.config_manager.workspace_path = original_workspace
 
     @pytest.mark.asyncio
-    async def test_delete_file_success(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    async def test_delete_file_success(self, engine: Engine, temp_dir: Path) -> None:
         """Test successfully deleting a file."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "test.txt"
         file_path.write_text("test content")
         request = DeleteFileRequest(path=str(file_path), workspace_only=False)
@@ -1396,9 +1378,9 @@ class TestDeleteFileRequest:
         assert not file_path.exists()
 
     @pytest.mark.asyncio
-    async def test_delete_empty_directory(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    async def test_delete_empty_directory(self, engine: Engine, temp_dir: Path) -> None:
         """Test deleting an empty directory."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         dir_path = temp_dir / "testdir"
         dir_path.mkdir()
         request = DeleteFileRequest(path=str(dir_path), workspace_only=False)
@@ -1412,9 +1394,9 @@ class TestDeleteFileRequest:
         assert not dir_path.exists()
 
     @pytest.mark.asyncio
-    async def test_delete_directory_with_contents(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    async def test_delete_directory_with_contents(self, engine: Engine, temp_dir: Path) -> None:
         """Test deleting a directory with contents."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         dir_path = temp_dir / "testdir"
         dir_path.mkdir()
         (dir_path / "file1.txt").write_text("content1")
@@ -1439,10 +1421,10 @@ class TestDeleteFileRequest:
 
     @pytest.mark.asyncio
     async def test_delete_directory_without_collect_returns_only_top_level(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
+        self, engine: Engine, temp_dir: Path
     ) -> None:
         """Test that deleting a directory without collect_deleted_paths returns only the top-level path."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         dir_path = temp_dir / "testdir"
         dir_path.mkdir()
         (dir_path / "file1.txt").write_text("content1")
@@ -1460,9 +1442,9 @@ class TestDeleteFileRequest:
         assert not dir_path.exists()
 
     @pytest.mark.asyncio
-    async def test_delete_nonexistent_file_fails(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    async def test_delete_nonexistent_file_fails(self, engine: Engine, temp_dir: Path) -> None:
         """Test that deleting a nonexistent file fails."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "nonexistent.txt"
         request = DeleteFileRequest(path=str(file_path), workspace_only=False)
 
@@ -1472,9 +1454,9 @@ class TestDeleteFileRequest:
         assert result.failure_reason == FileIOFailureReason.FILE_NOT_FOUND
 
     @pytest.mark.asyncio
-    async def test_delete_invalid_path_fails(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_delete_invalid_path_fails(self, engine: Engine) -> None:
         """Test that deleting with neither path nor file_entry fails."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         request = DeleteFileRequest(path=None, file_entry=None)
 
         result = await os_manager.on_delete_file_request(request)
@@ -1483,9 +1465,9 @@ class TestDeleteFileRequest:
         assert result.failure_reason == FileIOFailureReason.INVALID_PATH
 
     @pytest.mark.asyncio
-    async def test_delete_with_permission_error(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    async def test_delete_with_permission_error(self, engine: Engine, temp_dir: Path) -> None:
         """Test that permission errors are properly handled."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "test.txt"
         file_path.write_text("test content")
 
@@ -1501,9 +1483,9 @@ class TestDeleteFileRequest:
         assert result.failure_reason == FileIOFailureReason.PERMISSION_DENIED
 
     @pytest.mark.asyncio
-    async def test_delete_file_behavior_permanently_delete(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    async def test_delete_file_behavior_permanently_delete(self, engine: Engine, temp_dir: Path) -> None:
         """Test default PERMANENTLY_DELETE behavior for files."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "test.txt"
         file_path.write_text("test content")
         request = DeleteFileRequest(
@@ -1519,11 +1501,9 @@ class TestDeleteFileRequest:
         assert not file_path.exists()
 
     @pytest.mark.asyncio
-    async def test_delete_directory_behavior_permanently_delete(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    async def test_delete_directory_behavior_permanently_delete(self, engine: Engine, temp_dir: Path) -> None:
         """Test default PERMANENTLY_DELETE behavior for directories."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         dir_path = temp_dir / "testdir"
         dir_path.mkdir()
         (dir_path / "file1.txt").write_text("content1")
@@ -1541,11 +1521,9 @@ class TestDeleteFileRequest:
         assert not dir_path.exists()
 
     @pytest.mark.asyncio
-    async def test_delete_file_behavior_recycle_bin_only_success(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    async def test_delete_file_behavior_recycle_bin_only_success(self, engine: Engine, temp_dir: Path) -> None:
         """Test RECYCLE_BIN_ONLY behavior successfully sends file to recycle bin."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "test.txt"
         file_path.write_text("test content")
 
@@ -1565,11 +1543,9 @@ class TestDeleteFileRequest:
         mock_send2trash.send2trash.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_delete_directory_behavior_recycle_bin_only_success(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    async def test_delete_directory_behavior_recycle_bin_only_success(self, engine: Engine, temp_dir: Path) -> None:
         """Test RECYCLE_BIN_ONLY behavior successfully sends directory to recycle bin."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         dir_path = temp_dir / "testdir"
         dir_path.mkdir()
         (dir_path / "file1.txt").write_text("content1")
@@ -1591,11 +1567,9 @@ class TestDeleteFileRequest:
         mock_send2trash.send2trash.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_delete_file_behavior_recycle_bin_only_failure(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    async def test_delete_file_behavior_recycle_bin_only_failure(self, engine: Engine, temp_dir: Path) -> None:
         """Test RECYCLE_BIN_ONLY behavior returns failure when recycle bin unavailable."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "test.txt"
         file_path.write_text("test content")
 
@@ -1614,11 +1588,9 @@ class TestDeleteFileRequest:
         assert result.failure_reason == FileIOFailureReason.IO_ERROR
 
     @pytest.mark.asyncio
-    async def test_delete_directory_behavior_recycle_bin_only_failure(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    async def test_delete_directory_behavior_recycle_bin_only_failure(self, engine: Engine, temp_dir: Path) -> None:
         """Test RECYCLE_BIN_ONLY behavior returns failure for directories when I/O error occurs."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         dir_path = temp_dir / "testdir"
         dir_path.mkdir()
         (dir_path / "file1.txt").write_text("content1")
@@ -1638,11 +1610,9 @@ class TestDeleteFileRequest:
         assert result.failure_reason == FileIOFailureReason.IO_ERROR
 
     @pytest.mark.asyncio
-    async def test_delete_file_behavior_prefer_recycle_bin_uses_trash(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    async def test_delete_file_behavior_prefer_recycle_bin_uses_trash(self, engine: Engine, temp_dir: Path) -> None:
         """Test PREFER_RECYCLE_BIN behavior uses recycle bin when available."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "test.txt"
         file_path.write_text("test content")
 
@@ -1663,10 +1633,10 @@ class TestDeleteFileRequest:
 
     @pytest.mark.asyncio
     async def test_delete_directory_behavior_prefer_recycle_bin_uses_trash(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
+        self, engine: Engine, temp_dir: Path
     ) -> None:
         """Test PREFER_RECYCLE_BIN behavior uses recycle bin for directories when available."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         dir_path = temp_dir / "testdir"
         dir_path.mkdir()
         (dir_path / "file1.txt").write_text("content1")
@@ -1688,11 +1658,9 @@ class TestDeleteFileRequest:
         mock_send2trash.send2trash.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_delete_file_behavior_prefer_recycle_bin_falls_back(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    async def test_delete_file_behavior_prefer_recycle_bin_falls_back(self, engine: Engine, temp_dir: Path) -> None:
         """Test PREFER_RECYCLE_BIN behavior falls back to permanent deletion when trash fails."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "test.txt"
         file_path.write_text("test content")
 
@@ -1715,10 +1683,10 @@ class TestDeleteFileRequest:
 
     @pytest.mark.asyncio
     async def test_delete_directory_behavior_prefer_recycle_bin_falls_back(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
+        self, engine: Engine, temp_dir: Path
     ) -> None:
         """Test PREFER_RECYCLE_BIN behavior falls back to permanent deletion for directories when trash fails."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         dir_path = temp_dir / "testdir"
         dir_path.mkdir()
         (dir_path / "file1.txt").write_text("content1")
@@ -1742,11 +1710,9 @@ class TestDeleteFileRequest:
         assert isinstance(result.result_details, ResultDetails)
 
     @pytest.mark.asyncio
-    async def test_delete_outcome_default_is_sent_to_recycle_bin(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    async def test_delete_outcome_default_is_sent_to_recycle_bin(self, engine: Engine, temp_dir: Path) -> None:
         """Test that default deletion (no behavior specified) reports SENT_TO_RECYCLE_BIN outcome."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "test.txt"
         file_path.write_text("test content")
         request = DeleteFileRequest(path=str(file_path), workspace_only=False)
@@ -1767,16 +1733,16 @@ class TestGetFileInfoRequest:
             yield Path(tmpdir)
 
     @pytest.fixture(autouse=True)
-    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+    def setup_workspace(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
         """Automatically set workspace to temp_dir for all tests."""
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        original_workspace = engine.config_manager.workspace_path
+        engine.config_manager.workspace_path = temp_dir
         yield
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.config_manager.workspace_path = original_workspace
 
-    def test_get_file_info_success(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_get_file_info_success(self, engine: Engine, temp_dir: Path) -> None:
         """Test successfully getting file info."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "test.txt"
         file_path.write_text("test content")
         request = GetFileInfoRequest(path=str(file_path), workspace_only=False)
@@ -1790,9 +1756,9 @@ class TestGetFileInfoRequest:
         assert result.file_entry.size > 0
         assert result.file_entry.mime_type is not None
 
-    def test_get_directory_info_success(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_get_directory_info_success(self, engine: Engine, temp_dir: Path) -> None:
         """Test successfully getting directory info."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         dir_path = temp_dir / "testdir"
         dir_path.mkdir()
         request = GetFileInfoRequest(path=str(dir_path), workspace_only=False)
@@ -1805,9 +1771,9 @@ class TestGetFileInfoRequest:
         assert result.file_entry.name == "testdir"
         assert result.file_entry.mime_type is None
 
-    def test_get_file_info_nonexistent_returns_none(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_get_file_info_nonexistent_returns_none(self, engine: Engine, temp_dir: Path) -> None:
         """Test that getting info for nonexistent path returns success with file_entry=None."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "nonexistent.txt"
         request = GetFileInfoRequest(path=str(file_path), workspace_only=False)
 
@@ -1816,9 +1782,9 @@ class TestGetFileInfoRequest:
         assert isinstance(result, GetFileInfoResultSuccess)
         assert result.file_entry is None
 
-    def test_get_file_info_empty_path_fails(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_get_file_info_empty_path_fails(self, engine: Engine) -> None:
         """Test that empty path fails."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         request = GetFileInfoRequest(path="", workspace_only=False)
 
         result = os_manager.on_get_file_info_request(request)
@@ -1852,16 +1818,16 @@ class TestCreateNewFilePolicy:
             yield Path(tmpdir)
 
     @pytest.fixture(autouse=True)
-    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+    def setup_workspace(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
         """Automatically set workspace to temp_dir for all tests."""
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        original_workspace = engine.config_manager.workspace_path
+        engine.config_manager.workspace_path = temp_dir
         yield
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.config_manager.workspace_path = original_workspace
 
-    def test_create_new_first_file(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_create_new_first_file(self, engine: Engine, temp_dir: Path) -> None:
         """Test CREATE_NEW policy creates file with requested name if available."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "test.txt"
         request = WriteFileRequest(
             file_path=str(file_path),
@@ -1877,9 +1843,9 @@ class TestCreateNewFilePolicy:
         assert Path(result.final_file_path).resolve() == expected_path.resolve()
         assert expected_path.read_text() == "First file"
 
-    def test_create_new_increments_suffix(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_create_new_increments_suffix(self, engine: Engine, temp_dir: Path) -> None:
         """Test CREATE_NEW policy increments suffix for subsequent files."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "output.txt"
 
         # Create first file (gets output.txt since it's available)
@@ -1912,9 +1878,9 @@ class TestCreateNewFilePolicy:
         assert isinstance(result3, WriteFileResultSuccess)
         assert (temp_dir / "output_2.txt").exists()
 
-    def test_create_new_fills_gaps(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_create_new_fills_gaps(self, engine: Engine, temp_dir: Path) -> None:
         """Test CREATE_NEW policy fills gaps in sequence."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "render.png"
 
         # Create render.png and files with gaps manually
@@ -1934,7 +1900,7 @@ class TestCreateNewFilePolicy:
         assert Path(result.final_file_path).resolve() == expected_path.resolve()
 
     def test_create_new_with_fully_resolved_macro_should_use_suffix_injection(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
+        self, engine: Engine, temp_dir: Path
     ) -> None:
         """Test CREATE_NEW policy with fully-resolved MacroPath falls back to suffix injection.
 
@@ -1945,7 +1911,7 @@ class TestCreateNewFilePolicy:
         from griptape_nodes.common.macro_parser import ParsedMacro
         from griptape_nodes.retained_mode.events.project_events import MacroPath
 
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
 
         # Create first file manually
         first_file = temp_dir / "render.png"
@@ -2025,17 +1991,15 @@ class TestGetNextUnusedFilenameRequest:
             yield Path(tmpdir)
 
     @pytest.fixture(autouse=True)
-    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+    def setup_workspace(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
+        original_workspace = engine.config_manager.workspace_path
+        engine.config_manager.workspace_path = temp_dir
         yield
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.config_manager.workspace_path = original_workspace
 
-    def test_base_filename_available_returns_unindexed_path(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    def test_base_filename_available_returns_unindexed_path(self, engine: Engine, temp_dir: Path) -> None:
         """When the base filename is free, preview returns that path and no index."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         requested_path = temp_dir / "render.png"
 
         result = os_manager.on_get_next_unused_filename_request(
@@ -2047,11 +2011,9 @@ class TestGetNextUnusedFilenameRequest:
         assert result.index_used is None
         assert not requested_path.exists()
 
-    def test_existing_base_filename_returns_indexed_candidate(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    def test_existing_base_filename_returns_indexed_candidate(self, engine: Engine, temp_dir: Path) -> None:
         """When base exists, preview switches to indexed naming."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         (temp_dir / "render.png").write_text("base")
 
         result = os_manager.on_get_next_unused_filename_request(
@@ -2062,9 +2024,9 @@ class TestGetNextUnusedFilenameRequest:
         assert result.index_used == 1
         assert Path(result.available_filename).resolve() == (temp_dir / "render_1.png").resolve()
 
-    def test_macro_without_unresolved_index_fails(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_macro_without_unresolved_index_fails(self, engine: Engine, temp_dir: Path) -> None:
         """Macro path without an unresolved index variable cannot be auto-incremented."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         macro_path = MacroPath(parsed_macro=ParsedMacro(f"{temp_dir}/render.png"), variables={})
 
         result = os_manager.on_get_next_unused_filename_request(GetNextUnusedFilenameRequest(file_path=macro_path))
@@ -2072,7 +2034,7 @@ class TestGetNextUnusedFilenameRequest:
         assert isinstance(result, GetNextUnusedFilenameResultFailure)
         assert result.failure_reason == FileIOFailureReason.INVALID_PATH
 
-    def test_sequence_format_glob_uses_permissive_wildcard(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_sequence_format_glob_uses_permissive_wildcard(self, engine: Engine) -> None:
         """The glob builder emits ``*`` for ``SequenceFormat`` slots, not fixed-width ``?`` chars.
 
         Pins the new branch added for #4902: ``SequenceFormat`` means
@@ -2083,8 +2045,8 @@ class TestGetNextUnusedFilenameRequest:
         """
         from griptape_nodes.common.macro_parser.resolution import partial_resolve
 
-        os_manager = griptape_nodes.OSManager()
-        secrets_manager = GriptapeNodes.SecretsManager()
+        os_manager = engine.os_manager
+        secrets_manager = engine.secrets_manager
 
         # `SequenceFormat` (new): permissive `*` wildcard, accepts any digit count.
         sequence_macro = ParsedMacro("/anywhere/render_v{###}.png")
@@ -2108,15 +2070,15 @@ class TestGetNextVersionIndexRequest:
             yield Path(tmpdir)
 
     @pytest.fixture(autouse=True)
-    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+    def setup_workspace(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
+        original_workspace = engine.config_manager.workspace_path
+        engine.config_manager.workspace_path = temp_dir
         yield
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.config_manager.workspace_path = original_workspace
 
-    def test_required_index_returns_one_when_no_matches(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_required_index_returns_one_when_no_matches(self, engine: Engine, temp_dir: Path) -> None:
         """Required index templates start at index 1 when nothing exists yet."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
 
         request = GetNextVersionIndexRequest(
             macro_path=MacroPath(
@@ -2129,9 +2091,9 @@ class TestGetNextVersionIndexRequest:
         assert isinstance(result, GetNextVersionIndexResultSuccess)
         assert result.index == 1
 
-    def test_optional_index_is_rejected_as_invalid_path(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_optional_index_is_rejected_as_invalid_path(self, engine: Engine, temp_dir: Path) -> None:
         """Optional index templates currently fail because no required unresolved index exists."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
 
         request = GetNextVersionIndexRequest(
             macro_path=MacroPath(
@@ -2144,9 +2106,9 @@ class TestGetNextVersionIndexRequest:
         assert isinstance(result, GetNextVersionIndexResultFailure)
         assert result.failure_reason == FileIOFailureReason.INVALID_PATH
 
-    def test_missing_unresolved_index_returns_failure(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_missing_unresolved_index_returns_failure(self, engine: Engine, temp_dir: Path) -> None:
         """Requests without an unresolved {_index} variable should fail as invalid path input."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         request = GetNextVersionIndexRequest(
             macro_path=MacroPath(
                 parsed_macro=ParsedMacro("{outputs}/render.png"),
@@ -2159,7 +2121,7 @@ class TestGetNextVersionIndexRequest:
         assert isinstance(result, GetNextVersionIndexResultFailure)
         assert result.failure_reason == FileIOFailureReason.INVALID_PATH
 
-    def test_sequence_slot_scan_skips_non_numeric_siblings(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_sequence_slot_scan_skips_non_numeric_siblings(self, engine: Engine, temp_dir: Path) -> None:
         """Regression: scanning a `{###}` macro with a non-numeric sibling must not crash.
 
         `SequenceFormat` slots use a permissive `*` glob, so `render_vfinal.png`
@@ -2173,7 +2135,7 @@ class TestGetNextVersionIndexRequest:
         (temp_dir / "render_v002.png").touch()
         (temp_dir / "render_vfinal.png").touch()  # non-numeric sibling — the crash trigger
 
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         request = GetNextVersionIndexRequest(
             macro_path=MacroPath(
                 parsed_macro=ParsedMacro("{outputs}/render_v{###}.png"),
@@ -2195,15 +2157,15 @@ class TestMakeDirectoryRequest:
             yield Path(tmpdir)
 
     @pytest.fixture(autouse=True)
-    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+    def setup_workspace(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
+        original_workspace = engine.config_manager.workspace_path
+        engine.config_manager.workspace_path = temp_dir
         yield
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.config_manager.workspace_path = original_workspace
 
-    def test_create_new_directory_success(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_create_new_directory_success(self, engine: Engine, temp_dir: Path) -> None:
         """Creating a directory that does not yet exist returns success with already_existed=False."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         dir_path = temp_dir / "new_dir"
 
         result = os_manager.on_make_directory_request(MakeDirectoryRequest(path=str(dir_path)))
@@ -2213,9 +2175,9 @@ class TestMakeDirectoryRequest:
         assert not result.already_existed
         assert Path(result.created_path).resolve() == dir_path.resolve()
 
-    def test_directory_already_exists_exist_ok_true(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_directory_already_exists_exist_ok_true(self, engine: Engine, temp_dir: Path) -> None:
         """When the directory already exists and exist_ok=True, returns success with already_existed=True."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         dir_path = temp_dir / "existing_dir"
         dir_path.mkdir()
 
@@ -2224,9 +2186,9 @@ class TestMakeDirectoryRequest:
         assert isinstance(result, MakeDirectoryResultSuccess)
         assert result.already_existed
 
-    def test_directory_already_exists_exist_ok_false(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_directory_already_exists_exist_ok_false(self, engine: Engine, temp_dir: Path) -> None:
         """When the directory already exists and exist_ok=False, returns POLICY_NO_OVERWRITE failure."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         dir_path = temp_dir / "existing_dir"
         dir_path.mkdir()
 
@@ -2235,9 +2197,9 @@ class TestMakeDirectoryRequest:
         assert isinstance(result, MakeDirectoryResultFailure)
         assert result.failure_reason == FileIOFailureReason.POLICY_NO_OVERWRITE
 
-    def test_file_at_path_returns_invalid_path(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_file_at_path_returns_invalid_path(self, engine: Engine, temp_dir: Path) -> None:
         """When a file already exists at the requested path, returns INVALID_PATH failure."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "not_a_dir.txt"
         file_path.write_text("content")
 
@@ -2246,9 +2208,9 @@ class TestMakeDirectoryRequest:
         assert isinstance(result, MakeDirectoryResultFailure)
         assert result.failure_reason == FileIOFailureReason.INVALID_PATH
 
-    def test_create_parents_true(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_create_parents_true(self, engine: Engine, temp_dir: Path) -> None:
         """With create_parents=True, missing intermediate directories are created."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         dir_path = temp_dir / "a" / "b" / "c"
 
         result = os_manager.on_make_directory_request(MakeDirectoryRequest(path=str(dir_path), create_parents=True))
@@ -2256,9 +2218,9 @@ class TestMakeDirectoryRequest:
         assert isinstance(result, MakeDirectoryResultSuccess)
         assert dir_path.is_dir()
 
-    def test_create_parents_false_missing_parent(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_create_parents_false_missing_parent(self, engine: Engine, temp_dir: Path) -> None:
         """With create_parents=False and a missing parent, returns POLICY_NO_CREATE_PARENT_DIRS failure."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         dir_path = temp_dir / "missing_parent" / "child"
 
         result = os_manager.on_make_directory_request(MakeDirectoryRequest(path=str(dir_path), create_parents=False))
@@ -2266,9 +2228,9 @@ class TestMakeDirectoryRequest:
         assert isinstance(result, MakeDirectoryResultFailure)
         assert result.failure_reason == FileIOFailureReason.POLICY_NO_CREATE_PARENT_DIRS
 
-    def test_invalid_path_returns_failure(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_invalid_path_returns_failure(self, engine: Engine, temp_dir: Path) -> None:
         """A path that cannot be resolved returns INVALID_PATH before any filesystem operation."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
 
         with patch.object(OSManager, "_resolve_file_path", side_effect=ValueError("bad path")):
             result = os_manager.on_make_directory_request(MakeDirectoryRequest(path=str(temp_dir / "any")))
@@ -2276,9 +2238,9 @@ class TestMakeDirectoryRequest:
         assert isinstance(result, MakeDirectoryResultFailure)
         assert result.failure_reason == FileIOFailureReason.INVALID_PATH
 
-    def test_permission_denied_returns_failure(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_permission_denied_returns_failure(self, engine: Engine, temp_dir: Path) -> None:
         """A PermissionError from mkdir is surfaced as a PERMISSION_DENIED failure."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         dir_path = temp_dir / "protected_dir"
 
         with patch.object(Path, "mkdir", side_effect=PermissionError("Permission denied")):
@@ -2297,9 +2259,9 @@ class TestCopyFile:
         with tempfile.TemporaryDirectory() as tmpdir:
             yield Path(tmpdir)
 
-    def test_copy_file_copies_contents(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_copy_file_copies_contents(self, engine: Engine, temp_dir: Path) -> None:
         """A basic copy replicates contents and returns the byte count."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         src = temp_dir / "src.txt"
         dst = temp_dir / "dst.txt"
         content = "hello, world"
@@ -2310,14 +2272,14 @@ class TestCopyFile:
         assert dst.read_text() == content
         assert bytes_copied == len(content.encode())
 
-    def test_copy_file_ignores_eperm_from_metadata(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_copy_file_ignores_eperm_from_metadata(self, engine: Engine, temp_dir: Path) -> None:
         """An EPERM from the metadata step (e.g. chflags SF_ARCHIVED on an SMB mount) must not fail the copy.
 
         Regression test for issue #5109: shutil.copy2 propagates the EPERM that chflags raises when
         replicating BSD file flags onto an SMB destination, even though the file contents copy fine.
         _copy_file copies contents first and then best-effort the metadata, swallowing the EPERM.
         """
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         src = temp_dir / "src.txt"
         dst = temp_dir / "dst.txt"
         content = "contents survive metadata failure"

--- a/tests/unit/retained_mode/managers/test_os_manager_write_file_request.py
+++ b/tests/unit/retained_mode/managers/test_os_manager_write_file_request.py
@@ -28,6 +28,7 @@ from griptape_nodes.common.macro_parser import ParsedMacro
 from griptape_nodes.common.project_templates.default_project_template import DEFAULT_PROJECT_TEMPLATE
 from griptape_nodes.common.project_templates.situation import SituationFilePolicy
 from griptape_nodes.files.file import File, FileDestination, FileLoadError, FileWriteError
+from griptape_nodes.retained_mode.engine import Engine
 from griptape_nodes.retained_mode.events.artifact_events import RegisterArtifactProviderRequest
 from griptape_nodes.retained_mode.events.base_events import ResultDetails
 from griptape_nodes.retained_mode.events.os_events import (
@@ -48,7 +49,6 @@ from griptape_nodes.retained_mode.file_metadata.sidecar_metadata import (
     SituationMetadata,
     SituationPolicy,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.artifact_providers.base_artifact_provider import WriteVettingPolicy
 from griptape_nodes.retained_mode.managers.artifact_providers.image.image_artifact_provider import (
     ImageArtifactProvider,
@@ -70,16 +70,16 @@ class TestCreateNewWarningLevelResultDetails:
             yield Path(tmpdir)
 
     @pytest.fixture(autouse=True)
-    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+    def setup_workspace(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
         """Automatically set workspace to temp_dir for all tests."""
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        original_workspace = engine.config_manager.workspace_path
+        engine.config_manager.workspace_path = temp_dir
         yield
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.config_manager.workspace_path = original_workspace
 
-    def test_create_new_fallback_warning_level(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_create_new_fallback_warning_level(self, engine: Engine, temp_dir: Path) -> None:
         """Test CREATE_NEW returns WARNING-level ResultDetails when falling back to indexed path."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "test.txt"
 
         # Create the originally requested file so CREATE_NEW must fall back
@@ -107,9 +107,9 @@ class TestCreateNewWarningLevelResultDetails:
         assert "already existed" in detail.message.lower()
         assert str(file_path) in detail.message or "test.txt" in detail.message
 
-    def test_create_new_first_try_no_warning(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_create_new_first_try_no_warning(self, engine: Engine, temp_dir: Path) -> None:
         """Test CREATE_NEW returns normal success (not WARNING) when first-try succeeds."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "newfile.txt"
 
         # Don't create the file - let CREATE_NEW succeed on first try
@@ -132,9 +132,9 @@ class TestCreateNewWarningLevelResultDetails:
         assert detail.level == logging.DEBUG  # Normal success is DEBUG, not WARNING
         assert "successfully" in detail.message.lower()
 
-    def test_create_new_fallback_multiple_times(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_create_new_fallback_multiple_times(self, engine: Engine, temp_dir: Path) -> None:
         """Test CREATE_NEW generates multiple DEBUG messages for multiple fallbacks."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "output.txt"
 
         # Create original file
@@ -173,16 +173,16 @@ class TestBlanketExceptionHandling:
             yield Path(tmpdir)
 
     @pytest.fixture(autouse=True)
-    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+    def setup_workspace(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
         """Automatically set workspace to temp_dir for all tests."""
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        original_workspace = engine.config_manager.workspace_path
+        engine.config_manager.workspace_path = temp_dir
         yield
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.config_manager.workspace_path = original_workspace
 
-    def test_blanket_exception_on_path_resolution(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_blanket_exception_on_path_resolution(self, engine: Engine, temp_dir: Path) -> None:
         """Test blanket exception handler for unexpected error during path resolution."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "test.txt"
 
         request = WriteFileRequest(file_path=str(file_path), content="Content")
@@ -196,9 +196,9 @@ class TestBlanketExceptionHandling:
         assert isinstance(result.result_details, ResultDetails)
         assert "unexpected error" in result.result_details.result_details[0].message.lower()
 
-    def test_blanket_exception_on_write_operation(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_blanket_exception_on_write_operation(self, engine: Engine, temp_dir: Path) -> None:
         """Test blanket exception handler for unexpected error during write."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "test.txt"
 
         request = WriteFileRequest(file_path=str(file_path), content="Content")
@@ -212,11 +212,9 @@ class TestBlanketExceptionHandling:
         assert isinstance(result.result_details, ResultDetails)
         assert "unexpected error" in result.result_details.result_details[0].message.lower()
 
-    def test_blanket_exception_on_macro_resolution_in_candidate_loop(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    def test_blanket_exception_on_macro_resolution_in_candidate_loop(self, engine: Engine, temp_dir: Path) -> None:
         """Test blanket exception handler for unexpected error during CREATE_NEW macro resolution."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "output.txt"
 
         # Create original file to trigger CREATE_NEW fallback
@@ -254,16 +252,16 @@ class TestParentDirectoryMatchCase:
             yield Path(tmpdir)
 
     @pytest.fixture(autouse=True)
-    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+    def setup_workspace(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
         """Automatically set workspace to temp_dir for all tests."""
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        original_workspace = engine.config_manager.workspace_path
+        engine.config_manager.workspace_path = temp_dir
         yield
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.config_manager.workspace_path = original_workspace
 
-    def test_parent_directory_permission_denied_message(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_parent_directory_permission_denied_message(self, engine: Engine, temp_dir: Path) -> None:
         """Test match/case generates correct message for PERMISSION_DENIED."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "subdir" / "test.txt"
 
         request = WriteFileRequest(file_path=str(file_path), content="Content", create_parents=True)
@@ -281,9 +279,9 @@ class TestParentDirectoryMatchCase:
         assert "permission denied" in message.lower()
         assert "parent directory" in message.lower()
 
-    def test_parent_directory_no_create_message(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_parent_directory_no_create_message(self, engine: Engine, temp_dir: Path) -> None:
         """Test match/case generates correct message for POLICY_NO_CREATE_PARENT_DIRS."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "nonexistent" / "test.txt"
 
         request = WriteFileRequest(file_path=str(file_path), content="Content", create_parents=False)
@@ -298,9 +296,9 @@ class TestParentDirectoryMatchCase:
         assert "parent directory" in message.lower()
         assert "not exist" in message.lower() or "does not exist" in message.lower()
 
-    def test_parent_directory_generic_io_error_message(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_parent_directory_generic_io_error_message(self, engine: Engine, temp_dir: Path) -> None:
         """Test match/case default case generates generic error message."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "subdir" / "test.txt"
 
         request = WriteFileRequest(file_path=str(file_path), content="Content", create_parents=True)
@@ -326,16 +324,16 @@ class TestOnDemandCandidateGeneration:
             yield Path(tmpdir)
 
     @pytest.fixture(autouse=True)
-    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+    def setup_workspace(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
         """Automatically set workspace to temp_dir for all tests."""
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        original_workspace = engine.config_manager.workspace_path
+        engine.config_manager.workspace_path = temp_dir
         yield
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.config_manager.workspace_path = original_workspace
 
-    def test_on_demand_generation_early_success(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_on_demand_generation_early_success(self, engine: Engine, temp_dir: Path) -> None:
         """Test CREATE_NEW only resolves macros until it finds available filename."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "output.txt"
 
         # CREATE_NEW always tries the first-try path first (without index)
@@ -377,9 +375,9 @@ class TestOnDemandCandidateGeneration:
             f"Expected >= {min_expected_resolutions} macro resolution, got {resolve_call_count}"
         )
 
-    def test_on_demand_generation_stops_on_success(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_on_demand_generation_stops_on_success(self, engine: Engine, temp_dir: Path) -> None:
         """Test CREATE_NEW stops generating candidates immediately after successful write."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "test.txt"
 
         # Create original file to trigger fallback
@@ -423,16 +421,16 @@ class TestMetadataInjection:
             yield Path(tmpdir)
 
     @pytest.fixture(autouse=True)
-    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+    def setup_workspace(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
         """Automatically set workspace to temp_dir for all tests."""
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        original_workspace = engine.config_manager.workspace_path
+        engine.config_manager.workspace_path = temp_dir
         yield
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.config_manager.workspace_path = original_workspace
 
-    def test_metadata_injected_for_bytes_content(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_metadata_injected_for_bytes_content(self, engine: Engine, temp_dir: Path) -> None:
         """Test that prepare_content_for_write is called for bytes content."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "image.png"
         original_bytes = b"fake png bytes"
         injected_bytes = b"fake png bytes with metadata"
@@ -440,16 +438,16 @@ class TestMetadataInjection:
         request = WriteFileRequest(file_path=str(file_path), content=original_bytes)
 
         with patch.object(
-            griptape_nodes.ArtifactManager(), "prepare_content_for_write", return_value=injected_bytes
+            engine.artifact_manager, "prepare_content_for_write", return_value=injected_bytes
         ) as mock_prepare:
             result = os_manager.on_write_file_request(request)
 
         assert isinstance(result, WriteFileResultSuccess)
         mock_prepare.assert_called_once_with(original_bytes, "image.png")
 
-    def test_metadata_not_injected_when_skip_flag_set(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_metadata_not_injected_when_skip_flag_set(self, engine: Engine, temp_dir: Path) -> None:
         """Test that injection is skipped when skip_metadata_injection=True."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "image.png"
 
         request = WriteFileRequest(
@@ -458,55 +456,55 @@ class TestMetadataInjection:
             skip_metadata_injection=True,
         )
 
-        with patch.object(griptape_nodes.ArtifactManager(), "prepare_content_for_write") as mock_prepare:
+        with patch.object(engine.artifact_manager, "prepare_content_for_write") as mock_prepare:
             result = os_manager.on_write_file_request(request)
 
         assert isinstance(result, WriteFileResultSuccess)
         mock_prepare.assert_not_called()
 
-    def test_metadata_not_injected_when_config_disabled(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_metadata_not_injected_when_config_disabled(self, engine: Engine, temp_dir: Path) -> None:
         """Test that injection is skipped when auto_inject_workflow_metadata config is False."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "image.png"
 
         request = WriteFileRequest(file_path=str(file_path), content=b"fake png bytes")
 
         with (
             patch.object(
-                griptape_nodes.ConfigManager(),
+                engine.config_manager,
                 "get_config_value",
                 side_effect=lambda key, **kwargs: (
                     False if key == "auto_inject_workflow_metadata" else kwargs.get("default")
                 ),
             ),
-            patch.object(griptape_nodes.ArtifactManager(), "prepare_content_for_write") as mock_prepare,
+            patch.object(engine.artifact_manager, "prepare_content_for_write") as mock_prepare,
         ):
             result = os_manager.on_write_file_request(request)
 
         assert isinstance(result, WriteFileResultSuccess)
         mock_prepare.assert_not_called()
 
-    def test_metadata_not_injected_for_str_content(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_metadata_not_injected_for_str_content(self, engine: Engine, temp_dir: Path) -> None:
         """Test that injection is skipped for str content (only bytes are images)."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "text.txt"
 
         request = WriteFileRequest(file_path=str(file_path), content="text content")
 
-        with patch.object(griptape_nodes.ArtifactManager(), "prepare_content_for_write") as mock_prepare:
+        with patch.object(engine.artifact_manager, "prepare_content_for_write") as mock_prepare:
             result = os_manager.on_write_file_request(request)
 
         assert isinstance(result, WriteFileResultSuccess)
         mock_prepare.assert_not_called()
 
     def test_injection_failure_logs_warning_and_write_succeeds(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path, caplog: pytest.LogCaptureFixture
+        self, engine: Engine, temp_dir: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Test that injection failure logs a warning and the write succeeds with original content."""
-        griptape_nodes.ArtifactManager().on_handle_register_artifact_provider_request(
+        engine.artifact_manager.on_handle_register_artifact_provider_request(
             RegisterArtifactProviderRequest(provider_class=ImageArtifactProvider)
         )
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "image.png"
         original_bytes = b"fake png bytes"
 
@@ -519,16 +517,16 @@ class TestMetadataInjection:
         assert file_path.read_bytes() == original_bytes
         assert any("Attempted to collect workflow metadata" in record.message for record in caplog.records)
 
-    def test_injected_content_is_written_to_disk(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_injected_content_is_written_to_disk(self, engine: Engine, temp_dir: Path) -> None:
         """Test that the injected (modified) content is what gets written to disk."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "image.png"
         original_bytes = b"fake png bytes"
         injected_bytes = b"fake png bytes with metadata injected"
 
         request = WriteFileRequest(file_path=str(file_path), content=original_bytes)
 
-        with patch.object(griptape_nodes.ArtifactManager(), "prepare_content_for_write", return_value=injected_bytes):
+        with patch.object(engine.artifact_manager, "prepare_content_for_write", return_value=injected_bytes):
             result = os_manager.on_write_file_request(request)
 
         assert isinstance(result, WriteFileResultSuccess)
@@ -549,9 +547,9 @@ class TestSidecarMetadata:
             yield Path(tmpdir).resolve()
 
     @pytest.fixture(autouse=True)
-    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+    def setup_workspace(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
         """Set workspace to temp_dir and load a project template for sidecar path resolution."""
-        config_manager = griptape_nodes.ConfigManager()
+        config_manager = engine.config_manager
         original_workspace = config_manager.workspace_path
         # Set the *configured* workspace_directory, not just the workspace_path property.
         # The project loaded below is parentless, so activation resolves its workspace via
@@ -563,18 +561,18 @@ class TestSidecarMetadata:
         # Create a project template file so sidecar path resolution has a project to use
         project_yml = temp_dir / "project_template.yml"
         project_yml.write_text(DEFAULT_PROJECT_TEMPLATE.to_overlay_yaml(DEFAULT_PROJECT_TEMPLATE))
-        load_result = GriptapeNodes.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
+        load_result = engine.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
         if isinstance(load_result, LoadProjectTemplateResultSuccess):
-            GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
+            engine.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
 
         yield
 
-        GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=None))
+        engine.handle_request(SetCurrentProjectRequest(project_id=None))
         config_manager.set_config_value("workspace_directory", str(original_workspace))
 
-    def test_sidecar_not_written_without_file_metadata(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_sidecar_not_written_without_file_metadata(self, engine: Engine, temp_dir: Path) -> None:
         """Test that no sidecar is written when file_metadata is not provided."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "output.txt"
 
         request = WriteFileRequest(file_path=str(file_path), content="hello")
@@ -584,11 +582,11 @@ class TestSidecarMetadata:
         sidecar_path = temp_dir / ".griptape-nodes-metadata" / "output.txt.json"
         assert not sidecar_path.exists(), "Sidecar should not be written when file_metadata is not provided"
 
-    def test_sidecar_written_when_file_metadata_provided(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_sidecar_written_when_file_metadata_provided(self, engine: Engine, temp_dir: Path) -> None:
         """Test that a sidecar is written when file_metadata is explicitly provided."""
         import json as _json
 
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "output.txt"
         file_metadata = SidecarContent(
             situation=SituationMetadata(name="save_node_output", macro="{outputs}/output.txt"),
@@ -604,11 +602,11 @@ class TestSidecarMetadata:
         assert data["schema_version"] == "0.1.0"
         assert "saved_at" in data
 
-    def test_sidecar_contains_situation_info_when_provided(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_sidecar_contains_situation_info_when_provided(self, engine: Engine, temp_dir: Path) -> None:
         """Test sidecar includes situation block when file_metadata has situation info."""
         import json as _json
 
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "image.png"
         file_metadata = SidecarContent(
             situation=SituationMetadata(
@@ -629,11 +627,11 @@ class TestSidecarMetadata:
         assert data["situation"]["policy"]["on_collision"] == "create_new"
         assert data["situation"]["policy"]["create_dirs"] is True
 
-    def test_sidecar_written_for_indexed_fallback_path(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_sidecar_written_for_indexed_fallback_path(self, engine: Engine, temp_dir: Path) -> None:
         """Test sidecar is written at the actual indexed fallback path, not the requested path."""
         import json as _json
 
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "output.txt"
         file_path.write_text("Original")
         file_metadata = SidecarContent(
@@ -655,9 +653,7 @@ class TestSidecarMetadata:
         data = _json.loads(sidecar_path.read_text())
         assert data["schema_version"] == "0.1.0"
 
-    def test_sidecar_file_extension_unchanged_for_alias_extensions(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    def test_sidecar_file_extension_unchanged_for_alias_extensions(self, engine: Engine, temp_dir: Path) -> None:
         """Sidecar's ``file_extension`` variable must reflect the on-disk name, not the raw sniff.
 
         Regression for the alias-extension case (jpg/jpeg, tif/tiff, m4v/mp4):
@@ -670,7 +666,7 @@ class TestSidecarMetadata:
         """
         import json as _json
 
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         file_path = temp_dir / "photo.jpeg"
         # Bind file_extension in the sidecar's situation variables so the
         # sidecar update path has something to (potentially) overwrite.
@@ -724,24 +720,24 @@ class TestExtensionCoercion:
             yield Path(tmpdir).resolve()
 
     @pytest.fixture(autouse=True)
-    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+    def setup_workspace(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
         """Set workspace and register the image artifact provider so sniff_extension works."""
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        original_workspace = engine.config_manager.workspace_path
+        engine.config_manager.workspace_path = temp_dir
 
-        griptape_nodes.ArtifactManager().on_handle_register_artifact_provider_request(
+        engine.artifact_manager.on_handle_register_artifact_provider_request(
             RegisterArtifactProviderRequest(provider_class=ImageArtifactProvider)
         )
 
         yield
 
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.config_manager.workspace_path = original_workspace
 
     def test_default_coerce_renames_jpeg_when_destination_is_png(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path, caplog: pytest.LogCaptureFixture
+        self, engine: Engine, temp_dir: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
         """JPEG bytes saved to a .png path should be renamed to .jpeg by default."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         requested_path = temp_dir / "image.png"
 
         request = WriteFileRequest(file_path=str(requested_path), content=_jpeg_bytes())
@@ -755,11 +751,9 @@ class TestExtensionCoercion:
         assert not requested_path.exists()
         assert any("destination has been adjusted" in r.message for r in caplog.records)
 
-    def test_strict_mode_returns_extension_mismatch_failure(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    def test_strict_mode_returns_extension_mismatch_failure(self, engine: Engine, temp_dir: Path) -> None:
         """With coerce_extension_to_match_bytes=False, mismatched bytes should fail and leave no file."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         requested_path = temp_dir / "image.png"
 
         request = WriteFileRequest(
@@ -774,9 +768,9 @@ class TestExtensionCoercion:
         assert not requested_path.exists()
         assert not (temp_dir / "image.jpg").exists()
 
-    def test_coerce_no_op_when_bytes_match_suffix(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_coerce_no_op_when_bytes_match_suffix(self, engine: Engine, temp_dir: Path) -> None:
         """No rename, no warning when bytes already match the destination suffix."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         requested_path = temp_dir / "image.png"
 
         request = WriteFileRequest(file_path=str(requested_path), content=_png_bytes())
@@ -787,10 +781,10 @@ class TestExtensionCoercion:
         assert requested_path.exists()
 
     def test_coerce_no_op_when_sniff_returns_none(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path, caplog: pytest.LogCaptureFixture
+        self, engine: Engine, temp_dir: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Unrecognized bytes log a 'Could not identify' warning and write through unchanged."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         requested_path = temp_dir / "blob.png"
 
         request = WriteFileRequest(file_path=str(requested_path), content=b"\x00\x01\x02\x03 not a known format")
@@ -801,11 +795,9 @@ class TestExtensionCoercion:
         assert Path(result.final_file_path) == requested_path
         assert any("Could not recognize the bytes as a known file format" in r.message for r in caplog.records)
 
-    def test_coerce_updates_sidecar_file_extension_variable(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path
-    ) -> None:
+    def test_coerce_updates_sidecar_file_extension_variable(self, engine: Engine, temp_dir: Path) -> None:
         """When coercion fires, the sidecar's situation.variables.file_extension is rewritten to match."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         requested_path = temp_dir / "image.png"
 
         file_metadata = SidecarContent(
@@ -831,9 +823,9 @@ class TestExtensionCoercion:
         assert request.file_metadata.situation.variables is not None
         assert request.file_metadata.situation.variables["file_extension"] == "jpg"
 
-    def test_coerce_skipped_for_text_content(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_coerce_skipped_for_text_content(self, engine: Engine, temp_dir: Path) -> None:
         """Text writes should never trigger sniffing/rename."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         requested_path = temp_dir / "notes.png"
 
         request = WriteFileRequest(file_path=str(requested_path), content="just some text")
@@ -859,23 +851,23 @@ class TestOSWritePermissionVet:
             yield Path(tmpdir).resolve()
 
     @pytest.fixture(autouse=True)
-    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+    def setup_workspace(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
         # Register the image provider so PNG/JPEG bytes are recognized; the
         # vet under test is provider.check_write_permission on the returned
         # provider instance.
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        original_workspace = engine.config_manager.workspace_path
+        engine.config_manager.workspace_path = temp_dir
 
-        griptape_nodes.ArtifactManager().on_handle_register_artifact_provider_request(
+        engine.artifact_manager.on_handle_register_artifact_provider_request(
             RegisterArtifactProviderRequest(provider_class=ImageArtifactProvider)
         )
 
         yield
 
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.config_manager.workspace_path = original_workspace
 
     def test_deny_returns_codec_not_permitted_and_no_file(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+        self, engine: Engine, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A provider that denies must abort the write before any bytes hit disk."""
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
@@ -885,9 +877,9 @@ class TestOSWritePermissionVet:
         # Image provider defaults to ``None`` policy (no vet). Override its
         # policy to ``FROM_BYTES`` and its from-bytes hook to deny -- keeps the
         # test focused on the vet dispatch without dragging in disk staging.
-        provider_classes = griptape_nodes.ArtifactManager()._registry.get_provider_classes_by_format("png")
+        provider_classes = engine.artifact_manager._registry.get_provider_classes_by_format("png")
         assert provider_classes, "PNG must resolve to the registered image provider"
-        provider = griptape_nodes.ArtifactManager()._registry.get_or_create_provider_instance(provider_classes[0])
+        provider = engine.artifact_manager._registry.get_or_create_provider_instance(provider_classes[0])
         monkeypatch.setattr(
             provider.__class__, "get_write_vetting_policy", staticmethod(lambda: WriteVettingPolicy.FROM_BYTES)
         )
@@ -897,7 +889,7 @@ class TestOSWritePermissionVet:
             lambda data, detected_format: expected_denial,  # noqa: ARG005
         )
 
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         requested_path = temp_dir / "image.png"
         request = WriteFileRequest(file_path=str(requested_path), content=_png_bytes())
         result = os_manager.on_write_file_request(request)
@@ -913,9 +905,9 @@ class TestOSWritePermissionVet:
         assert "sniffed" not in str(result.result_details).lower()
         assert not requested_path.exists()
 
-    def test_allow_writes_normally(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_allow_writes_normally(self, engine: Engine, temp_dir: Path) -> None:
         """The default ``None`` policy skips the vet entirely -> allow."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         requested_path = temp_dir / "image.png"
 
         request = WriteFileRequest(file_path=str(requested_path), content=_png_bytes())
@@ -926,7 +918,7 @@ class TestOSWritePermissionVet:
         assert requested_path.exists()
 
     def test_unrecognized_bytes_skip_vet_entirely(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+        self, engine: Engine, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """If sniff returns None (no provider claims the bytes), the vet is never invoked."""
         called: list[bool] = []
@@ -937,9 +929,9 @@ class TestOSWritePermissionVet:
         # Spy on ArtifactManager.get_write_vetting_policy: if OSManager ever
         # asks about an unrecognized format, we'd see it here. sniff on the
         # blob returns None, so the vet block never even reads the policy.
-        monkeypatch.setattr(griptape_nodes.ArtifactManager(), "get_write_vetting_policy", spy_policy)
+        monkeypatch.setattr(engine.artifact_manager, "get_write_vetting_policy", spy_policy)
 
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         requested_path = temp_dir / "blob.dat"
 
         request = WriteFileRequest(file_path=str(requested_path), content=b"\x00\x01 not a known format")
@@ -950,7 +942,7 @@ class TestOSWritePermissionVet:
         assert requested_path.exists()
 
     def test_deny_returns_codec_not_permitted_and_no_file_for_extensionless_destination(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+        self, engine: Engine, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Regression: extension-less destinations must not bypass the codec vet.
 
@@ -964,9 +956,9 @@ class TestOSWritePermissionVet:
 
         expected_denial = CheckpointDenial(failures=(CheckpointFailure(detail="This codec is not licensed."),))
 
-        provider_classes = griptape_nodes.ArtifactManager()._registry.get_provider_classes_by_format("png")
+        provider_classes = engine.artifact_manager._registry.get_provider_classes_by_format("png")
         assert provider_classes, "PNG must resolve to the registered image provider"
-        provider = griptape_nodes.ArtifactManager()._registry.get_or_create_provider_instance(provider_classes[0])
+        provider = engine.artifact_manager._registry.get_or_create_provider_instance(provider_classes[0])
         monkeypatch.setattr(
             provider.__class__, "get_write_vetting_policy", staticmethod(lambda: WriteVettingPolicy.FROM_BYTES)
         )
@@ -976,7 +968,7 @@ class TestOSWritePermissionVet:
             lambda data, detected_format: expected_denial,  # noqa: ARG005
         )
 
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         # Destination has NO extension. Sniff on bytes classifies as PNG,
         # provider denies, OSManager must refuse the write. Before the fix
         # this would return Success and leave the file on disk.
@@ -990,7 +982,7 @@ class TestOSWritePermissionVet:
         assert not requested_path.exists()
 
     def test_append_writes_are_not_vetted(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+        self, engine: Engine, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Appends skip the codec vet: the tail alone has no container header to classify."""
         called: list[bool] = []
@@ -998,9 +990,9 @@ class TestOSWritePermissionVet:
         def spy_policy(fmt: str) -> None:  # noqa: ARG001
             called.append(True)
 
-        monkeypatch.setattr(griptape_nodes.ArtifactManager(), "get_write_vetting_policy", spy_policy)
+        monkeypatch.setattr(engine.artifact_manager, "get_write_vetting_policy", spy_policy)
 
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         requested_path = temp_dir / "image.png"
         # Seed the file so append has something to append to.
         requested_path.write_bytes(_png_bytes())
@@ -1011,7 +1003,7 @@ class TestOSWritePermissionVet:
         assert called == []
 
     def test_unrecognized_policy_variant_raises_loudly(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+        self, engine: Engine, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A future ``WriteVettingPolicy`` variant OSManager doesn't know how to dispatch must fail loud.
 
@@ -1020,12 +1012,12 @@ class TestOSWritePermissionVet:
         sentinel string the switch doesn't recognize.
         """
         monkeypatch.setattr(
-            griptape_nodes.ArtifactManager(),
+            engine.artifact_manager,
             "get_write_vetting_policy",
             lambda fmt: "future_variant",  # noqa: ARG005
         )
 
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         requested_path = temp_dir / "image.png"
         request = WriteFileRequest(file_path=str(requested_path), content=_png_bytes())
         with pytest.raises(RuntimeError, match="Unrecognized WriteVettingPolicy"):
@@ -1034,7 +1026,7 @@ class TestOSWritePermissionVet:
         assert not requested_path.exists()
 
     def test_from_path_policy_stages_bytes_and_provides_path_to_provider(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+        self, engine: Engine, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """When a provider declares ``FROM_PATH`` OSManager stages bytes, hands the provider a path, and truncates + deletes after.
 
@@ -1050,15 +1042,15 @@ class TestOSWritePermissionVet:
             assert Path(source_path).read_bytes() == _png_bytes()
             seen_paths.append(source_path)
 
-        provider_classes = griptape_nodes.ArtifactManager()._registry.get_provider_classes_by_format("png")
+        provider_classes = engine.artifact_manager._registry.get_provider_classes_by_format("png")
         assert provider_classes
-        provider = griptape_nodes.ArtifactManager()._registry.get_or_create_provider_instance(provider_classes[0])
+        provider = engine.artifact_manager._registry.get_or_create_provider_instance(provider_classes[0])
         monkeypatch.setattr(
             provider.__class__, "get_write_vetting_policy", staticmethod(lambda: WriteVettingPolicy.FROM_PATH)
         )
         monkeypatch.setattr(provider, "check_write_format_from_path", from_path_hook)
 
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         requested_path = temp_dir / "image.png"
         request = WriteFileRequest(file_path=str(requested_path), content=_png_bytes())
         result = os_manager.on_write_file_request(request)
@@ -1071,16 +1063,16 @@ class TestOSWritePermissionVet:
         assert not Path(seen_paths[0]).exists(), "staged codec-vet temp must be cleaned up"
 
     def test_from_path_policy_staging_failure_fails_closed(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+        self, engine: Engine, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """If staging the vet's temp file blows up, the write must be refused, not permitted.
 
         An unstageable vet cannot verify the write is compliant -- fail closed
         rather than silently blessing bytes because we couldn't run the check.
         """
-        provider_classes = griptape_nodes.ArtifactManager()._registry.get_provider_classes_by_format("png")
+        provider_classes = engine.artifact_manager._registry.get_provider_classes_by_format("png")
         assert provider_classes
-        provider = griptape_nodes.ArtifactManager()._registry.get_or_create_provider_instance(provider_classes[0])
+        provider = engine.artifact_manager._registry.get_or_create_provider_instance(provider_classes[0])
         monkeypatch.setattr(
             provider.__class__, "get_write_vetting_policy", staticmethod(lambda: WriteVettingPolicy.FROM_PATH)
         )
@@ -1094,7 +1086,7 @@ class TestOSWritePermissionVet:
 
         # Break the staging step by making the SAVE_TEMP_FILE macro resolve fail.
         # Easiest: monkeypatch _stage_bytes_at_temp on the manager to raise.
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
 
         def raise_staging(*_args, **_kwargs):  # type: ignore[no-untyped-def]  # noqa: ANN202
             msg = "simulated staging outage"
@@ -1114,7 +1106,7 @@ class TestOSWritePermissionVet:
         assert provider_hook_calls == []
 
     def test_from_path_policy_cleanup_dispatches_delete_file_request(
-        self, griptape_nodes: GriptapeNodes, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
+        self, engine: Engine, temp_dir: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Cleanup must go through ``DeleteFileRequest``, not raw ``Path.unlink``.
 
@@ -1131,9 +1123,9 @@ class TestOSWritePermissionVet:
             DeletionOutcome,
         )
 
-        provider_classes = griptape_nodes.ArtifactManager()._registry.get_provider_classes_by_format("png")
+        provider_classes = engine.artifact_manager._registry.get_provider_classes_by_format("png")
         assert provider_classes
-        provider = griptape_nodes.ArtifactManager()._registry.get_or_create_provider_instance(provider_classes[0])
+        provider = engine.artifact_manager._registry.get_or_create_provider_instance(provider_classes[0])
         monkeypatch.setattr(
             provider.__class__, "get_write_vetting_policy", staticmethod(lambda: WriteVettingPolicy.FROM_PATH)
         )
@@ -1163,13 +1155,13 @@ class TestOSWritePermissionVet:
                 result_details="delete recorded by spy",
             )
 
-        event_manager = griptape_nodes.EventManager()
+        event_manager = engine.event_manager
         registry = event_manager._request_type_to_manager
         monkeypatch.setitem(registry, DeleteFileRequest, spy_delete_handler)
 
         requested_path = temp_dir / "image.png"
         request = WriteFileRequest(file_path=str(requested_path), content=_png_bytes())
-        result = griptape_nodes.OSManager().on_write_file_request(request)
+        result = engine.os_manager.on_write_file_request(request)
 
         assert isinstance(result, WriteFileResultSuccess)
         # Exactly one DeleteFileRequest for the staged temp; not more (would
@@ -1199,25 +1191,25 @@ class TestExtensionCoercionDoesNotClobberPriorSave:
             yield Path(tmpdir).resolve()
 
     @pytest.fixture(autouse=True)
-    def setup_project(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
+    def setup_project(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
+        original_workspace = engine.config_manager.workspace_path
 
         project_yml = temp_dir / "project_template.yml"
         project_yml.write_text(DEFAULT_PROJECT_TEMPLATE.to_overlay_yaml(DEFAULT_PROJECT_TEMPLATE))
-        load_result = GriptapeNodes.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
+        load_result = engine.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
         if isinstance(load_result, LoadProjectTemplateResultSuccess):
-            GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
+            engine.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
 
-        griptape_nodes.ArtifactManager().on_handle_register_artifact_provider_request(
+        engine.artifact_manager.on_handle_register_artifact_provider_request(
             RegisterArtifactProviderRequest(provider_class=ImageArtifactProvider)
         )
 
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        engine.config_manager.workspace_path = temp_dir
 
         yield
 
-        GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=None))
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.handle_request(SetCurrentProjectRequest(project_id=None))
+        engine.config_manager.workspace_path = original_workspace
 
     @pytest.fixture
     def outputs_dir(self, temp_dir: Path, setup_project: None) -> Path:  # noqa: ARG002
@@ -1250,10 +1242,10 @@ class TestExtensionCoercionDoesNotClobberPriorSave:
         assert not (outputs_dir / "render_v002.png").exists()
 
     def test_plain_path_create_new_with_mismatched_bytes_does_not_clobber(
-        self, griptape_nodes: GriptapeNodes, outputs_dir: Path
+        self, engine: Engine, outputs_dir: Path
     ) -> None:
         """Plain string path variant: two JPEG saves to ``output.png`` produce two .jpg files."""
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         requested_path = outputs_dir / "output.png"
 
         first_result = os_manager.on_write_file_request(
@@ -1304,7 +1296,7 @@ class TestCreateNewMacroIndexSeed:
             yield Path(tmpdir).resolve()
 
     @pytest.fixture(autouse=True)
-    def setup_project(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+    def setup_project(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
         # Production macro resolution requires a loaded project so `{outputs}` from the
         # default template can resolve to <workspace>/outputs.
         #
@@ -1313,20 +1305,20 @@ class TestCreateNewMacroIndexSeed:
         # from the project/workspace config layers (see ProjectManager._activate_project),
         # which would clobber any earlier workspace_path assignment. Setting it AFTER
         # activation makes our temp_dir stick for the duration of the test.
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
+        original_workspace = engine.config_manager.workspace_path
 
         project_yml = temp_dir / "project_template.yml"
         project_yml.write_text(DEFAULT_PROJECT_TEMPLATE.to_overlay_yaml(DEFAULT_PROJECT_TEMPLATE))
-        load_result = GriptapeNodes.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
+        load_result = engine.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
         if isinstance(load_result, LoadProjectTemplateResultSuccess):
-            GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
+            engine.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
 
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        engine.config_manager.workspace_path = temp_dir
 
         yield
 
-        GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=None))
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.handle_request(SetCurrentProjectRequest(project_id=None))
+        engine.config_manager.workspace_path = original_workspace
 
     @pytest.fixture
     def outputs_dir(self, temp_dir: Path, setup_project: None) -> Path:  # noqa: ARG002
@@ -1570,19 +1562,19 @@ class TestOptionalPaddedIndexCollision:
             yield Path(tmpdir).resolve()
 
     @pytest.fixture(autouse=True)
-    def setup_project(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+    def setup_project(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
         # Same load-then-force ordering as TestCreateNewMacroIndexSeed: SetCurrentProject
         # remerges workspace_path from project config layers, so we set it AFTER.
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
+        original_workspace = engine.config_manager.workspace_path
         project_yml = temp_dir / "project_template.yml"
         project_yml.write_text(DEFAULT_PROJECT_TEMPLATE.to_overlay_yaml(DEFAULT_PROJECT_TEMPLATE))
-        load_result = GriptapeNodes.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
+        load_result = engine.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
         if isinstance(load_result, LoadProjectTemplateResultSuccess):
-            GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+            engine.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
+        engine.config_manager.workspace_path = temp_dir
         yield
-        GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=None))
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.handle_request(SetCurrentProjectRequest(project_id=None))
+        engine.config_manager.workspace_path = original_workspace
 
     @pytest.fixture
     def outputs_dir(self, temp_dir: Path, setup_project: None) -> Path:  # noqa: ARG002
@@ -1739,20 +1731,20 @@ class TestCreateNewMacroIndexSeedDefensiveFallthrough:
             yield Path(tmpdir).resolve()
 
     @pytest.fixture(autouse=True)
-    def setup_project(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+    def setup_project(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
         # Same ordering as TestCreateNewMacroIndexSeed.setup_project — load + activate
         # FIRST, then force workspace_path. SetCurrentProjectRequest re-derives the
         # workspace from project config layers and would otherwise clobber temp_dir.
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
+        original_workspace = engine.config_manager.workspace_path
         project_yml = temp_dir / "project_template.yml"
         project_yml.write_text(DEFAULT_PROJECT_TEMPLATE.to_overlay_yaml(DEFAULT_PROJECT_TEMPLATE))
-        load_result = GriptapeNodes.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
+        load_result = engine.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
         if isinstance(load_result, LoadProjectTemplateResultSuccess):
-            GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+            engine.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
+        engine.config_manager.workspace_path = temp_dir
         yield
-        GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=None))
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.handle_request(SetCurrentProjectRequest(project_id=None))
+        engine.config_manager.workspace_path = original_workspace
 
     @pytest.fixture
     def outputs_dir(self, temp_dir: Path, setup_project: None) -> Path:  # noqa: ARG002
@@ -1868,20 +1860,20 @@ class TestCreateNewMacroIndexSeedWindowsPaths:
             yield Path(tmpdir).resolve()
 
     @pytest.fixture(autouse=True)
-    def setup_project(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+    def setup_project(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
         # Same ordering as TestCreateNewMacroIndexSeed.setup_project — load + activate
         # FIRST, then force workspace_path so SetCurrentProject's project-config remerge
         # doesn't clobber temp_dir.
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
+        original_workspace = engine.config_manager.workspace_path
         project_yml = temp_dir / "project_template.yml"
         project_yml.write_text(DEFAULT_PROJECT_TEMPLATE.to_overlay_yaml(DEFAULT_PROJECT_TEMPLATE))
-        load_result = GriptapeNodes.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
+        load_result = engine.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
         if isinstance(load_result, LoadProjectTemplateResultSuccess):
-            GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+            engine.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
+        engine.config_manager.workspace_path = temp_dir
         yield
-        GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=None))
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.handle_request(SetCurrentProjectRequest(project_id=None))
+        engine.config_manager.workspace_path = original_workspace
 
     def test_long_windows_path_gap_fill(self, temp_dir: Path) -> None:
         r"""Workspace + nested dirs + filename combine to >260 chars; gap-fill must still work.
@@ -1958,30 +1950,30 @@ class TestWriteTempFileRequest:
             yield Path(tmpdir).resolve()
 
     @pytest.fixture(autouse=True)
-    def setup_workspace(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+    def setup_workspace(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
         """Load the default project template so SAVE_TEMP_FILE resolves."""
-        config_manager = griptape_nodes.ConfigManager()
+        config_manager = engine.config_manager
         original_workspace = config_manager.workspace_path
         config_manager.set_config_value("workspace_directory", str(temp_dir))
 
         project_yml = temp_dir / "project_template.yml"
         project_yml.write_text(DEFAULT_PROJECT_TEMPLATE.to_overlay_yaml(DEFAULT_PROJECT_TEMPLATE))
-        load_result = GriptapeNodes.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
+        load_result = engine.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
         if isinstance(load_result, LoadProjectTemplateResultSuccess):
-            GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
+            engine.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
 
         yield
 
-        GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=None))
+        engine.handle_request(SetCurrentProjectRequest(project_id=None))
         config_manager.set_config_value("workspace_directory", str(original_workspace))
 
-    def test_stages_bytes_at_project_temp_path(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_stages_bytes_at_project_temp_path(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.events.os_events import (
             WriteTempFileRequest,
             WriteTempFileResultSuccess,
         )
 
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         payload = b"probe target bytes"
 
         result = os_manager.on_write_temp_file_request(
@@ -2002,7 +1994,7 @@ class TestWriteTempFileRequest:
         assert staged.suffix == ".mp4"
         assert "probe" in staged.stem
 
-    def test_caller_controls_uniqueness_via_variables(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_caller_controls_uniqueness_via_variables(self, engine: Engine) -> None:
         """The handler does not inject uuids -- callers who want uniqueness supply their own.
 
         SAVE_TEMP_FILE's on-collision policy is OVERWRITE, so two callers passing
@@ -2015,7 +2007,7 @@ class TestWriteTempFileRequest:
             WriteTempFileResultSuccess,
         )
 
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
 
         result_a = os_manager.on_write_temp_file_request(
             WriteTempFileRequest(content=b"a", variables={"file_name_base": "unique-a", "file_extension": "mp4"})
@@ -2030,7 +2022,7 @@ class TestWriteTempFileRequest:
         assert Path(result_a.staged_path).read_bytes() == b"a"
         assert Path(result_b.staged_path).read_bytes() == b"b"
 
-    def test_lands_under_project_temp_directory(self, griptape_nodes: GriptapeNodes, temp_dir: Path) -> None:
+    def test_lands_under_project_temp_directory(self, engine: Engine, temp_dir: Path) -> None:
         """The staged path is under the project's ``{temp}`` directory, not the OS temp dir.
 
         Confirms we're using the SAVE_TEMP_FILE situation's project-scoped
@@ -2043,7 +2035,7 @@ class TestWriteTempFileRequest:
             WriteTempFileResultSuccess,
         )
 
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
 
         result = os_manager.on_write_temp_file_request(
             WriteTempFileRequest(content=b"payload", variables={"file_name_base": "probe", "file_extension": "mp4"})
@@ -2056,7 +2048,7 @@ class TestWriteTempFileRequest:
         # differences (e.g. macOS ``/var`` vs ``/private/var``).
         assert temp_dir.resolve() in staged.parents
 
-    def test_returns_failure_when_variables_do_not_resolve_macro(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_returns_failure_when_variables_do_not_resolve_macro(self, engine: Engine) -> None:
         """Caller omitting a required macro variable surfaces as a Failure.
 
         The SAVE_TEMP_FILE macro references ``{file_name_base}`` and
@@ -2070,14 +2062,14 @@ class TestWriteTempFileRequest:
             WriteTempFileResultFailure,
         )
 
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         result = os_manager.on_write_temp_file_request(WriteTempFileRequest(content=b"payload", variables={}))
 
         assert isinstance(result, WriteTempFileResultFailure)
         assert result.failure_reason == FileIOFailureReason.INVALID_PATH
 
     def test_returns_failure_when_situation_registry_missing_save_temp_file(
-        self, griptape_nodes: GriptapeNodes, monkeypatch: pytest.MonkeyPatch
+        self, engine: Engine, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """SAVE_TEMP_FILE absent from the situation registry -> Failure result.
 
@@ -2099,11 +2091,11 @@ class TestWriteTempFileRequest:
         def situation_missing_handler(request: GetSituationRequest) -> GetSituationResultFailure:  # noqa: ARG001
             return GetSituationResultFailure(result_details="situation missing (test)")
 
-        event_manager = griptape_nodes.EventManager()
+        event_manager = engine.event_manager
         registry = event_manager._request_type_to_manager
         monkeypatch.setitem(registry, GetSituationRequest, situation_missing_handler)
 
-        os_manager = griptape_nodes.OSManager()
+        os_manager = engine.os_manager
         result = os_manager.on_write_temp_file_request(
             WriteTempFileRequest(content=b"payload", variables={"file_name_base": "probe", "file_extension": "mp4"})
         )
@@ -2135,23 +2127,23 @@ class TestFailedWriteLeavesNoLitter:
             yield Path(tmpdir).resolve()
 
     @pytest.fixture(autouse=True)
-    def setup_project(self, temp_dir: Path, griptape_nodes: GriptapeNodes) -> Generator[None, None, None]:
+    def setup_project(self, temp_dir: Path, engine: Engine) -> Generator[None, None, None]:
         # Mirrors TestPaddedIndexMacroSaves: load + activate the project first, then pin
         # workspace_path, since activation re-derives it.
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
+        original_workspace = engine.config_manager.workspace_path
 
         project_yml = temp_dir / "project_template.yml"
         project_yml.write_text(DEFAULT_PROJECT_TEMPLATE.to_overlay_yaml(DEFAULT_PROJECT_TEMPLATE))
-        load_result = GriptapeNodes.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
+        load_result = engine.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
         if isinstance(load_result, LoadProjectTemplateResultSuccess):
-            GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
+            engine.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
 
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        engine.config_manager.workspace_path = temp_dir
 
         yield
 
-        GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=None))
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.handle_request(SetCurrentProjectRequest(project_id=None))
+        engine.config_manager.workspace_path = original_workspace
 
     @pytest.fixture
     def outputs_dir(self, temp_dir: Path, setup_project: None) -> Path:  # noqa: ARG002
@@ -2213,13 +2205,13 @@ class TestFailedWriteLeavesNoLitter:
         assert list(outputs_dir.iterdir()) == []
 
     def test_fail_policy_lock_failure_leaves_no_file(
-        self, outputs_dir: Path, monkeypatch: pytest.MonkeyPatch, griptape_nodes: GriptapeNodes
+        self, outputs_dir: Path, monkeypatch: pytest.MonkeyPatch, engine: Engine
     ) -> None:
         """The FAIL policy also writes with mode="x", so it leaked debris too."""
         self._fail_lock_times(monkeypatch, count=None)
         target = outputs_dir / "single.png"
 
-        result = griptape_nodes.OSManager().on_write_file_request(
+        result = engine.os_manager.on_write_file_request(
             WriteFileRequest(
                 file_path=str(target),
                 content=b"payload",
@@ -2232,7 +2224,7 @@ class TestFailedWriteLeavesNoLitter:
         assert not target.exists()
 
     def test_write_error_leaves_no_partial_file(
-        self, outputs_dir: Path, monkeypatch: pytest.MonkeyPatch, griptape_nodes: GriptapeNodes
+        self, outputs_dir: Path, monkeypatch: pytest.MonkeyPatch, engine: Engine
     ) -> None:
         """A mid-write failure is worse than zero-byte: the debris has a plausible size."""
 
@@ -2243,7 +2235,7 @@ class TestFailedWriteLeavesNoLitter:
         monkeypatch.setattr("griptape_nodes.retained_mode.managers.os_manager.os.fsync", exploding_fsync)
         target = outputs_dir / "partial.png"
 
-        result = griptape_nodes.OSManager().on_write_file_request(
+        result = engine.os_manager.on_write_file_request(
             WriteFileRequest(
                 file_path=str(target),
                 content=b"A" * 4096,
@@ -2255,7 +2247,7 @@ class TestFailedWriteLeavesNoLitter:
         assert not target.exists()
 
     def test_cleanup_cannot_be_armed_against_a_non_exclusive_open(
-        self, outputs_dir: Path, monkeypatch: pytest.MonkeyPatch, griptape_nodes: GriptapeNodes
+        self, outputs_dir: Path, monkeypatch: pytest.MonkeyPatch, engine: Engine
     ) -> None:
         """The exclusive-create flag is derived from ``mode``, so the two cannot disagree.
 
@@ -2271,19 +2263,19 @@ class TestFailedWriteLeavesNoLitter:
         # Even with every lock attempt rigged to fail, mode="x" over an existing file
         # raises from open() first, so the cleanup is never reachable.
         with pytest.raises(FileExistsError):
-            griptape_nodes.OSManager()._write_locked_discarding_debris(str(target), b"replacement", "utf-8", mode="x")
+            engine.os_manager._write_locked_discarding_debris(str(target), b"replacement", "utf-8", mode="x")
 
         assert target.read_bytes() == b"REAL USER DATA"
 
     def test_overwrite_never_deletes_pre_existing_file(
-        self, outputs_dir: Path, monkeypatch: pytest.MonkeyPatch, griptape_nodes: GriptapeNodes
+        self, outputs_dir: Path, monkeypatch: pytest.MonkeyPatch, engine: Engine
     ) -> None:
         """Guards the mode="x" gate: under "w" the file may predate us and hold real data."""
         target = outputs_dir / "precious.png"
         target.write_bytes(b"REAL USER DATA")
         self._fail_lock_times(monkeypatch, count=None)
 
-        result = griptape_nodes.OSManager().on_write_file_request(
+        result = engine.os_manager.on_write_file_request(
             WriteFileRequest(
                 file_path=str(target),
                 content=b"replacement",
@@ -2298,10 +2290,10 @@ class TestFailedWriteLeavesNoLitter:
 class TestMacroFailureMessageIsReadable:
     """Error messages must name the macro template, not dump the ParsedMacro repr."""
 
-    def test_failure_details_show_template_not_dataclass_repr(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_failure_details_show_template_not_dataclass_repr(self, engine: Engine) -> None:
         template = "{outputs}/{file_name_base}_v{###}.{file_extension}"
 
-        result = griptape_nodes.OSManager().on_write_file_request(
+        result = engine.os_manager.on_write_file_request(
             WriteFileRequest(
                 file_path=MacroPath(ParsedMacro(template), {}),
                 content=b"payload",

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -1,5 +1,7 @@
 """Tests for ProjectManager macro event handlers."""
 
+from __future__ import annotations
+
 import logging
 import os
 import sys
@@ -15,6 +17,7 @@ if TYPE_CHECKING:
     from griptape_nodes.common.project_templates.directory import PerPlatformPathMacro
     from griptape_nodes.common.project_templates.loader import ProjectOverlayData
     from griptape_nodes.common.project_templates.project_path import PerPlatformProjectPath, ResolvedProjectPath
+    from griptape_nodes.retained_mode.engine import Engine
     from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultFailure
 
 from griptape_nodes.common.macro_parser import MacroMatchFailureReason
@@ -192,7 +195,7 @@ class TestProjectManagerMacroHandlers:
             "file_extension": "py",
         }
 
-    def test_match_path_auto_resolve_on_supplies_builtin_anchors(self, tmp_path: Path) -> None:
+    def test_match_path_auto_resolve_on_supplies_builtin_anchors(self, engine: Engine, tmp_path: Path) -> None:
         """``auto_resolve_builtins=True`` lets the handler resolve ``{workspace_dir}`` itself.
 
         Drives the handler through ``handle_request`` against a real loaded project
@@ -206,17 +209,16 @@ class TestProjectManagerMacroHandlers:
             LoadProjectTemplateResultSuccess,
             SetCurrentProjectRequest,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         workspace = tmp_path.resolve()
-        original_workspace = GriptapeNodes.ConfigManager().workspace_path
+        original_workspace = engine.config_manager.workspace_path
         project_yml = workspace / "project_template.yml"
         project_yml.write_text(DEFAULT_PROJECT_TEMPLATE.to_overlay_yaml(DEFAULT_PROJECT_TEMPLATE))
-        load_result = GriptapeNodes.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
+        load_result = engine.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
         assert isinstance(load_result, LoadProjectTemplateResultSuccess)
-        GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
+        engine.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
         # SetCurrentProjectRequest re-derives workspace_path; force it back.
-        GriptapeNodes.ConfigManager().workspace_path = workspace
+        engine.config_manager.workspace_path = workspace
 
         try:
             # Macro templates use forward-slash separators (the cross-platform
@@ -236,7 +238,7 @@ class TestProjectManagerMacroHandlers:
                 auto_resolve_builtins=True,
             )
 
-            result = GriptapeNodes.handle_request(request)
+            result = engine.handle_request(request)
 
             assert isinstance(result, AttemptMatchPathAgainstMacroResultSuccess)
             assert result.match_failure is None
@@ -246,10 +248,10 @@ class TestProjectManagerMacroHandlers:
             # workspace_dir was supplied by the handler — auto-resolution made the match possible.
             assert "workspace_dir" in result.extracted_variables
         finally:
-            GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=None))
-            GriptapeNodes.ConfigManager().workspace_path = original_workspace
+            engine.handle_request(SetCurrentProjectRequest(project_id=None))
+            engine.config_manager.workspace_path = original_workspace
 
-    def test_match_path_auto_resolve_rejects_conflicting_caller_override(self, tmp_path: Path) -> None:
+    def test_match_path_auto_resolve_rejects_conflicting_caller_override(self, engine: Engine, tmp_path: Path) -> None:
         """Caller-supplied builtin overrides that disagree with the project are rejected.
 
         Pins the shared "no silent override of builtins" policy: every handler
@@ -266,16 +268,15 @@ class TestProjectManagerMacroHandlers:
             LoadProjectTemplateResultSuccess,
             SetCurrentProjectRequest,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         workspace = tmp_path.resolve()
-        original_workspace = GriptapeNodes.ConfigManager().workspace_path
+        original_workspace = engine.config_manager.workspace_path
         project_yml = workspace / "project_template.yml"
         project_yml.write_text(DEFAULT_PROJECT_TEMPLATE.to_overlay_yaml(DEFAULT_PROJECT_TEMPLATE))
-        load_result = GriptapeNodes.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
+        load_result = engine.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
         assert isinstance(load_result, LoadProjectTemplateResultSuccess)
-        GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
-        GriptapeNodes.ConfigManager().workspace_path = workspace
+        engine.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
+        engine.config_manager.workspace_path = workspace
 
         try:
             # Caller asserts workspace_dir is "/elsewhere" — different from the real workspace.
@@ -288,15 +289,15 @@ class TestProjectManagerMacroHandlers:
                 auto_resolve_builtins=True,
             )
 
-            result = GriptapeNodes.handle_request(request)
+            result = engine.handle_request(request)
 
             # Hard failure (not a match-failure result_success): caller violated
             # the "no override of builtins" contract that all macro handlers share.
             assert isinstance(result, AttemptMatchPathAgainstMacroResultFailure)
             assert "workspace_dir" in str(result.result_details)
         finally:
-            GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=None))
-            GriptapeNodes.ConfigManager().workspace_path = original_workspace
+            engine.handle_request(SetCurrentProjectRequest(project_id=None))
+            engine.config_manager.workspace_path = original_workspace
 
     def test_match_path_auto_resolve_supplies_non_directory_builtin_verbatim(
         self,
@@ -863,7 +864,7 @@ class TestProjectManagerBuiltinVariables:
         parsed_macro = ParsedMacro("{workflow_dir?:/}outputs/image.png")
         request = GetPathForMacroRequest(parsed_macro=parsed_macro, variables={})
 
-        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+        with caplog.at_level(logging.WARNING, logger="engine"):
             result = project_manager_with_template.on_get_path_for_macro_request(request)
 
         assert isinstance(result, GetPathForMacroResultSuccess)
@@ -2471,7 +2472,7 @@ situations:
 
         with (
             patch("griptape_nodes.retained_mode.managers.project_manager.File") as mock_file_cls,
-            caplog.at_level(logging.ERROR, logger="griptape_nodes"),
+            caplog.at_level(logging.ERROR, logger="engine"),
         ):
             mock_file_instance = Mock()
             mock_file_instance.aread_text = AsyncMock(return_value="not: valid: yaml: : :\n  - broken")
@@ -3751,9 +3752,9 @@ class TestResolveWorkspaceDirForProjectId:
         project_id: str | None,
         parent_id: str | None = None,
         parent_path: str | None = None,
-        workspace_dir: "str | PerPlatformProjectPath | None" = None,
-        libraries_dir: "str | PerPlatformProjectPath | None" = None,
-    ) -> "ProjectOverlayData":
+        workspace_dir: str | PerPlatformProjectPath | None = None,
+        libraries_dir: str | PerPlatformProjectPath | None = None,
+    ) -> ProjectOverlayData:
         """Build a minimal ProjectOverlayData carrying only the id / parent-link / workspace fields the walk reads."""
         from griptape_nodes.common.project_templates.loader import ProjectOverlayData, YAMLLineInfo
 
@@ -3862,7 +3863,7 @@ class TestResolveWorkspaceDirForProjectId:
             project_file_path: Path,
             *,
             record_status: bool = True,  # noqa: ARG001  # accepted to mirror the production keyword call; unused by the stub
-        ) -> "tuple[ProjectValidationInfo, ProjectOverlayData] | LoadProjectTemplateResultFailure":
+        ) -> tuple[ProjectValidationInfo, ProjectOverlayData] | LoadProjectTemplateResultFailure:
             overlay = path_to_overlay.get(canonicalize_for_identity(project_file_path))
             if overlay is None:
                 from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateResultFailure
@@ -4593,14 +4594,14 @@ class TestResolveLibrariesRootForProjectId(TestResolveWorkspaceDirForProjectId):
             project_file_path: Path,
             *,
             record_status: bool = True,
-        ) -> "tuple[ProjectValidationInfo, ProjectOverlayData] | LoadProjectTemplateResultFailure":
+        ) -> tuple[ProjectValidationInfo, ProjectOverlayData] | LoadProjectTemplateResultFailure:
             key = canonicalize_for_identity(project_file_path)
             read_counts[key] = read_counts.get(key, 0) + 1
             return await inner_read_overlay(project_file_path, record_status=record_status)
 
         pm._read_overlay = counting_read_overlay  # type: ignore[method-assign]
 
-        def probe(node_path: Path, overlay: "ProjectOverlayData") -> "ResolvedProjectPath":
+        def probe(node_path: Path, overlay: ProjectOverlayData) -> ResolvedProjectPath:
             return pm._resolve_template_path_field(overlay.libraries_dir, node_path, "libraries_dir")
 
         result = await pm._nearest_ancestor_value_offline(child_canonical, id_index, probe)
@@ -5305,7 +5306,7 @@ class TestProjectManagerProjectWorkspaces:
         project_workspaces: dict[str, str] | None = None,
         configured_root: str | None = None,
         child_adjacent_config: dict | None = None,
-    ) -> "tuple[ProjectManager, Mock, Path, Path]":
+    ) -> tuple[ProjectManager, Mock, Path, Path]:
         """Build a pm whose child is loaded but whose parent lives only on disk (#5149 setup).
 
         Models the frozen-worker registry: the child is in the live registry, the parent is
@@ -6086,7 +6087,7 @@ situations:
 
         with (
             patch.object(pm, "_load_and_cache_project_template", new=AsyncMock()) as mock_load,
-            caplog.at_level(logging.WARNING, logger="griptape_nodes"),
+            caplog.at_level(logging.WARNING, logger="engine"),
         ):
             await pm._load_registered_projects()
             mock_load.assert_not_called()
@@ -6112,7 +6113,7 @@ situations:
 
         with (
             patch.object(pm, "on_load_project_template_request", new=AsyncMock(return_value=failure)),
-            caplog.at_level(logging.WARNING, logger="griptape_nodes"),
+            caplog.at_level(logging.WARNING, logger="engine"),
         ):
             await pm._load_registered_projects()
 
@@ -6856,7 +6857,7 @@ class TestProjectDirectoryRecursion:
 
     def _make_pm_with_directories(
         self,
-        directories: "dict[str, str | PerPlatformPathMacro]",
+        directories: dict[str, str | PerPlatformPathMacro],
         *,
         environment: dict[str, str] | None = None,
         workspace_path: Path = Path("/workspace"),
@@ -8457,7 +8458,7 @@ class TestValidateProjectTemplateParentChain:
             "directories": {},
         }
 
-        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+        with caplog.at_level(logging.WARNING, logger="engine"):
             result = pm.on_validate_project_template_request(
                 ValidateProjectTemplateRequest(template_data=template_data)
             )
@@ -8609,7 +8610,7 @@ situations:
 
         with (
             patch.object(pm, "on_load_project_template_request", new=AsyncMock()) as mock_load,
-            caplog.at_level(logging.WARNING, logger="griptape_nodes"),
+            caplog.at_level(logging.WARNING, logger="engine"),
         ):
             await pm._load_registered_projects()
             mock_load.assert_not_called()
@@ -8635,7 +8636,7 @@ situations:
 
         with (
             patch.object(pm, "on_load_project_template_request", new=AsyncMock()) as mock_load,
-            caplog.at_level(logging.WARNING, logger="griptape_nodes"),
+            caplog.at_level(logging.WARNING, logger="engine"),
         ):
             await pm._load_registered_projects()
             mock_load.assert_not_called()
@@ -10699,31 +10700,29 @@ class TestClassifyLibraries:
 class TestExportProject:
     """Test on_export_project_request packages a loaded project to a portable .zip."""
 
-    def test_export_not_loaded_project_fails(self, griptape_nodes: object, tmp_path: Path) -> None:  # noqa: ARG002
+    def test_export_not_loaded_project_fails(self, engine: Engine, tmp_path: Path) -> None:
         """Exporting an unregistered project id returns a Failure."""
         from griptape_nodes.retained_mode.events.project_events import ExportProjectRequest, ExportProjectResultFailure
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-        pm = GriptapeNodes.ProjectManager()
+        pm = engine.project_manager
         result = pm.on_export_project_request(
             ExportProjectRequest(project_id="not-a-real-project", destination_path=tmp_path / "out.zip")
         )
         assert isinstance(result, ExportProjectResultFailure)
 
-    def test_export_system_defaults_fails(self, griptape_nodes: object, tmp_path: Path) -> None:  # noqa: ARG002
+    def test_export_system_defaults_fails(self, engine: Engine, tmp_path: Path) -> None:
         """Exporting the file-less system defaults project returns a Failure."""
         from griptape_nodes.retained_mode.events.project_events import ExportProjectRequest, ExportProjectResultFailure
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY
 
-        pm = GriptapeNodes.ProjectManager()
+        pm = engine.project_manager
         result = pm.on_export_project_request(
             ExportProjectRequest(project_id=SYSTEM_DEFAULTS_KEY, destination_path=tmp_path / "out.zip")
         )
         assert isinstance(result, ExportProjectResultFailure)
 
     @pytest.mark.asyncio
-    async def test_export_missing_destination_dir_fails(self, griptape_nodes: object, tmp_path: Path) -> None:  # noqa: ARG002
+    async def test_export_missing_destination_dir_fails(self, engine: Engine, tmp_path: Path) -> None:
         """Exporting to a destination whose parent dir is missing returns a Failure."""
         from griptape_nodes.retained_mode.events.project_events import (
             ExportProjectRequest,
@@ -10731,9 +10730,8 @@ class TestExportProject:
             LoadProjectTemplateRequest,
             LoadProjectTemplateResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-        pm = GriptapeNodes.ProjectManager()
+        pm = engine.project_manager
         project_yaml = _write_project_base_dir(tmp_path / "proj")
         load_result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=project_yaml))
         assert isinstance(load_result, LoadProjectTemplateResultSuccess)
@@ -10747,7 +10745,7 @@ class TestExportProject:
         assert isinstance(result, ExportProjectResultFailure)
 
     @pytest.mark.asyncio
-    async def test_export_referenced_library_round_trip(self, griptape_nodes: object, tmp_path: Path) -> None:  # noqa: ARG002
+    async def test_export_referenced_library_round_trip(self, engine: Engine, tmp_path: Path) -> None:
         """A download lib is referenced (config only), assets travel, .env never does.
 
         Also asserts a known secret value never leaks into the archive bytes and
@@ -10761,14 +10759,13 @@ class TestExportProject:
             LoadProjectTemplateRequest,
             LoadProjectTemplateResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.publishing.project_packager import (
             ADJACENT_CONFIG_FILENAME,
             MANIFEST_FILENAME,
             PROJECT_TEMPLATE_FILENAME,
         )
 
-        pm = GriptapeNodes.ProjectManager()
+        pm = engine.project_manager
         base_dir = tmp_path / "proj"
         project_yaml = _write_project_base_dir(
             base_dir, _download_config("https://example.com/lib.git", "v1.2.3", "remote_lib")
@@ -10810,7 +10807,7 @@ class TestExportProject:
     @pytest.mark.asyncio
     async def test_export_prunes_downloaded_library_sink_inside_base_dir(
         self,
-        griptape_nodes: object,  # noqa: ARG002
+        engine: Engine,
         tmp_path: Path,
     ) -> None:
         """A download lib cloned into libraries/ inside the base dir ships no source.
@@ -10828,9 +10825,8 @@ class TestExportProject:
             LoadProjectTemplateRequest,
             LoadProjectTemplateResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-        pm = GriptapeNodes.ProjectManager()
+        pm = engine.project_manager
         base_dir = tmp_path / "proj"
         project_yaml = _write_project_base_dir(base_dir, _download_config("owner/remote_lib", "v1.0.0", "remote_lib"))
         # Simulate the engine having cloned the referenced lib into the sink.
@@ -10861,7 +10857,7 @@ class TestExportProject:
             assert b"DOWNLOADED-SOURCE-SHOULD-NOT-TRAVEL" not in archive_bytes
 
     @pytest.mark.asyncio
-    async def test_export_nulls_parent_and_id_in_template(self, griptape_nodes: object, tmp_path: Path) -> None:  # noqa: ARG002
+    async def test_export_nulls_parent_and_id_in_template(self, engine: Engine, tmp_path: Path) -> None:
         """The bundled YAML has parent links and id nulled, dirs still macro strings."""
         import zipfile
 
@@ -10873,10 +10869,9 @@ class TestExportProject:
             LoadProjectTemplateRequest,
             LoadProjectTemplateResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.publishing.project_packager import PROJECT_TEMPLATE_FILENAME
 
-        pm = GriptapeNodes.ProjectManager()
+        pm = engine.project_manager
         project_yaml = _write_project_base_dir(tmp_path / "proj")
         load_result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=project_yaml))
         assert isinstance(load_result, LoadProjectTemplateResultSuccess)
@@ -10899,7 +10894,7 @@ class TestExportProject:
     @pytest.mark.asyncio
     async def test_export_copies_local_library_and_rewrites_config(
         self,
-        griptape_nodes: object,  # noqa: ARG002
+        engine: Engine,
         tmp_path: Path,
     ) -> None:
         """A register-only local lib is true-copied and its config path is package-relative."""
@@ -10912,12 +10907,11 @@ class TestExportProject:
             LoadProjectTemplateRequest,
             LoadProjectTemplateResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.managers.settings import LIBRARIES_TO_REGISTER_KEY
         from griptape_nodes.retained_mode.publishing.project_packager import ADJACENT_CONFIG_FILENAME
         from griptape_nodes.utils.dict_utils import get_dot_value
 
-        pm = GriptapeNodes.ProjectManager()
+        pm = engine.project_manager
         # The local library lives OUTSIDE the project base dir (absolute path), the
         # confirmed-real shape that must be copied and rewritten to be portable.
         lib_dir = tmp_path / "external_lib"
@@ -10952,7 +10946,7 @@ class TestExportProject:
     @pytest.mark.asyncio
     async def test_import_copied_local_library_resolves_against_new_base_dir(
         self,
-        griptape_nodes: object,  # noqa: ARG002
+        engine: Engine,
         tmp_path: Path,
     ) -> None:
         """A COPY_LOCAL lib is extracted and its rewritten config path resolves at the target.
@@ -10971,11 +10965,10 @@ class TestExportProject:
             LoadProjectTemplateRequest,
             LoadProjectTemplateResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.managers.settings import LIBRARIES_TO_REGISTER_KEY
         from griptape_nodes.utils.dict_utils import get_dot_value
 
-        pm = GriptapeNodes.ProjectManager()
+        pm = engine.project_manager
         lib_dir = tmp_path / "external_lib"
         lib_dir.mkdir()
         (lib_dir / "griptape_nodes_library.json").write_text('{"name": "external_lib"}', encoding="utf-8")
@@ -11005,7 +10998,7 @@ class TestExportProject:
     @pytest.mark.asyncio
     async def test_export_drops_self_referential_workspace_directory(
         self,
-        griptape_nodes: object,  # noqa: ARG002
+        engine: Engine,
         tmp_path: Path,
     ) -> None:
         """A workspace_directory equal to the project's own base dir is dropped on export.
@@ -11024,13 +11017,12 @@ class TestExportProject:
             LoadProjectTemplateRequest,
             LoadProjectTemplateResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.publishing.project_packager import (
             ADJACENT_CONFIG_FILENAME,
             WORKSPACE_DIRECTORY_KEY,
         )
 
-        pm = GriptapeNodes.ProjectManager()
+        pm = engine.project_manager
         base_dir = tmp_path / "proj"
         # workspace_directory points at the project's own base dir (self-contained).
         project_yaml = _write_project_base_dir(base_dir, {WORKSPACE_DIRECTORY_KEY: str(base_dir)})
@@ -11050,7 +11042,7 @@ class TestExportProject:
     @pytest.mark.asyncio
     async def test_export_preserves_external_workspace_directory(
         self,
-        griptape_nodes: object,  # noqa: ARG002
+        engine: Engine,
         tmp_path: Path,
     ) -> None:
         """A workspace_directory pointing outside the project's base dir is preserved.
@@ -11067,13 +11059,12 @@ class TestExportProject:
             LoadProjectTemplateRequest,
             LoadProjectTemplateResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.publishing.project_packager import (
             ADJACENT_CONFIG_FILENAME,
             WORKSPACE_DIRECTORY_KEY,
         )
 
-        pm = GriptapeNodes.ProjectManager()
+        pm = engine.project_manager
         base_dir = tmp_path / "proj"
         external_workspace = tmp_path / "shared_workspace"
         external_workspace.mkdir()
@@ -11094,7 +11085,7 @@ class TestExportProject:
     @pytest.mark.asyncio
     async def test_export_same_basename_copied_libraries_stay_distinct(
         self,
-        griptape_nodes: object,  # noqa: ARG002
+        engine: Engine,
         tmp_path: Path,
     ) -> None:
         """Two COPY_LOCAL libs whose containing dirs share a basename keep distinct paths.
@@ -11113,7 +11104,6 @@ class TestExportProject:
             LoadProjectTemplateRequest,
             LoadProjectTemplateResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.managers.settings import LIBRARIES_TO_REGISTER_KEY
         from griptape_nodes.retained_mode.publishing.project_packager import (
             ADJACENT_CONFIG_FILENAME,
@@ -11121,7 +11111,7 @@ class TestExportProject:
         )
         from griptape_nodes.utils.dict_utils import get_dot_value
 
-        pm = GriptapeNodes.ProjectManager()
+        pm = engine.project_manager
         # Two libraries in same-basename containing dirs under different parents.
         lib_dir_a = tmp_path / "a" / "shared_lib"
         lib_dir_b = tmp_path / "b" / "shared_lib"
@@ -11179,37 +11169,35 @@ class TestExportProject:
 class TestPreviewImportProject:
     """Test on_preview_import_project_request reads a manifest without extracting."""
 
-    def test_preview_missing_archive_fails(self, griptape_nodes: object, tmp_path: Path) -> None:  # noqa: ARG002
+    def test_preview_missing_archive_fails(self, engine: Engine, tmp_path: Path) -> None:
         """Previewing a non-existent archive returns a Failure."""
         from griptape_nodes.retained_mode.events.project_events import (
             PreviewImportProjectRequest,
             PreviewImportProjectResultFailure,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-        pm = GriptapeNodes.ProjectManager()
+        pm = engine.project_manager
         result = pm.on_preview_import_project_request(
             PreviewImportProjectRequest(archive_path=tmp_path / "missing.zip")
         )
         assert isinstance(result, PreviewImportProjectResultFailure)
 
-    def test_preview_non_zip_fails(self, griptape_nodes: object, tmp_path: Path) -> None:  # noqa: ARG002
+    def test_preview_non_zip_fails(self, engine: Engine, tmp_path: Path) -> None:
         """Previewing a file that is not a zip returns a Failure."""
         from griptape_nodes.retained_mode.events.project_events import (
             PreviewImportProjectRequest,
             PreviewImportProjectResultFailure,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         not_a_zip = tmp_path / "plain.zip"
         not_a_zip.write_text("this is not a zip archive", encoding="utf-8")
 
-        pm = GriptapeNodes.ProjectManager()
+        pm = engine.project_manager
         result = pm.on_preview_import_project_request(PreviewImportProjectRequest(archive_path=not_a_zip))
         assert isinstance(result, PreviewImportProjectResultFailure)
 
     @pytest.mark.asyncio
-    async def test_non_dict_manifest_fails_cleanly(self, griptape_nodes: object, tmp_path: Path) -> None:  # noqa: ARG002
+    async def test_non_dict_manifest_fails_cleanly(self, engine: Engine, tmp_path: Path) -> None:
         """A valid-JSON-but-non-dict manifest returns a clean Failure, not a traceback.
 
         A tampered package whose manifest.json parses to a list/number/string would
@@ -11226,14 +11214,13 @@ class TestPreviewImportProject:
             PreviewImportProjectRequest,
             PreviewImportProjectResultFailure,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.publishing.project_packager import MANIFEST_FILENAME
 
         bad_manifest_zip = tmp_path / "bad-manifest.zip"
         with zipfile.ZipFile(bad_manifest_zip, "w") as archive:
             archive.writestr(MANIFEST_FILENAME, "[]")
 
-        pm = GriptapeNodes.ProjectManager()
+        pm = engine.project_manager
 
         preview_result = pm.on_preview_import_project_request(
             PreviewImportProjectRequest(archive_path=bad_manifest_zip)
@@ -11248,7 +11235,7 @@ class TestPreviewImportProject:
     @pytest.mark.asyncio
     async def test_preview_valid_archive_returns_manifest_and_unset_secrets(
         self,
-        griptape_nodes: object,  # noqa: ARG002
+        engine: Engine,
         tmp_path: Path,
     ) -> None:
         """A valid package previews its manifest plus the unset required secret keys."""
@@ -11259,9 +11246,8 @@ class TestPreviewImportProject:
             PreviewImportProjectRequest,
             PreviewImportProjectResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-        pm = GriptapeNodes.ProjectManager()
+        pm = engine.project_manager
         project_yaml = _write_project_base_dir(tmp_path / "proj")
         load_result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=project_yaml))
         assert isinstance(load_result, LoadProjectTemplateResultSuccess)
@@ -11287,7 +11273,7 @@ class TestImportProject:
     """Test on_import_project_request extracts a package and registers the project."""
 
     @pytest.mark.asyncio
-    async def test_import_registers_new_project_with_assets(self, griptape_nodes: object, tmp_path: Path) -> None:  # noqa: ARG002
+    async def test_import_registers_new_project_with_assets(self, engine: Engine, tmp_path: Path) -> None:
         """Importing into a fresh dir registers the project and activates it; macros follow the active workspace."""
         from griptape_nodes.common.macro_parser import ParsedMacro
         from griptape_nodes.retained_mode.events.project_events import (
@@ -11299,9 +11285,8 @@ class TestImportProject:
             LoadProjectTemplateRequest,
             LoadProjectTemplateResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-        pm = GriptapeNodes.ProjectManager()
+        pm = engine.project_manager
         project_yaml = _write_project_base_dir(tmp_path / "proj")
         load_result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=project_yaml))
         assert isinstance(load_result, LoadProjectTemplateResultSuccess)
@@ -11340,7 +11325,7 @@ class TestImportProject:
         assert source_dir not in macro_result.absolute_path.resolve().parents
 
     @pytest.mark.asyncio
-    async def test_import_with_new_name_renames_template(self, griptape_nodes: object, tmp_path: Path) -> None:  # noqa: ARG002
+    async def test_import_with_new_name_renames_template(self, engine: Engine, tmp_path: Path) -> None:
         """A new_project_name renames the imported template (duplicate/branch)."""
         from griptape_nodes.retained_mode.events.project_events import (
             ExportProjectRequest,
@@ -11349,9 +11334,8 @@ class TestImportProject:
             LoadProjectTemplateRequest,
             LoadProjectTemplateResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-        pm = GriptapeNodes.ProjectManager()
+        pm = engine.project_manager
         project_yaml = _write_project_base_dir(tmp_path / "proj")
         load_result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=project_yaml))
         assert isinstance(load_result, LoadProjectTemplateResultSuccess)
@@ -11370,7 +11354,7 @@ class TestImportProject:
         assert imported_info.template.name == "Branch X"
 
     @pytest.mark.asyncio
-    async def test_import_two_targets_are_distinct_projects(self, griptape_nodes: object, tmp_path: Path) -> None:  # noqa: ARG002
+    async def test_import_two_targets_are_distinct_projects(self, engine: Engine, tmp_path: Path) -> None:
         """Importing the same package to two dirs yields two distinct registrations."""
         from griptape_nodes.retained_mode.events.project_events import (
             ExportProjectRequest,
@@ -11379,9 +11363,8 @@ class TestImportProject:
             LoadProjectTemplateRequest,
             LoadProjectTemplateResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-        pm = GriptapeNodes.ProjectManager()
+        pm = engine.project_manager
         project_yaml = _write_project_base_dir(tmp_path / "proj")
         load_result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=project_yaml))
         assert isinstance(load_result, LoadProjectTemplateResultSuccess)
@@ -11402,7 +11385,7 @@ class TestImportProject:
         assert first.project_id != second.project_id
 
     @pytest.mark.asyncio
-    async def test_import_same_dir_without_overwrite_fails(self, griptape_nodes: object, tmp_path: Path) -> None:  # noqa: ARG002
+    async def test_import_same_dir_without_overwrite_fails(self, engine: Engine, tmp_path: Path) -> None:
         """Re-importing into a dir that already has a project file fails unless overwrite."""
         from griptape_nodes.retained_mode.events.project_events import (
             ExportProjectRequest,
@@ -11412,9 +11395,8 @@ class TestImportProject:
             LoadProjectTemplateRequest,
             LoadProjectTemplateResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-        pm = GriptapeNodes.ProjectManager()
+        pm = engine.project_manager
         project_yaml = _write_project_base_dir(tmp_path / "proj")
         load_result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=project_yaml))
         assert isinstance(load_result, LoadProjectTemplateResultSuccess)
@@ -11437,7 +11419,7 @@ class TestImportProject:
     @pytest.mark.asyncio
     async def test_import_unset_secret_reported_no_value_written(
         self,
-        griptape_nodes: object,  # noqa: ARG002
+        engine: Engine,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -11455,13 +11437,12 @@ class TestImportProject:
             LoadProjectTemplateRequest,
             LoadProjectTemplateResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         synthetic_key = "GTN_PACKAGING_TEST_UNSET_SECRET"
         monkeypatch.delenv(synthetic_key, raising=False)
 
-        pm = GriptapeNodes.ProjectManager()
-        secrets_manager = GriptapeNodes.SecretsManager()
+        pm = engine.project_manager
+        secrets_manager = engine.secrets_manager
         monkeypatch.setattr(
             type(secrets_manager),
             "secrets_to_register",
@@ -11488,7 +11469,7 @@ class TestImportProject:
         assert secrets_manager.get_secret(synthetic_key, should_error_on_not_found=False) is None
 
     @pytest.mark.asyncio
-    async def test_round_trip_with_string_paths_from_wire(self, griptape_nodes: object, tmp_path: Path) -> None:  # noqa: ARG002
+    async def test_round_trip_with_string_paths_from_wire(self, engine: Engine, tmp_path: Path) -> None:
         """Path-typed request fields arriving as wire strings round-trip cleanly.
 
         project_events declares destination_path/archive_path/target_directory as
@@ -11514,9 +11495,8 @@ class TestImportProject:
             PreviewImportProjectRequest,
             PreviewImportProjectResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-        pm = GriptapeNodes.ProjectManager()
+        pm = engine.project_manager
         project_yaml = _write_project_base_dir(tmp_path / "proj")
         load_result = await pm.on_load_project_template_request(LoadProjectTemplateRequest(project_path=project_yaml))
         assert isinstance(load_result, LoadProjectTemplateResultSuccess)
@@ -11813,15 +11793,14 @@ class TestHypotheticalMacroResolution:
         )
         assert isinstance(result, AttemptMatchPathAgainstMacroResultFailure)
 
-    def test_stored_project_variable_fills_macro(self) -> None:
+    def test_stored_project_variable_fills_macro(self, engine: Engine) -> None:
         """A stored project variable participates in path resolution (below caller, above env)."""
         from griptape_nodes.common.macro_parser import ParsedMacro
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.variable_types import FlowVariable, VariableLayer
 
         pm = self._pm_with_two_projects()
         project_x = str(Path("/projects/x") / "project.yml")
-        variables_manager = GriptapeNodes.VariablesManager()
+        variables_manager = engine.variables_manager
         stored_layer = VariableLayer()
         stored_layer.set(FlowVariable(name="shot_code", owning_flow_name=None, type="str", value="sc042"))
         variables_manager.set_project_variables(project_x, stored_layer)
@@ -11834,15 +11813,14 @@ class TestHypotheticalMacroResolution:
         finally:
             variables_manager.remove_project_variables(project_x)
 
-    def test_caller_supplied_value_beats_stored_project_variable(self) -> None:
+    def test_caller_supplied_value_beats_stored_project_variable(self, engine: Engine) -> None:
         """Precedence: caller-supplied > stored project variable."""
         from griptape_nodes.common.macro_parser import ParsedMacro
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.variable_types import FlowVariable, VariableLayer
 
         pm = self._pm_with_two_projects()
         project_x = str(Path("/projects/x") / "project.yml")
-        variables_manager = GriptapeNodes.VariablesManager()
+        variables_manager = engine.variables_manager
         stored_layer = VariableLayer()
         stored_layer.set(FlowVariable(name="shot_code", owning_flow_name=None, type="str", value="sc042"))
         variables_manager.set_project_variables(project_x, stored_layer)
@@ -11916,15 +11894,14 @@ class TestHypotheticalMacroResolution:
         assert isinstance(result, AttemptMapAbsolutePathToProjectResultSuccess)
         assert result.mapped_path is None
 
-    def test_state_analysis_counts_stored_project_variable_satisfied(self) -> None:
+    def test_state_analysis_counts_stored_project_variable_satisfied(self, engine: Engine) -> None:
         """State analysis agrees with path resolution about stored project variables."""
         from griptape_nodes.common.macro_parser import ParsedMacro
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.variable_types import FlowVariable, VariableLayer
 
         pm = self._pm_with_two_projects()
         project_x = str(Path("/projects/x") / "project.yml")
-        variables_manager = GriptapeNodes.VariablesManager()
+        variables_manager = engine.variables_manager
         stored_layer = VariableLayer()
         stored_layer.set(FlowVariable(name="shot_code", owning_flow_name=None, type="str", value="sc042"))
         variables_manager.set_project_variables(project_x, stored_layer)
@@ -12022,21 +11999,19 @@ class TestWritableProjectVariables:
     FRAME_START = 1001
 
     @pytest.fixture(autouse=True)
-    def _flow_context(self) -> "Any":
+    def _flow_context(self, engine: Engine) -> Any:
         """Bootstrap a workflow + flow: variable requests resolve a starting flow before scope logic."""
         from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
         from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-        gn = GriptapeNodes()
-        gn.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
-        gn.ContextManager().push_workflow("p4_test_wf")
-        result = gn.handle_request(
+        engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        engine.context_manager.push_workflow("p4_test_wf")
+        result = engine.handle_request(
             CreateFlowRequest(parent_flow_name=None, flow_name="p4_test_flow", set_as_new_context=True)
         )
         assert isinstance(result, CreateFlowResultSuccess)
         yield
-        gn.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
 
     VARIABLES_YAML = """
 variables:
@@ -12051,27 +12026,25 @@ variables:
 """
 
     @staticmethod
-    def _write_and_load(tmp_path: Path, extra_yaml: str) -> str:
+    def _write_and_load(engine: Engine, tmp_path: Path, extra_yaml: str) -> str:
         """Write a minimal project.yml with the given extra section, load it, return project_id."""
         from griptape_nodes.retained_mode.events.project_events import (
             LoadProjectTemplateRequest,
             LoadProjectTemplateResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         project_yml = tmp_path / "project_template.yml"
         base_yaml = DEFAULT_PROJECT_TEMPLATE.to_overlay_yaml(DEFAULT_PROJECT_TEMPLATE)
         project_yml.write_text(base_yaml + extra_yaml)
-        load_result = GriptapeNodes.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
+        load_result = engine.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
         assert isinstance(load_result, LoadProjectTemplateResultSuccess)
         return load_result.project_id
 
     @staticmethod
-    def _unload(project_id: str) -> None:
+    def _unload(engine: Engine, project_id: str) -> None:
         from griptape_nodes.retained_mode.events.project_events import UnregisterProjectTemplateRequest
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-        GriptapeNodes.handle_request(UnregisterProjectTemplateRequest(project_id=project_id))
+        engine.handle_request(UnregisterProjectTemplateRequest(project_id=project_id))
 
     def test_schema_parses_value_type_permission(self) -> None:
         from griptape_nodes.common.project_templates import ProjectVariableDef
@@ -12100,13 +12073,12 @@ variables:
         with pytest.raises(ValidationError, match="declares type 'int'"):
             ProjectVariableDef(name="shot", value="sc042", type="int")
 
-    def test_load_installs_stored_layer(self, tmp_path: Path) -> None:
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+    def test_load_installs_stored_layer(self, engine: Engine, tmp_path: Path) -> None:
         from griptape_nodes.retained_mode.variable_types import VariablePermission
 
-        project_id = self._write_and_load(tmp_path, self.VARIABLES_YAML)
+        project_id = self._write_and_load(engine, tmp_path, self.VARIABLES_YAML)
         try:
-            variables_manager = GriptapeNodes.VariablesManager()
+            variables_manager = engine.variables_manager
             values = variables_manager.stored_project_variable_values(project_id)
             assert values == {"shot_code": "sc042", "frame_start": self.FRAME_START, "facility": "mtl"}
             stored = {v.name: v for v in variables_manager.stored_project_variables(project_id)}
@@ -12114,37 +12086,35 @@ variables:
             assert stored["facility"].permission is VariablePermission.READ_ONLY
             assert stored["shot_code"].permission is VariablePermission.READ_WRITE
         finally:
-            self._unload(project_id)
+            self._unload(engine, project_id)
 
-    def test_unload_removes_stored_layer(self, tmp_path: Path) -> None:
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+    def test_unload_removes_stored_layer(self, engine: Engine, tmp_path: Path) -> None:
 
-        project_id = self._write_and_load(tmp_path, self.VARIABLES_YAML)
-        self._unload(project_id)
-        assert GriptapeNodes.VariablesManager().stored_project_variable_values(project_id) == {}
+        project_id = self._write_and_load(engine, tmp_path, self.VARIABLES_YAML)
+        self._unload(engine, project_id)
+        assert engine.variables_manager.stored_project_variable_values(project_id) == {}
 
-    def test_collision_with_computed_name_warns_and_is_shadowed(self, tmp_path: Path) -> None:
+    def test_collision_with_computed_name_warns_and_is_shadowed(self, engine: Engine, tmp_path: Path) -> None:
         """A variable named like a builtin loads with a warning; resolution returns the builtin."""
         from griptape_nodes.retained_mode.events.project_events import (
             LoadProjectTemplateRequest,
             LoadProjectTemplateResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         project_yml = tmp_path / "project_template.yml"
         base_yaml = DEFAULT_PROJECT_TEMPLATE.to_overlay_yaml(DEFAULT_PROJECT_TEMPLATE)
         project_yml.write_text(base_yaml + "\nvariables:\n  workspace_dir:\n    value: /hijack\n")
-        load_result = GriptapeNodes.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
+        load_result = engine.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
         assert isinstance(load_result, LoadProjectTemplateResultSuccess)
         try:
             warnings = [p for p in load_result.validation.problems if "workspace_dir" in p.message]
             assert warnings, "expected a collision warning for workspace_dir"
             # Resolution: computed wins — the stored /hijack value is unreachable.
-            pm = GriptapeNodes.ProjectManager()
+            pm = engine.project_manager
             resolved = pm.resolve_project_variable("workspace_dir", project_id=load_result.project_id)
             assert resolved.value != "/hijack"
         finally:
-            self._unload(load_result.project_id)
+            self._unload(engine, load_result.project_id)
 
     def test_parent_child_merge_overlay_and_tombstone(self) -> None:
         """Child overlay: replaces one entry, tombstones another, inherits the rest."""
@@ -12211,18 +12181,17 @@ variables:
         assert "flag" not in merged.variables
         assert any("flag" in p.field_path for p in validation.problems)
 
-    def test_set_value_writes_through_and_persists(self, tmp_path: Path) -> None:
+    def test_set_value_writes_through_and_persists(self, engine: Engine, tmp_path: Path) -> None:
         """SetVariableValue on a READ_WRITE project variable mutates the layer AND the file."""
         from griptape_nodes.retained_mode.events.variable_events import (
             SetVariableValueRequest,
             SetVariableValueResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.variable_types import VariableScope
 
-        project_id = self._write_and_load(tmp_path, self.VARIABLES_YAML)
+        project_id = self._write_and_load(engine, tmp_path, self.VARIABLES_YAML)
         try:
-            result = GriptapeNodes.handle_request(
+            result = engine.handle_request(
                 SetVariableValueRequest(
                     name="shot_code",
                     value="sc777",
@@ -12232,24 +12201,23 @@ variables:
             )
             assert isinstance(result, SetVariableValueResultSuccess)
             # Layer updated:
-            values = GriptapeNodes.VariablesManager().stored_project_variable_values(project_id)
+            values = engine.variables_manager.stored_project_variable_values(project_id)
             assert values["shot_code"] == "sc777"
             # File updated (eager persistence):
             assert "sc777" in (tmp_path / "project_template.yml").read_text()
         finally:
-            self._unload(project_id)
+            self._unload(engine, project_id)
 
-    def test_read_only_project_variable_refuses_write(self, tmp_path: Path) -> None:
+    def test_read_only_project_variable_refuses_write(self, engine: Engine, tmp_path: Path) -> None:
         from griptape_nodes.retained_mode.events.variable_events import (
             SetVariableValueRequest,
             SetVariableValueResultFailure,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.variable_types import VariableScope
 
-        project_id = self._write_and_load(tmp_path, self.VARIABLES_YAML)
+        project_id = self._write_and_load(engine, tmp_path, self.VARIABLES_YAML)
         try:
-            result = GriptapeNodes.handle_request(
+            result = engine.handle_request(
                 SetVariableValueRequest(
                     name="facility",
                     value="nyc",
@@ -12260,84 +12228,78 @@ variables:
             assert isinstance(result, SetVariableValueResultFailure)
             assert "read-only" in str(result.result_details)
             # Unchanged in the layer:
-            values = GriptapeNodes.VariablesManager().stored_project_variable_values(project_id)
+            values = engine.variables_manager.stored_project_variable_values(project_id)
             assert values["facility"] == "mtl"
         finally:
-            self._unload(project_id)
+            self._unload(engine, project_id)
 
-    def test_persisted_write_survives_reload(self, tmp_path: Path) -> None:
+    def test_persisted_write_survives_reload(self, engine: Engine, tmp_path: Path) -> None:
         """Write → unload → reload from disk: the new value comes back."""
         from griptape_nodes.retained_mode.events.variable_events import (
             SetVariableValueRequest,
             SetVariableValueResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.variable_types import VariableScope
 
-        project_id = self._write_and_load(tmp_path, self.VARIABLES_YAML)
-        result = GriptapeNodes.handle_request(
+        project_id = self._write_and_load(engine, tmp_path, self.VARIABLES_YAML)
+        result = engine.handle_request(
             SetVariableValueRequest(
                 name="shot_code", value="sc777", lookup_scope=VariableScope.PROJECT_ONLY, project_id=project_id
             )
         )
         assert isinstance(result, SetVariableValueResultSuccess)
-        self._unload(project_id)
+        self._unload(engine, project_id)
 
-        reloaded_id = self._write_and_load_existing(tmp_path)
+        reloaded_id = self._write_and_load_existing(engine, tmp_path)
         try:
-            values = GriptapeNodes.VariablesManager().stored_project_variable_values(reloaded_id)
+            values = engine.variables_manager.stored_project_variable_values(reloaded_id)
             assert values["shot_code"] == "sc777"
             # Untouched entries also survive the persist→reload round-trip.
             assert values["frame_start"] == self.FRAME_START
         finally:
-            self._unload(reloaded_id)
+            self._unload(engine, reloaded_id)
 
     @staticmethod
-    def _write_and_load_existing(tmp_path: Path) -> str:
+    def _write_and_load_existing(engine: Engine, tmp_path: Path) -> str:
         """Load the already-written project.yml (no rewrite)."""
         from griptape_nodes.retained_mode.events.project_events import (
             LoadProjectTemplateRequest,
             LoadProjectTemplateResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
-        load_result = GriptapeNodes.handle_request(
-            LoadProjectTemplateRequest(project_path=tmp_path / "project_template.yml")
-        )
+        load_result = engine.handle_request(LoadProjectTemplateRequest(project_path=tmp_path / "project_template.yml"))
         assert isinstance(load_result, LoadProjectTemplateResultSuccess)
         return load_result.project_id
 
-    def test_delete_project_variable_writes_through_and_persists(self, tmp_path: Path) -> None:
+    def test_delete_project_variable_writes_through_and_persists(self, engine: Engine, tmp_path: Path) -> None:
         from griptape_nodes.retained_mode.events.variable_events import (
             DeleteVariableRequest,
             DeleteVariableResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.variable_types import VariableScope
 
-        project_id = self._write_and_load(tmp_path, self.VARIABLES_YAML)
+        project_id = self._write_and_load(engine, tmp_path, self.VARIABLES_YAML)
         try:
-            result = GriptapeNodes.handle_request(
+            result = engine.handle_request(
                 DeleteVariableRequest(name="shot_code", lookup_scope=VariableScope.PROJECT_ONLY, project_id=project_id)
             )
             assert isinstance(result, DeleteVariableResultSuccess)
-            values = GriptapeNodes.VariablesManager().stored_project_variable_values(project_id)
+            values = engine.variables_manager.stored_project_variable_values(project_id)
             assert "shot_code" not in values
             assert "shot_code" not in (tmp_path / "project_template.yml").read_text()
         finally:
-            self._unload(project_id)
+            self._unload(engine, project_id)
 
-    def test_rename_project_variable_writes_through_and_persists(self, tmp_path: Path) -> None:
+    def test_rename_project_variable_writes_through_and_persists(self, engine: Engine, tmp_path: Path) -> None:
         from griptape_nodes.retained_mode.events.variable_events import (
             RenameVariableRequest,
             RenameVariableResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.variable_types import VariableScope
 
-        project_id = self._write_and_load(tmp_path, self.VARIABLES_YAML)
+        project_id = self._write_and_load(engine, tmp_path, self.VARIABLES_YAML)
         try:
-            result = GriptapeNodes.handle_request(
+            result = engine.handle_request(
                 RenameVariableRequest(
                     name="shot_code",
                     new_name="shot_id",
@@ -12346,14 +12308,14 @@ variables:
                 )
             )
             assert isinstance(result, RenameVariableResultSuccess)
-            values = GriptapeNodes.VariablesManager().stored_project_variable_values(project_id)
+            values = engine.variables_manager.stored_project_variable_values(project_id)
             assert "shot_code" not in values
             assert values["shot_id"] == "sc042"
             assert "shot_id" in (tmp_path / "project_template.yml").read_text()
         finally:
-            self._unload(project_id)
+            self._unload(engine, project_id)
 
-    def test_type_mismatched_value_write_refused_cleanly(self, tmp_path: Path) -> None:
+    def test_type_mismatched_value_write_refused_cleanly(self, engine: Engine, tmp_path: Path) -> None:
         """Writing a str to an int-typed project variable fails cleanly — no crash, no mutation, no file change.
 
         The write boundary gates value-vs-declared-type agreement BEFORE mutating, because
@@ -12364,13 +12326,12 @@ variables:
             SetVariableValueRequest,
             SetVariableValueResultFailure,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.variable_types import VariableScope
 
-        project_id = self._write_and_load(tmp_path, self.VARIABLES_YAML)
+        project_id = self._write_and_load(engine, tmp_path, self.VARIABLES_YAML)
         try:
             file_before = (tmp_path / "project_template.yml").read_text()
-            result = GriptapeNodes.handle_request(
+            result = engine.handle_request(
                 SetVariableValueRequest(
                     name="frame_start",
                     value="not_a_number",
@@ -12381,24 +12342,23 @@ variables:
             assert isinstance(result, SetVariableValueResultFailure)
             assert "'int'" in str(result.result_details)
             # Layer and file both untouched.
-            values = GriptapeNodes.VariablesManager().stored_project_variable_values(project_id)
+            values = engine.variables_manager.stored_project_variable_values(project_id)
             assert values["frame_start"] == self.FRAME_START
             assert (tmp_path / "project_template.yml").read_text() == file_before
         finally:
-            self._unload(project_id)
+            self._unload(engine, project_id)
 
-    def test_unsupported_type_write_refused_cleanly(self, tmp_path: Path) -> None:
+    def test_unsupported_type_write_refused_cleanly(self, engine: Engine, tmp_path: Path) -> None:
         """Setting a project variable's type to something outside str/int fails cleanly."""
         from griptape_nodes.retained_mode.events.variable_events import (
             SetVariableTypeRequest,
             SetVariableTypeResultFailure,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.variable_types import VariableScope
 
-        project_id = self._write_and_load(tmp_path, self.VARIABLES_YAML)
+        project_id = self._write_and_load(engine, tmp_path, self.VARIABLES_YAML)
         try:
-            result = GriptapeNodes.handle_request(
+            result = engine.handle_request(
                 SetVariableTypeRequest(
                     name="shot_code",
                     type="JSON",
@@ -12408,23 +12368,22 @@ variables:
             )
             assert isinstance(result, SetVariableTypeResultFailure)
             assert "only support" in str(result.result_details)
-            stored = {v.name: v for v in GriptapeNodes.VariablesManager().stored_project_variables(project_id)}
+            stored = {v.name: v for v in engine.variables_manager.stored_project_variables(project_id)}
             assert stored["shot_code"].type == "str"
         finally:
-            self._unload(project_id)
+            self._unload(engine, project_id)
 
-    def test_type_change_disagreeing_with_value_refused_cleanly(self, tmp_path: Path) -> None:
+    def test_type_change_disagreeing_with_value_refused_cleanly(self, engine: Engine, tmp_path: Path) -> None:
         """Re-typing shot_code (value 'sc042') to int fails: the stored value wouldn't agree."""
         from griptape_nodes.retained_mode.events.variable_events import (
             SetVariableTypeRequest,
             SetVariableTypeResultFailure,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.variable_types import VariableScope
 
-        project_id = self._write_and_load(tmp_path, self.VARIABLES_YAML)
+        project_id = self._write_and_load(engine, tmp_path, self.VARIABLES_YAML)
         try:
-            result = GriptapeNodes.handle_request(
+            result = engine.handle_request(
                 SetVariableTypeRequest(
                     name="shot_code",
                     type="int",
@@ -12434,9 +12393,9 @@ variables:
             )
             assert isinstance(result, SetVariableTypeResultFailure)
         finally:
-            self._unload(project_id)
+            self._unload(engine, project_id)
 
-    def test_deprecated_batch_set_refuses_project_variable(self, tmp_path: Path) -> None:
+    def test_deprecated_batch_set_refuses_project_variable(self, engine: Engine, tmp_path: Path) -> None:
         """The frozen SetVariables shim refuses even a READ_WRITE project variable.
 
         Deliberate divergence from SetVariableValueRequest (which writes through): the
@@ -12447,12 +12406,11 @@ variables:
             SetVariablesRequest,
             SetVariablesResultFailure,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.variable_types import VariableScope
 
-        project_id = self._write_and_load(tmp_path, self.VARIABLES_YAML)
+        project_id = self._write_and_load(engine, tmp_path, self.VARIABLES_YAML)
         try:
-            result = GriptapeNodes.handle_request(
+            result = engine.handle_request(
                 SetVariablesRequest(
                     variables={"shot_code": "sc777"},
                     lookup_scope=VariableScope.PROJECT_ONLY,
@@ -12462,23 +12420,22 @@ variables:
             assert isinstance(result, SetVariablesResultFailure)
             assert "SetVariableValueRequest" in str(result.result_details)
             # Untouched in the layer:
-            values = GriptapeNodes.VariablesManager().stored_project_variable_values(project_id)
+            values = engine.variables_manager.stored_project_variable_values(project_id)
             assert values["shot_code"] == "sc042"
         finally:
-            self._unload(project_id)
+            self._unload(engine, project_id)
 
-    def test_rename_project_variable_to_existing_stored_name_refused(self, tmp_path: Path) -> None:
+    def test_rename_project_variable_to_existing_stored_name_refused(self, engine: Engine, tmp_path: Path) -> None:
         """Renaming one stored project variable onto another is a same-layer collision."""
         from griptape_nodes.retained_mode.events.variable_events import (
             RenameVariableRequest,
             RenameVariableResultFailure,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.variable_types import VariableScope
 
-        project_id = self._write_and_load(tmp_path, self.VARIABLES_YAML)
+        project_id = self._write_and_load(engine, tmp_path, self.VARIABLES_YAML)
         try:
-            result = GriptapeNodes.handle_request(
+            result = engine.handle_request(
                 RenameVariableRequest(
                     name="shot_code",
                     new_name="frame_start",
@@ -12488,12 +12445,14 @@ variables:
             )
             assert isinstance(result, RenameVariableResultFailure)
             assert "already exists" in str(result.result_details)
-            values = GriptapeNodes.VariablesManager().stored_project_variable_values(project_id)
+            values = engine.variables_manager.stored_project_variable_values(project_id)
             assert values["shot_code"] == "sc042"
         finally:
-            self._unload(project_id)
+            self._unload(engine, project_id)
 
-    def test_rename_project_variable_to_own_projects_reserved_name_refused(self, tmp_path: Path) -> None:
+    def test_rename_project_variable_to_own_projects_reserved_name_refused(
+        self, engine: Engine, tmp_path: Path
+    ) -> None:
         """The reserved gate uses the variable's OWN project, not the current one.
 
         The loaded project declares a `dailies` directory — a computed (reserved) name in
@@ -12505,21 +12464,20 @@ variables:
             RenameVariableRequest,
             RenameVariableResultFailure,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.variable_types import VariableScope
 
         extra_yaml = (
             self.VARIABLES_YAML
             + '\ndirectories:\n  dailies:\n    path_macro: "{workspace_dir}/dailies"\n    description: "Dailies"\n'
         )
-        project_id = self._write_and_load(tmp_path, extra_yaml)
+        project_id = self._write_and_load(engine, tmp_path, extra_yaml)
         try:
             # Sanity: the discriminator is real — reserved in the loaded project, not in the current one.
-            pm = GriptapeNodes.ProjectManager()
+            pm = engine.project_manager
             assert "dailies" in pm.project_computed_names(project_id=project_id)
             assert "dailies" not in pm.project_computed_names(project_id=None)
 
-            result = GriptapeNodes.handle_request(
+            result = engine.handle_request(
                 RenameVariableRequest(
                     name="shot_code",
                     new_name="dailies",
@@ -12530,9 +12488,9 @@ variables:
             assert isinstance(result, RenameVariableResultFailure)
             assert "reserved" in str(result.result_details)
         finally:
-            self._unload(project_id)
+            self._unload(engine, project_id)
 
-    def test_delete_inherited_variable_tombstones_and_survives_reload(self, tmp_path: Path) -> None:
+    def test_delete_inherited_variable_tombstones_and_survives_reload(self, engine: Engine, tmp_path: Path) -> None:
         """Deleting a PARENT-inherited variable emits a null tombstone that survives reload.
 
         Child-declared deletions just omit the entry; inherited deletions must write
@@ -12546,7 +12504,6 @@ variables:
             DeleteVariableRequest,
             DeleteVariableResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.variable_types import VariableScope
 
         # Parent declares the variable; child inherits it.
@@ -12555,23 +12512,23 @@ variables:
             DEFAULT_PROJECT_TEMPLATE.to_overlay_yaml(DEFAULT_PROJECT_TEMPLATE)
             + "\nvariables:\n  studio_code:\n    value: mtl\n"
         )
-        parent_load = GriptapeNodes.handle_request(LoadProjectTemplateRequest(project_path=parent_yml))
+        parent_load = engine.handle_request(LoadProjectTemplateRequest(project_path=parent_yml))
         assert isinstance(parent_load, LoadProjectTemplateResultSuccess)
 
         child_yml = tmp_path / "child.yml"
         child_yml.write_text(
             DEFAULT_PROJECT_TEMPLATE.to_overlay_yaml(DEFAULT_PROJECT_TEMPLATE) + "\nparent_project_path: ./parent.yml\n"
         )
-        child_load = GriptapeNodes.handle_request(LoadProjectTemplateRequest(project_path=child_yml))
+        child_load = engine.handle_request(LoadProjectTemplateRequest(project_path=child_yml))
         assert isinstance(child_load, LoadProjectTemplateResultSuccess)
         child_id = child_load.project_id
 
         try:
             # Inherited into the child's stored layer:
-            values = GriptapeNodes.VariablesManager().stored_project_variable_values(child_id)
+            values = engine.variables_manager.stored_project_variable_values(child_id)
             assert values.get("studio_code") == "mtl"
 
-            result = GriptapeNodes.handle_request(
+            result = engine.handle_request(
                 DeleteVariableRequest(name="studio_code", lookup_scope=VariableScope.PROJECT_ONLY, project_id=child_id)
             )
             assert isinstance(result, DeleteVariableResultSuccess)
@@ -12579,22 +12536,21 @@ variables:
             assert '"studio_code": null' in child_yml.read_text()
 
             # Reload from disk: the parent value must NOT resurrect.
-            self._unload(child_id)
-            reload_result = GriptapeNodes.handle_request(LoadProjectTemplateRequest(project_path=child_yml))
+            self._unload(engine, child_id)
+            reload_result = engine.handle_request(LoadProjectTemplateRequest(project_path=child_yml))
             assert isinstance(reload_result, LoadProjectTemplateResultSuccess)
             child_id = reload_result.project_id
-            values_after = GriptapeNodes.VariablesManager().stored_project_variable_values(child_id)
+            values_after = engine.variables_manager.stored_project_variable_values(child_id)
             assert "studio_code" not in values_after
         finally:
-            self._unload(child_id)
-            self._unload(parent_load.project_id)
+            self._unload(engine, child_id)
+            self._unload(engine, parent_load.project_id)
 
-    def test_persist_with_no_backing_file_returns_error(self) -> None:
+    def test_persist_with_no_backing_file_returns_error(self, engine: Engine) -> None:
         """A project with no file path (e.g. system defaults) reports it can't persist."""
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY
 
-        pm = GriptapeNodes.ProjectManager()
+        pm = engine.project_manager
         error = pm.persist_project_variables(SYSTEM_DEFAULTS_KEY)
         assert error is not None
         assert "no backing file" in error
@@ -12605,7 +12561,7 @@ variables:
         assert "not loaded" in error
 
     def test_persist_failure_logs_warning_but_write_succeeds(
-        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+        self, engine: Engine, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
         """The eager-persist contract: a disk failure logs a warning; the acknowledged in-memory write stands."""
         from griptape_nodes.files.file import FileWriteError
@@ -12614,19 +12570,18 @@ variables:
             SetVariableValueRequest,
             SetVariableValueResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.variable_types import VariableScope
 
-        project_id = self._write_and_load(tmp_path, self.VARIABLES_YAML)
+        project_id = self._write_and_load(engine, tmp_path, self.VARIABLES_YAML)
         try:
             with (
                 patch(
                     "griptape_nodes.retained_mode.managers.project_manager.File.write_text",
                     side_effect=FileWriteError(FileIOFailureReason.DISK_FULL, "disk full"),
                 ),
-                caplog.at_level(logging.WARNING, logger="griptape_nodes"),
+                caplog.at_level(logging.WARNING, logger="engine"),
             ):
-                result = GriptapeNodes.handle_request(
+                result = engine.handle_request(
                     SetVariableValueRequest(
                         name="shot_code",
                         value="sc999",
@@ -12636,31 +12591,30 @@ variables:
                 )
             # The in-memory write is acknowledged despite the persist failure...
             assert isinstance(result, SetVariableValueResultSuccess)
-            values = GriptapeNodes.VariablesManager().stored_project_variable_values(project_id)
+            values = engine.variables_manager.stored_project_variable_values(project_id)
             assert values["shot_code"] == "sc999"
             # ...and the failure is surfaced in the log, naming the project.
             assert any("not persisted" in record.message for record in caplog.records)
             # The file kept its pre-write content.
             assert "sc999" not in (tmp_path / "project_template.yml").read_text()
         finally:
-            self._unload(project_id)
+            self._unload(engine, project_id)
 
-    def test_hypothetical_read_of_stored_variable(self, tmp_path: Path) -> None:
+    def test_hypothetical_read_of_stored_variable(self, engine: Engine, tmp_path: Path) -> None:
         """A loaded-but-not-current project's stored variables are readable via project_id."""
         from griptape_nodes.retained_mode.events.variable_events import (
             GetVariableRequest,
             GetVariableResultSuccess,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
         from griptape_nodes.retained_mode.variable_types import VariableScope
 
-        project_id = self._write_and_load(tmp_path, self.VARIABLES_YAML)
+        project_id = self._write_and_load(engine, tmp_path, self.VARIABLES_YAML)
         try:
             # Current project stays whatever it was — read the OTHER project by id.
-            result = GriptapeNodes.handle_request(
+            result = engine.handle_request(
                 GetVariableRequest(name="shot_code", lookup_scope=VariableScope.PROJECT_ONLY, project_id=project_id)
             )
             assert isinstance(result, GetVariableResultSuccess)
             assert result.variable.value == "sc042"
         finally:
-            self._unload(project_id)
+            self._unload(engine, project_id)

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -864,7 +864,7 @@ class TestProjectManagerBuiltinVariables:
         parsed_macro = ParsedMacro("{workflow_dir?:/}outputs/image.png")
         request = GetPathForMacroRequest(parsed_macro=parsed_macro, variables={})
 
-        with caplog.at_level(logging.WARNING, logger="engine"):
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
             result = project_manager_with_template.on_get_path_for_macro_request(request)
 
         assert isinstance(result, GetPathForMacroResultSuccess)
@@ -2472,7 +2472,7 @@ situations:
 
         with (
             patch("griptape_nodes.retained_mode.managers.project_manager.File") as mock_file_cls,
-            caplog.at_level(logging.ERROR, logger="engine"),
+            caplog.at_level(logging.ERROR, logger="griptape_nodes"),
         ):
             mock_file_instance = Mock()
             mock_file_instance.aread_text = AsyncMock(return_value="not: valid: yaml: : :\n  - broken")
@@ -6087,7 +6087,7 @@ situations:
 
         with (
             patch.object(pm, "_load_and_cache_project_template", new=AsyncMock()) as mock_load,
-            caplog.at_level(logging.WARNING, logger="engine"),
+            caplog.at_level(logging.WARNING, logger="griptape_nodes"),
         ):
             await pm._load_registered_projects()
             mock_load.assert_not_called()
@@ -6113,7 +6113,7 @@ situations:
 
         with (
             patch.object(pm, "on_load_project_template_request", new=AsyncMock(return_value=failure)),
-            caplog.at_level(logging.WARNING, logger="engine"),
+            caplog.at_level(logging.WARNING, logger="griptape_nodes"),
         ):
             await pm._load_registered_projects()
 
@@ -8458,7 +8458,7 @@ class TestValidateProjectTemplateParentChain:
             "directories": {},
         }
 
-        with caplog.at_level(logging.WARNING, logger="engine"):
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
             result = pm.on_validate_project_template_request(
                 ValidateProjectTemplateRequest(template_data=template_data)
             )
@@ -8610,7 +8610,7 @@ situations:
 
         with (
             patch.object(pm, "on_load_project_template_request", new=AsyncMock()) as mock_load,
-            caplog.at_level(logging.WARNING, logger="engine"),
+            caplog.at_level(logging.WARNING, logger="griptape_nodes"),
         ):
             await pm._load_registered_projects()
             mock_load.assert_not_called()
@@ -8636,7 +8636,7 @@ situations:
 
         with (
             patch.object(pm, "on_load_project_template_request", new=AsyncMock()) as mock_load,
-            caplog.at_level(logging.WARNING, logger="engine"),
+            caplog.at_level(logging.WARNING, logger="griptape_nodes"),
         ):
             await pm._load_registered_projects()
             mock_load.assert_not_called()
@@ -12579,7 +12579,7 @@ variables:
                     "griptape_nodes.retained_mode.managers.project_manager.File.write_text",
                     side_effect=FileWriteError(FileIOFailureReason.DISK_FULL, "disk full"),
                 ),
-                caplog.at_level(logging.WARNING, logger="engine"),
+                caplog.at_level(logging.WARNING, logger="griptape_nodes"),
             ):
                 result = engine.handle_request(
                     SetVariableValueRequest(

--- a/tests/unit/retained_mode/managers/test_variable_manager.py
+++ b/tests/unit/retained_mode/managers/test_variable_manager.py
@@ -639,7 +639,7 @@ class TestReservedNames:
         come back (e.g. duplicate name in the same flow).
         """
         _add_variable(engine, "dup_var", "first")
-        with caplog.at_level(logging.WARNING, logger="engine"):
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
             result = engine.handle_request(
                 CreateVariableRequest(
                     name="dup_var", type="str", value="second", owning_flow=flow_name, initial_setup=True

--- a/tests/unit/retained_mode/managers/test_variable_manager.py
+++ b/tests/unit/retained_mode/managers/test_variable_manager.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
+from griptape_nodes.retained_mode.engine import Engine
 from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
 from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
 from griptape_nodes.retained_mode.events.variable_events import (
@@ -46,7 +47,6 @@ from griptape_nodes.retained_mode.events.variable_events import (
     SetVariableValueRequest,
     SetVariableValueResultFailure,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.variable_types import (
     FlowVariable,
     VariableLayer,
@@ -99,58 +99,58 @@ def project_macros(macros: dict[str, Any]) -> Iterator[None]:
 
 
 @pytest.fixture
-def flow_name(griptape_nodes: GriptapeNodes) -> str:
+def flow_name(engine: Engine) -> str:
     """Bootstrap a clean workflow + flow and return the flow name."""
-    griptape_nodes.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
-    griptape_nodes.ContextManager().push_workflow("test_wf")
-    result = griptape_nodes.handle_request(
+    engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    engine.context_manager.push_workflow("test_wf")
+    result = engine.handle_request(
         CreateFlowRequest(parent_flow_name=None, flow_name="test_flow", set_as_new_context=True)
     )
     assert isinstance(result, CreateFlowResultSuccess)
     return "test_flow"
 
 
-def _add_variable(griptape_nodes: GriptapeNodes, name: str, value: object, type_: str = "str") -> None:
-    result = griptape_nodes.handle_request(CreateVariableRequest(name=name, type=type_, value=value))
+def _add_variable(engine: Engine, name: str, value: object, type_: str = "str") -> None:
+    result = engine.handle_request(CreateVariableRequest(name=name, type=type_, value=value))
     assert isinstance(result, CreateVariableResultSuccess)
 
 
 class TestListSubstitutablesRequest:
-    def test_returns_user_vars_and_macros(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
-        _add_variable(griptape_nodes, "SHOT", "sc001")
+    def test_returns_user_vars_and_macros(self, engine: Engine, flow_name: str) -> None:
+        _add_variable(engine, "SHOT", "sc001")
         with project_macros({"workspace_dir": "/workspace"}):
-            result = griptape_nodes.handle_request(ListSubstitutablesRequest(starting_flow=flow_name))
+            result = engine.handle_request(ListSubstitutablesRequest(starting_flow=flow_name))
         assert isinstance(result, ListSubstitutablesResultSuccess)
         assert {s.name for s in result.substitutables} == {"SHOT", "workspace_dir"}
 
-    def test_macro_has_correct_metadata(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_macro_has_correct_metadata(self, engine: Engine, flow_name: str) -> None:
         with project_macros({"workspace_dir": "/workspace"}):
-            result = griptape_nodes.handle_request(ListSubstitutablesRequest(starting_flow=flow_name))
+            result = engine.handle_request(ListSubstitutablesRequest(starting_flow=flow_name))
         assert isinstance(result, ListSubstitutablesResultSuccess)
         macro = next(s for s in result.substitutables if s.name == "workspace_dir")
         assert macro.source == "macro"
         assert macro.read_only is True
         assert macro.value == "/workspace"
 
-    def test_user_var_has_correct_metadata(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
-        _add_variable(griptape_nodes, "SHOT", "sc001")
+    def test_user_var_has_correct_metadata(self, engine: Engine, flow_name: str) -> None:
+        _add_variable(engine, "SHOT", "sc001")
         with project_macros({}):
-            result = griptape_nodes.handle_request(ListSubstitutablesRequest(starting_flow=flow_name))
+            result = engine.handle_request(ListSubstitutablesRequest(starting_flow=flow_name))
         assert isinstance(result, ListSubstitutablesResultSuccess)
         var = next(s for s in result.substitutables if s.name == "SHOT")
         assert var.source == "variable"
         assert var.read_only is False
         assert var.value == "sc001"
 
-    def test_flow_var_shadows_macro_on_name_collision(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_flow_var_shadows_macro_on_name_collision(self, engine: Engine, flow_name: str) -> None:
         """Precedence FLOW > PROJECT: a flow-scoped user var shadows a project macro of the same name.
 
         Uses a non-reserved project name (a builtin/directory name can't be taken by a
         flow var — see TestReservedNames), so the shadow is one the API actually permits.
         """
-        _add_variable(griptape_nodes, "custom_var", "/my/override")
+        _add_variable(engine, "custom_var", "/my/override")
         with project_macros({"custom_var": "/project"}):
-            result = griptape_nodes.handle_request(ListSubstitutablesRequest(starting_flow=flow_name))
+            result = engine.handle_request(ListSubstitutablesRequest(starting_flow=flow_name))
         assert isinstance(result, ListSubstitutablesResultSuccess)
         entries = [s for s in result.substitutables if s.name == "custom_var"]
         assert len(entries) == 1
@@ -158,18 +158,18 @@ class TestListSubstitutablesRequest:
         assert entries[0].read_only is False
         assert entries[0].value == "/my/override"
 
-    def test_macro_shadows_global_on_name_collision(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_macro_shadows_global_on_name_collision(self, engine: Engine, flow_name: str) -> None:
         """Precedence PROJECT > GLOBAL: a project macro shadows a global user var of the same name.
 
         Uses a non-reserved name — reserved names (real builtins like workspace_dir) can't be
         taken by a global at all (see TestReservedNames), so the collision must be staged with
         a name only the patched project layer claims.
         """
-        griptape_nodes.handle_request(
+        engine.handle_request(
             CreateVariableRequest(name="custom_var", type="str", value="/my/override", is_global=True)
         )
         with project_macros({"custom_var": "/workspace"}):
-            result = griptape_nodes.handle_request(ListSubstitutablesRequest(starting_flow=flow_name))
+            result = engine.handle_request(ListSubstitutablesRequest(starting_flow=flow_name))
         assert isinstance(result, ListSubstitutablesResultSuccess)
         entries = [s for s in result.substitutables if s.name == "custom_var"]
         assert len(entries) == 1
@@ -177,66 +177,62 @@ class TestListSubstitutablesRequest:
         assert entries[0].read_only is True
         assert entries[0].value == "/workspace"
 
-    def test_filters_out_non_substitutable_user_vars(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_filters_out_non_substitutable_user_vars(self, engine: Engine, flow_name: str) -> None:
         """User vars with non-str/int values are excluded, matching ResolveSubstitutionRequest behavior."""
-        _add_variable(griptape_nodes, "SHOT", "sc001")
-        _add_variable(griptape_nodes, "META", None)
-        _add_variable(griptape_nodes, "TAGS", ["a", "b"])
+        _add_variable(engine, "SHOT", "sc001")
+        _add_variable(engine, "META", None)
+        _add_variable(engine, "TAGS", ["a", "b"])
         with project_macros({}):
-            result = griptape_nodes.handle_request(ListSubstitutablesRequest(starting_flow=flow_name))
+            result = engine.handle_request(ListSubstitutablesRequest(starting_flow=flow_name))
         assert isinstance(result, ListSubstitutablesResultSuccess)
         names = {s.name for s in result.substitutables}
         assert "SHOT" in names
         assert "META" not in names
         assert "TAGS" not in names
 
-    def test_returns_empty_when_no_vars_and_no_macros(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_returns_empty_when_no_vars_and_no_macros(self, engine: Engine, flow_name: str) -> None:
         with project_macros({}):
-            result = griptape_nodes.handle_request(ListSubstitutablesRequest(starting_flow=flow_name))
+            result = engine.handle_request(ListSubstitutablesRequest(starting_flow=flow_name))
         assert isinstance(result, ListSubstitutablesResultSuccess)
         assert result.substitutables == []
 
-    def test_returns_failure_for_unknown_flow(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_returns_failure_for_unknown_flow(self, engine: Engine) -> None:
         with project_macros({}):
-            result = griptape_nodes.handle_request(ListSubstitutablesRequest(starting_flow="does_not_exist"))
+            result = engine.handle_request(ListSubstitutablesRequest(starting_flow="does_not_exist"))
         assert isinstance(result, ListSubstitutablesResultFailure)
 
 
 class TestGetVariablesRequest:
     """GetVariablesRequest probes specific names in scope; misses are data, not failures."""
 
-    def test_probe_resolves_requested_names(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
-        _add_variable(griptape_nodes, "SHOT", "sc001")
-        _add_variable(griptape_nodes, "SHOW", "myshow")
-        result = griptape_nodes.handle_request(GetVariablesRequest(starting_flow=flow_name, names=["SHOT"]))
+    def test_probe_resolves_requested_names(self, engine: Engine, flow_name: str) -> None:
+        _add_variable(engine, "SHOT", "sc001")
+        _add_variable(engine, "SHOW", "myshow")
+        result = engine.handle_request(GetVariablesRequest(starting_flow=flow_name, names=["SHOT"]))
         assert isinstance(result, GetVariablesResultSuccess)
         assert result.variables == {"SHOT": "sc001"}
         assert result.unresolved == []
 
-    def test_probe_reports_misses_as_unresolved_not_failure(
-        self, griptape_nodes: GriptapeNodes, flow_name: str
-    ) -> None:
+    def test_probe_reports_misses_as_unresolved_not_failure(self, engine: Engine, flow_name: str) -> None:
         """The ParsedMacro use case: probe required+optional names, decide from unresolved."""
-        _add_variable(griptape_nodes, "SHOT", "sc001")
-        result = griptape_nodes.handle_request(GetVariablesRequest(starting_flow=flow_name, names=["SHOT", "MISSING"]))
+        _add_variable(engine, "SHOT", "sc001")
+        result = engine.handle_request(GetVariablesRequest(starting_flow=flow_name, names=["SHOT", "MISSING"]))
         assert isinstance(result, GetVariablesResultSuccess)
         assert result.variables == {"SHOT": "sc001"}
         assert result.unresolved == ["MISSING"]
 
-    def test_probe_walks_project_layer(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_probe_walks_project_layer(self, engine: Engine, flow_name: str) -> None:
         """The probe uses the full layered walk — project entries resolve (unlike the old user-only view)."""
         with project_macros({"workspace_dir": "/workspace"}):
-            result = griptape_nodes.handle_request(
-                GetVariablesRequest(starting_flow=flow_name, names=["workspace_dir"])
-            )
+            result = engine.handle_request(GetVariablesRequest(starting_flow=flow_name, names=["workspace_dir"]))
         assert isinstance(result, GetVariablesResultSuccess)
         assert result.variables == {"workspace_dir": "/workspace"}
 
-    def test_probe_honors_lookup_scope(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_probe_honors_lookup_scope(self, engine: Engine, flow_name: str) -> None:
         """GLOBAL_ONLY probe skips flow layers: the flow var is a miss, not a hit."""
-        _add_variable(griptape_nodes, "flow_only", "from_flow")
+        _add_variable(engine, "flow_only", "from_flow")
         with project_macros({}):
-            result = griptape_nodes.handle_request(
+            result = engine.handle_request(
                 GetVariablesRequest(
                     starting_flow=flow_name, names=["flow_only"], lookup_scope=VariableScope.GLOBAL_ONLY
                 )
@@ -245,83 +241,81 @@ class TestGetVariablesRequest:
         assert result.variables == {}
         assert result.unresolved == ["flow_only"]
 
-    def test_empty_names_fails(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
-        result = griptape_nodes.handle_request(GetVariablesRequest(starting_flow=flow_name))
+    def test_empty_names_fails(self, engine: Engine, flow_name: str) -> None:
+        result = engine.handle_request(GetVariablesRequest(starting_flow=flow_name))
         assert isinstance(result, GetVariablesResultFailure)
         assert "ListVariablesRequest" in str(result.result_details)
 
-    def test_returns_failure_for_unknown_flow(self, griptape_nodes: GriptapeNodes) -> None:
-        result = griptape_nodes.handle_request(GetVariablesRequest(starting_flow="does_not_exist", names=["x"]))
+    def test_returns_failure_for_unknown_flow(self, engine: Engine) -> None:
+        result = engine.handle_request(GetVariablesRequest(starting_flow="does_not_exist", names=["x"]))
         assert isinstance(result, GetVariablesResultFailure)
 
 
 class TestResolveSubstitutionRequest:
     """ResolveSubstitutionRequest layers project vars with user vars; precedence FLOW > PROJECT > GLOBAL."""
 
-    def test_returns_user_vars_and_macros(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
-        _add_variable(griptape_nodes, "SHOT", "sc001")
+    def test_returns_user_vars_and_macros(self, engine: Engine, flow_name: str) -> None:
+        _add_variable(engine, "SHOT", "sc001")
         with project_macros({"workspace_dir": "/workspace"}):
-            result = griptape_nodes.handle_request(ResolveSubstitutionRequest(starting_flow=flow_name))
+            result = engine.handle_request(ResolveSubstitutionRequest(starting_flow=flow_name))
         assert isinstance(result, ResolveSubstitutionResultSuccess)
         assert result.variables["SHOT"] == "sc001"
         assert result.variables["workspace_dir"] == "/workspace"
 
-    def test_flow_var_wins_over_macro(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_flow_var_wins_over_macro(self, engine: Engine, flow_name: str) -> None:
         """A flow-scoped user var shadows the project macro (new precedence: FLOW > PROJECT).
 
         Uses a non-reserved project name — a builtin/directory name can't be taken by a
         flow var (see TestReservedNames).
         """
-        _add_variable(griptape_nodes, "custom_var", "/my/override")
+        _add_variable(engine, "custom_var", "/my/override")
         with project_macros({"custom_var": "/project"}):
-            result = griptape_nodes.handle_request(ResolveSubstitutionRequest(starting_flow=flow_name))
+            result = engine.handle_request(ResolveSubstitutionRequest(starting_flow=flow_name))
         assert isinstance(result, ResolveSubstitutionResultSuccess)
         assert result.variables["custom_var"] == "/my/override"
 
-    def test_macro_wins_over_global(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_macro_wins_over_global(self, engine: Engine, flow_name: str) -> None:
         """A project macro shadows a global user var (precedence: PROJECT > GLOBAL).
 
         Non-reserved name: reserved names can't be taken by a global at all, so the
         collision is staged with a name only the patched project layer claims.
         """
-        griptape_nodes.handle_request(
+        engine.handle_request(
             CreateVariableRequest(name="custom_var", type="str", value="/my/override", is_global=True)
         )
         with project_macros({"custom_var": "/workspace"}):
-            result = griptape_nodes.handle_request(ResolveSubstitutionRequest(starting_flow=flow_name))
+            result = engine.handle_request(ResolveSubstitutionRequest(starting_flow=flow_name))
         assert isinstance(result, ResolveSubstitutionResultSuccess)
         assert result.variables["custom_var"] == "/workspace"
 
-    def test_named_lookup_finds_macro(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_named_lookup_finds_macro(self, engine: Engine, flow_name: str) -> None:
         with project_macros({"workspace_dir": "/workspace"}):
-            result = griptape_nodes.handle_request(
-                ResolveSubstitutionRequest(starting_flow=flow_name, names=["workspace_dir"])
-            )
+            result = engine.handle_request(ResolveSubstitutionRequest(starting_flow=flow_name, names=["workspace_dir"]))
         assert isinstance(result, ResolveSubstitutionResultSuccess)
         assert result.variables == {"workspace_dir": "/workspace"}
 
-    def test_named_lookup_fails_if_not_in_vars_or_macros(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
-        _add_variable(griptape_nodes, "SHOT", "sc001")
+    def test_named_lookup_fails_if_not_in_vars_or_macros(self, engine: Engine, flow_name: str) -> None:
+        _add_variable(engine, "SHOT", "sc001")
         with project_macros({"workspace_dir": "/workspace"}):
-            result = griptape_nodes.handle_request(
+            result = engine.handle_request(
                 ResolveSubstitutionRequest(starting_flow=flow_name, names=["SHOT", "workspace_dir", "MISSING"])
             )
         assert isinstance(result, ResolveSubstitutionResultFailure)
         assert result.unresolved == ["MISSING"]
         assert result.resolved == {"SHOT": "sc001", "workspace_dir": "/workspace"}
 
-    def test_returns_failure_for_unknown_flow(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_returns_failure_for_unknown_flow(self, engine: Engine) -> None:
         with project_macros({}):
-            result = griptape_nodes.handle_request(ResolveSubstitutionRequest(starting_flow="does_not_exist"))
+            result = engine.handle_request(ResolveSubstitutionRequest(starting_flow="does_not_exist"))
         assert isinstance(result, ResolveSubstitutionResultFailure)
 
 
 class TestProjectLayerScopes:
     """PROJECT_ONLY and HIERARCHICAL_FROM_PROJECT — new opt-in scopes."""
 
-    def test_project_only_returns_project_entry(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_project_only_returns_project_entry(self, engine: Engine, flow_name: str) -> None:
         with project_macros({"workspace_dir": "/proj"}):
-            result = griptape_nodes.handle_request(
+            result = engine.handle_request(
                 GetVariableRequest(
                     name="workspace_dir", starting_flow=flow_name, lookup_scope=VariableScope.PROJECT_ONLY
                 )
@@ -329,30 +323,30 @@ class TestProjectLayerScopes:
         assert isinstance(result, GetVariableResultSuccess)
         assert result.variable.value == "/proj"
 
-    def test_project_only_ignores_flow_var(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_project_only_ignores_flow_var(self, engine: Engine, flow_name: str) -> None:
         # Non-reserved name so the flow var can be created; PROJECT_ONLY still ignores it.
-        _add_variable(griptape_nodes, "custom_var", "/from_flow")
+        _add_variable(engine, "custom_var", "/from_flow")
         with project_macros({"custom_var": "/from_project"}):
-            result = griptape_nodes.handle_request(
+            result = engine.handle_request(
                 GetVariableRequest(name="custom_var", starting_flow=flow_name, lookup_scope=VariableScope.PROJECT_ONLY)
             )
         assert isinstance(result, GetVariableResultSuccess)
         assert result.variable.value == "/from_project"
 
-    def test_project_only_missing_returns_failure(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_project_only_missing_returns_failure(self, engine: Engine, flow_name: str) -> None:
         with project_macros({}):
-            result = griptape_nodes.handle_request(
+            result = engine.handle_request(
                 GetVariableRequest(
                     name="workspace_dir", starting_flow=flow_name, lookup_scope=VariableScope.PROJECT_ONLY
                 )
             )
         assert isinstance(result, GetVariableResultFailure)
 
-    def test_hierarchical_from_project_finds_project(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_hierarchical_from_project_finds_project(self, engine: Engine, flow_name: str) -> None:
         # Non-reserved name so the flow var can be created; the FROM_PROJECT walk skips it.
-        _add_variable(griptape_nodes, "custom_var", "/from_flow")
+        _add_variable(engine, "custom_var", "/from_flow")
         with project_macros({"custom_var": "/from_project"}):
-            result = griptape_nodes.handle_request(
+            result = engine.handle_request(
                 GetVariableRequest(
                     name="custom_var",
                     starting_flow=flow_name,
@@ -363,14 +357,12 @@ class TestProjectLayerScopes:
         # Flow var must not shadow — the walk skips flows entirely.
         assert result.variable.value == "/from_project"
 
-    def test_hierarchical_from_project_falls_through_to_global(
-        self, griptape_nodes: GriptapeNodes, flow_name: str
-    ) -> None:
-        griptape_nodes.handle_request(
+    def test_hierarchical_from_project_falls_through_to_global(self, engine: Engine, flow_name: str) -> None:
+        engine.handle_request(
             CreateVariableRequest(name="only_global", type="str", value="from_global", is_global=True)
         )
         with project_macros({}):
-            result = griptape_nodes.handle_request(
+            result = engine.handle_request(
                 GetVariableRequest(
                     name="only_global",
                     starting_flow=flow_name,
@@ -380,10 +372,10 @@ class TestProjectLayerScopes:
         assert isinstance(result, GetVariableResultSuccess)
         assert result.variable.value == "from_global"
 
-    def test_hierarchical_from_project_ignores_flow_vars(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
-        _add_variable(griptape_nodes, "only_flow", "from_flow")
+    def test_hierarchical_from_project_ignores_flow_vars(self, engine: Engine, flow_name: str) -> None:
+        _add_variable(engine, "only_flow", "from_flow")
         with project_macros({}):
-            result = griptape_nodes.handle_request(
+            result = engine.handle_request(
                 GetVariableRequest(
                     name="only_flow",
                     starting_flow=flow_name,
@@ -392,17 +384,17 @@ class TestProjectLayerScopes:
             )
         assert isinstance(result, GetVariableResultFailure)
 
-    def test_hierarchical_walks_flow_project_global(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_hierarchical_walks_flow_project_global(self, engine: Engine, flow_name: str) -> None:
         """HIERARCHICAL: flow first, then project, then global."""
         # Only in project layer:
         with project_macros({"workspace_dir": "/from_project"}):
-            result = griptape_nodes.handle_request(GetVariableRequest(name="workspace_dir", starting_flow=flow_name))
+            result = engine.handle_request(GetVariableRequest(name="workspace_dir", starting_flow=flow_name))
         assert isinstance(result, GetVariableResultSuccess)
         assert result.variable.value == "/from_project"
 
-    def test_has_variable_reports_found_scope_project(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_has_variable_reports_found_scope_project(self, engine: Engine, flow_name: str) -> None:
         with project_macros({"workspace_dir": "/from_project"}):
-            result = griptape_nodes.handle_request(HasVariableRequest(name="workspace_dir", starting_flow=flow_name))
+            result = engine.handle_request(HasVariableRequest(name="workspace_dir", starting_flow=flow_name))
         assert isinstance(result, HasVariableResultSuccess)
         assert result.exists is True
         assert result.found_scope is VariableScope.PROJECT_ONLY
@@ -411,11 +403,11 @@ class TestProjectLayerScopes:
 class TestListVariablesLayerProvenance:
     """ListVariablesResultSuccess.layers is parallel to variables and names each entry's layer."""
 
-    def test_hierarchical_tags_each_layer(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
-        _add_variable(griptape_nodes, "flow_var", "f")
-        griptape_nodes.handle_request(CreateVariableRequest(name="global_var", type="str", value="g", is_global=True))
+    def test_hierarchical_tags_each_layer(self, engine: Engine, flow_name: str) -> None:
+        _add_variable(engine, "flow_var", "f")
+        engine.handle_request(CreateVariableRequest(name="global_var", type="str", value="g", is_global=True))
         with project_macros({"workspace_dir": "/proj"}):
-            result = griptape_nodes.handle_request(
+            result = engine.handle_request(
                 ListVariablesRequest(starting_flow=flow_name, lookup_scope=VariableScope.HIERARCHICAL)
             )
         assert isinstance(result, ListVariablesResultSuccess)
@@ -425,15 +417,13 @@ class TestListVariablesLayerProvenance:
         assert layer_by_name["workspace_dir"] is VariableLayerKind.PROJECT
         assert layer_by_name["global_var"] is VariableLayerKind.GLOBAL
 
-    def test_shadowing_reports_winning_layer(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_shadowing_reports_winning_layer(self, engine: Engine, flow_name: str) -> None:
         # Same name in flow and global — hierarchical resolution keeps the flow one,
         # and the layers field must say FLOW for it.
-        _add_variable(griptape_nodes, "shadowed", "from_flow")
-        griptape_nodes.handle_request(
-            CreateVariableRequest(name="shadowed", type="str", value="from_global", is_global=True)
-        )
+        _add_variable(engine, "shadowed", "from_flow")
+        engine.handle_request(CreateVariableRequest(name="shadowed", type="str", value="from_global", is_global=True))
         with project_macros({}):
-            result = griptape_nodes.handle_request(
+            result = engine.handle_request(
                 ListVariablesRequest(starting_flow=flow_name, lookup_scope=VariableScope.HIERARCHICAL)
             )
         assert isinstance(result, ListVariablesResultSuccess)
@@ -443,15 +433,13 @@ class TestListVariablesLayerProvenance:
         assert variable.value == "from_flow"
         assert layer is VariableLayerKind.FLOW
 
-    def test_all_scope_keeps_alignment_across_duplicates(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_all_scope_keeps_alignment_across_duplicates(self, engine: Engine, flow_name: str) -> None:
         # ALL returns every layer's entry without shadowing; the parallel lists must
         # stay aligned even when the same name appears twice.
-        _add_variable(griptape_nodes, "dup", "from_flow")
-        griptape_nodes.handle_request(
-            CreateVariableRequest(name="dup", type="str", value="from_global", is_global=True)
-        )
+        _add_variable(engine, "dup", "from_flow")
+        engine.handle_request(CreateVariableRequest(name="dup", type="str", value="from_global", is_global=True))
         with project_macros({}):
-            result = griptape_nodes.handle_request(
+            result = engine.handle_request(
                 ListVariablesRequest(starting_flow=flow_name, lookup_scope=VariableScope.ALL)
             )
         assert isinstance(result, ListVariablesResultSuccess)
@@ -506,18 +494,18 @@ class TestVariableLayerPrimitive:
 class TestAllScopePointLookup:
     """ALL is an enumeration scope; a single-name lookup under it degrades to CURRENT_FLOW_ONLY."""
 
-    def test_get_variable_with_all_scope_finds_flow_var(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
-        _add_variable(griptape_nodes, "flow_var", "v")
-        result = griptape_nodes.handle_request(
+    def test_get_variable_with_all_scope_finds_flow_var(self, engine: Engine, flow_name: str) -> None:
+        _add_variable(engine, "flow_var", "v")
+        result = engine.handle_request(
             GetVariableRequest(name="flow_var", starting_flow=flow_name, lookup_scope=VariableScope.ALL)
         )
         assert isinstance(result, GetVariableResultSuccess)
         assert result.variable.value == "v"
 
-    def test_get_variable_with_all_scope_misses_global(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_get_variable_with_all_scope_misses_global(self, engine: Engine, flow_name: str) -> None:
         """ALL point-lookup only consults the starting flow — a global is not found."""
-        griptape_nodes.handle_request(CreateVariableRequest(name="only_global", type="str", value="g", is_global=True))
-        result = griptape_nodes.handle_request(
+        engine.handle_request(CreateVariableRequest(name="only_global", type="str", value="g", is_global=True))
+        result = engine.handle_request(
             GetVariableRequest(name="only_global", starting_flow=flow_name, lookup_scope=VariableScope.ALL)
         )
         assert isinstance(result, GetVariableResultFailure)
@@ -526,9 +514,9 @@ class TestAllScopePointLookup:
 class TestVariablePermission:
     """READ_ONLY variables refuse writes uniformly."""
 
-    def test_set_value_on_project_variable_fails(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_set_value_on_project_variable_fails(self, engine: Engine, flow_name: str) -> None:
         with project_macros({"workspace_dir": "/proj"}):
-            result = griptape_nodes.handle_request(
+            result = engine.handle_request(
                 SetVariableValueRequest(name="workspace_dir", value="/new", starting_flow=flow_name)
             )
         assert isinstance(result, SetVariableValueResultFailure)
@@ -536,35 +524,35 @@ class TestVariablePermission:
         # 'project', recorded at discovery, not inferred from the search scope.
         assert "project layer" in str(result.result_details)
 
-    def test_delete_project_variable_fails(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_delete_project_variable_fails(self, engine: Engine, flow_name: str) -> None:
         with project_macros({"workspace_dir": "/proj"}):
-            result = griptape_nodes.handle_request(DeleteVariableRequest(name="workspace_dir", starting_flow=flow_name))
+            result = engine.handle_request(DeleteVariableRequest(name="workspace_dir", starting_flow=flow_name))
         assert isinstance(result, DeleteVariableResultFailure)
 
-    def test_rename_project_variable_fails(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_rename_project_variable_fails(self, engine: Engine, flow_name: str) -> None:
         with project_macros({"workspace_dir": "/proj"}):
-            result = griptape_nodes.handle_request(
+            result = engine.handle_request(
                 RenameVariableRequest(name="workspace_dir", new_name="new", starting_flow=flow_name)
             )
         assert isinstance(result, RenameVariableResultFailure)
 
-    def test_rename_flow_var_to_reserved_name_fails(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_rename_flow_var_to_reserved_name_fails(self, engine: Engine, flow_name: str) -> None:
         """Renaming a flow var to a reserved project name (workspace_dir) is refused.
 
         Matches create's rule — a flow var may not take a reserved project builtin/directory
         name — so the two agree. workspace_dir is reserved by the loaded system-defaults project.
         """
-        _add_variable(griptape_nodes, "temp_name", "sc001")
-        result = griptape_nodes.handle_request(
+        _add_variable(engine, "temp_name", "sc001")
+        result = engine.handle_request(
             RenameVariableRequest(name="temp_name", new_name="workspace_dir", starting_flow=flow_name)
         )
         assert isinstance(result, RenameVariableResultFailure)
         assert "reserved" in str(result.result_details)
 
-    def test_set_variables_batch_with_project_hit_fails(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
-        _add_variable(griptape_nodes, "SHOT", "sc001")
+    def test_set_variables_batch_with_project_hit_fails(self, engine: Engine, flow_name: str) -> None:
+        _add_variable(engine, "SHOT", "sc001")
         with project_macros({"workspace_dir": "/proj"}):
-            result = griptape_nodes.handle_request(
+            result = engine.handle_request(
                 SetVariablesRequest(
                     starting_flow=flow_name,
                     variables={"SHOT": "sc002", "workspace_dir": "/hacked"},
@@ -572,7 +560,7 @@ class TestVariablePermission:
             )
         assert isinstance(result, SetVariablesResultFailure)
         # SHOT must NOT have been written (all-or-nothing).
-        after = griptape_nodes.handle_request(GetVariablesRequest(starting_flow=flow_name, names=["SHOT"]))
+        after = engine.handle_request(GetVariablesRequest(starting_flow=flow_name, names=["SHOT"]))
         assert isinstance(after, GetVariablesResultSuccess)
         assert after.variables == {"SHOT": "sc001"}
 
@@ -584,20 +572,20 @@ class TestReservedNames:
     so these exercise the real ProjectManager.project_computed_names path — no patching.
     """
 
-    def test_create_flow_var_with_reserved_name_fails(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
-        result = griptape_nodes.handle_request(
+    def test_create_flow_var_with_reserved_name_fails(self, engine: Engine, flow_name: str) -> None:
+        result = engine.handle_request(
             CreateVariableRequest(name="workspace_dir", type="str", value="/hijack", owning_flow=flow_name)
         )
         assert isinstance(result, CreateVariableResultFailure)
         assert "reserved" in str(result.result_details)
 
-    def test_create_flow_var_with_unreserved_name_succeeds(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
-        result = griptape_nodes.handle_request(
+    def test_create_flow_var_with_unreserved_name_succeeds(self, engine: Engine, flow_name: str) -> None:
+        result = engine.handle_request(
             CreateVariableRequest(name="not_a_builtin", type="str", value="ok", owning_flow=flow_name)
         )
         assert isinstance(result, CreateVariableResultSuccess)
 
-    def test_initial_setup_replay_bypasses_reserved_gate(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_initial_setup_replay_bypasses_reserved_gate(self, engine: Engine, flow_name: str) -> None:
         """Workflow load-replay (initial_setup=True) recreates a reserved-named variable.
 
         Load re-executes captured CreateVariableRequests and DISCARDS the results, so a
@@ -605,7 +593,7 @@ class TestReservedNames:
         (saved before the name was reserved). The recreated flow variable is shadowed by
         the project's computed value in resolution — exactly the pre-reservation behavior.
         """
-        result = griptape_nodes.handle_request(
+        result = engine.handle_request(
             CreateVariableRequest(
                 name="workspace_dir",
                 type="str",
@@ -616,7 +604,7 @@ class TestReservedNames:
         )
         assert isinstance(result, CreateVariableResultSuccess)
         # Stored in the flow layer (CURRENT_FLOW_ONLY sees it)...
-        stored = griptape_nodes.handle_request(
+        stored = engine.handle_request(
             GetVariableRequest(
                 name="workspace_dir", starting_flow=flow_name, lookup_scope=VariableScope.CURRENT_FLOW_ONLY
             )
@@ -625,36 +613,34 @@ class TestReservedNames:
         assert stored.variable.value == "/from_saved_workflow"
 
     @pytest.mark.usefixtures("flow_name")
-    def test_initial_setup_replay_of_global_bypasses_reserved_gate(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_initial_setup_replay_of_global_bypasses_reserved_gate(self, engine: Engine) -> None:
         """Same replay exemption for globals — is_global=True round-trips through save/load too."""
-        result = griptape_nodes.handle_request(
+        result = engine.handle_request(
             CreateVariableRequest(
                 name="workspace_dir", type="str", value="/global_from_save", is_global=True, initial_setup=True
             )
         )
         assert isinstance(result, CreateVariableResultSuccess)
 
-    def test_live_create_still_refused_after_replay_exemption(
-        self, griptape_nodes: GriptapeNodes, flow_name: str
-    ) -> None:
+    def test_live_create_still_refused_after_replay_exemption(self, engine: Engine, flow_name: str) -> None:
         """The exemption is replay-only: the same request WITHOUT initial_setup stays refused."""
-        result = griptape_nodes.handle_request(
+        result = engine.handle_request(
             CreateVariableRequest(name="workspace_dir", type="str", value="/hijack", owning_flow=flow_name)
         )
         assert isinstance(result, CreateVariableResultFailure)
         assert "reserved" in str(result.result_details)
 
     def test_replay_failure_is_logged_not_silent(
-        self, griptape_nodes: GriptapeNodes, flow_name: str, caplog: pytest.LogCaptureFixture
+        self, engine: Engine, flow_name: str, caplog: pytest.LogCaptureFixture
     ) -> None:
         """A replayed create that fails for a NON-reserved reason logs a warning.
 
         Load discards results, so the log is the only signal a saved variable didn't
         come back (e.g. duplicate name in the same flow).
         """
-        _add_variable(griptape_nodes, "dup_var", "first")
-        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
-            result = griptape_nodes.handle_request(
+        _add_variable(engine, "dup_var", "first")
+        with caplog.at_level(logging.WARNING, logger="engine"):
+            result = engine.handle_request(
                 CreateVariableRequest(
                     name="dup_var", type="str", value="second", owning_flow=flow_name, initial_setup=True
                 )
@@ -662,60 +648,56 @@ class TestReservedNames:
         assert isinstance(result, CreateVariableResultFailure)
         assert any("could not recreate variable 'dup_var'" in r.message for r in caplog.records)
 
-    def test_create_with_blank_name_fails(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_create_with_blank_name_fails(self, engine: Engine, flow_name: str) -> None:
         for blank in ("", "   "):
-            result = griptape_nodes.handle_request(
+            result = engine.handle_request(
                 CreateVariableRequest(name=blank, type="str", value="x", owning_flow=flow_name)
             )
             assert isinstance(result, CreateVariableResultFailure)
             assert "empty name" in str(result.result_details)
 
     @pytest.mark.usefixtures("flow_name")
-    def test_create_global_with_reserved_name_fails(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_create_global_with_reserved_name_fails(self, engine: Engine) -> None:
         """Reserved means reserved in EVERY scope: a global may not take a reserved name either.
 
         Depends on the flow_name fixture for clean engine state + a current project, but
         doesn't need the flow value itself (globals aren't flow-scoped).
         """
-        result = griptape_nodes.handle_request(
+        result = engine.handle_request(
             CreateVariableRequest(name="workspace_dir", type="str", value="/global", is_global=True)
         )
         assert isinstance(result, CreateVariableResultFailure)
         assert "reserved" in str(result.result_details)
 
-    def test_create_flow_var_shadowing_a_global_is_allowed(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_create_flow_var_shadowing_a_global_is_allowed(self, engine: Engine, flow_name: str) -> None:
         """A flow var may share a name with a global (only reserved names are refused)."""
-        griptape_nodes.handle_request(
-            CreateVariableRequest(name="shared", type="str", value="from_global", is_global=True)
-        )
-        result = griptape_nodes.handle_request(
+        engine.handle_request(CreateVariableRequest(name="shared", type="str", value="from_global", is_global=True))
+        result = engine.handle_request(
             CreateVariableRequest(name="shared", type="str", value="from_flow", owning_flow=flow_name)
         )
         assert isinstance(result, CreateVariableResultSuccess)
 
-    def test_rename_to_same_name_is_noop_success(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_rename_to_same_name_is_noop_success(self, engine: Engine, flow_name: str) -> None:
         """Renaming a variable to its current name is an idempotent success, not a self-collision crash."""
-        _add_variable(griptape_nodes, "keeper", "v1")
-        result = griptape_nodes.handle_request(
-            RenameVariableRequest(name="keeper", new_name="keeper", starting_flow=flow_name)
-        )
+        _add_variable(engine, "keeper", "v1")
+        result = engine.handle_request(RenameVariableRequest(name="keeper", new_name="keeper", starting_flow=flow_name))
         assert isinstance(result, RenameVariableResultSuccess)
         # Value preserved.
-        after = griptape_nodes.handle_request(GetVariablesRequest(starting_flow=flow_name, names=["keeper"]))
+        after = engine.handle_request(GetVariablesRequest(starting_flow=flow_name, names=["keeper"]))
         assert isinstance(after, GetVariablesResultSuccess)
         assert after.variables == {"keeper": "v1"}
 
-    def test_rename_to_blank_name_fails(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
-        _add_variable(griptape_nodes, "keeper", "v1")
+    def test_rename_to_blank_name_fails(self, engine: Engine, flow_name: str) -> None:
+        _add_variable(engine, "keeper", "v1")
         for blank in ("", "   "):
-            result = griptape_nodes.handle_request(
+            result = engine.handle_request(
                 RenameVariableRequest(name="keeper", new_name=blank, starting_flow=flow_name)
             )
             assert isinstance(result, RenameVariableResultFailure)
             assert "empty name" in str(result.result_details)
 
     @pytest.mark.usefixtures("flow_name")
-    def test_rename_reserved_named_global_to_itself_is_noop_success(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_rename_reserved_named_global_to_itself_is_noop_success(self, engine: Engine) -> None:
         """A pre-existing global whose name is reserved can still be renamed to itself.
 
         Creating a reserved-named global is refused now, but variables from workflows saved
@@ -725,26 +707,24 @@ class TestReservedNames:
         it, a no-op rename of a reserved-named variable would surface a spurious 'that name is
         reserved' failure.
         """
-        griptape_nodes.VariablesManager()._global_layer.set(
+        engine.variables_manager._global_layer.set(
             FlowVariable(name="workspace_dir", owning_flow_name=None, type="str", value="/g")
         )
-        result = griptape_nodes.handle_request(
+        result = engine.handle_request(
             RenameVariableRequest(
                 name="workspace_dir", new_name="workspace_dir", lookup_scope=VariableScope.GLOBAL_ONLY
             )
         )
         assert isinstance(result, RenameVariableResultSuccess)
 
-    def test_rename_read_only_variable_to_itself_is_noop_success(
-        self, griptape_nodes: GriptapeNodes, flow_name: str
-    ) -> None:
+    def test_rename_read_only_variable_to_itself_is_noop_success(self, engine: Engine, flow_name: str) -> None:
         """Rename-to-self succeeds even on a READ_ONLY variable — nothing is mutated.
 
         The no-op short-circuit runs before the read-only refusal (and every other gate):
         a resolved project builtin like workspace_dir is READ_ONLY, and renaming it to its
         own name must be an idempotent success, not a 'read-only' Failure.
         """
-        result = griptape_nodes.handle_request(
+        result = engine.handle_request(
             RenameVariableRequest(
                 name="workspace_dir",
                 new_name="workspace_dir",
@@ -754,11 +734,9 @@ class TestReservedNames:
         )
         assert isinstance(result, RenameVariableResultSuccess)
 
-    def test_rename_read_only_variable_to_new_name_still_refused(
-        self, griptape_nodes: GriptapeNodes, flow_name: str
-    ) -> None:
+    def test_rename_read_only_variable_to_new_name_still_refused(self, engine: Engine, flow_name: str) -> None:
         """The no-op reorder must not weaken the real gate: an ACTUAL rename of READ_ONLY still fails."""
-        result = griptape_nodes.handle_request(
+        result = engine.handle_request(
             RenameVariableRequest(
                 name="workspace_dir",
                 new_name="my_workspace",
@@ -769,48 +747,40 @@ class TestReservedNames:
         assert isinstance(result, RenameVariableResultFailure)
         assert "read-only" in str(result.result_details)
 
-    def test_variable_details_reports_reserved_for_builtin(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_variable_details_reports_reserved_for_builtin(self, engine: Engine, flow_name: str) -> None:
         """GetVariableDetails populates reserved: True for a resolved computed name, False for a user variable."""
-        builtin_details = griptape_nodes.handle_request(
+        builtin_details = engine.handle_request(
             GetVariableDetailsRequest(name="workspace_dir", starting_flow=flow_name)
         )
         assert isinstance(builtin_details, GetVariableDetailsResultSuccess)
         assert builtin_details.details.reserved is True
 
-        _add_variable(griptape_nodes, "my_var", "v")
-        user_details = griptape_nodes.handle_request(GetVariableDetailsRequest(name="my_var", starting_flow=flow_name))
+        _add_variable(engine, "my_var", "v")
+        user_details = engine.handle_request(GetVariableDetailsRequest(name="my_var", starting_flow=flow_name))
         assert isinstance(user_details, GetVariableDetailsResultSuccess)
         assert user_details.details.reserved is False
 
     @pytest.mark.usefixtures("flow_name")
-    def test_delete_global_variable_routes_to_global_layer(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_delete_global_variable_routes_to_global_layer(self, engine: Engine) -> None:
         """Delete routes by layer provenance — a global (owning_flow_name=None) leaves the global layer."""
-        griptape_nodes.handle_request(CreateVariableRequest(name="g_del", type="str", value="v", is_global=True))
-        result = griptape_nodes.handle_request(
-            DeleteVariableRequest(name="g_del", lookup_scope=VariableScope.GLOBAL_ONLY)
-        )
+        engine.handle_request(CreateVariableRequest(name="g_del", type="str", value="v", is_global=True))
+        result = engine.handle_request(DeleteVariableRequest(name="g_del", lookup_scope=VariableScope.GLOBAL_ONLY))
         assert isinstance(result, DeleteVariableResultSuccess)
-        after = griptape_nodes.handle_request(
-            GetVariableValueRequest(name="g_del", lookup_scope=VariableScope.GLOBAL_ONLY)
-        )
+        after = engine.handle_request(GetVariableValueRequest(name="g_del", lookup_scope=VariableScope.GLOBAL_ONLY))
         assert isinstance(after, GetVariableValueResultFailure)
 
     @pytest.mark.usefixtures("flow_name")
-    def test_rename_global_variable_routes_to_global_layer(self, griptape_nodes: GriptapeNodes) -> None:
+    def test_rename_global_variable_routes_to_global_layer(self, engine: Engine) -> None:
         """Rename routes by layer provenance — a global renames within the global layer."""
-        griptape_nodes.handle_request(CreateVariableRequest(name="g_old", type="str", value="v", is_global=True))
-        result = griptape_nodes.handle_request(
+        engine.handle_request(CreateVariableRequest(name="g_old", type="str", value="v", is_global=True))
+        result = engine.handle_request(
             RenameVariableRequest(name="g_old", new_name="g_new", lookup_scope=VariableScope.GLOBAL_ONLY)
         )
         assert isinstance(result, RenameVariableResultSuccess)
-        new_val = griptape_nodes.handle_request(
-            GetVariableValueRequest(name="g_new", lookup_scope=VariableScope.GLOBAL_ONLY)
-        )
+        new_val = engine.handle_request(GetVariableValueRequest(name="g_new", lookup_scope=VariableScope.GLOBAL_ONLY))
         assert isinstance(new_val, GetVariableValueResultSuccess)
         assert new_val.value == "v"
-        old_val = griptape_nodes.handle_request(
-            GetVariableValueRequest(name="g_old", lookup_scope=VariableScope.GLOBAL_ONLY)
-        )
+        old_val = engine.handle_request(GetVariableValueRequest(name="g_old", lookup_scope=VariableScope.GLOBAL_ONLY))
         assert isinstance(old_val, GetVariableValueResultFailure)
 
 
@@ -823,21 +793,19 @@ class TestGetProjectVariableRealBody:
     (they go live for real when #5142 wires set_project_variables at load).
     """
 
-    def test_computed_name_resolves_via_real_dispatch(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_computed_name_resolves_via_real_dispatch(self, engine: Engine, flow_name: str) -> None:
         """A real builtin resolves through membership check → resolve_project_variable."""
-        result = griptape_nodes.handle_request(
+        result = engine.handle_request(
             GetVariableRequest(name="workspace_dir", starting_flow=flow_name, lookup_scope=VariableScope.PROJECT_ONLY)
         )
         assert isinstance(result, GetVariableResultSuccess)
         assert result.variable.permission is VariablePermission.READ_ONLY
         assert result.variable.value  # resolved from live config; exact value is environment-specific
 
-    def test_computed_name_with_unready_context_silent_skips(
-        self, griptape_nodes: GriptapeNodes, flow_name: str
-    ) -> None:
+    def test_computed_name_with_unready_context_silent_skips(self, engine: Engine, flow_name: str) -> None:
         """A computed name whose resolver raises context-not-ready yields not-found — no crash, no stored fallback."""
-        variables_manager = griptape_nodes.VariablesManager()
-        project_id = griptape_nodes.ProjectManager().resolve_project_id(None)
+        variables_manager = engine.variables_manager
+        project_id = engine.project_manager.resolve_project_id(None)
         assert project_id is not None
         # Stage a same-named stored entry to prove the silent-skip does NOT fall through to it.
         stored_layer = VariableLayer()
@@ -845,11 +813,11 @@ class TestGetProjectVariableRealBody:
         variables_manager.set_project_variables(project_id, stored_layer)
         try:
             with patch.object(
-                type(griptape_nodes.ProjectManager()),
+                type(engine.project_manager),
                 "resolve_project_variable",
                 side_effect=RuntimeError("context not ready"),
             ):
-                result = griptape_nodes.handle_request(
+                result = engine.handle_request(
                     GetVariableRequest(
                         name="workspace_dir", starting_flow=flow_name, lookup_scope=VariableScope.PROJECT_ONLY
                     )
@@ -858,19 +826,17 @@ class TestGetProjectVariableRealBody:
         finally:
             variables_manager.remove_project_variables(project_id)
 
-    def test_non_computed_name_falls_through_to_stored_snapshot(
-        self, griptape_nodes: GriptapeNodes, flow_name: str
-    ) -> None:
+    def test_non_computed_name_falls_through_to_stored_snapshot(self, engine: Engine, flow_name: str) -> None:
         """A stored-only name skips resolve entirely and returns a snapshot copy, not the stored object."""
-        variables_manager = griptape_nodes.VariablesManager()
-        project_id = griptape_nodes.ProjectManager().resolve_project_id(None)
+        variables_manager = engine.variables_manager
+        project_id = engine.project_manager.resolve_project_id(None)
         assert project_id is not None
         stored = FlowVariable(name="team_prefix", owning_flow_name=None, type="str", value="vfx")
         stored_layer = VariableLayer()
         stored_layer.set(stored)
         variables_manager.set_project_variables(project_id, stored_layer)
         try:
-            result = griptape_nodes.handle_request(
+            result = engine.handle_request(
                 GetVariableRequest(name="team_prefix", starting_flow=flow_name, lookup_scope=VariableScope.PROJECT_ONLY)
             )
             assert isinstance(result, GetVariableResultSuccess)
@@ -884,23 +850,21 @@ class TestGetProjectVariableRealBody:
 class TestProjectVariableSerialization:
     """Regression: project-layer variables must cross the request boundary as plain, serializable FlowVariables."""
 
-    def test_get_variable_from_project_returns_plain_flow_variable(
-        self, griptape_nodes: GriptapeNodes, flow_name: str
-    ) -> None:
+    def test_get_variable_from_project_returns_plain_flow_variable(self, engine: Engine, flow_name: str) -> None:
         """A HIERARCHICAL Get that resolves to the project layer returns a plain, serializable FlowVariable."""
         with project_macros({"workspace_dir": "/proj"}):
-            result = griptape_nodes.handle_request(GetVariableRequest(name="workspace_dir", starting_flow=flow_name))
+            result = engine.handle_request(GetVariableRequest(name="workspace_dir", starting_flow=flow_name))
         assert isinstance(result, GetVariableResultSuccess)
         # Must be a plain FlowVariable carrying a stored value — no live resolver.
         assert type(result.variable) is FlowVariable
         assert result.variable.value == "/proj"
 
-    def test_get_variable_from_project_serializes(self, griptape_nodes: GriptapeNodes, flow_name: str) -> None:
+    def test_get_variable_from_project_serializes(self, engine: Engine, flow_name: str) -> None:
         """The Success payload must survive cattrs unstructure (the broadcast path)."""
         from griptape_nodes.retained_mode.events.event_converter import safe_unstructure
 
         with project_macros({"workspace_dir": "/proj"}):
-            result = griptape_nodes.handle_request(GetVariableRequest(name="workspace_dir", starting_flow=flow_name))
+            result = engine.handle_request(GetVariableRequest(name="workspace_dir", starting_flow=flow_name))
         assert isinstance(result, GetVariableResultSuccess)
         serialized = safe_unstructure(result)
         assert serialized["variable"]["name"] == "workspace_dir"

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -71,7 +71,6 @@ from griptape_nodes.retained_mode.events.workflow_events import (
     WorkflowInfoSummary,
     WorkflowStatus,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.context_manager import ContextManager
 from griptape_nodes.retained_mode.managers.fitness_problems.workflows import (
     InvalidTomlFormatProblem,
@@ -165,9 +164,9 @@ class TestWorkflowManager:
         assert isinstance(result["is_user_defined"], bool)
         assert result["is_user_defined"] is True
 
-    def test_on_import_workflow_request_success(self, griptape_nodes: Engine) -> None:
+    def test_on_import_workflow_request_success(self, engine: Engine) -> None:
         """Test successful workflow import."""
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         request = ImportWorkflowRequest(file_path="/path/to/workflow.py")
 
         mock_metadata = MagicMock()
@@ -196,9 +195,9 @@ class TestWorkflowManager:
             # Registry key is derived from the file path (minus extension), not from metadata.name.
             assert result.workflow_name == "workflow"
 
-    def test_on_import_workflow_request_already_registered(self, griptape_nodes: Engine) -> None:
+    def test_on_import_workflow_request_already_registered(self, engine: Engine) -> None:
         """Test import when workflow is already registered."""
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         request = ImportWorkflowRequest(file_path="/path/to/workflow.py")
 
         mock_metadata = MagicMock()
@@ -220,9 +219,9 @@ class TestWorkflowManager:
             # Registry key is derived from the file path (minus extension), not from metadata.name.
             assert result.workflow_name == "/path/to/workflow"
 
-    def test_on_import_workflow_request_metadata_load_failure(self, griptape_nodes: Engine) -> None:
+    def test_on_import_workflow_request_metadata_load_failure(self, engine: Engine) -> None:
         """Test import when metadata loading fails."""
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         request = ImportWorkflowRequest(file_path="/path/to/workflow.py")
 
         with patch.object(
@@ -236,9 +235,9 @@ class TestWorkflowManager:
             assert isinstance(result.result_details, ResultDetails)
             assert result.result_details.result_details[0].message == "Failed to load metadata"
 
-    def test_on_import_workflow_request_registration_failure(self, griptape_nodes: Engine) -> None:
+    def test_on_import_workflow_request_registration_failure(self, engine: Engine) -> None:
         """Test import when registration fails."""
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         request = ImportWorkflowRequest(file_path="/path/to/workflow.py")
 
         mock_metadata = MagicMock()
@@ -265,9 +264,9 @@ class TestWorkflowManager:
             assert isinstance(result.result_details, ResultDetails)
             assert result.result_details.result_details[0].message == "Registration failed"
 
-    def test_get_workflow_metadata_success(self, griptape_nodes: Engine) -> None:
+    def test_get_workflow_metadata_success(self, engine: Engine) -> None:
         """Ensure GetWorkflowMetadataRequest returns workflow.metadata directly."""
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         request = GetWorkflowMetadataRequest(workflow_name="my_workflow")
 
         mock_metadata = MagicMock()
@@ -280,9 +279,9 @@ class TestWorkflowManager:
         assert isinstance(result, GetWorkflowMetadataResultSuccess)
         assert result.workflow_metadata is mock_metadata
 
-    def test_get_workflow_metadata_not_found(self, griptape_nodes: Engine) -> None:
+    def test_get_workflow_metadata_not_found(self, engine: Engine) -> None:
         """Ensure GetWorkflowMetadataRequest returns failure when workflow missing."""
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         request = GetWorkflowMetadataRequest(workflow_name="missing_workflow")
 
         with patch.object(WorkflowRegistry, "get_workflow_by_name", side_effect=KeyError("not found")):
@@ -290,9 +289,9 @@ class TestWorkflowManager:
 
         assert isinstance(result, GetWorkflowMetadataResultFailure)
 
-    def test_set_workflow_metadata_success(self, griptape_nodes: Engine) -> None:
+    def test_set_workflow_metadata_success(self, engine: Engine) -> None:
         """Ensure SetWorkflowMetadataRequest replaces metadata and persists header."""
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         workflow_manager._workflows_loading_complete.set()  # type: ignore[attr-defined]
 
         # Provide a full metadata object (mock is fine as we stub header replacement)
@@ -321,9 +320,9 @@ class TestWorkflowManager:
         assert isinstance(result, SetWorkflowMetadataResultSuccess)
         write_mock.assert_called_once()
 
-    def test_on_create_workflow_from_template_request_success(self, griptape_nodes: Engine) -> None:
+    def test_on_create_workflow_from_template_request_success(self, engine: Engine) -> None:
         """Test successful create workflow from template (Griptape or user-provided)."""
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         request = CreateWorkflowFromTemplateRequest(template_name="my_template")
 
         mock_template = MagicMock()
@@ -379,9 +378,9 @@ class TestWorkflowManager:
         assert result.workflow_name == "my_template_1"
         assert result.file_path == new_full_path
 
-    def test_on_create_workflow_from_template_request_absolute_file_path(self, griptape_nodes: Engine) -> None:
+    def test_on_create_workflow_from_template_request_absolute_file_path(self, engine: Engine) -> None:
         """Test that templates with absolute file paths save the new workflow in the workspace, not at the template path."""
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         request = CreateWorkflowFromTemplateRequest(
             template_name="/some/external/library/workflows/templates/my_template"
         )
@@ -441,9 +440,9 @@ class TestWorkflowManager:
         # not the full absolute path, so the file is saved in the workspace.
         assert generate_unique_filename_calls == ["my_template"]
 
-    def test_on_create_workflow_from_template_request_template_not_found(self, griptape_nodes: Engine) -> None:
+    def test_on_create_workflow_from_template_request_template_not_found(self, engine: Engine) -> None:
         """Test create from template when template is not in registry."""
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         request = CreateWorkflowFromTemplateRequest(template_name="missing_template")
 
         with patch.object(
@@ -456,9 +455,9 @@ class TestWorkflowManager:
         assert isinstance(result, CreateWorkflowFromTemplateResultFailure)
         assert "missing_template" in str(result.result_details)
 
-    def test_on_create_workflow_from_template_request_not_a_template(self, griptape_nodes: Engine) -> None:
+    def test_on_create_workflow_from_template_request_not_a_template(self, engine: Engine) -> None:
         """Test create from template when workflow is not marked as template."""
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         request = CreateWorkflowFromTemplateRequest(template_name="regular_workflow")
 
         mock_workflow = MagicMock()
@@ -476,9 +475,9 @@ class TestWorkflowManager:
         assert isinstance(result, CreateWorkflowFromTemplateResultFailure)
         assert "not marked as a template" in str(result.result_details)
 
-    def test_on_create_workflow_from_template_request_template_file_not_found(self, griptape_nodes: Engine) -> None:
+    def test_on_create_workflow_from_template_request_template_file_not_found(self, engine: Engine) -> None:
         """Test create from template when template file does not exist."""
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         request = CreateWorkflowFromTemplateRequest(template_name="my_template")
 
         mock_template = MagicMock()
@@ -502,8 +501,8 @@ class TestWorkflowManager:
 
     # Removed tests for invalid keys/types; metadata is replaced as a whole object
 
-    def test_on_move_workflow_request_workflow_not_found(self, griptape_nodes: Engine) -> None:
-        workflow_manager = griptape_nodes.WorkflowManager()
+    def test_on_move_workflow_request_workflow_not_found(self, engine: Engine) -> None:
+        workflow_manager = engine.workflow_manager
         request = MoveWorkflowRequest(workflow_name="nonexistent", target_directory="subdir")
 
         with patch.object(WorkflowRegistry, "get_workflow_by_name", side_effect=KeyError("not found")):
@@ -512,8 +511,8 @@ class TestWorkflowManager:
         assert isinstance(result, MoveWorkflowResultFailure)
         assert "nonexistent" in str(result.result_details)
 
-    def test_on_move_workflow_request_source_file_missing(self, griptape_nodes: Engine) -> None:
-        workflow_manager = griptape_nodes.WorkflowManager()
+    def test_on_move_workflow_request_source_file_missing(self, engine: Engine) -> None:
+        workflow_manager = engine.workflow_manager
         request = MoveWorkflowRequest(workflow_name="my_workflow", target_directory="subdir")
 
         mock_workflow = MagicMock()
@@ -529,8 +528,8 @@ class TestWorkflowManager:
         assert isinstance(result, MoveWorkflowResultFailure)
         assert "/workspace/my_workflow.py" in str(result.result_details)
 
-    def test_on_move_workflow_request_target_already_exists(self, griptape_nodes: Engine) -> None:
-        workflow_manager = griptape_nodes.WorkflowManager()
+    def test_on_move_workflow_request_target_already_exists(self, engine: Engine) -> None:
+        workflow_manager = engine.workflow_manager
         request = MoveWorkflowRequest(workflow_name="my_workflow", target_directory="subdir")
 
         mock_workflow = MagicMock()
@@ -547,14 +546,14 @@ class TestWorkflowManager:
         assert isinstance(result, MoveWorkflowResultFailure)
         assert "already exists" in str(result.result_details)
 
-    def test_on_move_workflow_request_success_directory_change(self, griptape_nodes: Engine) -> None:
-        workflow_manager = griptape_nodes.WorkflowManager()
+    def test_on_move_workflow_request_success_directory_change(self, engine: Engine) -> None:
+        workflow_manager = engine.workflow_manager
         request = MoveWorkflowRequest(workflow_name="my_workflow", target_directory="subdir")
 
         mock_workflow = MagicMock()
         mock_workflow.file_path = "my_workflow.py"
 
-        config_mgr = griptape_nodes.ConfigManager()
+        config_mgr = engine.config_manager
         with (
             patch.object(WorkflowRegistry, "get_workflow_by_name", return_value=mock_workflow),
             patch.object(WorkflowRegistry, "get_complete_file_path", return_value="/workspace/my_workflow.py"),
@@ -571,16 +570,16 @@ class TestWorkflowManager:
         assert result.new_workflow_name == "subdir/my_workflow"
         mock_rekey.assert_called_once_with("my_workflow", "subdir/my_workflow")
 
-    def test_on_move_workflow_request_no_rekey_same_directory(self, griptape_nodes: Engine) -> None:
+    def test_on_move_workflow_request_no_rekey_same_directory(self, engine: Engine) -> None:
         """Moving within the same directory level produces the same registry key; no rekey occurs."""
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         # Workflow already in "subdir", moving target is also "subdir" — key stays the same.
         request = MoveWorkflowRequest(workflow_name="subdir/my_workflow", target_directory="subdir")
 
         mock_workflow = MagicMock()
         mock_workflow.file_path = "subdir/my_workflow.py"
 
-        config_mgr = griptape_nodes.ConfigManager()
+        config_mgr = engine.config_manager
         with (
             patch.object(WorkflowRegistry, "get_workflow_by_name", return_value=mock_workflow),
             patch.object(WorkflowRegistry, "get_complete_file_path", return_value="/workspace/subdir/my_workflow.py"),
@@ -596,15 +595,15 @@ class TestWorkflowManager:
         assert result.new_workflow_name == "subdir/my_workflow"
         mock_rekey.assert_not_called()
 
-    def test_on_move_workflow_request_updates_context_for_current_workflow(self, griptape_nodes: Engine) -> None:
-        workflow_manager = griptape_nodes.WorkflowManager()
+    def test_on_move_workflow_request_updates_context_for_current_workflow(self, engine: Engine) -> None:
+        workflow_manager = engine.workflow_manager
         request = MoveWorkflowRequest(workflow_name="my_workflow", target_directory="subdir")
 
         mock_workflow = MagicMock()
         mock_workflow.file_path = "my_workflow.py"
 
-        context_mgr = griptape_nodes.ContextManager()
-        config_mgr = griptape_nodes.ConfigManager()
+        context_mgr = engine.context_manager
+        config_mgr = engine.config_manager
         with (
             patch.object(WorkflowRegistry, "get_workflow_by_name", return_value=mock_workflow),
             patch.object(WorkflowRegistry, "get_complete_file_path", return_value="/workspace/my_workflow.py"),
@@ -626,15 +625,15 @@ class TestWorkflowManager:
         # registry, so a rekey without a repoint leaves the builtin on the pre-move directory.
         mock_set_file_path.assert_called_once_with(str(config_mgr.workspace_path / "subdir" / "my_workflow.py"))
 
-    def test_on_move_workflow_request_does_not_update_context_for_other_workflow(self, griptape_nodes: Engine) -> None:
-        workflow_manager = griptape_nodes.WorkflowManager()
+    def test_on_move_workflow_request_does_not_update_context_for_other_workflow(self, engine: Engine) -> None:
+        workflow_manager = engine.workflow_manager
         request = MoveWorkflowRequest(workflow_name="my_workflow", target_directory="subdir")
 
         mock_workflow = MagicMock()
         mock_workflow.file_path = "my_workflow.py"
 
-        context_mgr = griptape_nodes.ContextManager()
-        config_mgr = griptape_nodes.ConfigManager()
+        context_mgr = engine.context_manager
+        config_mgr = engine.config_manager
         with (
             patch.object(WorkflowRegistry, "get_workflow_by_name", return_value=mock_workflow),
             patch.object(WorkflowRegistry, "get_complete_file_path", return_value="/workspace/my_workflow.py"),
@@ -653,7 +652,7 @@ class TestWorkflowManager:
         mock_set_name.assert_not_called()
 
     def test_on_move_workflow_request_updates_context_file_path_for_current_workflow(
-        self, griptape_nodes: Engine, tmp_path: Path
+        self, engine: Engine, tmp_path: Path
     ) -> None:
         """Moving the open workflow repoints the context's retained path at the new directory.
 
@@ -667,9 +666,9 @@ class TestWorkflowManager:
 
         from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
 
-        workflow_manager = griptape_nodes.WorkflowManager()
-        context_manager = griptape_nodes.ContextManager()
-        config_manager = griptape_nodes.ConfigManager()
+        workflow_manager = engine.workflow_manager
+        context_manager = engine.context_manager
+        config_manager = engine.config_manager
 
         workspace = tmp_path.resolve()
         (workspace / "my_workflow.py").write_text("# stub")
@@ -706,7 +705,7 @@ class TestWorkflowManager:
 
     # --- Save workflow: unsaved -> saved transition ---
 
-    def test_on_save_workflow_rekeys_context_stack_on_first_save(self, griptape_nodes: Engine) -> None:
+    def test_on_save_workflow_rekeys_context_stack_on_first_save(self, engine: Engine) -> None:
         """First save of an unsaved workflow rekeys the registry entry and updates the context stack in-place."""
         from datetime import UTC, datetime
 
@@ -722,8 +721,8 @@ class TestWorkflowManager:
             SaveWorkflowResultSuccess,
         )
 
-        workflow_manager = griptape_nodes.WorkflowManager()
-        context_manager = griptape_nodes.ContextManager()
+        workflow_manager = engine.workflow_manager
+        context_manager = engine.context_manager
 
         unsaved_key = "unsaved:abc-123"
         saved_key = "my_flow"
@@ -768,7 +767,7 @@ class TestWorkflowManager:
                 msg = f"Unexpected request type in test: {type(req).__name__}"
                 raise AssertionError(msg)
 
-            workspace = griptape_nodes.ConfigManager().workspace_path
+            workspace = engine.config_manager.workspace_path
             saved_full_path = workspace / f"{saved_key}.py"
             save_file_success = SaveWorkflowFileFromSerializedFlowResultSuccess(
                 file_path=str(saved_full_path),
@@ -778,7 +777,7 @@ class TestWorkflowManager:
 
             try:
                 with (
-                    patch.object(griptape_nodes, "ahandle_request", side_effect=fake_ahandle_request),
+                    patch.object(engine, "ahandle_request", side_effect=fake_ahandle_request),
                     patch.object(
                         workflow_manager,
                         "_save_workflow_file_inline",
@@ -813,9 +812,9 @@ class TestWorkflowManager:
                 if context_manager.has_current_workflow():
                     context_manager.pop_workflow()
 
-    def test_on_set_workflow_metadata_updates_unsaved_workflow_in_memory(self, griptape_nodes: Engine) -> None:
+    def test_on_set_workflow_metadata_updates_unsaved_workflow_in_memory(self, engine: Engine) -> None:
         """SetWorkflowMetadataRequest on an unsaved workflow updates registry metadata without touching disk."""
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         workflow_manager._workflows_loading_complete.set()
 
         unsaved_key = "unsaved:meta-test"
@@ -840,7 +839,7 @@ class TestWorkflowManager:
             # Still unsaved — no disk file materialized.
             assert workflow.file_path is None
 
-    def test_first_save_uses_display_name_when_requested_name_is_unsaved_key(self, griptape_nodes: Engine) -> None:
+    def test_first_save_uses_display_name_when_requested_name_is_unsaved_key(self, engine: Engine) -> None:
         """First save of an unsaved workflow derives the filename from metadata.name, not the synthetic key."""
         from griptape_nodes.retained_mode.events.flow_events import (
             GetTopLevelFlowResultSuccess,
@@ -853,9 +852,9 @@ class TestWorkflowManager:
             SaveWorkflowResultSuccess,
         )
 
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         workflow_manager._workflows_loading_complete.set()
-        context_manager = griptape_nodes.ContextManager()
+        context_manager = engine.context_manager
 
         unsaved_key = "unsaved:filename-test"
         display_name = "workflow_25"
@@ -914,7 +913,7 @@ class TestWorkflowManager:
                     result_details="ok",
                 )
 
-            workspace = griptape_nodes.ConfigManager().workspace_path
+            workspace = engine.config_manager.workspace_path
 
             def fake_resolve_destination(file_name: str, situation: str, **_vars: object) -> MagicMock:  # noqa: ARG001
                 stub = MagicMock()
@@ -923,7 +922,7 @@ class TestWorkflowManager:
 
             try:
                 with (
-                    patch.object(griptape_nodes, "ahandle_request", side_effect=fake_ahandle_request),
+                    patch.object(engine, "ahandle_request", side_effect=fake_ahandle_request),
                     patch.object(
                         workflow_manager,
                         "_save_workflow_file_inline",
@@ -1025,10 +1024,10 @@ class TestWorkflowManager:
         captured["persist_calls"] = mock_persist.call_args_list
         return captured
 
-    def test_rename_preserves_workspace_subdir(self, griptape_nodes: Engine) -> None:
+    def test_rename_preserves_workspace_subdir(self, engine: Engine) -> None:
         """Renaming a workflow in a sub-directory keeps it there (bar/workflow -> bar/new_name)."""
         captured = self._run_rename(
-            griptape_nodes.WorkflowManager(),
+            engine.workflow_manager,
             self._RenameScenario(
                 workflow_name="bar/workflow",
                 requested_name="new_name",
@@ -1039,10 +1038,10 @@ class TestWorkflowManager:
         )
         assert captured["save_file_name"] == "bar/new_name"
 
-    def test_rename_root_workflow_has_no_directory(self, griptape_nodes: Engine) -> None:
+    def test_rename_root_workflow_has_no_directory(self, engine: Engine) -> None:
         """Renaming a workspace-root workflow has no directory prefix."""
         captured = self._run_rename(
-            griptape_nodes.WorkflowManager(),
+            engine.workflow_manager,
             self._RenameScenario(
                 workflow_name="workflow",
                 requested_name="new_name",
@@ -1053,10 +1052,10 @@ class TestWorkflowManager:
         )
         assert captured["save_file_name"] == "new_name"
 
-    def test_rename_preserves_absolute_dir_and_reregisters(self, griptape_nodes: Engine) -> None:
+    def test_rename_preserves_absolute_dir_and_reregisters(self, engine: Engine) -> None:
         """Renaming an externally-registered (absolute path) workflow keeps it external and re-registers it."""
         captured = self._run_rename(
-            griptape_nodes.WorkflowManager(),
+            engine.workflow_manager,
             self._RenameScenario(
                 workflow_name="/ext/workflow",
                 requested_name="new_name",
@@ -1070,19 +1069,19 @@ class TestWorkflowManager:
         persist_calls = captured["persist_calls"]
         assert persist_calls == [call("/ext/new_name.py")]
 
-    def test_rename_updates_context_file_path(self, griptape_nodes: Engine) -> None:
+    def test_rename_updates_context_file_path(self, engine: Engine) -> None:
         """Renaming the open workflow moves the context's retained path onto the new file.
 
         Rename keeps the directory, so `workflow_dir` survives either way; the path itself would
         otherwise keep naming a file that no longer exists on disk.
         """
-        context_manager = griptape_nodes.ContextManager()
+        context_manager = engine.context_manager
 
         context_manager.push_workflow(workflow_name="bar/workflow")
         context_manager.set_current_workflow_file_path("/workspace/bar/workflow.py")
         try:
             self._run_rename(
-                griptape_nodes.WorkflowManager(),
+                engine.workflow_manager,
                 self._RenameScenario(
                     workflow_name="bar/workflow",
                     requested_name="new_name",
@@ -1097,10 +1096,10 @@ class TestWorkflowManager:
         finally:
             context_manager.pop_workflow()
 
-    def test_rename_returns_new_registry_key(self, griptape_nodes: Engine) -> None:
+    def test_rename_returns_new_registry_key(self, engine: Engine) -> None:
         """The returned new_workflow_name is the real directory-qualified key, not the bare stem."""
         captured = self._run_rename(
-            griptape_nodes.WorkflowManager(),
+            engine.workflow_manager,
             self._RenameScenario(
                 workflow_name="bar/workflow",
                 requested_name="new_name",
@@ -1111,14 +1110,14 @@ class TestWorkflowManager:
         )
         assert captured["result_new_name"] == "bar/new_name"
 
-    def test_rename_default_matches_file_name(self, griptape_nodes: Engine) -> None:
+    def test_rename_default_matches_file_name(self, engine: Engine) -> None:
         """Default behavior (MATCH_FILE_NAME): display name tracks the new file basename.
 
         Preserves historical wire behavior — callers who don't set display_name_behavior see the
         same result they did before the enum was introduced.
         """
         captured = self._run_rename(
-            griptape_nodes.WorkflowManager(),
+            engine.workflow_manager,
             self._RenameScenario(
                 workflow_name="my_workflow",
                 requested_name="my_workflow_renamed",
@@ -1130,7 +1129,7 @@ class TestWorkflowManager:
         )
         assert captured["save_display_name"] == "my_workflow_renamed"
 
-    def test_rename_preserve_existing_keeps_display_name(self, griptape_nodes: Engine) -> None:
+    def test_rename_preserve_existing_keeps_display_name(self, engine: Engine) -> None:
         """PRESERVE_EXISTING opt-in: SaveWorkflowRequest receives the source's metadata.name, not the new file stem.
 
         Fix for issue #4992 — with this enum value, renaming a workflow whose display name diverges
@@ -1139,7 +1138,7 @@ class TestWorkflowManager:
         from griptape_nodes.retained_mode.events.workflow_events import RenameDisplayNameBehavior
 
         captured = self._run_rename(
-            griptape_nodes.WorkflowManager(),
+            engine.workflow_manager,
             self._RenameScenario(
                 workflow_name="my_workflow",
                 requested_name="my_workflow_renamed",
@@ -1152,12 +1151,12 @@ class TestWorkflowManager:
         )
         assert captured["save_display_name"] == "My Cool Workflow"
 
-    def test_rename_override_uses_provided_display_name(self, griptape_nodes: Engine) -> None:
+    def test_rename_override_uses_provided_display_name(self, engine: Engine) -> None:
         """OVERRIDE forwards the caller-supplied display_name to SaveWorkflowRequest."""
         from griptape_nodes.retained_mode.events.workflow_events import RenameDisplayNameBehavior
 
         captured = self._run_rename(
-            griptape_nodes.WorkflowManager(),
+            engine.workflow_manager,
             self._RenameScenario(
                 workflow_name="my_workflow",
                 requested_name="my_workflow_renamed",
@@ -1173,7 +1172,7 @@ class TestWorkflowManager:
         )
         assert captured["save_display_name"] == "Renamed On Purpose"
 
-    def test_rename_override_strips_surrounding_whitespace(self, griptape_nodes: Engine) -> None:
+    def test_rename_override_strips_surrounding_whitespace(self, engine: Engine) -> None:
         """OVERRIDE forwards ``display_name`` stripped so validation and resolution agree on the canonical form.
 
         Regression coverage: ``_validate_rename_display_name`` gates OVERRIDE on
@@ -1184,7 +1183,7 @@ class TestWorkflowManager:
         from griptape_nodes.retained_mode.events.workflow_events import RenameDisplayNameBehavior
 
         captured = self._run_rename(
-            griptape_nodes.WorkflowManager(),
+            engine.workflow_manager,
             self._RenameScenario(
                 workflow_name="my_workflow",
                 requested_name="my_workflow_renamed",
@@ -1209,7 +1208,7 @@ class TestWorkflowManager:
     )
     def test_rename_rejects_display_name_without_override(
         self,
-        griptape_nodes: Engine,
+        engine: Engine,
         non_override_behavior: str,
     ) -> None:
         """Supplying display_name with a non-OVERRIDE behavior fails fast so it can't be silently ignored."""
@@ -1219,13 +1218,13 @@ class TestWorkflowManager:
             RenameWorkflowResultFailure,
         )
 
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
 
         async def fake_ahandle_request(req: object) -> object:
             msg = f"Save/delete must not run when display_name is used with non-OVERRIDE; got {type(req).__name__}"
             raise AssertionError(msg)
 
-        with patch.object(GriptapeNodes, "ahandle_request", side_effect=fake_ahandle_request):
+        with patch.object(engine, "ahandle_request", side_effect=fake_ahandle_request):
             result = asyncio.run(
                 workflow_manager.on_rename_workflow_request(
                     RenameWorkflowRequest(
@@ -1243,7 +1242,7 @@ class TestWorkflowManager:
     @pytest.mark.parametrize("empty_display_name", [None, "", "   "])
     def test_rename_override_rejects_missing_display_name(
         self,
-        griptape_nodes: Engine,
+        engine: Engine,
         empty_display_name: str | None,
     ) -> None:
         """OVERRIDE without a non-empty display_name fails fast without invoking the save pipeline."""
@@ -1253,13 +1252,13 @@ class TestWorkflowManager:
             RenameWorkflowResultFailure,
         )
 
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
 
         async def fake_ahandle_request(req: object) -> object:
             msg = f"Save/delete must not run when OVERRIDE has no display_name; got {type(req).__name__}"
             raise AssertionError(msg)
 
-        with patch.object(GriptapeNodes, "ahandle_request", side_effect=fake_ahandle_request):
+        with patch.object(engine, "ahandle_request", side_effect=fake_ahandle_request):
             result = asyncio.run(
                 workflow_manager.on_rename_workflow_request(
                     RenameWorkflowRequest(
@@ -1275,7 +1274,7 @@ class TestWorkflowManager:
         assert "OVERRIDE" in str(result.result_details)
 
     def test_rename_preserve_existing_falls_back_to_requested_name_when_source_display_name_blank(
-        self, griptape_nodes: Engine
+        self, engine: Engine
     ) -> None:
         """PRESERVE_EXISTING with a blank source metadata.name falls back to the requested name.
 
@@ -1287,7 +1286,7 @@ class TestWorkflowManager:
         from griptape_nodes.retained_mode.events.workflow_events import RenameDisplayNameBehavior
 
         captured = self._run_rename(
-            griptape_nodes.WorkflowManager(),
+            engine.workflow_manager,
             self._RenameScenario(
                 workflow_name="my_workflow",
                 requested_name="my_workflow_renamed",
@@ -1300,9 +1299,7 @@ class TestWorkflowManager:
         )
         assert captured["save_display_name"] == "my_workflow_renamed"
 
-    def test_rename_preserve_existing_falls_back_to_requested_name_when_source_missing(
-        self, griptape_nodes: Engine
-    ) -> None:
+    def test_rename_preserve_existing_falls_back_to_requested_name_when_source_missing(self, engine: Engine) -> None:
         """PRESERVE_EXISTING with an unregistered source workflow falls back to the requested name.
 
         Save-As-style path: caller asks to rename a workflow that isn't in the registry (e.g. the
@@ -1318,7 +1315,7 @@ class TestWorkflowManager:
             SaveWorkflowResultSuccess,
         )
 
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         captured: dict[str, object] = {}
 
         async def fake_ahandle_request(req: object) -> object:
@@ -1351,7 +1348,7 @@ class TestWorkflowManager:
         assert isinstance(result, RenameWorkflowResultSuccess)
         assert captured["save_display_name"] == "never_registered_renamed"
 
-    def test_rename_surfaces_delete_failure_from_bookkeeping(self, griptape_nodes: Engine) -> None:
+    def test_rename_surfaces_delete_failure_from_bookkeeping(self, engine: Engine) -> None:
         """When the post-save delete of the old registry entry fails, rename surfaces RenameWorkflowResultFailure.
 
         Save succeeds, but the follow-up DeleteWorkflowRequest for the old key comes back as
@@ -1367,7 +1364,7 @@ class TestWorkflowManager:
             SaveWorkflowResultSuccess,
         )
 
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         mock_source = MagicMock()
         mock_source.file_path = "old.py"
         mock_source.metadata.name = "Old Display"
@@ -1388,7 +1385,7 @@ class TestWorkflowManager:
             patch.object(WorkflowRegistry, "has_workflow_with_name", return_value=True),
             patch.object(WorkflowRegistry, "get_workflow_by_name", return_value=mock_source),
             patch.object(workflow_manager, "_persist_external_workflow_registration"),
-            patch.object(GriptapeNodes, "ahandle_request", side_effect=fake_ahandle_request),
+            patch.object(engine, "ahandle_request", side_effect=fake_ahandle_request),
         ):
             result = asyncio.run(
                 workflow_manager.on_rename_workflow_request(
@@ -1402,9 +1399,9 @@ class TestWorkflowManager:
         assert "'old'" in str(result.result_details)
         assert "'new'" in str(result.result_details)
 
-    def test_resolve_named_save_path_absolute_skips_sub_dirs(self, griptape_nodes: Engine) -> None:
+    def test_resolve_named_save_path_absolute_skips_sub_dirs(self, engine: Engine) -> None:
         """An absolute requested name routes the full path to _build_workflow_save_path with no sub_dirs."""
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         # Anchor to the current filesystem root so the path is absolute on Windows
         # (which needs a drive letter) as well as POSIX.
         abs_requested = Path(Path.cwd().anchor) / "ext" / "new_name"
@@ -1424,9 +1421,9 @@ class TestWorkflowManager:
         assert resolved.file_name == "new_name"
         assert resolved.relative_file_path == str(abs_path)
 
-    def test_resolve_named_save_path_relative_passes_sub_dirs(self, griptape_nodes: Engine) -> None:
+    def test_resolve_named_save_path_relative_passes_sub_dirs(self, engine: Engine) -> None:
         """A relative requested name splits into stem + sub_dirs (unchanged behavior)."""
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         fake_destination = MagicMock()
 
         with patch.object(
@@ -1441,7 +1438,7 @@ class TestWorkflowManager:
         mock_build.assert_called_once_with("new_name.py", sub_dirs="team", situation_name="save_workflow")
         assert resolved.file_name == "new_name"
 
-    def test_delete_active_workflow_clears_context_stack(self, griptape_nodes: Engine) -> None:
+    def test_delete_active_workflow_clears_context_stack(self, engine: Engine) -> None:
         """Deleting the active workflow tears down its flows and pops the context stack.
 
         Regression guard for the "phantom workflow" bug: a frontend that reloads after
@@ -1450,10 +1447,10 @@ class TestWorkflowManager:
         from griptape_nodes.exe_types.flow import ControlFlow
         from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
 
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         workflow_manager._workflows_loading_complete.set()
-        context_manager = griptape_nodes.ContextManager()
-        object_manager = griptape_nodes.ObjectManager()
+        context_manager = engine.context_manager
+        object_manager = engine.object_manager
 
         workflow_key = "unsaved:delete-active"
 
@@ -1462,7 +1459,7 @@ class TestWorkflowManager:
             context_manager.push_workflow(workflow_name=workflow_key)
 
             # Create a top-level flow under the active workflow so there's state to tear down.
-            create_result = griptape_nodes.handle_request(CreateFlowRequest(parent_flow_name=None))
+            create_result = engine.handle_request(CreateFlowRequest(parent_flow_name=None))
             assert isinstance(create_result, CreateFlowResultSuccess)
             flow_name = create_result.flow_name
             assert object_manager.has_object_with_name(flow_name)
@@ -1484,15 +1481,15 @@ class TestWorkflowManager:
                 if context_manager.has_current_workflow():
                     context_manager.pop_workflow()
 
-    def test_delete_non_active_workflow_leaves_context_untouched(self, griptape_nodes: Engine) -> None:
+    def test_delete_non_active_workflow_leaves_context_untouched(self, engine: Engine) -> None:
         """Deleting a workflow that isn't the active one must not touch the context stack.
 
         Covers the published-workflow subprocess cleanup path, which deletes by key without
         expecting the context stack to change.
         """
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         workflow_manager._workflows_loading_complete.set()
-        context_manager = griptape_nodes.ContextManager()
+        context_manager = engine.context_manager
 
         active_key = "unsaved:keep-me"
         other_key = "unsaved:delete-me"
@@ -1519,13 +1516,13 @@ class TestWorkflowManager:
                     context_manager.pop_workflow()
 
     @pytest.mark.asyncio
-    async def test_startup_scan_skips_unsaved_prefix_files(self, griptape_nodes: Engine, tmp_path: Path) -> None:
+    async def test_startup_scan_skips_unsaved_prefix_files(self, engine: Engine, tmp_path: Path) -> None:
         """Leaked `unsaved:<uuid>.py` files on disk must be skipped during the workspace scan.
 
         Pre-fix saves wrote these files; `_determine_save_target` no longer does, but any
         previously-leaked file must not trip the scanner with `Failed to register workflow`.
         """
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
 
         header = WorkflowManager.WORKFLOW_METADATA_HEADER
         metadata_block = "\n".join(
@@ -1555,16 +1552,16 @@ class TestWorkflowManager:
     # --- Metadata header parse failures ---
 
     @pytest.mark.asyncio
-    async def test_malformed_toml_header_reports_unusable(self, griptape_nodes: GriptapeNodes, tmp_path: Path) -> None:
+    async def test_malformed_toml_header_reports_unusable(self, engine: Engine, tmp_path: Path) -> None:
         """A header that is not valid TOML is UNUSABLE, not a crash.
 
         The read path parses with tomllib, which is stricter than the tomlkit it replaced,
         so this pins the strictness: a header this rejects must land in UNUSABLE with an
         InvalidTomlFormatProblem rather than reaching schema validation.
         """
-        workflow_manager = griptape_nodes.WorkflowManager()
-        griptape_nodes.ConfigManager().workspace_path = tmp_path
-        griptape_nodes.LibraryManager()._libraries_loading_complete.set()
+        workflow_manager = engine.workflow_manager
+        engine.config_manager.workspace_path = tmp_path
+        engine.library_manager._libraries_loading_complete.set()
 
         header = WorkflowManager.WORKFLOW_METADATA_HEADER
         # Unclosed table declaration: parses as a header block, fails as TOML.
@@ -1581,18 +1578,16 @@ class TestWorkflowManager:
         assert any(isinstance(problem, InvalidTomlFormatProblem) for problem in info.problems)
 
     @pytest.mark.asyncio
-    async def test_header_missing_griptape_nodes_section_reports_unusable(
-        self, griptape_nodes: GriptapeNodes, tmp_path: Path
-    ) -> None:
+    async def test_header_missing_griptape_nodes_section_reports_unusable(self, engine: Engine, tmp_path: Path) -> None:
         """A header without [tool.griptape-nodes] is UNUSABLE.
 
         Covers both ways the section lookup can fail now that tomllib returns plain dicts:
         the key being absent (KeyError) and `tool` being a scalar, so subscripting it raises
         TypeError. Both must be caught and reported, not escape as an unhandled error.
         """
-        workflow_manager = griptape_nodes.WorkflowManager()
-        griptape_nodes.ConfigManager().workspace_path = tmp_path
-        griptape_nodes.LibraryManager()._libraries_loading_complete.set()
+        workflow_manager = engine.workflow_manager
+        engine.config_manager.workspace_path = tmp_path
+        engine.library_manager._libraries_loading_complete.set()
 
         header = WorkflowManager.WORKFLOW_METADATA_HEADER
         cases = {
@@ -1614,20 +1609,20 @@ class TestWorkflowManager:
 
     # --- WorkflowInfo payload helpers ---
 
-    def test_build_workflow_info_key_uses_workspace_join(self, griptape_nodes: Engine) -> None:
+    def test_build_workflow_info_key_uses_workspace_join(self, engine: Engine) -> None:
         """_build_workflow_info_key matches the key construction used when storing info (no symlink resolution)."""
-        workflow_manager = griptape_nodes.WorkflowManager()
-        workspace = griptape_nodes.ConfigManager().workspace_path
+        workflow_manager = engine.workflow_manager
+        workspace = engine.config_manager.workspace_path
 
         key = workflow_manager._build_workflow_info_key("workflows/my_workflow.py")
 
         assert key == str(workspace / "workflows/my_workflow.py")
 
-    def test_build_workflow_info_payload_good_status_no_problems(self, griptape_nodes: Engine) -> None:
+    def test_build_workflow_info_payload_good_status_no_problems(self, engine: Engine) -> None:
         """_build_workflow_info_payload produces correct payload for a GOOD workflow with no problems."""
         from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
 
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         wf_info = WorkflowManager.WorkflowInfo(
             status=WorkflowStatus.GOOD,
             workflow_path="/workspace/workflows/my_workflow.py",
@@ -1643,14 +1638,14 @@ class TestWorkflowManager:
         assert payload.problems == []
         assert payload.workflow_dependencies == []
 
-    def test_build_workflow_info_payload_collates_problems(self, griptape_nodes: Engine) -> None:
+    def test_build_workflow_info_payload_collates_problems(self, engine: Engine) -> None:
         """_build_workflow_info_payload calls collate_problems_for_display on each problem type."""
         from griptape_nodes.retained_mode.managers.fitness_problems.workflows.library_not_registered_problem import (
             LibraryNotRegisteredProblem,
         )
         from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
 
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         wf_info = WorkflowManager.WorkflowInfo(
             status=WorkflowStatus.UNUSABLE,
             workflow_path="/workspace/workflows/broken.py",
@@ -1667,11 +1662,11 @@ class TestWorkflowManager:
         assert "lib-a" in payload.problems[0]
         assert "lib-b" in payload.problems[0]
 
-    def test_build_workflow_info_payload_includes_dependencies(self, griptape_nodes: Engine) -> None:
+    def test_build_workflow_info_payload_includes_dependencies(self, engine: Engine) -> None:
         """_build_workflow_info_payload passes WorkflowDependencyInfo instances through directly."""
         from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
 
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         wf_info = WorkflowManager.WorkflowInfo(
             status=WorkflowStatus.FLAWED,
             workflow_path="/workspace/workflows/flawed.py",
@@ -1698,9 +1693,9 @@ class TestWorkflowManager:
 
     # --- GetWorkflowInfoRequest ---
 
-    def test_on_get_workflow_info_request_workflow_not_in_registry_fails(self, griptape_nodes: Engine) -> None:
+    def test_on_get_workflow_info_request_workflow_not_in_registry_fails(self, engine: Engine) -> None:
         """GetWorkflowInfoRequest with unknown workflow_name returns failure."""
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         request = GetWorkflowInfoRequest(workflow_name="missing_workflow")
 
         with patch.object(WorkflowRegistry, "get_workflow_by_name", side_effect=KeyError("not found")):
@@ -1709,9 +1704,9 @@ class TestWorkflowManager:
         assert isinstance(result, GetWorkflowInfoResultFailure)
         assert "missing_workflow" in str(result.result_details)
 
-    def test_on_get_workflow_info_request_no_info_for_path_fails(self, griptape_nodes: Engine) -> None:
+    def test_on_get_workflow_info_request_no_info_for_path_fails(self, engine: Engine) -> None:
         """GetWorkflowInfoRequest returns failure when no WorkflowInfo is stored for the resolved path."""
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         request = GetWorkflowInfoRequest(workflow_name="my_workflow")
 
         mock_workflow = MagicMock()
@@ -1723,17 +1718,17 @@ class TestWorkflowManager:
 
         assert isinstance(result, GetWorkflowInfoResultFailure)
 
-    def test_on_get_workflow_info_request_success(self, griptape_nodes: Engine) -> None:
+    def test_on_get_workflow_info_request_success(self, engine: Engine) -> None:
         """GetWorkflowInfoRequest succeeds when WorkflowInfo exists for the workflow."""
         from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
 
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         request = GetWorkflowInfoRequest(workflow_name="my_workflow")
 
         mock_workflow = MagicMock()
         mock_workflow.file_path = "workflows/my_workflow.py"
 
-        workspace = griptape_nodes.ConfigManager().workspace_path
+        workspace = engine.config_manager.workspace_path
         info_key = str(workspace / "workflows/my_workflow.py")
         wf_info = WorkflowManager.WorkflowInfo(
             status=WorkflowStatus.GOOD,
@@ -1753,9 +1748,9 @@ class TestWorkflowManager:
 
     # --- ListAllWorkflowInfoRequest ---
 
-    def test_on_list_all_workflow_info_request_registry_failure(self, griptape_nodes: Engine) -> None:
+    def test_on_list_all_workflow_info_request_registry_failure(self, engine: Engine) -> None:
         """ListAllWorkflowInfoRequest returns failure when listing workflows raises."""
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         request = ListAllWorkflowInfoRequest()
 
         with patch.object(WorkflowRegistry, "list_workflows", side_effect=Exception("registry error")):
@@ -1764,14 +1759,14 @@ class TestWorkflowManager:
         assert isinstance(result, ListAllWorkflowInfoResultFailure)
         assert "registry error" in str(result.result_details)
 
-    def test_on_list_all_workflow_info_request_success(self, griptape_nodes: Engine) -> None:
+    def test_on_list_all_workflow_info_request_success(self, engine: Engine) -> None:
         """ListAllWorkflowInfoRequest returns info for every workflow that has a stored WorkflowInfo."""
         from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
 
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         request = ListAllWorkflowInfoRequest()
 
-        workspace = griptape_nodes.ConfigManager().workspace_path
+        workspace = engine.config_manager.workspace_path
         info_key = str(workspace / "workflows/my_workflow.py")
         wf_info = WorkflowManager.WorkflowInfo(
             status=WorkflowStatus.GOOD,
@@ -1793,9 +1788,9 @@ class TestWorkflowManager:
         assert "my_workflow" in result.workflow_infos
         assert result.workflow_infos["my_workflow"].status == "GOOD"
 
-    def test_on_list_all_workflow_info_request_skips_workflows_without_info(self, griptape_nodes: Engine) -> None:
+    def test_on_list_all_workflow_info_request_skips_workflows_without_info(self, engine: Engine) -> None:
         """ListAllWorkflowInfoRequest omits workflows that have no stored WorkflowInfo."""
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         request = ListAllWorkflowInfoRequest()
 
         mock_workflow = MagicMock()
@@ -1811,9 +1806,9 @@ class TestWorkflowManager:
         assert isinstance(result, ListAllWorkflowInfoResultSuccess)
         assert result.workflow_infos == {}
 
-    def test_on_list_all_workflow_info_request_skips_unknown_registry_keys(self, griptape_nodes: Engine) -> None:
+    def test_on_list_all_workflow_info_request_skips_unknown_registry_keys(self, engine: Engine) -> None:
         """ListAllWorkflowInfoRequest skips registry keys that can't be looked up."""
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         request = ListAllWorkflowInfoRequest()
 
         with (
@@ -1827,13 +1822,13 @@ class TestWorkflowManager:
 
     # --- _build_workflow_save_path ---
 
-    def test_build_workflow_save_path_returns_destination_from_situation(self, griptape_nodes: Engine) -> None:
+    def test_build_workflow_save_path_returns_destination_from_situation(self, engine: Engine) -> None:
         """The destination from the save_workflow situation is returned verbatim — no upstream macro resolution.
 
         Resolving the macro upstream would strip the seed-and-retry context needed
         for unresolved required ``{x:NN}`` slots inside OSManager (issue #4941).
         """
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
 
         fake_destination = MagicMock()
 
@@ -1849,9 +1844,9 @@ class TestWorkflowManager:
         fake_destination.resolve.assert_not_called()
         assert save_path.relative_file_path == "my_workflow.py"
 
-    def test_build_workflow_save_path_preserves_sub_dirs(self, griptape_nodes: Engine) -> None:
+    def test_build_workflow_save_path_preserves_sub_dirs(self, engine: Engine) -> None:
         """sub_dirs flow through as macro variables and into the registry-relative display string."""
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
 
         fake_destination = MagicMock()
 
@@ -1892,18 +1887,16 @@ class TestWorkflowManager:
             workflow_shape=WorkflowShape(inputs={}, outputs={}) if with_shape else None,
         )
 
-    def _generate(self, griptape_nodes: Engine, *, with_shape: bool = False) -> str:
-        workflow_manager = griptape_nodes.WorkflowManager()
+    def _generate(self, engine: Engine, *, with_shape: bool = False) -> str:
+        workflow_manager = engine.workflow_manager
         return workflow_manager._generate_workflow_file_content(
             serialized_flow_commands=self._empty_serialized_flow_commands(),
             workflow_metadata=self._minimal_workflow_metadata(with_shape=with_shape),
         )
 
-    def test_generate_workflow_file_content_wraps_graph_building_in_async_build_workflow(
-        self, griptape_nodes: Engine
-    ) -> None:
+    def test_generate_workflow_file_content_wraps_graph_building_in_async_build_workflow(self, engine: Engine) -> None:
         """Saved workflows must wrap graph-building statements in `async def build_workflow()`."""
-        content = self._generate(griptape_nodes)
+        content = self._generate(engine)
 
         # The file must declare build_workflow as an async function.
         module = ast.parse(content)
@@ -1912,13 +1905,13 @@ class TestWorkflowManager:
         ]
         assert len(build_workflow_defs) == 1, "build_workflow must be defined exactly once as async"
 
-    def test_generate_workflow_file_content_is_inert_at_import(self, griptape_nodes: Engine) -> None:
+    def test_generate_workflow_file_content_is_inert_at_import(self, engine: Engine) -> None:
         """A shape-free saved workflow must contain no module-level side effects.
 
         Only function/class definitions and imports should appear at the top level so that
         `exec()`-ing the module does not mutate engine state until build_workflow() is awaited.
         """
-        content = self._generate(griptape_nodes)
+        content = self._generate(engine)
         module = ast.parse(content)
 
         allowed_top_level = (
@@ -1934,9 +1927,9 @@ class TestWorkflowManager:
                 f"Unexpected top-level statement of type {type(node).__name__} in shape-free workflow"
             )
 
-    def test_generate_workflow_file_content_prereq_lives_inside_build_workflow(self, griptape_nodes: Engine) -> None:
+    def test_generate_workflow_file_content_prereq_lives_inside_build_workflow(self, engine: Engine) -> None:
         """Prerequisite code (context_manager setup) must live inside build_workflow, not at module scope."""
-        content = self._generate(griptape_nodes)
+        content = self._generate(engine)
         module = ast.parse(content)
 
         build_workflow = next(
@@ -1947,7 +1940,7 @@ class TestWorkflowManager:
         assert "context_manager.push_workflow(file_path=__file__)" in body_src
 
     def test_generate_workflow_file_content_registers_declared_libraries_in_build_workflow(
-        self, griptape_nodes: Engine
+        self, engine: Engine
     ) -> None:
         """build_workflow() must register every library named in node_libraries_referenced.
 
@@ -1959,7 +1952,7 @@ class TestWorkflowManager:
         """
         from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
 
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         metadata = WorkflowMetadata(
             name="test_workflow",
             schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
@@ -1997,7 +1990,7 @@ class TestWorkflowManager:
         assert "RegisterLibraryFromFileRequest" in top_level_imports
 
     def test_generate_workflow_file_content_omits_register_calls_when_no_libraries_declared(
-        self, griptape_nodes: Engine
+        self, engine: Engine
     ) -> None:
         """With an empty node_libraries_referenced list, no register calls are emitted.
 
@@ -2005,10 +1998,10 @@ class TestWorkflowManager:
         a library, and makes sure the empty-loop branch in _generate_workflow_run_prerequisite_code
         does not regress to emitting stray RegisterLibraryFromFileRequest noise.
         """
-        content = self._generate(griptape_nodes)
+        content = self._generate(engine)
         assert "RegisterLibraryFromFileRequest" not in content
 
-    def test_generated_build_workflow_registers_libraries_before_creating_nodes(self, griptape_nodes: Engine) -> None:
+    def test_generated_build_workflow_registers_libraries_before_creating_nodes(self, engine: Engine) -> None:
         """build_workflow() must dispatch RegisterLibraryFromFileRequest before any CreateNodeRequest.
 
         Captures the runtime contract for issue #4584: when a generated workflow runs as a
@@ -2023,7 +2016,7 @@ class TestWorkflowManager:
         from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileRequest
         from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, SerializedNodeCommands
 
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
 
         flow = SerializedFlowCommands(
             flow_initialization_command=_CreateFlowRequest(
@@ -2066,7 +2059,7 @@ class TestWorkflowManager:
 
         dispatched: list[object] = []
 
-        original_ahandle = GriptapeNodes.ahandle_request
+        original_ahandle = engine.ahandle_request
 
         async def recording_ahandle_request(request: object) -> object:
             dispatched.append(request)
@@ -2074,7 +2067,9 @@ class TestWorkflowManager:
 
         exec_globals: dict[str, object] = {"__file__": "runtime_order_test.py"}
         exec(compile(script_source, "<runtime_order_test>", "exec"), exec_globals)  # noqa: S102
-        with patch.object(GriptapeNodes, "ahandle_request", side_effect=recording_ahandle_request):
+        # The generated source calls the facade, which resolves to this engine, so stubbing the
+        # instance method is enough to record what build_workflow dispatches.
+        with patch.object(engine, "ahandle_request", side_effect=recording_ahandle_request):
             asyncio.run(exec_globals["build_workflow"]())  # type: ignore[operator]
 
         register_indices = [i for i, req in enumerate(dispatched) if isinstance(req, RegisterLibraryFromFileRequest)]
@@ -2091,9 +2086,9 @@ class TestWorkflowManager:
             f" got order {[type(r).__name__ for r in dispatched]}"
         )
 
-    def test_generate_workflow_file_content_empty_build_workflow_has_pass_body(self, griptape_nodes: Engine) -> None:
+    def test_generate_workflow_file_content_empty_build_workflow_has_pass_body(self, engine: Engine) -> None:
         """If we somehow produce no graph-building statements, build_workflow should still be valid Python."""
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         # Stub out the two generators so main_body ends up empty and the `or [ast.Pass()]` branch runs.
         with (
             patch.object(workflow_manager, "_generate_workflow_run_prerequisite_code", return_value=[]),
@@ -2115,13 +2110,13 @@ class TestWorkflowManager:
         assert len(build_workflow.body) == 1
         assert isinstance(build_workflow.body[0], ast.Pass)
 
-    def test_generate_workflow_file_content_aexecute_awaits_build_workflow_first(self, griptape_nodes: Engine) -> None:
+    def test_generate_workflow_file_content_aexecute_awaits_build_workflow_first(self, engine: Engine) -> None:
         """aexecute_workflow must `await build_workflow()` before running the executor.
 
         Shape-bearing workflows emit execute_workflow + aexecute_workflow, and the async
         version is expected to construct the graph before invoking the executor.
         """
-        content = self._generate(griptape_nodes, with_shape=True)
+        content = self._generate(engine, with_shape=True)
         module = ast.parse(content)
 
         aexecute = next(
@@ -2136,9 +2131,9 @@ class TestWorkflowManager:
         assert isinstance(call.func, ast.Name)
         assert call.func.id == "build_workflow"
 
-    def test_generate_workflow_file_content_ensure_context_is_async(self, griptape_nodes: Engine) -> None:
+    def test_generate_workflow_file_content_ensure_context_is_async(self, engine: Engine) -> None:
         """_ensure_workflow_context is now async and must await ahandle_request."""
-        content = self._generate(griptape_nodes, with_shape=True)
+        content = self._generate(engine, with_shape=True)
         module = ast.parse(content)
 
         ensure = next(
@@ -2151,13 +2146,13 @@ class TestWorkflowManager:
         # Sanity check: the old sync variant is gone.
         assert "GriptapeNodes.handle_request(" not in body_src
 
-    def test_generate_workflow_file_content_is_valid_python(self, griptape_nodes: Engine) -> None:
+    def test_generate_workflow_file_content_is_valid_python(self, engine: Engine) -> None:
         """Generated content must parse cleanly (no smuggled-string comments left behind)."""
-        content = self._generate(griptape_nodes, with_shape=True)
+        content = self._generate(engine, with_shape=True)
         # ast.parse raises SyntaxError if rewrite_string_comments left bad output behind.
         ast.parse(content)
 
-    def test_collect_object_imports_routes_dynamic_module_to_deferred(self, griptape_nodes: Engine) -> None:
+    def test_collect_object_imports_routes_dynamic_module_to_deferred(self, engine: Engine) -> None:
         """Dynamic library class imports must go into deferred_imports, not import_recorder.
 
         Regression for #4738: _collect_object_imports previously routed all imports through
@@ -2167,7 +2162,7 @@ class TestWorkflowManager:
         """
         from griptape_nodes.retained_mode.managers.workflow_manager import ImportRecorder
 
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         fake_class = type("FakeClass", (), {})
         fake_module = MagicMock()
         fake_module.__name__ = "gtn_dynamic_module_foo_py_123"
@@ -2180,9 +2175,9 @@ class TestWorkflowManager:
                 "griptape_nodes.retained_mode.managers.workflow_manager.getmodule",
                 return_value=fake_module,
             ),
-            patch.object(griptape_nodes.LibraryManager(), "is_dynamic_module", return_value=True),
+            patch.object(engine.library_manager, "is_dynamic_module", return_value=True),
             patch.object(
-                griptape_nodes.LibraryManager(),
+                engine.library_manager,
                 "get_stable_namespace_for_dynamic_module",
                 return_value="my_lib.foo",
             ),
@@ -2209,7 +2204,7 @@ class TestWorkflowVariablePersistence:
             node_libraries_referenced=[],
         )
 
-    def test_generate_create_variable_code_emits_expected_call(self, griptape_nodes: Engine) -> None:
+    def test_generate_create_variable_code_emits_expected_call(self, engine: Engine) -> None:
         """The AST helper should produce a single CreateVariableRequest call per command."""
         import ast
 
@@ -2218,7 +2213,7 @@ class TestWorkflowVariablePersistence:
         from griptape_nodes.retained_mode.events.variable_events import CreateVariableRequest
         from griptape_nodes.retained_mode.managers.workflow_manager import ImportRecorder
 
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         import_recorder = ImportRecorder()
 
         serialized_command = SerializedFlowCommands.SerializedVariableCommand(
@@ -2253,29 +2248,29 @@ class TestWorkflowVariablePersistence:
         imports_text = import_recorder.generate_imports()
         assert "CreateVariableRequest" in imports_text
 
-    def _push_clean_flow_context(self, griptape_nodes: Engine, flow_name: str = "ControlFlow_1") -> str:
+    def _push_clean_flow_context(self, engine: Engine, flow_name: str = "ControlFlow_1") -> str:
         """Clear state, push a workflow context, and create a single empty flow. Returns the flow name."""
         from griptape_nodes.retained_mode.events.flow_events import (
             CreateFlowRequest,
             CreateFlowResultSuccess,
         )
 
-        variables_manager = griptape_nodes.VariablesManager()
-        context_manager = griptape_nodes.ContextManager()
+        variables_manager = engine.variables_manager
+        context_manager = engine.context_manager
 
         if context_manager.has_current_workflow():
-            GriptapeNodes.clear_current_workflow_data()
+            engine.clear_current_workflow_data()
         variables_manager.clear_object_state()
 
         context_manager.push_workflow(workflow_name="round_trip_workflow")
 
-        flow_result = GriptapeNodes.handle_request(
+        flow_result = engine.handle_request(
             CreateFlowRequest(parent_flow_name=None, flow_name=flow_name, set_as_new_context=False)
         )
         assert isinstance(flow_result, CreateFlowResultSuccess)
         return flow_result.flow_name
 
-    def test_declared_variable_gets_serialized(self, griptape_nodes: Engine) -> None:
+    def test_declared_variable_gets_serialized(self, engine: Engine) -> None:
         """A flow-scoped variable that is declared via a VariableReference should be serialized."""
         from griptape_nodes.exe_types.node_types import VariableReference
         from griptape_nodes.retained_mode.events.variable_events import (
@@ -2284,11 +2279,11 @@ class TestWorkflowVariablePersistence:
         )
         from griptape_nodes.retained_mode.variable_types import VariableScope
 
-        flow_manager = griptape_nodes.FlowManager()
-        flow_name = self._push_clean_flow_context(griptape_nodes)
+        flow_manager = engine.flow_manager
+        flow_name = self._push_clean_flow_context(engine)
 
         assert isinstance(
-            GriptapeNodes.handle_request(
+            engine.handle_request(
                 CreateVariableRequest(
                     name="declared_var", type="str", is_global=False, value="dog", owning_flow=flow_name
                 )
@@ -2306,18 +2301,18 @@ class TestWorkflowVariablePersistence:
         assert {cmd.create_variable_command.name for cmd in commands} == {"declared_var"}
         assert len(unique_values) == 1
 
-    def test_orphan_variable_is_dropped(self, griptape_nodes: Engine) -> None:
+    def test_orphan_variable_is_dropped(self, engine: Engine) -> None:
         """A variable in engine state with no declared reference must not be serialized."""
         from griptape_nodes.retained_mode.events.variable_events import (
             CreateVariableRequest,
             CreateVariableResultSuccess,
         )
 
-        flow_manager = griptape_nodes.FlowManager()
-        flow_name = self._push_clean_flow_context(griptape_nodes)
+        flow_manager = engine.flow_manager
+        flow_name = self._push_clean_flow_context(engine)
 
         assert isinstance(
-            GriptapeNodes.handle_request(
+            engine.handle_request(
                 CreateVariableRequest(
                     name="orphan_var", type="str", is_global=False, value="cat", owning_flow=flow_name
                 )
@@ -2335,13 +2330,13 @@ class TestWorkflowVariablePersistence:
         assert commands == []
         assert unique_values == {}
 
-    def test_declared_but_missing_variable_is_dropped(self, griptape_nodes: Engine) -> None:
+    def test_declared_but_missing_variable_is_dropped(self, engine: Engine) -> None:
         """A reference to a variable that does not exist in the flow should not produce a command."""
         from griptape_nodes.exe_types.node_types import VariableReference
         from griptape_nodes.retained_mode.variable_types import VariableScope
 
-        flow_manager = griptape_nodes.FlowManager()
-        flow_name = self._push_clean_flow_context(griptape_nodes)
+        flow_manager = engine.flow_manager
+        flow_name = self._push_clean_flow_context(engine)
 
         unique_values: dict[SerializedNodeCommands.UniqueParameterValueUUID, object] = {}
         commands = flow_manager._serialize_variables_for_flow(
@@ -2352,7 +2347,7 @@ class TestWorkflowVariablePersistence:
 
         assert commands == []
 
-    def test_global_only_scope_is_skipped(self, griptape_nodes: Engine) -> None:
+    def test_global_only_scope_is_skipped(self, engine: Engine) -> None:
         """GLOBAL_ONLY references are deferred for now and must not produce a command."""
         from griptape_nodes.exe_types.node_types import VariableReference
         from griptape_nodes.retained_mode.events.variable_events import (
@@ -2361,13 +2356,13 @@ class TestWorkflowVariablePersistence:
         )
         from griptape_nodes.retained_mode.variable_types import VariableScope
 
-        flow_manager = griptape_nodes.FlowManager()
-        flow_name = self._push_clean_flow_context(griptape_nodes)
+        flow_manager = engine.flow_manager
+        flow_name = self._push_clean_flow_context(engine)
 
         # Create a flow-scoped variable with the same name as a pretend-global. It should not match,
         # because the GLOBAL_ONLY scope is unsupported for serialization and must be skipped.
         assert isinstance(
-            GriptapeNodes.handle_request(
+            engine.handle_request(
                 CreateVariableRequest(
                     name="shared_name", type="str", is_global=False, value="local", owning_flow=flow_name
                 )
@@ -2384,7 +2379,7 @@ class TestWorkflowVariablePersistence:
 
         assert commands == []
 
-    def test_hierarchical_reference_only_serializes_at_owning_flow(self, griptape_nodes: Engine) -> None:
+    def test_hierarchical_reference_only_serializes_at_owning_flow(self, engine: Engine) -> None:
         """A HIERARCHICAL reference resolved against a child flow must not serialize an ancestor-owned variable."""
         from griptape_nodes.exe_types.node_types import VariableReference
         from griptape_nodes.retained_mode.events.flow_events import (
@@ -2397,10 +2392,10 @@ class TestWorkflowVariablePersistence:
         )
         from griptape_nodes.retained_mode.variable_types import VariableScope
 
-        flow_manager = griptape_nodes.FlowManager()
-        parent_flow_name = self._push_clean_flow_context(griptape_nodes, flow_name="ParentFlow")
+        flow_manager = engine.flow_manager
+        parent_flow_name = self._push_clean_flow_context(engine, flow_name="ParentFlow")
 
-        child_flow_result = GriptapeNodes.handle_request(
+        child_flow_result = engine.handle_request(
             CreateFlowRequest(parent_flow_name=parent_flow_name, flow_name="ChildFlow", set_as_new_context=False)
         )
         assert isinstance(child_flow_result, CreateFlowResultSuccess)
@@ -2408,7 +2403,7 @@ class TestWorkflowVariablePersistence:
 
         # Variable lives on the parent.
         assert isinstance(
-            GriptapeNodes.handle_request(
+            engine.handle_request(
                 CreateVariableRequest(
                     name="ancestor_var",
                     type="str",
@@ -2440,7 +2435,7 @@ class TestWorkflowVariablePersistence:
         )
         assert {cmd.create_variable_command.name for cmd in parent_commands} == {"ancestor_var"}
 
-    def test_save_load_preserves_flow_scoped_variables(self, griptape_nodes: Engine) -> None:
+    def test_save_load_preserves_flow_scoped_variables(self, engine: Engine) -> None:
         """Round-trip: declare a flow-scoped variable, serialize, clear, exec, confirm it is restored."""
         from griptape_nodes.exe_types.node_types import NodeDependencies, VariableReference
         from griptape_nodes.retained_mode.events.flow_events import (
@@ -2455,12 +2450,12 @@ class TestWorkflowVariablePersistence:
         )
         from griptape_nodes.retained_mode.variable_types import VariableScope
 
-        workflow_manager = griptape_nodes.WorkflowManager()
-        variables_manager = griptape_nodes.VariablesManager()
-        flow_name = self._push_clean_flow_context(griptape_nodes)
+        workflow_manager = engine.workflow_manager
+        variables_manager = engine.variables_manager
+        flow_name = self._push_clean_flow_context(engine)
 
         assert isinstance(
-            GriptapeNodes.handle_request(
+            engine.handle_request(
                 CreateVariableRequest(
                     name="flow_scoped_var", type="str", is_global=False, value="dog", owning_flow=flow_name
                 )
@@ -2475,7 +2470,7 @@ class TestWorkflowVariablePersistence:
         from griptape_nodes.retained_mode.events.flow_events import SerializedFlowCommands
         from griptape_nodes.retained_mode.events.node_events import SerializedNodeCommands
 
-        flow_manager = griptape_nodes.FlowManager()
+        flow_manager = engine.flow_manager
         original_aggregate = flow_manager._aggregate_flow_dependencies
 
         def aggregate_with_declared_ref(
@@ -2493,7 +2488,7 @@ class TestWorkflowVariablePersistence:
             "_aggregate_flow_dependencies",
             side_effect=aggregate_with_declared_ref,
         ):
-            serialize_result = GriptapeNodes.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_name))
+            serialize_result = engine.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_name))
 
         assert isinstance(serialize_result, SerializeFlowToCommandsResultSuccess)
         serialized_commands = serialize_result.serialized_flow_commands
@@ -2515,7 +2510,7 @@ class TestWorkflowVariablePersistence:
         assert "name='flow_scoped_var'" in script_source
 
         # Clear everything, then exec the script and confirm the variable is rebuilt.
-        GriptapeNodes.clear_current_workflow_data()
+        engine.clear_current_workflow_data()
         variables_manager.clear_object_state()
 
         exec_globals: dict[str, object] = {"__file__": "test_workflow.py"}
@@ -2526,7 +2521,7 @@ class TestWorkflowVariablePersistence:
         build_workflow = exec_globals["build_workflow"]
         asyncio.run(build_workflow())  # type: ignore[operator]
 
-        flow_value = GriptapeNodes.handle_request(
+        flow_value = engine.handle_request(
             GetVariableValueRequest(
                 name="flow_scoped_var", starting_flow=flow_name, lookup_scope=VariableScope.CURRENT_FLOW_ONLY
             )
@@ -2534,7 +2529,7 @@ class TestWorkflowVariablePersistence:
         assert isinstance(flow_value, GetVariableValueResultSuccess)
         assert flow_value.value == "dog"
 
-    def test_save_drops_orphan_variables_end_to_end(self, griptape_nodes: Engine) -> None:
+    def test_save_drops_orphan_variables_end_to_end(self, engine: Engine) -> None:
         """The var.py scenario: a variable with no declaring node must not survive serialization."""
         from griptape_nodes.retained_mode.events.flow_events import (
             SerializeFlowToCommandsRequest,
@@ -2545,12 +2540,12 @@ class TestWorkflowVariablePersistence:
             CreateVariableResultSuccess,
         )
 
-        flow_name = self._push_clean_flow_context(griptape_nodes)
+        flow_name = self._push_clean_flow_context(engine)
 
         # Simulate the bug: a variable was created (via some now-deleted SetVariable node) but no
         # node currently declares it.
         assert isinstance(
-            GriptapeNodes.handle_request(
+            engine.handle_request(
                 CreateVariableRequest(
                     name="orphan_var", type="str", is_global=False, value="stale", owning_flow=flow_name
                 )
@@ -2558,7 +2553,7 @@ class TestWorkflowVariablePersistence:
             CreateVariableResultSuccess,
         )
 
-        serialize_result = GriptapeNodes.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_name))
+        serialize_result = engine.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_name))
         assert isinstance(serialize_result, SerializeFlowToCommandsResultSuccess)
         assert serialize_result.serialized_flow_commands.serialized_variable_commands == []
 
@@ -2610,7 +2605,7 @@ class TestVariableReferenceAccess:
             VariableReference(name="foo", scope=VariableScope.HIERARCHICAL, access=VariableAccess.READ_WRITE),
         }
 
-    def test_serializer_ignores_access(self, griptape_nodes: Engine) -> None:
+    def test_serializer_ignores_access(self, engine: Engine) -> None:
         """Serialization filtering is access-agnostic: any declared reference keeps the variable."""
         from griptape_nodes.exe_types.node_types import VariableAccess, VariableReference
         from griptape_nodes.retained_mode.events.variable_events import (
@@ -2619,12 +2614,12 @@ class TestVariableReferenceAccess:
         )
         from griptape_nodes.retained_mode.variable_types import VariableScope
 
-        flow_manager = griptape_nodes.FlowManager()
+        flow_manager = engine.flow_manager
         persistence = TestWorkflowVariablePersistence()
-        flow_name = persistence._push_clean_flow_context(griptape_nodes)
+        flow_name = persistence._push_clean_flow_context(engine)
 
         assert isinstance(
-            GriptapeNodes.handle_request(
+            engine.handle_request(
                 CreateVariableRequest(name="only_read", type="str", is_global=False, value="cat", owning_flow=flow_name)
             ),
             CreateVariableResultSuccess,
@@ -2646,7 +2641,7 @@ class TestVariableReferenceAccess:
 class TestLibraryResolutionOnLoad:
     """run_workflow resolves declared libraries before exec via the metadata header."""
 
-    def test_ensure_libraries_dispatches_ahandle_request_per_library(self, griptape_nodes: Engine) -> None:
+    def test_ensure_libraries_dispatches_ahandle_request_per_library(self, engine: Engine) -> None:
         """_ensure_libraries_for_workflow dispatches one RegisterLibraryFromFileRequest per declared library."""
         from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
         from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
@@ -2656,7 +2651,7 @@ class TestLibraryResolutionOnLoad:
         )
         from griptape_nodes.retained_mode.events.workflow_events import LoadWorkflowMetadataResultSuccess
 
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         metadata = WorkflowMetadata(
             name="t",
             schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
@@ -2679,7 +2674,7 @@ class TestLibraryResolutionOnLoad:
 
         with (
             patch.object(workflow_manager, "on_load_workflow_metadata_request", AsyncMock(return_value=load_result)),
-            patch.object(griptape_nodes, "ahandle_request", side_effect=fake_ahandle_request),
+            patch.object(engine, "ahandle_request", side_effect=fake_ahandle_request),
         ):
             result = asyncio.run(
                 workflow_manager._ensure_libraries_for_workflow(
@@ -2692,14 +2687,14 @@ class TestLibraryResolutionOnLoad:
         assert [r.library_name for r in dispatched] == ["Example Library", "Other Library"]
         assert all(r.perform_discovery_if_not_found for r in dispatched)
 
-    def test_ensure_libraries_returns_failure_when_registration_fails(self, griptape_nodes: Engine) -> None:
+    def test_ensure_libraries_returns_failure_when_registration_fails(self, engine: Engine) -> None:
         """A failed library registration short-circuits with a WorkflowExecutionResult failure."""
         from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
         from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
         from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileResultFailure
         from griptape_nodes.retained_mode.events.workflow_events import LoadWorkflowMetadataResultSuccess
 
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         metadata = WorkflowMetadata(
             name="t",
             schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
@@ -2713,7 +2708,7 @@ class TestLibraryResolutionOnLoad:
         with (
             patch.object(workflow_manager, "on_load_workflow_metadata_request", AsyncMock(return_value=load_result)),
             patch.object(
-                GriptapeNodes,
+                engine,
                 "ahandle_request",
                 AsyncMock(return_value=RegisterLibraryFromFileResultFailure(result_details="not found")),
             ),
@@ -2729,7 +2724,7 @@ class TestLibraryResolutionOnLoad:
         assert result.execution_successful is False
         assert "Missing Library" in result.execution_details
 
-    def test_ensure_libraries_failure_message_uses_filename_and_renders_semver(self, griptape_nodes: Engine) -> None:
+    def test_ensure_libraries_failure_message_uses_filename_and_renders_semver(self, engine: Engine) -> None:
         """Failure message uses the workflow file name (not full path) and renders v<version> for semver values."""
         import logging as _logging
 
@@ -2741,7 +2736,7 @@ class TestLibraryResolutionOnLoad:
         )
         from griptape_nodes.retained_mode.events.workflow_events import LoadWorkflowMetadataResultSuccess
 
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         metadata = WorkflowMetadata(
             name="t",
             schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
@@ -2760,7 +2755,7 @@ class TestLibraryResolutionOnLoad:
 
         with (
             patch.object(workflow_manager, "on_load_workflow_metadata_request", AsyncMock(return_value=load_result)),
-            patch.object(griptape_nodes, "ahandle_request", side_effect=fake_ahandle_request),
+            patch.object(engine, "ahandle_request", side_effect=fake_ahandle_request),
         ):
             result = asyncio.run(
                 workflow_manager._ensure_libraries_for_workflow(
@@ -2781,14 +2776,14 @@ class TestLibraryResolutionOnLoad:
         assert len(dispatched) == 1
         assert dispatched[0].failure_log_level == _logging.DEBUG
 
-    def test_ensure_libraries_failure_message_omits_non_semver_version(self, griptape_nodes: Engine) -> None:
+    def test_ensure_libraries_failure_message_omits_non_semver_version(self, engine: Engine) -> None:
         """Non-semver `library_version` values (e.g. unavailable-library placeholder) are not rendered as v<...>."""
         from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
         from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
         from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileResultFailure
         from griptape_nodes.retained_mode.events.workflow_events import LoadWorkflowMetadataResultSuccess
 
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         placeholder = "<version unavailable; workflow was saved when library was unable to be loaded>"
         metadata = WorkflowMetadata(
             name="t",
@@ -2803,7 +2798,7 @@ class TestLibraryResolutionOnLoad:
         with (
             patch.object(workflow_manager, "on_load_workflow_metadata_request", AsyncMock(return_value=load_result)),
             patch.object(
-                GriptapeNodes,
+                engine,
                 "ahandle_request",
                 AsyncMock(return_value=RegisterLibraryFromFileResultFailure(result_details="not found")),
             ),
@@ -2822,14 +2817,14 @@ class TestLibraryResolutionOnLoad:
         assert placeholder not in result.execution_details
         assert " v" not in result.execution_details.split("Missing Library", 1)[1]
 
-    def test_ensure_libraries_failure_message_omits_empty_version(self, griptape_nodes: Engine) -> None:
+    def test_ensure_libraries_failure_message_omits_empty_version(self, engine: Engine) -> None:
         """An empty `library_version` falls through the semver check and renders no version suffix."""
         from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
         from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
         from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileResultFailure
         from griptape_nodes.retained_mode.events.workflow_events import LoadWorkflowMetadataResultSuccess
 
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         metadata = WorkflowMetadata(
             name="t",
             schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
@@ -2843,7 +2838,7 @@ class TestLibraryResolutionOnLoad:
         with (
             patch.object(workflow_manager, "on_load_workflow_metadata_request", AsyncMock(return_value=load_result)),
             patch.object(
-                GriptapeNodes,
+                engine,
                 "ahandle_request",
                 AsyncMock(return_value=RegisterLibraryFromFileResultFailure(result_details="not found")),
             ),
@@ -2860,17 +2855,17 @@ class TestLibraryResolutionOnLoad:
         assert "Missing Library" in result.execution_details
         assert " v" not in result.execution_details.split("Missing Library", 1)[1]
 
-    def test_ensure_libraries_is_noop_when_metadata_missing(self, griptape_nodes: Engine) -> None:
+    def test_ensure_libraries_is_noop_when_metadata_missing(self, engine: Engine) -> None:
         """If metadata can't be loaded, _ensure_libraries_for_workflow returns None (tolerant fallback)."""
         from griptape_nodes.retained_mode.events.workflow_events import LoadWorkflowMetadataResultFailure
 
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         load_result = LoadWorkflowMetadataResultFailure(result_details="no metadata")
 
         ahandle_spy = AsyncMock()
         with (
             patch.object(workflow_manager, "on_load_workflow_metadata_request", AsyncMock(return_value=load_result)),
-            patch.object(GriptapeNodes, "ahandle_request", ahandle_spy),
+            patch.object(engine, "ahandle_request", ahandle_spy),
         ):
             result = asyncio.run(
                 workflow_manager._ensure_libraries_for_workflow(
@@ -2886,7 +2881,7 @@ class TestLibraryResolutionOnLoad:
 class TestWorkflowsLoadingGate:
     """Gated handlers must not deadlock when invoked during library load (issue #4470)."""
 
-    def test_workflows_loading_complete_is_set_on_init(self, griptape_nodes: Engine) -> None:
+    def test_workflows_loading_complete_is_set_on_init(self, engine: Engine) -> None:
         """The gate starts as set so handlers invoked before first refresh return immediately.
 
         The hazard is: a node __init__ fires a workflow query during library load, but
@@ -2894,18 +2889,18 @@ class TestWorkflowsLoadingGate:
         started unset, the handler would block forever. Starting set means handlers
         see an empty registry (the truth during startup) and return a clean empty result.
         """
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
 
         assert workflow_manager._workflows_loading_complete.is_set()
 
-    def test_list_all_workflows_returns_immediately_before_first_refresh(self, griptape_nodes: Engine) -> None:
+    def test_list_all_workflows_returns_immediately_before_first_refresh(self, engine: Engine) -> None:
         """on_list_all_workflows_request does not hang when invoked before refresh_workflow_registry."""
         from griptape_nodes.retained_mode.events.workflow_events import (
             ListAllWorkflowsRequest,
             ListAllWorkflowsResultSuccess,
         )
 
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
 
         async def gated() -> object:
             return await asyncio.wait_for(
@@ -2921,7 +2916,7 @@ class TestWorkflowsLoadingGate:
 class TestWorkflowMetadataTransitiveDeps:
     """node_libraries_referenced in saved workflow metadata includes transitive library_dependencies."""
 
-    def test_transitive_library_dep_included_in_metadata(self, griptape_nodes: Engine) -> None:
+    def test_transitive_library_dep_included_in_metadata(self, engine: Engine) -> None:
         """When lib-a has library_dependency on lib-b, generated metadata lists both in node_libraries_referenced."""
         from datetime import UTC, datetime
 
@@ -2929,8 +2924,8 @@ class TestWorkflowMetadataTransitiveDeps:
         from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
         from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
 
-        workflow_manager = griptape_nodes.WorkflowManager()
-        lib_mgr = griptape_nodes.LibraryManager()
+        workflow_manager = engine.workflow_manager
+        lib_mgr = engine.library_manager
 
         commands = SerializedFlowCommands(
             flow_initialization_command=None,
@@ -2996,9 +2991,7 @@ class TestWorkflowSaveSituationMacro:
         return tmp_path.resolve()
 
     @pytest.fixture(autouse=True)
-    def setup_versioned_save_workflow_project(
-        self, temp_dir: Path, griptape_nodes: Engine
-    ) -> "Generator[None, None, None]":
+    def setup_versioned_save_workflow_project(self, temp_dir: Path, engine: Engine) -> "Generator[None, None, None]":
         """Load a project that overrides save_workflow to CREATE_NEW with a `{_index:03}` slot.
 
         Mirrors the fixture in TestCreateNewMacroIndexSeed: the project is loaded
@@ -3017,7 +3010,7 @@ class TestWorkflowSaveSituationMacro:
             SetCurrentProjectRequest,
         )
 
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
+        original_workspace = engine.config_manager.workspace_path
 
         versioned_save_workflow = SituationTemplate(
             name="save_workflow",
@@ -3034,16 +3027,16 @@ class TestWorkflowSaveSituationMacro:
 
         project_yml = temp_dir / "project_template.yml"
         project_yml.write_text(custom_template.to_overlay_yaml(DEFAULT_PROJECT_TEMPLATE))
-        load_result = GriptapeNodes.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
+        load_result = engine.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
         assert isinstance(load_result, LoadProjectTemplateResultSuccess)
-        GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
+        engine.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
 
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        engine.config_manager.workspace_path = temp_dir
 
         yield
 
-        GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=None))
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.handle_request(SetCurrentProjectRequest(project_id=None))
+        engine.config_manager.workspace_path = original_workspace
 
     @staticmethod
     def _empty_commands() -> SerializedFlowCommands:
@@ -3059,9 +3052,9 @@ class TestWorkflowSaveSituationMacro:
             node_types_used=set(),
         )
 
-    def _save(self, griptape_nodes: Engine, file_name: str) -> str:
+    def _save(self, engine: Engine, file_name: str) -> str:
         """Drive _save_workflow_file_inline against the versioned save_workflow situation."""
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         destination, _relative = workflow_manager._build_workflow_save_path(f"{file_name}.py")
 
         result = workflow_manager._save_workflow_file_inline(
@@ -3086,25 +3079,25 @@ class TestWorkflowSaveSituationMacro:
         )
         return result.file_path
 
-    def test_first_save_writes_v001(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+    def test_first_save_writes_v001(self, engine: Engine, temp_dir: Path) -> None:
         """Bug #4941: the first save with `{_index:03}` must produce v001 (not fail with MISSING_REQUIRED)."""
-        saved_path = self._save(griptape_nodes, "my_workflow")
+        saved_path = self._save(engine, "my_workflow")
 
         assert Path(saved_path) == temp_dir / "my_workflow_v001.py"
         assert (temp_dir / "my_workflow_v001.py").exists()
 
-    def test_successive_saves_increment_padded_index(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+    def test_successive_saves_increment_padded_index(self, engine: Engine, temp_dir: Path) -> None:
         """Saving the same workflow three times produces v001, v002, v003 (padding preserved)."""
         for _ in range(3):
-            self._save(griptape_nodes, "my_workflow")
+            self._save(engine, "my_workflow")
 
         assert (temp_dir / "my_workflow_v001.py").exists()
         assert (temp_dir / "my_workflow_v002.py").exists()
         assert (temp_dir / "my_workflow_v003.py").exists()
 
-    def test_sub_dirs_route_into_subdirectory(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+    def test_sub_dirs_route_into_subdirectory(self, engine: Engine, temp_dir: Path) -> None:
         """A sub-directory in the requested name routes into `{sub_dirs?:/}` and still picks v001."""
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         destination, relative = workflow_manager._build_workflow_save_path("my_workflow.py", sub_dirs="episode")
         assert relative == str(Path("episode") / "my_workflow.py")
 
@@ -3144,7 +3137,7 @@ class TestCreateVersionedWorkflow:
         return tmp_path.resolve()
 
     @pytest.fixture(autouse=True)
-    def setup_default_project(self, temp_dir: Path, griptape_nodes: Engine) -> "Generator[None, None, None]":
+    def setup_default_project(self, temp_dir: Path, engine: Engine) -> "Generator[None, None, None]":
         """Load the default project template (which ships create_versioned_workflow).
 
         Same fixture ordering as TestWorkflowSaveSituationMacro: load + activate
@@ -3158,31 +3151,31 @@ class TestCreateVersionedWorkflow:
             SetCurrentProjectRequest,
         )
 
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
+        original_workspace = engine.config_manager.workspace_path
 
         project_yml = temp_dir / "project_template.yml"
         project_yml.write_text(DEFAULT_PROJECT_TEMPLATE.to_overlay_yaml(DEFAULT_PROJECT_TEMPLATE))
-        load_result = GriptapeNodes.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
+        load_result = engine.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
         assert isinstance(load_result, LoadProjectTemplateResultSuccess)
-        GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
+        engine.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
 
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        engine.config_manager.workspace_path = temp_dir
 
         yield
 
         WorkflowRegistry._workflows.clear()
-        GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=None))
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.handle_request(SetCurrentProjectRequest(project_id=None))
+        engine.config_manager.workspace_path = original_workspace
 
     @staticmethod
     def _determine(
-        griptape_nodes: Engine,
+        engine: Engine,
         *,
         requested_file_name: str | None,
         current_workflow_name: str | None,
         create_versioned: bool,
     ) -> WorkflowManager.SaveWorkflowTargetInfo:
-        return griptape_nodes.WorkflowManager()._determine_save_target(
+        return engine.workflow_manager._determine_save_target(
             requested_file_name=requested_file_name,
             current_workflow_name=current_workflow_name,
             create_versioned=create_versioned,
@@ -3206,7 +3199,7 @@ class TestCreateVersionedWorkflow:
         )
         WorkflowRegistry.generate_new_workflow(registry_key=registry_key, metadata=metadata, file_path=file_name)
 
-    def test_create_versioned_short_circuits_overwrite_existing(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+    def test_create_versioned_short_circuits_overwrite_existing(self, engine: Engine, temp_dir: Path) -> None:
         """Even when the workflow is already saved, create_versioned=True routes through the versioned situation.
 
         Without this fix, the OVERWRITE_EXISTING branch would win on the second
@@ -3220,7 +3213,7 @@ class TestCreateVersionedWorkflow:
             )
 
             target = self._determine(
-                griptape_nodes,
+                engine,
                 requested_file_name="my_flow_v001",
                 current_workflow_name="my_flow_v001",
                 create_versioned=True,
@@ -3237,9 +3230,7 @@ class TestCreateVersionedWorkflow:
             # The OVERWRITE_EXISTING path-mode is NOT taken.
             assert target.file_path is None
 
-    def test_create_versioned_match_path_passes_full_matched_dict_through(
-        self, griptape_nodes: Engine, temp_dir: Path
-    ) -> None:
+    def test_create_versioned_match_path_passes_full_matched_dict_through(self, engine: Engine, temp_dir: Path) -> None:
         """Saving over `my_flow_v001` produces a destination whose MacroPath carries every matched variable.
 
         The destination's MacroPath has every variable the situation's macro
@@ -3258,7 +3249,7 @@ class TestCreateVersionedWorkflow:
             )
 
             target = self._determine(
-                griptape_nodes,
+                engine,
                 requested_file_name=None,
                 current_workflow_name="my_flow_v001",
                 create_versioned=True,
@@ -3273,9 +3264,7 @@ class TestCreateVersionedWorkflow:
             assert macro_vars.get("file_extension") == "py"
             assert macro_vars.get("_index") == 1
 
-    def test_create_versioned_match_recovers_index_when_stem_contains_v(
-        self, griptape_nodes: Engine, temp_dir: Path
-    ) -> None:
+    def test_create_versioned_match_recovers_index_when_stem_contains_v(self, engine: Engine, temp_dir: Path) -> None:
         """Reverse-match handles base names that themselves contain the ``_v`` anchor lookalike.
 
         Regression coverage for the cjkindel review on #4989: previously the
@@ -3296,7 +3285,7 @@ class TestCreateVersionedWorkflow:
             )
 
             target = self._determine(
-                griptape_nodes,
+                engine,
                 requested_file_name=None,
                 current_workflow_name="my_v1_report_v007",
                 create_versioned=True,
@@ -3311,7 +3300,7 @@ class TestCreateVersionedWorkflow:
             assert macro_vars.get("file_extension") == "py"
 
     def test_create_versioned_with_requested_name_matching_existing_workflow_runs_match(
-        self, griptape_nodes: Engine, temp_dir: Path
+        self, engine: Engine, temp_dir: Path
     ) -> None:
         """The UI re-sends the open workflow's key as ``file_name``; we still reverse-match.
 
@@ -3335,7 +3324,7 @@ class TestCreateVersionedWorkflow:
 
             # UI sends the loaded workflow's registry key as requested_file_name.
             target = self._determine(
-                griptape_nodes,
+                engine,
                 requested_file_name="my_flow_v002",
                 current_workflow_name="my_flow_v002",
                 create_versioned=True,
@@ -3352,7 +3341,7 @@ class TestCreateVersionedWorkflow:
             # the whole prior stem ("my_flow_v002") and _index would be unbound.
             assert macro_vars.get("file_name_base") != "my_flow_v002"
 
-    def test_create_versioned_false_preserves_overwrite_existing(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+    def test_create_versioned_false_preserves_overwrite_existing(self, engine: Engine, temp_dir: Path) -> None:
         """create_versioned=False against a saved workflow keeps the standard OVERWRITE_EXISTING path."""
         with patch.dict(WorkflowRegistry._workflows, {}, clear=True):
             self._register_saved_workflow(
@@ -3360,7 +3349,7 @@ class TestCreateVersionedWorkflow:
             )
 
             target = self._determine(
-                griptape_nodes,
+                engine,
                 requested_file_name="my_flow",
                 current_workflow_name="my_flow",
                 create_versioned=False,
@@ -3372,7 +3361,7 @@ class TestCreateVersionedWorkflow:
             assert target.file_path.name == "my_flow.py"
 
     def test_warning_logged_when_save_workflow_customized_to_create_new(
-        self, griptape_nodes: Engine, temp_dir: Path, caplog: pytest.LogCaptureFixture
+        self, engine: Engine, temp_dir: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
         """A project that flips `save_workflow` to create_new triggers a warning on non-versioned saves.
 
@@ -3405,13 +3394,13 @@ class TestCreateVersionedWorkflow:
         )
         project_yml = temp_dir / "project_template.yml"
         project_yml.write_text(custom.to_overlay_yaml(DEFAULT_PROJECT_TEMPLATE))
-        load_result = GriptapeNodes.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
+        load_result = engine.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
         assert isinstance(load_result, LoadProjectTemplateResultSuccess)
-        GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
+        engine.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
 
         with patch.dict(WorkflowRegistry._workflows, {}, clear=True), caplog.at_level("WARNING"):
             self._determine(
-                griptape_nodes,
+                engine,
                 requested_file_name="my_flow",
                 current_workflow_name=None,
                 create_versioned=False,
@@ -3422,7 +3411,7 @@ class TestCreateVersionedWorkflow:
         )
 
     def test_warning_logged_when_create_versioned_workflow_customized_to_overwrite(
-        self, griptape_nodes: Engine, temp_dir: Path, caplog: pytest.LogCaptureFixture
+        self, engine: Engine, temp_dir: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Inverse mismatch: create_versioned=True against a `create_versioned_workflow` flipped to overwrite.
 
@@ -3461,13 +3450,13 @@ class TestCreateVersionedWorkflow:
         )
         project_yml = temp_dir / "project_template.yml"
         project_yml.write_text(custom.to_overlay_yaml(DEFAULT_PROJECT_TEMPLATE))
-        load_result = GriptapeNodes.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
+        load_result = engine.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
         assert isinstance(load_result, LoadProjectTemplateResultSuccess)
-        GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
+        engine.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
 
         with patch.dict(WorkflowRegistry._workflows, {}, clear=True), caplog.at_level("WARNING"):
             self._determine(
-                griptape_nodes,
+                engine,
                 requested_file_name="my_flow",
                 current_workflow_name=None,
                 create_versioned=True,
@@ -3495,11 +3484,11 @@ class TestCreateVersionedWorkflow:
         # is what makes the seed-and-retry produce v001/v002/...
         assert "_index" in situation.macro or "#" in situation.macro
 
-    def test_first_versioned_save_with_no_registry_entry(self, griptape_nodes: Engine) -> None:
+    def test_first_versioned_save_with_no_registry_entry(self, engine: Engine) -> None:
         """create_versioned=True on a brand-new workflow uses the requested name and lands at CREATE_VERSIONED."""
         with patch.dict(WorkflowRegistry._workflows, {}, clear=True):
             target = self._determine(
-                griptape_nodes,
+                engine,
                 requested_file_name="brand_new_flow",
                 current_workflow_name=None,
                 create_versioned=True,
@@ -3518,7 +3507,7 @@ class TestCreateVersionedWorkflow:
 
     # --- #4956 helper: Step 2 (match) / Step 3 (no-match) / Step 1b (unsaved) -----------
 
-    def test_step2_match_path_with_customized_versioned_macro(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+    def test_step2_match_path_with_customized_versioned_macro(self, engine: Engine, temp_dir: Path) -> None:
         """Customizing the versioned situation's macro still round-trips: matched dict goes through verbatim.
 
         Regression coverage for #4956 — confirms we don't hardcode any variable
@@ -3556,11 +3545,11 @@ class TestCreateVersionedWorkflow:
         )
         project_yml = temp_dir / "project_template.yml"
         project_yml.write_text(custom.to_overlay_yaml(DEFAULT_PROJECT_TEMPLATE))
-        load_result = GriptapeNodes.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
+        load_result = engine.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
         assert isinstance(load_result, LoadProjectTemplateResultSuccess)
-        GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
+        engine.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
         # SetCurrentProjectRequest re-derives workspace_path; force it back.
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        engine.config_manager.workspace_path = temp_dir
 
         with patch.dict(WorkflowRegistry._workflows, {}, clear=True):
             # Workflow that was previously saved under this customized macro
@@ -3573,7 +3562,7 @@ class TestCreateVersionedWorkflow:
             )
 
             target = self._determine(
-                griptape_nodes,
+                engine,
                 requested_file_name=None,
                 current_workflow_name="my_flow.0017",
                 create_versioned=True,
@@ -3588,7 +3577,7 @@ class TestCreateVersionedWorkflow:
             assert macro_vars.get("_index") == 17  # noqa: PLR2004 - literal version from setup
             assert macro_vars.get("file_extension") == "py"
 
-    def test_step3_no_match_path_falls_back_to_file_stem(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+    def test_step3_no_match_path_falls_back_to_file_stem(self, engine: Engine, temp_dir: Path) -> None:
         """A workflow saved under a NON-versioned situation produces a new versioned series on create_versioned.
 
         The file `random_name.py` doesn't match the versioned situation's macro
@@ -3607,7 +3596,7 @@ class TestCreateVersionedWorkflow:
             )
 
             target = self._determine(
-                griptape_nodes,
+                engine,
                 requested_file_name=None,
                 current_workflow_name="random_name",
                 create_versioned=True,
@@ -3623,7 +3612,7 @@ class TestCreateVersionedWorkflow:
                 "Step 3 (no-match) must leave _index unbound so the seed-and-retry assigns 1 on write."
             )
 
-    def test_step1b_unsaved_workflow_uses_display_name(self, griptape_nodes: Engine) -> None:
+    def test_step1b_unsaved_workflow_uses_display_name(self, engine: Engine) -> None:
         """create_versioned=True on an unsaved workflow uses display_name as the base.
 
         The unsaved workflow has no file_path → Step 1b kicks in →
@@ -3636,7 +3625,7 @@ class TestCreateVersionedWorkflow:
             _register_unsaved_workflow(key=unsaved_key, name="My Pretty Flow")
 
             target = self._determine(
-                griptape_nodes,
+                engine,
                 requested_file_name=None,
                 current_workflow_name=unsaved_key,
                 create_versioned=True,
@@ -3650,9 +3639,7 @@ class TestCreateVersionedWorkflow:
             # No index assigned yet — the seed handles that on write.
             assert "_index" not in macro_vars
 
-    def test_create_versioned_invalid_situation_macro_raises_value_error(
-        self, griptape_nodes: Engine, temp_dir: Path
-    ) -> None:
+    def test_create_versioned_invalid_situation_macro_raises_value_error(self, engine: Engine, temp_dir: Path) -> None:
         """A malformed situation macro surfaces as a clear ValueError, not an opaque crash.
 
         ``SituationTemplate`` validates macro syntax at template load, so
@@ -3679,15 +3666,13 @@ class TestCreateVersionedWorkflow:
                 pytest.raises(ValueError, match="create_versioned_workflow"),
             ):
                 self._determine(
-                    griptape_nodes,
+                    engine,
                     requested_file_name=None,
                     current_workflow_name="my_flow_v001",
                     create_versioned=True,
                 )
 
-    def test_create_versioned_missing_situation_raises_value_error(
-        self, griptape_nodes: Engine, temp_dir: Path
-    ) -> None:
+    def test_create_versioned_missing_situation_raises_value_error(self, engine: Engine, temp_dir: Path) -> None:
         """When the active project lacks the versioned situation, the reverse-match raises with the situation name.
 
         Pins the GetSituationResultSuccess guard at the top of
@@ -3707,7 +3692,7 @@ class TestCreateVersionedWorkflow:
                 temp_dir, registry_key="my_flow_v001", file_name="my_flow_v001.py", display_name="my_flow"
             )
 
-            real_handle = griptape_nodes.handle_request
+            real_handle = engine.handle_request
 
             def fake_handle(req: RequestPayload) -> object:
                 if isinstance(req, GetSituationRequest):
@@ -3715,18 +3700,18 @@ class TestCreateVersionedWorkflow:
                 return real_handle(req)
 
             with (
-                patch.object(griptape_nodes, "handle_request", side_effect=fake_handle),
+                patch.object(engine, "handle_request", side_effect=fake_handle),
                 pytest.raises(ValueError, match="not found in the active project template"),
             ):
                 self._determine(
-                    griptape_nodes,
+                    engine,
                     requested_file_name=None,
                     current_workflow_name="my_flow_v001",
                     create_versioned=True,
                 )
 
     def test_create_versioned_match_dispatch_failure_surfaces_underlying_cause(
-        self, griptape_nodes: Engine, temp_dir: Path
+        self, engine: Engine, temp_dir: Path
     ) -> None:
         """When the match handler crashes, the error message includes the underlying exception.
 
@@ -3747,7 +3732,7 @@ class TestCreateVersionedWorkflow:
                 temp_dir, registry_key="my_flow_v001", file_name="my_flow_v001.py", display_name="my_flow"
             )
 
-            real_handle = griptape_nodes.handle_request
+            real_handle = engine.handle_request
             synthetic_exc = RuntimeError("synthetic match-handler crash for test")
 
             def fake_handle(req: RequestPayload) -> object:
@@ -3759,11 +3744,11 @@ class TestCreateVersionedWorkflow:
                 return real_handle(req)
 
             with (
-                patch.object(griptape_nodes, "handle_request", side_effect=fake_handle),
+                patch.object(engine, "handle_request", side_effect=fake_handle),
                 pytest.raises(ValueError, match="synthetic match-handler crash") as exc_info,
             ):
                 self._determine(
-                    griptape_nodes,
+                    engine,
                     requested_file_name=None,
                     current_workflow_name="my_flow_v001",
                     create_versioned=True,
@@ -3776,7 +3761,7 @@ class TestCreateVersionedWorkflow:
 
     def test_create_versioned_timestamp_fallback_when_no_candidate_workflow(
         self,
-        griptape_nodes: Engine,
+        engine: Engine,
     ) -> None:
         """Step 5: no current AND no target workflow → timestamp-derived filename.
 
@@ -3788,7 +3773,7 @@ class TestCreateVersionedWorkflow:
         with patch.dict(WorkflowRegistry._workflows, {}, clear=True):
             # Empty registry + no current workflow + no target → Step 5.
             target = self._determine(
-                griptape_nodes,
+                engine,
                 requested_file_name=None,
                 current_workflow_name=None,
                 create_versioned=True,
@@ -3826,7 +3811,7 @@ class TestSaveWorkflowDisplayNameFallback:
 
     @staticmethod
     def _capture_display_name(
-        griptape_nodes: Engine,
+        engine: Engine,
         *,
         request_file_name: str | None,
         request_display_name: str | None,
@@ -3848,8 +3833,8 @@ class TestSaveWorkflowDisplayNameFallback:
             SaveWorkflowRequest,
         )
 
-        workflow_manager = griptape_nodes.WorkflowManager()
-        context_manager = griptape_nodes.ContextManager()
+        workflow_manager = engine.workflow_manager
+        context_manager = engine.context_manager
 
         empty_commands = SerializedFlowCommands(
             flow_initialization_command=None,
@@ -3884,7 +3869,7 @@ class TestSaveWorkflowDisplayNameFallback:
         def capture_inline(**kwargs: object) -> SaveWorkflowFileFromSerializedFlowResultSuccess:
             # display_name is what we're testing — record it then return success.
             captured["display_name"] = kwargs.get("display_name")  # type: ignore[assignment]
-            workspace = griptape_nodes.ConfigManager().workspace_path
+            workspace = engine.config_manager.workspace_path
             file_name = kwargs.get("file_name", "stub")
             return SaveWorkflowFileFromSerializedFlowResultSuccess(
                 file_path=str(workspace / f"{file_name}.py"),
@@ -3899,7 +3884,7 @@ class TestSaveWorkflowDisplayNameFallback:
 
         try:
             with (
-                patch.object(griptape_nodes, "ahandle_request", side_effect=fake_ahandle_request),
+                patch.object(engine, "ahandle_request", side_effect=fake_ahandle_request),
                 patch.object(workflow_manager, "_save_workflow_file_inline", side_effect=capture_inline),
                 patch.object(workflow_manager, "extract_workflow_shape", side_effect=ValueError("no shape")),
             ):
@@ -3914,7 +3899,7 @@ class TestSaveWorkflowDisplayNameFallback:
 
         return captured.get("display_name")
 
-    def test_explicit_request_display_name_wins(self, griptape_nodes: Engine) -> None:
+    def test_explicit_request_display_name_wins(self, engine: Engine) -> None:
         """Branch 1: ``request.display_name`` is explicit caller intent and always wins.
 
         Even when the registry has an existing display_name AND request.file_name
@@ -3925,7 +3910,7 @@ class TestSaveWorkflowDisplayNameFallback:
             _register_unsaved_workflow(key=unsaved_key, name="In-Memory Label")
 
             captured = TestSaveWorkflowDisplayNameFallback._capture_display_name(
-                griptape_nodes,
+                engine,
                 request_file_name="some_file_name",
                 request_display_name="Caller-Specified Label",
                 current_workflow_name=unsaved_key,
@@ -3933,7 +3918,7 @@ class TestSaveWorkflowDisplayNameFallback:
 
             assert captured == "Caller-Specified Label"
 
-    def test_existing_registry_display_name_used_when_request_omits(self, griptape_nodes: Engine) -> None:
+    def test_existing_registry_display_name_used_when_request_omits(self, engine: Engine) -> None:
         """Branch 2: when request.display_name is None, the registry's existing display_name wins over the file_name.
 
         Pins the "preserve human-readable label across re-saves" rule — a
@@ -3944,7 +3929,7 @@ class TestSaveWorkflowDisplayNameFallback:
         from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
 
         registry_key = "preserved_display_name_test"
-        workspace = griptape_nodes.ConfigManager().workspace_path
+        workspace = engine.config_manager.workspace_path
         stub_path = workspace / f"{registry_key}.py"
         with patch.dict(WorkflowRegistry._workflows, {}, clear=True):
             stub_path.write_text("# stub")
@@ -3961,7 +3946,7 @@ class TestSaveWorkflowDisplayNameFallback:
                 )
 
                 captured = TestSaveWorkflowDisplayNameFallback._capture_display_name(
-                    griptape_nodes,
+                    engine,
                     request_file_name=registry_key,
                     request_display_name=None,
                     current_workflow_name=registry_key,
@@ -3972,9 +3957,7 @@ class TestSaveWorkflowDisplayNameFallback:
             finally:
                 stub_path.unlink(missing_ok=True)
 
-    def test_no_request_display_name_no_existing_metadata_uses_resolved_file_name_stem(
-        self, griptape_nodes: Engine
-    ) -> None:
+    def test_no_request_display_name_no_existing_metadata_uses_resolved_file_name_stem(self, engine: Engine) -> None:
         """Branch 3: fresh Save As with no registry entry — the resolved stem becomes the display name.
 
         This is the case that the manual-test bug surfaced: typing "a" should
@@ -3988,7 +3971,7 @@ class TestSaveWorkflowDisplayNameFallback:
             _register_unsaved_workflow(key=unsaved_key, name="ignored - we use resolved file_name")
 
             captured = TestSaveWorkflowDisplayNameFallback._capture_display_name(
-                griptape_nodes,
+                engine,
                 request_file_name="episode/my_wf",
                 request_display_name=None,
                 current_workflow_name=unsaved_key,
@@ -3997,7 +3980,7 @@ class TestSaveWorkflowDisplayNameFallback:
             # _resolve_named_save_path returns parts.stem — "my_wf", not "episode/my_wf".
             assert captured == "my_wf"
 
-    def test_first_save_of_unsaved_uses_metadata_derived_stem_not_synthetic_key(self, griptape_nodes: Engine) -> None:
+    def test_first_save_of_unsaved_uses_metadata_derived_stem_not_synthetic_key(self, engine: Engine) -> None:
         """Fresh save of an unsaved workflow must not surface "unsaved:<uuid>" as the display name.
 
         Regression guard for the bug where branch 3 read ``Path(request.file_name).stem``
@@ -4010,7 +3993,7 @@ class TestSaveWorkflowDisplayNameFallback:
             _register_unsaved_workflow(key=unsaved_key, name="My Cool Workflow")
 
             captured = TestSaveWorkflowDisplayNameFallback._capture_display_name(
-                griptape_nodes,
+                engine,
                 request_file_name=unsaved_key,
                 request_display_name=None,
                 current_workflow_name=unsaved_key,
@@ -4021,7 +4004,7 @@ class TestSaveWorkflowDisplayNameFallback:
             # The resolved stem is the sanitized metadata.name.
             assert captured == "My_Cool_Workflow"
 
-    def test_typed_save_as_name_survives_versioned_resolution(self, griptape_nodes: Engine) -> None:
+    def test_typed_save_as_name_survives_versioned_resolution(self, engine: Engine) -> None:
         """The user typed "a" — display name stays "a" even when the macro resolves the file to "a_v001".
 
         Pins the versioned-save UI re-save fix from commit 5c3f0bf3: branch 3 must feed off
@@ -4034,7 +4017,7 @@ class TestSaveWorkflowDisplayNameFallback:
             _register_unsaved_workflow(key=unsaved_key, name="ignored - user typed a new name")
 
             captured = TestSaveWorkflowDisplayNameFallback._capture_display_name(
-                griptape_nodes,
+                engine,
                 request_file_name="a",
                 request_display_name=None,
                 current_workflow_name=unsaved_key,
@@ -4042,7 +4025,7 @@ class TestSaveWorkflowDisplayNameFallback:
 
             assert captured == "a"
 
-    def test_metadata_derived_stem_used_when_no_file_name_and_no_existing(self, griptape_nodes: Engine) -> None:
+    def test_metadata_derived_stem_used_when_no_file_name_and_no_existing(self, engine: Engine) -> None:
         """Branch 3 (no request.file_name path): the metadata-derived stem still fills the display name.
 
         Prior expectation for this scenario was ``None`` (rung 4), because rung 3 keyed off
@@ -4055,7 +4038,7 @@ class TestSaveWorkflowDisplayNameFallback:
             _register_unsaved_workflow(key=unsaved_key, name="Used Only For Filename Derivation")
 
             captured = TestSaveWorkflowDisplayNameFallback._capture_display_name(
-                griptape_nodes,
+                engine,
                 request_file_name=None,
                 request_display_name=None,
                 current_workflow_name=unsaved_key,
@@ -4153,7 +4136,7 @@ class TestScrubForAstConstant:
         assert result.value == (1,)
         assert type(result.value) is tuple
 
-    def test_generate_workflow_file_content_scrubs_button_in_ui_options(self, griptape_nodes: Engine) -> None:
+    def test_generate_workflow_file_content_scrubs_button_in_ui_options(self, engine: Engine) -> None:
         """End-to-end regression for #5013: a Button in ui_options must not break the saved file.
 
         Drives the real generator (``_generate_workflow_file_content``) with a node whose
@@ -4206,7 +4189,7 @@ class TestScrubForAstConstant:
             node_libraries_referenced=[],
             workflow_shape=None,
         )
-        content = griptape_nodes.WorkflowManager()._generate_workflow_file_content(
+        content = engine.workflow_manager._generate_workflow_file_content(
             serialized_flow_commands=flow_commands,
             workflow_metadata=metadata,
         )
@@ -4232,8 +4215,8 @@ class TestSelectTopLevelImportedFlow:
         engine.flow_manager = flow_manager
         return engine
 
-    def test_selects_flow_parented_to_import_target(self, griptape_nodes: Engine) -> None:
-        workflow_manager = griptape_nodes.WorkflowManager()
+    def test_selects_flow_parented_to_import_target(self, engine: Engine) -> None:
+        workflow_manager = engine.workflow_manager
         # Top-level flow is parented to the target; the group's body flow is parented to the top-level.
         mock_engine = self._flow_manager_with_parents({"ControlFlow_2": "ParentFlow", "Group_subflow": "ControlFlow_2"})
 
@@ -4244,12 +4227,12 @@ class TestSelectTopLevelImportedFlow:
         assert selected == "ControlFlow_2"
 
     def test_falls_back_deterministically_when_none_parented_to_target(
-        self, griptape_nodes: Engine, caplog: pytest.LogCaptureFixture
+        self, engine: Engine, caplog: pytest.LogCaptureFixture
     ) -> None:
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         mock_engine = self._flow_manager_with_parents({"Zeta_flow": "Other", "Alpha_flow": "Other"})
 
-        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+        with caplog.at_level(logging.WARNING, logger="engine"):
             selected = workflow_manager._select_top_level_imported_flow(
                 {"Zeta_flow", "Alpha_flow"}, "ParentFlow", "wf", mock_engine
             )
@@ -4262,12 +4245,12 @@ class TestSelectTopLevelImportedFlow:
         ), f"expected a fallback warning, got: {[r.getMessage() for r in caplog.records]}"
 
     def test_falls_back_deterministically_when_multiple_parented_to_target(
-        self, griptape_nodes: Engine, caplog: pytest.LogCaptureFixture
+        self, engine: Engine, caplog: pytest.LogCaptureFixture
     ) -> None:
-        workflow_manager = griptape_nodes.WorkflowManager()
+        workflow_manager = engine.workflow_manager
         mock_engine = self._flow_manager_with_parents({"Zeta_flow": "ParentFlow", "Alpha_flow": "ParentFlow"})
 
-        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+        with caplog.at_level(logging.WARNING, logger="engine"):
             selected = workflow_manager._select_top_level_imported_flow(
                 {"Zeta_flow", "Alpha_flow"}, "ParentFlow", "wf", mock_engine
             )
@@ -4284,10 +4267,8 @@ class TestExecuteWorkflowImport:
     """WorkflowManager._execute_workflow_import tests."""
 
     @pytest.mark.asyncio
-    async def test_returns_top_level_imported_flow(
-        self, griptape_nodes: Engine, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        workflow_manager = griptape_nodes.WorkflowManager()
+    async def test_returns_top_level_imported_flow(self, engine: Engine, monkeypatch: pytest.MonkeyPatch) -> None:
+        workflow_manager = engine.workflow_manager
 
         request = ImportWorkflowAsReferencedSubFlowRequest(
             workflow_name="wf", flow_name="ParentFlow", imported_flow_metadata=None, track_as_referenced=False
@@ -4302,11 +4283,11 @@ class TestExecuteWorkflowImport:
             {"ParentFlow": object()},
             {"ParentFlow": object(), "ControlFlow_2": object(), "Group_subflow": object()},
         ]
-        monkeypatch.setattr(griptape_nodes, "_object_manager", object_manager)
+        monkeypatch.setattr(engine, "_object_manager", object_manager)
 
         # ContextManager().flow(...) is used purely as a context manager wrapping the import.
         context_manager = MagicMock(spec=ContextManager)
-        monkeypatch.setattr(griptape_nodes, "_context_manager", context_manager)
+        monkeypatch.setattr(engine, "_context_manager", context_manager)
 
         monkeypatch.setattr(
             workflow_manager,
@@ -4323,7 +4304,7 @@ class TestExecuteWorkflowImport:
         result = await workflow_manager._execute_workflow_import(request, workflow, "ParentFlow")
 
         # It selects via the helper (passing the new-flows set, target flow, workflow name, and engine)...
-        select_mock.assert_called_once_with({"ControlFlow_2", "Group_subflow"}, "ParentFlow", "wf", griptape_nodes)
+        select_mock.assert_called_once_with({"ControlFlow_2", "Group_subflow"}, "ParentFlow", "wf", engine)
         # ...and returns exactly what the helper chose.
         assert isinstance(result, ImportWorkflowAsReferencedSubFlowResultSuccess)
         assert result.created_flow_name == "ControlFlow_2"
@@ -4347,7 +4328,7 @@ class TestSaveWorkflowOverwriteProtection:
         return tmp_path.resolve()
 
     @pytest.fixture(autouse=True)
-    def setup_default_project(self, temp_dir: Path, griptape_nodes: Engine) -> "Generator[None, None, None]":
+    def setup_default_project(self, temp_dir: Path, engine: Engine) -> "Generator[None, None, None]":
         """Load + activate the default project template, then force the workspace.
 
         Same ordering as TestCreateVersionedWorkflow: activate first so
@@ -4361,21 +4342,21 @@ class TestSaveWorkflowOverwriteProtection:
             SetCurrentProjectRequest,
         )
 
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
+        original_workspace = engine.config_manager.workspace_path
 
         project_yml = temp_dir / "project_template.yml"
         project_yml.write_text(DEFAULT_PROJECT_TEMPLATE.to_overlay_yaml(DEFAULT_PROJECT_TEMPLATE))
-        load_result = GriptapeNodes.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
+        load_result = engine.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
         assert isinstance(load_result, LoadProjectTemplateResultSuccess)
-        GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
+        engine.handle_request(SetCurrentProjectRequest(project_id=load_result.project_id))
 
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        engine.config_manager.workspace_path = temp_dir
 
         yield
 
         WorkflowRegistry._workflows.clear()
-        GriptapeNodes.handle_request(SetCurrentProjectRequest(project_id=None))
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.handle_request(SetCurrentProjectRequest(project_id=None))
+        engine.config_manager.workspace_path = original_workspace
 
     @staticmethod
     def _register_saved_workflow(temp_dir: Path, *, registry_key: str, contents: str) -> Path:
@@ -4395,7 +4376,7 @@ class TestSaveWorkflowOverwriteProtection:
 
     @staticmethod
     def _save(
-        griptape_nodes: Engine,
+        engine: Engine,
         *,
         file_name: str,
         current_workflow_name: str,
@@ -4410,8 +4391,8 @@ class TestSaveWorkflowOverwriteProtection:
         )
         from griptape_nodes.retained_mode.events.workflow_events import SaveWorkflowRequest
 
-        workflow_manager = griptape_nodes.WorkflowManager()
-        context_manager = griptape_nodes.ContextManager()
+        workflow_manager = engine.workflow_manager
+        context_manager = engine.context_manager
 
         empty_commands = SerializedFlowCommands(
             flow_initialization_command=None,
@@ -4450,7 +4431,7 @@ class TestSaveWorkflowOverwriteProtection:
             if context_manager.has_current_workflow():
                 context_manager.pop_workflow()
 
-    def test_self_save_with_dotted_name_succeeds(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+    def test_self_save_with_dotted_name_succeeds(self, engine: Engine, temp_dir: Path) -> None:
         """Re-saving the open workflow succeeds even with ``overwrite_existing=False``.
 
         ``%d.%m_%H.%M`` is the engine's own default auto-generated name, so a
@@ -4466,7 +4447,7 @@ class TestSaveWorkflowOverwriteProtection:
             stub_path = self._register_saved_workflow(temp_dir, registry_key=registry_key, contents="# original")
 
             result = self._save(
-                griptape_nodes,
+                engine,
                 file_name=registry_key,
                 current_workflow_name=registry_key,
                 overwrite_existing=False,
@@ -4478,7 +4459,7 @@ class TestSaveWorkflowOverwriteProtection:
             assert "# original" not in stub_path.read_text()
 
     def test_collision_with_different_workflow_reports_policy_no_overwrite(
-        self, griptape_nodes: Engine, temp_dir: Path
+        self, engine: Engine, temp_dir: Path
     ) -> None:
         """Saving onto another workflow's file fails with the typed reason and leaves it intact.
 
@@ -4494,7 +4475,7 @@ class TestSaveWorkflowOverwriteProtection:
             victim_path = self._register_saved_workflow(temp_dir, registry_key="theirs", contents="# theirs")
 
             result = self._save(
-                griptape_nodes,
+                engine,
                 file_name="theirs",
                 current_workflow_name="mine",
                 overwrite_existing=False,
@@ -4505,7 +4486,7 @@ class TestSaveWorkflowOverwriteProtection:
             # The other workflow's file is untouched.
             assert victim_path.read_text() == "# theirs"
 
-    def test_collision_overwrites_when_permitted(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+    def test_collision_overwrites_when_permitted(self, engine: Engine, temp_dir: Path) -> None:
         """``overwrite_existing=True`` (the default) still replaces the other workflow's file."""
         from griptape_nodes.retained_mode.events.workflow_events import SaveWorkflowResultSuccess
 
@@ -4514,7 +4495,7 @@ class TestSaveWorkflowOverwriteProtection:
             victim_path = self._register_saved_workflow(temp_dir, registry_key="theirs", contents="# theirs")
 
             result = self._save(
-                griptape_nodes,
+                engine,
                 file_name="theirs",
                 current_workflow_name="mine",
                 overwrite_existing=True,
@@ -4545,16 +4526,16 @@ class TestWorkflowBranchDisplayNames:
         return tmp_path.resolve()
 
     @pytest.fixture(autouse=True)
-    def workspace(self, temp_dir: Path, griptape_nodes: Engine) -> "Generator[None, None, None]":
+    def workspace(self, temp_dir: Path, engine: Engine) -> "Generator[None, None, None]":
         """Point the workspace at a temp dir so registry keys resolve to real files."""
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+        original_workspace = engine.config_manager.workspace_path
+        engine.config_manager.workspace_path = temp_dir
         with patch.dict(WorkflowRegistry._workflows, {}, clear=True):
             yield
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.config_manager.workspace_path = original_workspace
 
     @staticmethod
-    def _register_workflow(griptape_nodes: Engine, temp_dir: Path, *, registry_key: str, display_name: str) -> Path:
+    def _register_workflow(engine: Engine, temp_dir: Path, *, registry_key: str, display_name: str) -> Path:
         """Write a workflow file carrying a real metadata header and register it."""
         metadata = WorkflowMetadata(
             name=display_name,
@@ -4563,7 +4544,7 @@ class TestWorkflowBranchDisplayNames:
             node_libraries_referenced=[],
             creation_date=datetime.now(UTC),
         )
-        header = griptape_nodes.WorkflowManager()._generate_workflow_metadata_header(metadata)
+        header = engine.workflow_manager._generate_workflow_metadata_header(metadata)
         assert header is not None
 
         relative_file_path = f"{registry_key}.py"
@@ -4581,20 +4562,20 @@ class TestWorkflowBranchDisplayNames:
         """Read ``metadata.name`` back out of the workflow file on disk."""
         return read_workflow_metadata(temp_dir / f"{registry_key}.py").name
 
-    def _register_source(self, griptape_nodes: Engine, temp_dir: Path) -> Path:
+    def _register_source(self, engine: Engine, temp_dir: Path) -> Path:
         return self._register_workflow(
-            griptape_nodes, temp_dir, registry_key=self.SOURCE_KEY, display_name=self.SOURCE_DISPLAY_NAME
+            engine, temp_dir, registry_key=self.SOURCE_KEY, display_name=self.SOURCE_DISPLAY_NAME
         )
 
-    def test_branch_of_nested_workflow_gets_readable_display_name(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+    def test_branch_of_nested_workflow_gets_readable_display_name(self, engine: Engine, temp_dir: Path) -> None:
         """The reported bug: the branch's label was the full registry key path.
 
         The key still carries the directories (it is a file path), but the label is derived from the
         source's display name.
         """
-        self._register_source(griptape_nodes, temp_dir)
+        self._register_source(engine, temp_dir)
 
-        result = GriptapeNodes.handle_request(BranchWorkflowRequest(workflow_name=self.SOURCE_KEY))
+        result = engine.handle_request(BranchWorkflowRequest(workflow_name=self.SOURCE_KEY))
 
         assert isinstance(result, BranchWorkflowResultSuccess)
         branch_key = result.branched_workflow_name
@@ -4606,23 +4587,23 @@ class TestWorkflowBranchDisplayNames:
         # The branch relationship is keyed on the registry key, not the label.
         assert branch.metadata.branched_from == self.SOURCE_KEY
 
-    def test_branch_leaves_source_display_name_alone(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+    def test_branch_leaves_source_display_name_alone(self, engine: Engine, temp_dir: Path) -> None:
         """Branching must not touch the source's label."""
-        self._register_source(griptape_nodes, temp_dir)
+        self._register_source(engine, temp_dir)
 
-        result = GriptapeNodes.handle_request(BranchWorkflowRequest(workflow_name=self.SOURCE_KEY))
+        result = engine.handle_request(BranchWorkflowRequest(workflow_name=self.SOURCE_KEY))
 
         assert isinstance(result, BranchWorkflowResultSuccess)
         source = WorkflowRegistry.get_workflow_by_name(self.SOURCE_KEY)
         assert source.metadata.name == self.SOURCE_DISPLAY_NAME
         assert self._persisted_display_name(temp_dir, self.SOURCE_KEY) == self.SOURCE_DISPLAY_NAME
 
-    def test_branch_counter_stays_in_step_with_registry_key(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+    def test_branch_counter_stays_in_step_with_registry_key(self, engine: Engine, temp_dir: Path) -> None:
         """The label's counter tracks the key's counter, so branches stay distinguishable."""
-        self._register_source(griptape_nodes, temp_dir)
+        self._register_source(engine, temp_dir)
 
-        first = GriptapeNodes.handle_request(BranchWorkflowRequest(workflow_name=self.SOURCE_KEY))
-        second = GriptapeNodes.handle_request(BranchWorkflowRequest(workflow_name=self.SOURCE_KEY))
+        first = engine.handle_request(BranchWorkflowRequest(workflow_name=self.SOURCE_KEY))
+        second = engine.handle_request(BranchWorkflowRequest(workflow_name=self.SOURCE_KEY))
 
         assert isinstance(first, BranchWorkflowResultSuccess)
         assert isinstance(second, BranchWorkflowResultSuccess)
@@ -4635,11 +4616,11 @@ class TestWorkflowBranchDisplayNames:
             "Shot 010 Comp (branch 2)"
         )
 
-    def test_branch_uses_explicit_display_name_when_provided(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+    def test_branch_uses_explicit_display_name_when_provided(self, engine: Engine, temp_dir: Path) -> None:
         """A caller-supplied label wins over the derivation, and is stripped."""
-        self._register_source(griptape_nodes, temp_dir)
+        self._register_source(engine, temp_dir)
 
-        result = GriptapeNodes.handle_request(
+        result = engine.handle_request(
             BranchWorkflowRequest(workflow_name=self.SOURCE_KEY, branched_workflow_display_name="  Lighting Test  ")
         )
 
@@ -4648,11 +4629,11 @@ class TestWorkflowBranchDisplayNames:
         assert WorkflowRegistry.get_workflow_by_name(branch_key).metadata.name == "Lighting Test"
         assert self._persisted_display_name(temp_dir, branch_key) == "Lighting Test"
 
-    def test_branch_rejects_blank_display_name(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+    def test_branch_rejects_blank_display_name(self, engine: Engine, temp_dir: Path) -> None:
         """A whitespace-only label would leave the branch looking nameless, so refuse it."""
-        self._register_source(griptape_nodes, temp_dir)
+        self._register_source(engine, temp_dir)
 
-        result = GriptapeNodes.handle_request(
+        result = engine.handle_request(
             BranchWorkflowRequest(workflow_name=self.SOURCE_KEY, branched_workflow_display_name="   ")
         )
 
@@ -4661,13 +4642,11 @@ class TestWorkflowBranchDisplayNames:
         # Nothing was created.
         assert WorkflowRegistry.get_branches_of_workflow(self.SOURCE_KEY) == []
 
-    def test_branch_with_caller_supplied_key_labels_from_final_segment(
-        self, griptape_nodes: Engine, temp_dir: Path
-    ) -> None:
+    def test_branch_with_caller_supplied_key_labels_from_final_segment(self, engine: Engine, temp_dir: Path) -> None:
         """When the caller picks the key, its last segment is the label -- never the whole path."""
-        self._register_source(griptape_nodes, temp_dir)
+        self._register_source(engine, temp_dir)
 
-        result = GriptapeNodes.handle_request(
+        result = engine.handle_request(
             BranchWorkflowRequest(workflow_name=self.SOURCE_KEY, branched_workflow_name="shots/sh010/my_experiment")
         )
 
@@ -4677,46 +4656,42 @@ class TestWorkflowBranchDisplayNames:
         assert WorkflowRegistry.get_workflow_by_name(branch_key).metadata.name == "my_experiment"
         assert self._persisted_display_name(temp_dir, branch_key) == "my_experiment"
 
-    def test_branch_of_path_shaped_label_does_not_propagate_the_path(
-        self, griptape_nodes: Engine, temp_dir: Path
-    ) -> None:
+    def test_branch_of_path_shaped_label_does_not_propagate_the_path(self, engine: Engine, temp_dir: Path) -> None:
         """Branches created before this fix carry their key as their label; don't carry it forward."""
         self._register_workflow(
-            griptape_nodes,
+            engine,
             temp_dir,
             registry_key="shots/sh010/comp_branch_1",
             display_name="shots/sh010/comp_branch_1",
         )
 
-        result = GriptapeNodes.handle_request(BranchWorkflowRequest(workflow_name="shots/sh010/comp_branch_1"))
+        result = engine.handle_request(BranchWorkflowRequest(workflow_name="shots/sh010/comp_branch_1"))
 
         assert isinstance(result, BranchWorkflowResultSuccess)
         branch_key = result.branched_workflow_name
         assert WorkflowRegistry.get_workflow_by_name(branch_key).metadata.name == "comp_branch_1 (branch 1)"
 
-    def test_branch_falls_back_to_key_segment_when_source_label_blank(
-        self, griptape_nodes: Engine, temp_dir: Path
-    ) -> None:
+    def test_branch_falls_back_to_key_segment_when_source_label_blank(self, engine: Engine, temp_dir: Path) -> None:
         """A corrupt (blank) source label falls back to the file name, not to emptiness."""
-        self._register_workflow(griptape_nodes, temp_dir, registry_key=self.SOURCE_KEY, display_name="   ")
+        self._register_workflow(engine, temp_dir, registry_key=self.SOURCE_KEY, display_name="   ")
 
-        result = GriptapeNodes.handle_request(BranchWorkflowRequest(workflow_name=self.SOURCE_KEY))
+        result = engine.handle_request(BranchWorkflowRequest(workflow_name=self.SOURCE_KEY))
 
         assert isinstance(result, BranchWorkflowResultSuccess)
         branch_key = result.branched_workflow_name
         assert WorkflowRegistry.get_workflow_by_name(branch_key).metadata.name == "comp (branch 1)"
 
-    def test_merge_preserves_source_display_name(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+    def test_merge_preserves_source_display_name(self, engine: Engine, temp_dir: Path) -> None:
         """Merging changes the source's contents, never its title.
 
         This site read the branch's ``branched_from`` (a registry key) into the source's
         ``metadata.name``, overwriting a correct label with a path and writing it to disk.
         """
-        self._register_source(griptape_nodes, temp_dir)
-        branch_result = GriptapeNodes.handle_request(BranchWorkflowRequest(workflow_name=self.SOURCE_KEY))
+        self._register_source(engine, temp_dir)
+        branch_result = engine.handle_request(BranchWorkflowRequest(workflow_name=self.SOURCE_KEY))
         assert isinstance(branch_result, BranchWorkflowResultSuccess)
 
-        merge_result = GriptapeNodes.handle_request(
+        merge_result = engine.handle_request(
             MergeWorkflowBranchRequest(workflow_name=branch_result.branched_workflow_name)
         )
 
@@ -4725,20 +4700,20 @@ class TestWorkflowBranchDisplayNames:
         assert source.metadata.name == self.SOURCE_DISPLAY_NAME
         assert self._persisted_display_name(temp_dir, self.SOURCE_KEY) == self.SOURCE_DISPLAY_NAME
 
-    def test_reset_preserves_branch_display_name(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+    def test_reset_preserves_branch_display_name(self, engine: Engine, temp_dir: Path) -> None:
         """Resetting discards the branch's content changes, not its title.
 
         This site wrote the branch's own registry key into its ``metadata.name`` and persisted it,
         so a reset silently renamed the branch to its file path.
         """
-        self._register_source(griptape_nodes, temp_dir)
-        branch_result = GriptapeNodes.handle_request(
+        self._register_source(engine, temp_dir)
+        branch_result = engine.handle_request(
             BranchWorkflowRequest(workflow_name=self.SOURCE_KEY, branched_workflow_display_name="Lighting Test")
         )
         assert isinstance(branch_result, BranchWorkflowResultSuccess)
         branch_key = branch_result.branched_workflow_name
 
-        reset_result = GriptapeNodes.handle_request(ResetWorkflowBranchRequest(workflow_name=branch_key))
+        reset_result = engine.handle_request(ResetWorkflowBranchRequest(workflow_name=branch_key))
 
         assert isinstance(reset_result, ResetWorkflowBranchResultSuccess)
         assert WorkflowRegistry.get_workflow_by_name(branch_key).metadata.name == "Lighting Test"
@@ -4762,17 +4737,15 @@ class TestRepairPathShapedDisplayName:
         return tmp_path.resolve()
 
     @pytest.fixture(autouse=True)
-    def workspace(self, temp_dir: Path, griptape_nodes: Engine) -> "Generator[None, None, None]":
-        original_workspace = griptape_nodes.ConfigManager().workspace_path
-        griptape_nodes.ConfigManager().workspace_path = temp_dir
+    def workspace(self, temp_dir: Path, engine: Engine) -> "Generator[None, None, None]":
+        original_workspace = engine.config_manager.workspace_path
+        engine.config_manager.workspace_path = temp_dir
         with patch.dict(WorkflowRegistry._workflows, {}, clear=True):
             yield
-        griptape_nodes.ConfigManager().workspace_path = original_workspace
+        engine.config_manager.workspace_path = original_workspace
 
     @staticmethod
-    def _write_and_register(
-        griptape_nodes: Engine, temp_dir: Path, *, relative_file_path: str, display_name: str
-    ) -> Path:
+    def _write_and_register(engine: Engine, temp_dir: Path, *, relative_file_path: str, display_name: str) -> Path:
         """Write a real workflow file with `display_name` in its header, then register it from disk."""
         metadata = WorkflowMetadata(
             name=display_name,
@@ -4781,21 +4754,21 @@ class TestRepairPathShapedDisplayName:
             node_libraries_referenced=[],
             creation_date=datetime.now(UTC),
         )
-        header = griptape_nodes.WorkflowManager()._generate_workflow_metadata_header(metadata)
+        header = engine.workflow_manager._generate_workflow_metadata_header(metadata)
         assert header is not None
 
         file_path = temp_dir / relative_file_path
         file_path.parent.mkdir(parents=True, exist_ok=True)
         file_path.write_text(f"{header}\n\nprint('body')\n", encoding="utf-8")
 
-        result = GriptapeNodes.handle_request(RegisterWorkflowRequest(metadata=metadata, file_name=relative_file_path))
+        result = engine.handle_request(RegisterWorkflowRequest(metadata=metadata, file_name=relative_file_path))
         assert isinstance(result, RegisterWorkflowResultSuccess)
         return file_path
 
-    def test_legacy_branch_name_is_repaired_on_load(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+    def test_legacy_branch_name_is_repaired_on_load(self, engine: Engine, temp_dir: Path) -> None:
         """The reported symptom, loaded from a file a pre-fix build wrote."""
         file_path = self._write_and_register(
-            griptape_nodes,
+            engine,
             temp_dir,
             relative_file_path="shots/sh010/comp_branch_1.py",
             display_name="shots/sh010/comp_branch_1",
@@ -4806,18 +4779,18 @@ class TestRepairPathShapedDisplayName:
         # In-memory only: the header on disk is deliberately left for the next save to rewrite.
         assert read_workflow_metadata(file_path).name == "shots/sh010/comp_branch_1"
 
-    def test_legacy_merged_source_name_is_repaired_on_load(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+    def test_legacy_merged_source_name_is_repaired_on_load(self, engine: Engine, temp_dir: Path) -> None:
         """The merge site overwrote a *source* workflow's title with its key; same fingerprint."""
         self._write_and_register(
-            griptape_nodes, temp_dir, relative_file_path="shots/sh010/comp.py", display_name="shots/sh010/comp"
+            engine, temp_dir, relative_file_path="shots/sh010/comp.py", display_name="shots/sh010/comp"
         )
 
         assert WorkflowRegistry.get_workflow_by_name("shots/sh010/comp").metadata.name == "comp"
 
-    def test_deeper_nesting_keeps_only_the_final_segment(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+    def test_deeper_nesting_keeps_only_the_final_segment(self, engine: Engine, temp_dir: Path) -> None:
         """The deeper the folder structure the worse the old label read; only the file name survives."""
         self._write_and_register(
-            griptape_nodes,
+            engine,
             temp_dir,
             relative_file_path="show/seq/shots/sh010/comp_branch_2.py",
             display_name="show/seq/shots/sh010/comp_branch_2",
@@ -4826,10 +4799,10 @@ class TestRepairPathShapedDisplayName:
         workflow = WorkflowRegistry.get_workflow_by_name("show/seq/shots/sh010/comp_branch_2")
         assert workflow.metadata.name == "comp_branch_2"
 
-    def test_real_display_name_is_left_alone(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+    def test_real_display_name_is_left_alone(self, engine: Engine, temp_dir: Path) -> None:
         """A proper title never equals its own registry key, so it is never touched."""
         self._write_and_register(
-            griptape_nodes,
+            engine,
             temp_dir,
             relative_file_path="shots/sh010/comp.py",
             display_name="Shot 010 Comp",
@@ -4837,10 +4810,10 @@ class TestRepairPathShapedDisplayName:
 
         assert WorkflowRegistry.get_workflow_by_name("shots/sh010/comp").metadata.name == "Shot 010 Comp"
 
-    def test_deliberate_separator_in_a_title_is_left_alone(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+    def test_deliberate_separator_in_a_title_is_left_alone(self, engine: Engine, temp_dir: Path) -> None:
         """Only exact key equality triggers repair -- a slash someone typed on purpose survives."""
         self._write_and_register(
-            griptape_nodes,
+            engine,
             temp_dir,
             relative_file_path="shots/sh010/comp.py",
             display_name="Lighting / Comp",
@@ -4848,21 +4821,19 @@ class TestRepairPathShapedDisplayName:
 
         assert WorkflowRegistry.get_workflow_by_name("shots/sh010/comp").metadata.name == "Lighting / Comp"
 
-    def test_workspace_root_workflow_matching_its_stem_is_left_alone(
-        self, griptape_nodes: Engine, temp_dir: Path
-    ) -> None:
+    def test_workspace_root_workflow_matching_its_stem_is_left_alone(self, engine: Engine, temp_dir: Path) -> None:
         """Name == key with no directories is the normal unnamed-workflow case, not the bug."""
-        self._write_and_register(griptape_nodes, temp_dir, relative_file_path="my_flow.py", display_name="my_flow")
+        self._write_and_register(engine, temp_dir, relative_file_path="my_flow.py", display_name="my_flow")
 
         assert WorkflowRegistry.get_workflow_by_name("my_flow").metadata.name == "my_flow"
 
-    def test_repaired_workflow_branches_with_a_readable_label(self, griptape_nodes: Engine, temp_dir: Path) -> None:
+    def test_repaired_workflow_branches_with_a_readable_label(self, engine: Engine, temp_dir: Path) -> None:
         """The payoff: branching a legacy workflow no longer carries the path forward."""
         self._write_and_register(
-            griptape_nodes, temp_dir, relative_file_path="shots/sh010/comp.py", display_name="shots/sh010/comp"
+            engine, temp_dir, relative_file_path="shots/sh010/comp.py", display_name="shots/sh010/comp"
         )
 
-        result = GriptapeNodes.handle_request(BranchWorkflowRequest(workflow_name="shots/sh010/comp"))
+        result = engine.handle_request(BranchWorkflowRequest(workflow_name="shots/sh010/comp"))
 
         assert isinstance(result, BranchWorkflowResultSuccess)
         branch = WorkflowRegistry.get_workflow_by_name(result.branched_workflow_name)

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -4232,7 +4232,7 @@ class TestSelectTopLevelImportedFlow:
         workflow_manager = engine.workflow_manager
         mock_engine = self._flow_manager_with_parents({"Zeta_flow": "Other", "Alpha_flow": "Other"})
 
-        with caplog.at_level(logging.WARNING, logger="engine"):
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
             selected = workflow_manager._select_top_level_imported_flow(
                 {"Zeta_flow", "Alpha_flow"}, "ParentFlow", "wf", mock_engine
             )
@@ -4250,7 +4250,7 @@ class TestSelectTopLevelImportedFlow:
         workflow_manager = engine.workflow_manager
         mock_engine = self._flow_manager_with_parents({"Zeta_flow": "ParentFlow", "Alpha_flow": "ParentFlow"})
 
-        with caplog.at_level(logging.WARNING, logger="engine"):
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
             selected = workflow_manager._select_top_level_imported_flow(
                 {"Zeta_flow", "Alpha_flow"}, "ParentFlow", "wf", mock_engine
             )

--- a/tests/unit/retained_mode/managers/test_workflow_manager_nested_codegen.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager_nested_codegen.py
@@ -56,7 +56,7 @@ def _flow_commands(
     )
 
 
-def _generate(griptape_nodes: Engine, serialized_flow_commands: SerializedFlowCommands) -> str:
+def _generate(engine: Engine, serialized_flow_commands: SerializedFlowCommands) -> str:
     metadata = WorkflowMetadata(
         name="nested_codegen_workflow",
         schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
@@ -64,13 +64,13 @@ def _generate(griptape_nodes: Engine, serialized_flow_commands: SerializedFlowCo
         node_libraries_referenced=[],
         workflow_shape=None,
     )
-    return griptape_nodes.WorkflowManager()._generate_workflow_file_content(
+    return engine.workflow_manager._generate_workflow_file_content(
         serialized_flow_commands=serialized_flow_commands, workflow_metadata=metadata
     )
 
 
 class TestNestedFlowCodegen:
-    def test_generates_nodes_from_a_flow_three_levels_deep(self, griptape_nodes: Engine) -> None:
+    def test_generates_nodes_from_a_flow_three_levels_deep(self, engine: Engine) -> None:
         """A node two subflows below the top must still be written into the file."""
         leaf = _node_commands("Leaf")
         commands = _flow_commands(
@@ -78,7 +78,7 @@ class TestNestedFlowCodegen:
             sub_flows=[_flow_commands("middle", sub_flows=[_flow_commands("bottom", nodes=[leaf])])],
         )
 
-        content = _generate(griptape_nodes, commands)
+        content = _generate(engine, commands)
 
         assert "'Leaf'" in content
         # Each Flow gets its own variable, so all three levels are rebuilt.
@@ -86,19 +86,19 @@ class TestNestedFlowCodegen:
         assert "flow1_name" in content
         assert "flow2_name" in content
 
-    def test_parents_each_subflow_to_the_flow_that_encloses_it(self, griptape_nodes: Engine) -> None:
+    def test_parents_each_subflow_to_the_flow_that_encloses_it(self, engine: Engine) -> None:
         """The generated hierarchy has to mirror the nesting, not flatten onto the top-level flow."""
         commands = _flow_commands(
             "top",
             sub_flows=[_flow_commands("middle", sub_flows=[_flow_commands("bottom", nodes=[_node_commands("Leaf")])])],
         )
 
-        content = _generate(griptape_nodes, commands)
+        content = _generate(engine, commands)
 
         assert "parent_flow_name=flow0_name" in content
         assert "parent_flow_name=flow1_name" in content
 
-    def test_gives_every_node_in_the_file_a_distinct_variable(self, griptape_nodes: Engine) -> None:
+    def test_gives_every_node_in_the_file_a_distinct_variable(self, engine: Engine) -> None:
         """Node variables are file-wide, so names must not restart per Flow and collide."""
         commands = _flow_commands(
             "top",
@@ -112,7 +112,7 @@ class TestNestedFlowCodegen:
             ],
         )
 
-        content = _generate(griptape_nodes, commands)
+        content = _generate(engine, commands)
 
         assigned_names = [
             target.id
@@ -123,13 +123,13 @@ class TestNestedFlowCodegen:
         ]
         assert sorted(assigned_names) == ["node0_name", "node1_name", "node2_name"]
 
-    def test_resolves_group_membership_across_a_deeper_subflow(self, griptape_nodes: Engine) -> None:
+    def test_resolves_group_membership_across_a_deeper_subflow(self, engine: Engine) -> None:
         """A group's member can be created in a subflow below it, and must still be named."""
         child = _node_commands("Child")
         group = _node_commands("Group", is_node_group=True, node_names_to_add=[child.node_uuid])
         commands = _flow_commands("top", nodes=[group], sub_flows=[_flow_commands("group_subflow", nodes=[child])])
 
-        content = _generate(griptape_nodes, commands)
+        content = _generate(engine, commands)
 
         # The child is referenced by its generated variable, and it has to be the variable belonging
         # to the child rather than to the group: resolving membership means looking the UUID up
@@ -139,7 +139,7 @@ class TestNestedFlowCodegen:
         child_variable_line = next(line for line in content.splitlines() if "'Child'" in line)
         assert child_variable_line.lstrip().startswith("node0_name")
 
-    def test_writes_a_connection_once_even_though_each_level_reports_it(self, griptape_nodes: Engine) -> None:
+    def test_writes_a_connection_once_even_though_each_level_reports_it(self, engine: Engine) -> None:
         """Every Flow's serialized connections include its subflows', so the same edge repeats.
 
         Re-creating a connection tears down and rebuilds whatever it was routed through, so the
@@ -159,13 +159,11 @@ class TestNestedFlowCodegen:
             sub_flows=[_flow_commands("child", nodes=[source, target], connections=[connection])],
         )
 
-        content = _generate(griptape_nodes, commands)
+        content = _generate(engine, commands)
 
         assert content.count("CreateConnectionRequest(") == 1
 
-    def test_writes_a_nested_group_wall_connection_once_and_after_the_group_exists(
-        self, griptape_nodes: Engine
-    ) -> None:
+    def test_writes_a_nested_group_wall_connection_once_and_after_the_group_exists(self, engine: Engine) -> None:
         """The duplicate that actually happens crosses a nested group's wall, so cover that shape.
 
         An edge into a nested group attaches to a proxy parameter on the group node, so it belongs to
@@ -193,7 +191,7 @@ class TestNestedFlowCodegen:
         # this edge too even though neither endpoint lives there.
         commands = _flow_commands("top", connections=[wall_connection], sub_flows=[outer_subflow])
 
-        content = _generate(griptape_nodes, commands)
+        content = _generate(engine, commands)
 
         assert content.count("CreateConnectionRequest(") == 1
         # The group's variable has to be assigned before the connection referring to it is written,
@@ -206,7 +204,7 @@ class TestNestedFlowCodegen:
         assert len(group_variable_lines) == 1, f"expected one line creating InnerGroup, got {group_variable_lines}"
         assert group_variable_lines[0] < connection_lines[0]
 
-    def test_refuses_to_write_a_group_whose_member_is_not_in_the_file(self, griptape_nodes: Engine) -> None:
+    def test_refuses_to_write_a_group_whose_member_is_not_in_the_file(self, engine: Engine) -> None:
         """Silently dropping the member would save a group the artist has to refill by hand."""
         missing_child = _node_commands("Child")
         group = _node_commands("Group", is_node_group=True, node_names_to_add=[missing_child.node_uuid])
@@ -214,10 +212,10 @@ class TestNestedFlowCodegen:
         commands = _flow_commands("top", nodes=[group])
 
         with pytest.raises(ValueError, match="nodes in the group 'Group'"):
-            _generate(griptape_nodes, commands)
+            _generate(engine, commands)
 
     def test_skips_a_connection_whose_endpoint_is_not_in_the_file_rather_than_failing_the_save(
-        self, griptape_nodes: Engine, caplog: pytest.LogCaptureFixture
+        self, engine: Engine, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Dropping the edge beats refusing to save: the artist keeps everything else.
 
@@ -238,14 +236,14 @@ class TestNestedFlowCodegen:
         commands = _flow_commands("top", nodes=[source], connections=[connection])
 
         with caplog.at_level(logging.ERROR):
-            content = _generate(griptape_nodes, commands)
+            content = _generate(engine, commands)
 
         assert "CreateConnectionRequest(" not in content
         assert "'A'" in content, "the node that could be written still has to be"
         ast.parse(content)
         assert "were never written to the file" in caplog.text
 
-    def test_emits_valid_python(self, griptape_nodes: Engine) -> None:
+    def test_emits_valid_python(self, engine: Engine) -> None:
         """Whatever the nesting depth, the file has to parse."""
         commands = _flow_commands(
             "top",
@@ -259,14 +257,14 @@ class TestNestedFlowCodegen:
             ],
         )
 
-        content = _generate(griptape_nodes, commands)
+        content = _generate(engine, commands)
 
         ast.parse(content)  # raises SyntaxError if the generated file is malformed
 
 
 class TestNestedFlowCodegenStructure:
     @pytest.mark.parametrize("depth", [1, 2, 4])
-    def test_each_level_is_written_inside_the_one_above_it(self, griptape_nodes: Engine, depth: int) -> None:
+    def test_each_level_is_written_inside_the_one_above_it(self, engine: Engine, depth: int) -> None:
         """Nodes must be created inside their own Flow's context block, at any depth."""
         commands = _flow_commands("level0", nodes=[_node_commands("Node0")])
         deepest = commands
@@ -275,7 +273,7 @@ class TestNestedFlowCodegenStructure:
             deepest.sub_flows_commands.append(child)
             deepest = child
 
-        content = _generate(griptape_nodes, commands)
+        content = _generate(engine, commands)
 
         # Deeper Flows are nested further in, so their statements are indented further.
         indents = []

--- a/tests/unit/retained_mode/publishing/test_workflow_packager.py
+++ b/tests/unit/retained_mode/publishing/test_workflow_packager.py
@@ -10,6 +10,7 @@ import pytest
 from dotenv import dotenv_values
 
 from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
+from griptape_nodes.retained_mode.engine import Engine
 from griptape_nodes.retained_mode.events.os_events import (
     DeleteFileRequest,
     DeleteFileResultSuccess,
@@ -31,7 +32,6 @@ from griptape_nodes.retained_mode.events.secrets_events import (
     GetAllSecretValuesRequest,
     GetAllSecretValuesResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.publishing.workflow_packager import (
     DOWNLOAD_MODELS_SCRIPT_NAME,
     WORKFLOW_DIR_MACRO,
@@ -1363,14 +1363,14 @@ class TestStagedPublish:
 
         assert (destination / "run.py").read_text(encoding="utf-8") == "new"
 
-    def test_restores_the_previous_bundle_if_the_swap_fails(self, tmp_path: Path) -> None:
+    def test_restores_the_previous_bundle_if_the_swap_fails(self, tmp_path: Path, engine: Engine) -> None:
         """A failure moving the new bundle into place leaves the destination populated."""
         packager = WorkflowPackager("test_workflow")
         destination = tmp_path / "bundle"
         destination.mkdir()
         (destination / "run.py").write_text("previous", encoding="utf-8")
 
-        real_handle_request = GriptapeNodes.handle_request
+        real_handle_request = engine.handle_request
         staged_bundle_move_attempted = False
 
         def fail_moving_new_bundle_into_place(request: object) -> object:
@@ -1400,14 +1400,14 @@ class TestStagedPublish:
 
         assert (destination / "run.py").read_text(encoding="utf-8") == "previous"
 
-    def test_keeps_the_moved_aside_bundle_when_rollback_fails(self, tmp_path: Path) -> None:
+    def test_keeps_the_moved_aside_bundle_when_rollback_fails(self, tmp_path: Path, engine: Engine) -> None:
         """If the destination cannot be restored, the only copy of the bundle is not deleted."""
         packager = WorkflowPackager("test_workflow")
         destination = tmp_path / "bundle"
         destination.mkdir()
         (destination / "run.py").write_text("previous", encoding="utf-8")
 
-        real_handle_request = GriptapeNodes.handle_request
+        real_handle_request = engine.handle_request
 
         def fail_every_move_to_the_destination(request: object) -> object:
             """Refuse both the swap and the rollback, leaving the destination missing."""
@@ -1435,14 +1435,14 @@ class TestStagedPublish:
         assert len(moved_aside) == 1
         assert (moved_aside[0] / "run.py").read_text(encoding="utf-8") == "previous"
 
-    def test_failure_names_the_destination_not_a_working_directory(self, tmp_path: Path) -> None:
+    def test_failure_names_the_destination_not_a_working_directory(self, tmp_path: Path, engine: Engine) -> None:
         """Every swap failure names the bundle the user published to, whichever move failed."""
         packager = WorkflowPackager("test_workflow")
         destination = tmp_path / "bundle"
         destination.mkdir()
         (destination / "run.py").write_text("previous", encoding="utf-8")
 
-        real_handle_request = GriptapeNodes.handle_request
+        real_handle_request = engine.handle_request
 
         def fail_moving_the_previous_bundle_aside(request: object) -> object:
             """Refuse the destination -> aside move, whose target is an internal path."""
@@ -1469,14 +1469,14 @@ class TestStagedPublish:
         assert f"'{destination}'" in str(failure.value)
         assert ".publish-" not in str(failure.value)
 
-    def test_cleanup_failure_does_not_fail_the_publish(self, tmp_path: Path) -> None:
+    def test_cleanup_failure_does_not_fail_the_publish(self, tmp_path: Path, engine: Engine) -> None:
         """A working directory that cannot be removed is logged, not raised over."""
         packager = WorkflowPackager("test_workflow")
         destination = tmp_path / "bundle"
         destination.mkdir()
         (destination / "run.py").write_text("previous", encoding="utf-8")
 
-        real_handle_request = GriptapeNodes.handle_request
+        real_handle_request = engine.handle_request
 
         def fail_deletes(request: object) -> object:
             """Report every delete as failed, leaving the working directories on disk."""
@@ -1495,7 +1495,7 @@ class TestStagedPublish:
 
         assert (destination / "run.py").read_text(encoding="utf-8") == "new"
 
-    def test_swap_routes_through_engine_requests(self, tmp_path: Path) -> None:
+    def test_swap_routes_through_engine_requests(self, tmp_path: Path, engine: Engine) -> None:
         """Staging directory creation and the swap go through OS request handlers."""
         packager = WorkflowPackager("test_workflow")
         destination = tmp_path / "bundle"
@@ -1503,7 +1503,7 @@ class TestStagedPublish:
         (destination / "run.py").write_text("previous", encoding="utf-8")
         seen: list[type] = []
 
-        real_handle_request = GriptapeNodes.handle_request
+        real_handle_request = engine.handle_request
 
         def record(request: object) -> object:
             seen.append(type(request))

--- a/tests/unit/retained_mode/test_engine_heartbeat.py
+++ b/tests/unit/retained_mode/test_engine_heartbeat.py
@@ -26,20 +26,20 @@ class TestEngineHeartbeatOrchestratorId:
     identify a worker engine and nest it under its orchestrator.
     """
 
-    def test_orchestrator_reports_none(self, griptape_nodes: Engine) -> None:
+    def test_orchestrator_reports_none(self, engine: Engine) -> None:
         # No GTN_ORCHESTRATOR_ENGINE_ID in the environment -> this engine IS the orchestrator.
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("GTN_ORCHESTRATOR_ENGINE_ID", None)
-            result = griptape_nodes.handle_engine_heartbeat_request(EngineHeartbeatRequest(heartbeat_id="hb-orch"))
+            result = engine.handle_engine_heartbeat_request(EngineHeartbeatRequest(heartbeat_id="hb-orch"))
 
         assert isinstance(result, EngineHeartbeatResultSuccess)
         assert result.orchestrator_engine_id is None
 
-    def test_worker_reports_spawning_orchestrator_id(self, griptape_nodes: Engine) -> None:
+    def test_worker_reports_spawning_orchestrator_id(self, engine: Engine) -> None:
         # A worker process is spawned with GTN_ORCHESTRATOR_ENGINE_ID set to its parent's id;
         # the heartbeat echoes it so the client can nest this worker under that orchestrator.
         with patch.dict(os.environ, {"GTN_ORCHESTRATOR_ENGINE_ID": "eng-orchestrator"}):
-            result = griptape_nodes.handle_engine_heartbeat_request(EngineHeartbeatRequest(heartbeat_id="hb-worker"))
+            result = engine.handle_engine_heartbeat_request(EngineHeartbeatRequest(heartbeat_id="hb-worker"))
 
         assert isinstance(result, EngineHeartbeatResultSuccess)
         assert result.orchestrator_engine_id == "eng-orchestrator"
@@ -53,13 +53,13 @@ class TestEngineHeartbeatOperatingSystem:
     carries it.
     """
 
-    def test_reports_the_os_it_is_running_on(self, griptape_nodes: Engine, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_reports_the_os_it_is_running_on(self, engine: Engine, monkeypatch: pytest.MonkeyPatch) -> None:
         # Patch the seam rather than sys.platform: this asserts the heartbeat carries whatever
         # OSManager reported, without telling the rest of the request it is on another OS. The
         # value is one no real platform produces, so the assertion cannot pass by coincidence on
         # a runner that happens to be that OS.
         monkeypatch.setattr(OSManager, "platform_name", staticmethod(lambda: "sentinel-os"))
-        result = griptape_nodes.handle_engine_heartbeat_request(EngineHeartbeatRequest(heartbeat_id="hb-os"))
+        result = engine.handle_engine_heartbeat_request(EngineHeartbeatRequest(heartbeat_id="hb-os"))
 
         assert isinstance(result, EngineHeartbeatResultSuccess)
         assert result.engine_os == "sentinel-os"

--- a/tests/unit/retained_mode/test_retained_mode_lock.py
+++ b/tests/unit/retained_mode/test_retained_mode_lock.py
@@ -1,19 +1,25 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from griptape_nodes.retained_mode.events.node_events import (
     BatchSetNodeLockStateResultFailure,
     SetLockNodeStateRequest,
     SetLockNodeStateResultFailure,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.retained_mode import RetainedMode
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
 
 
 class TestRetainedModeLock:
-    def test_lock_without_current_context_returns_failure(self) -> None:
+    def test_lock_without_current_context_returns_failure(self, engine: Engine) -> None:
         # Ensure empty current context for nodes
-        ctx = GriptapeNodes.ContextManager()
+        ctx = engine.context_manager
         while ctx.has_current_node():
             ctx.pop_node()
-        res = GriptapeNodes.handle_request(SetLockNodeStateRequest(node_name=None, lock=True))
+        res = engine.handle_request(SetLockNodeStateRequest(node_name=None, lock=True))
         assert isinstance(res, SetLockNodeStateResultFailure)
         assert "Current Context" in str(res.result_details)
 


### PR DESCRIPTION
Continue removing usage of the `GriptapeNodes` facade in favor of plain ol' engine object.