### PR TITLE
refactor(publishing): thread the engine into the project packager

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,9 +185,6 @@ ignore = [
 # exe_types/param_types/parameter_{image,audio,video,three_d}.py, which have no Engine of
 # their own yet, so it cannot come off this list until exe_types does.
 "src/griptape_nodes/utils/artifact_normalization.py" = ["TID251"]
-# project_packager.py reaches the facade from a module-level free function. Its engine has to be
-# threaded from project_manager.on_export_project_request through package_project_to_zip.
-"src/griptape_nodes/retained_mode/publishing/project_packager.py" = ["TID251"]
 
 [tool.ruff.lint.flake8-type-checking]
 runtime-evaluated-base-classes = ["pydantic.BaseModel"]

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -4141,7 +4141,9 @@ class ProjectManager(EngineScoped):
         required_secret_keys = self._collect_required_secret_keys()
 
         try:
-            result = package_project_to_zip(project_info, adjacent_config, destination_path, required_secret_keys)
+            result = package_project_to_zip(
+                self.engine, project_info, adjacent_config, destination_path, required_secret_keys
+            )
         except (RuntimeError, OSError) as err:
             return ExportProjectResultFailure(
                 result_details=(

--- a/src/griptape_nodes/retained_mode/publishing/project_packager.py
+++ b/src/griptape_nodes/retained_mode/publishing/project_packager.py
@@ -43,7 +43,6 @@ from griptape_nodes.retained_mode.events.os_events import (
     CopyTreeRequest,
     CopyTreeResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.settings import (
     DEFAULT_LIBRARIES_DIRECTORY,
     LIBRARIES_DIRECTORY_KEY,
@@ -58,6 +57,7 @@ from griptape_nodes.utils.library_utils import (
 from griptape_nodes.utils.version_utils import get_current_version
 
 if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
     from griptape_nodes.retained_mode.managers.project_manager import ProjectInfo
 
 logger = logging.getLogger("project_packager")
@@ -253,9 +253,9 @@ def _unique_dirname(name: str, used: set[str]) -> str:
     return f"{name}_{index}"
 
 
-def _copy_tree(source_path: Path, destination_path: Path, ignore_patterns: list[str]) -> None:
+def _copy_tree(engine: Engine, source_path: Path, destination_path: Path, ignore_patterns: list[str]) -> None:
     """Copy a directory tree via the engine's OS event system."""
-    result = GriptapeNodes.handle_request(
+    result = engine.handle_request(
         CopyTreeRequest(
             source_path=str(source_path),
             destination_path=str(destination_path),
@@ -276,6 +276,7 @@ def _copy_tree(source_path: Path, destination_path: Path, ignore_patterns: list[
 
 
 def package_project_to_zip(
+    engine: Engine,
     project_info: ProjectInfo,
     adjacent_config: dict,
     destination_zip: Path,
@@ -284,24 +285,26 @@ def package_project_to_zip(
     """Bundle a loaded project into a portable .zip at destination_zip.
 
     Convenience entrypoint: constructs a ProjectExporter and runs it.
+    engine is used to issue the copy-tree requests that stage the package.
     required_secret_keys is the KEY-NAME list to record in the manifest (collected
     by the caller; the packager never reads secret VALUES).
     """
-    return ProjectExporter(project_info, adjacent_config, destination_zip).run(required_secret_keys)
+    return ProjectExporter(engine, project_info, adjacent_config, destination_zip).run(required_secret_keys)
 
 
 class ProjectExporter:
     """Bundle a project base directory into a portable .zip.
 
-    Holds the packaging inputs (project, adjacent config, destination) plus the
-    per-run staging directory, so the pipeline helpers read shared state off self
-    instead of threading it through every signature.
+    Holds the packaging inputs (engine, project, adjacent config, destination) plus
+    the per-run staging directory, so the pipeline helpers read shared state off
+    self instead of threading it through every signature.
 
     Usage:
-        result = ProjectExporter(project_info, adjacent_config, destination).run(required_secret_keys)
+        result = ProjectExporter(engine, project_info, adjacent_config, destination).run(required_secret_keys)
     """
 
-    def __init__(self, project_info: ProjectInfo, adjacent_config: dict, destination_zip: Path) -> None:
+    def __init__(self, engine: Engine, project_info: ProjectInfo, adjacent_config: dict, destination_zip: Path) -> None:
+        self._engine = engine
         self._project_info = project_info
         self._adjacent_config = adjacent_config
         self._destination_zip = destination_zip
@@ -358,7 +361,7 @@ class ProjectExporter:
 
     def _mirror_base_dir(self) -> None:
         """Copy the project base-dir tree into staging, excluding secrets and caches."""
-        _copy_tree(self._project_base_dir, self._staging, _MIRROR_IGNORE_PATTERNS)
+        _copy_tree(self._engine, self._project_base_dir, self._staging, _MIRROR_IGNORE_PATTERNS)
 
     def _prune_download_library_sink(self) -> None:
         """Remove the downloaded-library sink from the mirrored tree.
@@ -462,7 +465,7 @@ class ProjectExporter:
         for local in classification.copied:
             dest_dirname = _unique_dirname(local.containing_dir.name, used_dirnames)
             used_dirnames.add(dest_dirname)
-            _copy_tree(local.containing_dir, libraries_root / dest_dirname, _LIBRARY_COPY_IGNORE_PATTERNS)
+            _copy_tree(self._engine, local.containing_dir, libraries_root / dest_dirname, _LIBRARY_COPY_IGNORE_PATTERNS)
 
             if local.path_within_containing_dir is None:
                 package_relative = f"{COPIED_LIBRARIES_DIRNAME}/{dest_dirname}"

--- a/tests/unit/retained_mode/publishing/test_project_packager.py
+++ b/tests/unit/retained_mode/publishing/test_project_packager.py
@@ -16,6 +16,7 @@ from griptape_nodes.common.project_templates import (
     ProjectValidationStatus,
 )
 from griptape_nodes.common.project_templates.project_path import PerPlatformProjectPath
+from griptape_nodes.retained_mode.engine import Engine
 from griptape_nodes.retained_mode.managers.project_manager import ProjectInfo
 from griptape_nodes.retained_mode.publishing.project_packager import ProjectExporter
 
@@ -35,38 +36,40 @@ def _project_info(base_dir: Path, *, libraries_dir: object = None, workspace_dir
     )
 
 
-def _exporter(base_dir: Path, *, adjacent_config: dict, **info_kwargs: object) -> ProjectExporter:
+def _exporter(engine: Engine, base_dir: Path, *, adjacent_config: dict, **info_kwargs: object) -> ProjectExporter:
     info = _project_info(base_dir, **info_kwargs)
-    return ProjectExporter(info, adjacent_config, base_dir / "out.zip")
+    return ProjectExporter(engine, info, adjacent_config, base_dir / "out.zip")
 
 
 class TestResolveLibrariesSink:
-    def test_defaults_to_base_dir_libraries(self, tmp_path: Path) -> None:
+    def test_defaults_to_base_dir_libraries(self, engine: Engine, tmp_path: Path) -> None:
         """No template fields and empty config -> <base>/libraries (legacy behavior)."""
-        exporter = _exporter(tmp_path, adjacent_config={})
+        exporter = _exporter(engine, tmp_path, adjacent_config={})
         assert exporter._resolve_libraries_sink() == tmp_path / "libraries"
 
-    def test_adjacent_libraries_directory_relative_to_base(self, tmp_path: Path) -> None:
-        exporter = _exporter(tmp_path, adjacent_config={"libraries_directory": "vendored"})
+    def test_adjacent_libraries_directory_relative_to_base(self, engine: Engine, tmp_path: Path) -> None:
+        exporter = _exporter(engine, tmp_path, adjacent_config={"libraries_directory": "vendored"})
         assert exporter._resolve_libraries_sink() == tmp_path / "vendored"
 
-    def test_adjacent_workspace_directory_relocates_sink(self, tmp_path: Path) -> None:
+    def test_adjacent_workspace_directory_relocates_sink(self, engine: Engine, tmp_path: Path) -> None:
         """A relative workspace_directory in config moves the workspace-relative sink."""
-        exporter = _exporter(tmp_path, adjacent_config={"workspace_directory": "ws"})
+        exporter = _exporter(engine, tmp_path, adjacent_config={"workspace_directory": "ws"})
         assert exporter._resolve_libraries_sink() == tmp_path / "ws" / "libraries"
 
-    def test_template_workspace_dir_wins_over_config(self, tmp_path: Path) -> None:
+    def test_template_workspace_dir_wins_over_config(self, engine: Engine, tmp_path: Path) -> None:
         """The template's own workspace_dir is honored over the adjacent config."""
         exporter = _exporter(
+            engine,
             tmp_path,
             adjacent_config={"workspace_directory": "ignored"},
             workspace_dir="ws-from-template",
         )
         assert exporter._resolve_libraries_sink() == tmp_path / "ws-from-template" / "libraries"
 
-    def test_template_libraries_dir_wins_over_everything(self, tmp_path: Path) -> None:
+    def test_template_libraries_dir_wins_over_everything(self, engine: Engine, tmp_path: Path) -> None:
         """The template's own libraries_dir is the highest-priority sink source."""
         exporter = _exporter(
+            engine,
             tmp_path,
             adjacent_config={"workspace_directory": "ws", "libraries_directory": "ignored"},
             workspace_dir="ws",
@@ -74,14 +77,14 @@ class TestResolveLibrariesSink:
         )
         assert exporter._resolve_libraries_sink() == tmp_path / "my-libs"
 
-    def test_absolute_template_libraries_dir_used_as_is(self, tmp_path: Path) -> None:
+    def test_absolute_template_libraries_dir_used_as_is(self, engine: Engine, tmp_path: Path) -> None:
         shared = tmp_path / "shared" / "libraries"
-        exporter = _exporter(tmp_path, adjacent_config={}, libraries_dir=str(shared))
+        exporter = _exporter(engine, tmp_path, adjacent_config={}, libraries_dir=str(shared))
         assert exporter._resolve_libraries_sink() == shared
 
-    def test_per_platform_libraries_dir_selects_active(self, tmp_path: Path) -> None:
+    def test_per_platform_libraries_dir_selects_active(self, engine: Engine, tmp_path: Path) -> None:
         """A per-platform libraries_dir reduces to the active platform's value."""
         abs_libs = tmp_path / "platform-libs"
         per_platform = PerPlatformProjectPath(default=str(abs_libs))
-        exporter = _exporter(tmp_path, adjacent_config={}, libraries_dir=per_platform)
+        exporter = _exporter(engine, tmp_path, adjacent_config={}, libraries_dir=per_platform)
         assert exporter._resolve_libraries_sink() == abs_libs


### PR DESCRIPTION
Continue removing usage of the GriptapeNodes facade in favor of plain ol' engine object.