### PR TITLE
refactor(engine): thread the engine into file metadata helpers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,8 +185,10 @@ ignore = [
 # WorkflowRegistry is still a process-global fake singleton reaching the facade for config.
 # Making it engine-owned is its own change, since it alters what node libraries import.
 "src/griptape_nodes/node_library/workflow_registry.py" = ["TID251"]
-"src/griptape_nodes/utils/**" = ["TID251"]
-"src/griptape_nodes/retained_mode/file_metadata/**" = ["TID251"]
+# artifact_normalization.py is called from Parameter converter closures in
+# exe_types/param_types/parameter_{image,audio,video,three_d}.py, which have no Engine of
+# their own yet, so it cannot come off this list until exe_types does.
+"src/griptape_nodes/utils/artifact_normalization.py" = ["TID251"]
 # project_packager.py reaches the facade from a module-level free function. Its engine has to be
 # threaded from project_manager.on_export_project_request through package_project_to_zip.
 "src/griptape_nodes/retained_mode/publishing/project_packager.py" = ["TID251"]

--- a/src/griptape_nodes/retained_mode/file_metadata/sidecar_metadata.py
+++ b/src/griptape_nodes/retained_mode/file_metadata/sidecar_metadata.py
@@ -32,10 +32,11 @@ from griptape_nodes.retained_mode.events.project_events import (
     GetSituationRequest,
     GetSituationResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from griptape_nodes.retained_mode.engine import Engine
 
 
 logger = logging.getLogger("griptape_nodes")
@@ -65,7 +66,7 @@ class SidecarContent(BaseModel):
     situation: SituationMetadata | None = None
 
 
-def _resolve_sidecar_path(file_path: Path) -> Path:
+def _resolve_sidecar_path(file_path: Path, engine: Engine) -> Path:
     """Resolve the sidecar path for a given file via the project template system.
 
     Uses the 'save_griptape_nodes_metadata' situation from the current project template to determine
@@ -74,6 +75,7 @@ def _resolve_sidecar_path(file_path: Path) -> Path:
 
     Args:
         file_path: Absolute path to the saved file.
+        engine: The engine whose request bus resolves the project and situation.
 
     Returns:
         Absolute path to the sidecar JSON file.
@@ -81,7 +83,7 @@ def _resolve_sidecar_path(file_path: Path) -> Path:
     Raises:
         RuntimeError: If project not loaded, situation not found, or path resolution fails.
     """
-    get_project_result = GriptapeNodes.handle_request(GetCurrentProjectRequest())
+    get_project_result = engine.handle_request(GetCurrentProjectRequest())
     if not isinstance(get_project_result, GetCurrentProjectResultSuccess):
         msg = "No current project loaded"
         raise RuntimeError(msg)  # noqa: TRY004
@@ -89,7 +91,7 @@ def _resolve_sidecar_path(file_path: Path) -> Path:
     workspace_dir = get_project_result.project_info.project_base_dir
     decomposed = decompose_source_path(file_path, workspace_dir)
 
-    get_situation_result = GriptapeNodes.handle_request(
+    get_situation_result = engine.handle_request(
         GetSituationRequest(situation_name=BuiltInSituation.SAVE_GRIPTAPE_NODES_METADATA)
     )
     if not isinstance(get_situation_result, GetSituationResultSuccess):
@@ -102,7 +104,7 @@ def _resolve_sidecar_path(file_path: Path) -> Path:
 
     situation = get_situation_result.situation
     parsed_macro = ParsedMacro(situation.macro)
-    path_result = GriptapeNodes.handle_request(
+    path_result = engine.handle_request(
         GetPathForMacroRequest(
             parsed_macro=parsed_macro,
             variables=variables,
@@ -115,7 +117,7 @@ def _resolve_sidecar_path(file_path: Path) -> Path:
     return path_result.absolute_path
 
 
-def write_sidecar(file_path: Path, metadata: SidecarContent | None) -> None:
+def write_sidecar(file_path: Path, metadata: SidecarContent | None, engine: Engine) -> None:
     """Write a sidecar JSON metadata file for the saved file.
 
     Resolves the sidecar path via the project template's 'save_griptape_nodes_metadata' situation,
@@ -126,9 +128,10 @@ def write_sidecar(file_path: Path, metadata: SidecarContent | None) -> None:
     Args:
         file_path: Absolute path to the file that was just saved.
         metadata: Caller-provided situation and variable context (may be None).
+        engine: The engine whose request bus resolves the sidecar path.
     """
     try:
-        sidecar_path = _resolve_sidecar_path(file_path)
+        sidecar_path = _resolve_sidecar_path(file_path, engine)
         content = metadata or SidecarContent()
         output = {
             "schema_version": SCHEMA_VERSION,

--- a/src/griptape_nodes/retained_mode/file_metadata/workflow_metadata.py
+++ b/src/griptape_nodes/retained_mode/file_metadata/workflow_metadata.py
@@ -1,10 +1,12 @@
 """Workflow metadata collection for files saved through the retained mode API."""
 
+from __future__ import annotations
+
 import base64
 import logging
 import pickle
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from griptape_nodes.exe_types.core_types import ParameterMode
 from griptape_nodes.exe_types.node_types import BaseNode
@@ -18,7 +20,9 @@ from griptape_nodes.retained_mode.events.node_events import (
     SerializeNodeToCommandsRequest,
     SerializeNodeToCommandsResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -29,11 +33,12 @@ METADATA_NAMESPACE = "gtn_"
 FLOW_COMMANDS_KEY = f"{METADATA_NAMESPACE}flow_commands"
 
 
-def _serialize_node(node_name: str) -> str | None:
+def _serialize_node(node_name: str, engine: Engine) -> str | None:
     """Serialize a specific node to JSON commands.
 
     Args:
         node_name: Name of the node to serialize
+        engine: The engine whose request bus performs the serialization
 
     Returns:
         JSON string of serialized node commands, or None if serialization fails
@@ -41,7 +46,7 @@ def _serialize_node(node_name: str) -> str | None:
     serialize_request = SerializeNodeToCommandsRequest(
         node_name=node_name,
     )
-    serialize_result = GriptapeNodes.handle_request(serialize_request)
+    serialize_result = engine.handle_request(serialize_request)
 
     if isinstance(serialize_result, SerializeNodeToCommandsResultSuccess):
         # Convert to dict and then to JSON string
@@ -50,17 +55,18 @@ def _serialize_node(node_name: str) -> str | None:
     return None
 
 
-def _serialize_flow(flow_name: str | None = None) -> str | None:
+def _serialize_flow(engine: Engine, flow_name: str | None = None) -> str | None:
     """Serialize a flow to pickle + base64 encoded commands.
 
     Args:
+        engine: The engine whose request bus and context manager perform the serialization
         flow_name: Name of the flow to serialize (None for current context flow)
 
     Returns:
         Base64-encoded pickle string of serialized flow commands, or None if serialization fails
     """
     # Validation: Check if we have a flow context
-    if flow_name is None and not GriptapeNodes.ContextManager().has_current_flow():
+    if flow_name is None and not engine.context_manager.has_current_flow():
         logger.warning("Cannot serialize flow: no current flow context available")
         return None
 
@@ -69,7 +75,7 @@ def _serialize_flow(flow_name: str | None = None) -> str | None:
         flow_name=flow_name,
         include_create_flow_command=False,
     )
-    serialize_result = GriptapeNodes.handle_request(serialize_request)
+    serialize_result = engine.handle_request(serialize_request)
 
     # Validation: Check if serialization succeeded
     if not isinstance(serialize_result, SerializeFlowToCommandsResultSuccess):
@@ -90,17 +96,18 @@ def _serialize_flow(flow_name: str | None = None) -> str | None:
         return encoded_data
 
 
-def _collect_parameter_values(node_name: str) -> dict[str, Any] | None:
+def _collect_parameter_values(node_name: str, engine: Engine) -> dict[str, Any] | None:
     """Collect current parameter values from a node's INPUT and PROPERTY parameters.
 
     Args:
         node_name: Name of the node to collect parameters from
+        engine: The engine whose object manager resolves the node
 
     Returns:
         Dictionary of parameter names to serialized values, or None if collection fails
     """
     # Failure case: Attempt to get node object
-    obj_mgr = GriptapeNodes.ObjectManager()
+    obj_mgr = engine.object_manager
     try:
         node = obj_mgr.attempt_get_object_by_name_as_type(node_name, BaseNode)
     except Exception as e:
@@ -169,11 +176,14 @@ def _collect_workflow_details(workflow_name: str, metadata: dict[str, str]) -> N
         pass
 
 
-def collect_workflow_metadata() -> dict[str, str]:
+def collect_workflow_metadata(engine: Engine) -> dict[str, str]:
     """Collect available workflow metadata from current execution context.
 
-    Gathers metadata from GriptapeNodes ContextManager and WorkflowRegistry.
+    Gathers metadata from the engine's ContextManager and WorkflowRegistry.
     All keys are prefixed with METADATA_NAMESPACE to avoid conflicts.
+
+    Args:
+        engine: The engine whose context manager and flow manager supply the metadata.
 
     Returns:
         Dictionary of metadata key-value pairs, may be empty if no context available
@@ -184,7 +194,7 @@ def collect_workflow_metadata() -> dict[str, str]:
     metadata[f"{METADATA_NAMESPACE}saved_at"] = datetime.now(UTC).isoformat()
 
     # Get context manager
-    context_manager = GriptapeNodes.ContextManager()
+    context_manager = engine.context_manager
 
     # Check workflow context
     if not context_manager.has_current_workflow():
@@ -205,7 +215,7 @@ def collect_workflow_metadata() -> dict[str, str]:
             metadata[f"{METADATA_NAMESPACE}flow_name"] = flow.name
 
             # Get resolving nodes (currently running nodes) from flow_state
-            flow_manager = GriptapeNodes.FlowManager()
+            flow_manager = engine.flow_manager
             _, resolving_nodes, _ = flow_manager.flow_state(flow)
 
             if resolving_nodes:
@@ -214,13 +224,13 @@ def collect_workflow_metadata() -> dict[str, str]:
 
             # Serialize the entire current flow to commands
             # This captures all nodes, connections, and parameter values in the flow
-            flow_commands = _serialize_flow()
+            flow_commands = _serialize_flow(engine)
             if flow_commands:
                 metadata[FLOW_COMMANDS_KEY] = flow_commands
 
             if resolving_nodes:
                 # Collect parameter values from the first resolving node
-                parameter_values = _collect_parameter_values(resolving_nodes[0])
+                parameter_values = _collect_parameter_values(resolving_nodes[0], engine)
                 if parameter_values:
                     # Store each parameter as its own metadata key
                     for param_name, param_value in parameter_values.items():

--- a/src/griptape_nodes/retained_mode/managers/artifact_providers/image/image_artifact_provider.py
+++ b/src/griptape_nodes/retained_mode/managers/artifact_providers/image/image_artifact_provider.py
@@ -188,7 +188,7 @@ class ImageArtifactProvider(BaseArtifactProvider):
             return data
 
         try:
-            metadata = collect_workflow_metadata()
+            metadata = collect_workflow_metadata(self.engine)
         except Exception as e:
             logger.warning("Attempted to collect workflow metadata for %s. Failed because: %s", file_name, e)
             return data

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -54,11 +54,13 @@ from griptape_nodes.retained_mode.events.os_events import (
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 from griptape_nodes.retained_mode.managers.settings import (
     DEFAULT_LIBRARIES_DIRECTORY,
+    DISCOVERY_MAX_DEPTH_KEY,
     LIBRARIES_DIRECTORY_KEY,
     WORKFLOWS_TO_REGISTER_KEY,
     Settings,
 )
 from griptape_nodes.utils.dict_utils import get_dot_value, merge_dicts, set_dot_value
+from griptape_nodes.utils.file_utils import DEFAULT_MAX_SEARCH_DEPTH
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -352,6 +354,18 @@ class ConfigManager(EngineScoped):
             possible_config_files.append(self._workspace_config_path)
 
         return [config_file for config_file in possible_config_files if config_file.exists()]
+
+    @property
+    def discovery_max_depth(self) -> int:
+        """Get the operator-configured recursion depth ceiling for recursive file discovery.
+
+        Overridable via the `GTN_CONFIG_DISCOVERY_MAX_DEPTH` env var; falls back to
+        DEFAULT_MAX_SEARCH_DEPTH when unset.
+
+        Returns:
+            The `discovery_max_depth` setting.
+        """
+        return self.get_config_value(DISCOVERY_MAX_DEPTH_KEY, default=DEFAULT_MAX_SEARCH_DEPTH, cast_type=int)
 
     def _load_config_from_env_vars(self) -> dict[str, Any]:
         """Load configuration values from GTN_CONFIG_ environment variables.

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -3997,7 +3997,9 @@ class LibraryManager(EngineScoped):
         about is exactly the file overwrite targets.
         """
         for manifest_path in await find_files_recursive(
-            libraries_path, LibraryManager.LIBRARY_CONFIG_GLOB_PATTERN, engine=self.engine
+            libraries_path,
+            LibraryManager.LIBRARY_CONFIG_GLOB_PATTERN,
+            max_depth=self.engine.config_manager.discovery_max_depth,
         ):
             try:
                 content = manifest_path.read_text(encoding="utf-8")
@@ -5938,7 +5940,9 @@ class LibraryManager(EngineScoped):
                 # directories and bounds recursion depth so a deep or symlink-looped
                 # tree can't stall the boot scan.
                 for lib_path in await find_files_recursive(
-                    path, LibraryManager.LIBRARY_CONFIG_GLOB_PATTERN, engine=self.engine
+                    path,
+                    LibraryManager.LIBRARY_CONFIG_GLOB_PATTERN,
+                    max_depth=self.engine.config_manager.discovery_max_depth,
                 ):
                     if lib_path not in seen_paths:
                         seen_paths.add(lib_path)

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -3974,8 +3974,7 @@ class LibraryManager(EngineScoped):
             return f"Failed to provision library '{library_label}' from '{git_url}': {download_result.result_details}"
         return None
 
-    @staticmethod
-    async def _installed_library_manifest_path(library_name: str, libraries_path: Path) -> Path | None:
+    async def _installed_library_manifest_path(self, library_name: str, libraries_path: Path) -> Path | None:
         """Return the on-disk manifest path for a provisioned library by name, or None.
 
         Scans the manifests under `libraries_directory` (where reconcile clones
@@ -3997,7 +3996,9 @@ class LibraryManager(EngineScoped):
         directory before re-cloning), guaranteeing the file the planner reasoned
         about is exactly the file overwrite targets.
         """
-        for manifest_path in await find_files_recursive(libraries_path, LibraryManager.LIBRARY_CONFIG_GLOB_PATTERN):
+        for manifest_path in await find_files_recursive(
+            libraries_path, LibraryManager.LIBRARY_CONFIG_GLOB_PATTERN, engine=self.engine
+        ):
             try:
                 content = manifest_path.read_text(encoding="utf-8")
                 manifest = json.loads(content)
@@ -4008,19 +4009,19 @@ class LibraryManager(EngineScoped):
 
         return None
 
-    @staticmethod
-    async def _installed_library_version(library_name: str, libraries_path: Path) -> str | None:
+    async def _installed_library_version(self, library_name: str, libraries_path: Path) -> str | None:
         """Return the on-disk version of a library by manifest name, or None when absent.
 
         Locates the provisioned manifest via `_installed_library_manifest_path`
         (the shared resolver), then reads `metadata.library_version`. None when no
         manifest matches or the version is absent/unreadable.
         """
-        manifest_path = await LibraryManager._installed_library_manifest_path(library_name, libraries_path)
+        manifest_path = await self._installed_library_manifest_path(library_name, libraries_path)
         return LibraryManager._library_version_from_manifest(manifest_path)
 
-    @staticmethod
-    async def _installed_manifest_path_for_download(download: LibraryDownload, libraries_path: Path) -> Path | None:
+    async def _installed_manifest_path_for_download(
+        self, download: LibraryDownload, libraries_path: Path
+    ) -> Path | None:
         """Return the on-disk manifest path for a download entry, or None when absent.
 
         Locates the installed copy the same way the download handler lands it:
@@ -4036,14 +4037,13 @@ class LibraryManager(EngineScoped):
         libraries root (correct post-activation).
         """
         if download.name is not None:
-            return await LibraryManager._installed_library_manifest_path(download.name, libraries_path)
+            return await self._installed_library_manifest_path(download.name, libraries_path)
 
         repo_name = extract_repo_name_from_url(download.git_url)
         repo_directory = libraries_path / repo_name
         return find_file_in_directory(repo_directory, LibraryManager.LIBRARY_CONFIG_GLOB_PATTERN)
 
-    @staticmethod
-    async def _installed_download_version(download: LibraryDownload, libraries_path: Path) -> str | None:
+    async def _installed_download_version(self, download: LibraryDownload, libraries_path: Path) -> str | None:
         """Return the on-disk version for a download entry, or None when absent.
 
         Resolves the installed manifest via `_installed_manifest_path_for_download`
@@ -4052,7 +4052,7 @@ class LibraryManager(EngineScoped):
         libraries directory through for the preview, or the live config's
         resolved root for the real reconcile.
         """
-        manifest_path = await LibraryManager._installed_manifest_path_for_download(download, libraries_path)
+        manifest_path = await self._installed_manifest_path_for_download(download, libraries_path)
         return LibraryManager._library_version_from_manifest(manifest_path)
 
     @staticmethod
@@ -5937,7 +5937,9 @@ class LibraryManager(EngineScoped):
                 # Recursively find library files. find_files_recursive skips hidden
                 # directories and bounds recursion depth so a deep or symlink-looped
                 # tree can't stall the boot scan.
-                for lib_path in await find_files_recursive(path, LibraryManager.LIBRARY_CONFIG_GLOB_PATTERN):
+                for lib_path in await find_files_recursive(
+                    path, LibraryManager.LIBRARY_CONFIG_GLOB_PATTERN, engine=self.engine
+                ):
                     if lib_path not in seen_paths:
                         seen_paths.add(lib_path)
                         discovered_entries.append(

--- a/src/griptape_nodes/retained_mode/managers/os_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/os_manager.py
@@ -2812,7 +2812,7 @@ class OSManager(EngineScoped):
 
         # Write sidecar metadata file if caller opted in by providing file_metadata
         if request.file_metadata is not None:
-            write_sidecar(final_file_path, request.file_metadata)
+            write_sidecar(final_file_path, request.file_metadata, self.engine)
 
         if used_indexed_fallback:
             msg = f"File written to indexed path: {final_file_path} (original path '{path_display}' already existed)"

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -2047,7 +2047,7 @@ class ProjectManager(EngineScoped):
         # Canonicalize directory-discovered files the same way _load_projects_from_directory does, so
         # their paths collide with registry paths under the path-identity comparisons used downstream.
         for directory in directory_paths:
-            discovered = await find_files_recursive(directory, WORKSPACE_PROJECT_FILE)
+            discovered = await find_files_recursive(directory, WORKSPACE_PROJECT_FILE, engine=self.engine)
             file_paths.extend(canonicalize_for_identity(path) for path in discovered)
 
         for canonical_path in file_paths:
@@ -5161,7 +5161,7 @@ class ProjectManager(EngineScoped):
         `discovery_max_depth` setting and hidden directories (e.g. .venv, .git)
         are skipped by find_files_recursive.
         """
-        discovered = await find_files_recursive(directory, WORKSPACE_PROJECT_FILE)
+        discovered = await find_files_recursive(directory, WORKSPACE_PROJECT_FILE, engine=self.engine)
         if not discovered:
             logger.warning(
                 "projects_to_register directory '%s' contains no '%s' files; skipping",

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -2047,7 +2047,9 @@ class ProjectManager(EngineScoped):
         # Canonicalize directory-discovered files the same way _load_projects_from_directory does, so
         # their paths collide with registry paths under the path-identity comparisons used downstream.
         for directory in directory_paths:
-            discovered = await find_files_recursive(directory, WORKSPACE_PROJECT_FILE, engine=self.engine)
+            discovered = await find_files_recursive(
+                directory, WORKSPACE_PROJECT_FILE, max_depth=self.engine.config_manager.discovery_max_depth
+            )
             file_paths.extend(canonicalize_for_identity(path) for path in discovered)
 
         for canonical_path in file_paths:
@@ -5161,7 +5163,9 @@ class ProjectManager(EngineScoped):
         `discovery_max_depth` setting and hidden directories (e.g. .venv, .git)
         are skipped by find_files_recursive.
         """
-        discovered = await find_files_recursive(directory, WORKSPACE_PROJECT_FILE, engine=self.engine)
+        discovered = await find_files_recursive(
+            directory, WORKSPACE_PROJECT_FILE, max_depth=self.engine.config_manager.discovery_max_depth
+        )
         if not discovered:
             logger.warning(
                 "projects_to_register directory '%s' contains no '%s' files; skipping",

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -6859,7 +6859,7 @@ class WorkflowManager(EngineScoped):
                 # find_files_recursive skips hidden directories (.venv, .git) and
                 # bounds recursion depth, so a deep or symlink-looped tree can't stall
                 # the boot scan.
-                for workflow_file in await find_files_recursive(path, "*.py"):
+                for workflow_file in await find_files_recursive(path, "*.py", engine=self.engine):
                     # Unsaved workflows are ephemeral; any file with this prefix is a
                     # leak from a pre-fix save and cannot be registered (the registry
                     # rejects unsaved keys paired with a file path).

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -6859,7 +6859,9 @@ class WorkflowManager(EngineScoped):
                 # find_files_recursive skips hidden directories (.venv, .git) and
                 # bounds recursion depth, so a deep or symlink-looped tree can't stall
                 # the boot scan.
-                for workflow_file in await find_files_recursive(path, "*.py", engine=self.engine):
+                for workflow_file in await find_files_recursive(
+                    path, "*.py", max_depth=self.engine.config_manager.discovery_max_depth
+                ):
                     # Unsaved workflows are ephemeral; any file with this prefix is a
                     # leak from a pre-fix save and cannot be registered (the registry
                     # rejects unsaved keys paired with a file path).

--- a/src/griptape_nodes/utils/file_utils.py
+++ b/src/griptape_nodes/utils/file_utils.py
@@ -9,37 +9,16 @@ from dataclasses import dataclass
 from fnmatch import fnmatch
 from functools import partial
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import anyio
 import anyio.to_thread
 
-from griptape_nodes.retained_mode.managers.settings import DISCOVERY_MAX_DEPTH_KEY
-
-if TYPE_CHECKING:
-    from griptape_nodes.retained_mode.engine import Engine
-
 logger = logging.getLogger(__name__)
 
-# Fallback ceiling on how deep recursive discovery walks, used only when the
-# `discovery_max_depth` engine setting cannot be read. Bounds boot-time scans
-# against pathologically deep trees and symlink loops without a visited-set.
+# Fallback ceiling on how deep recursive discovery walks when a caller has no
+# operator-configured value of its own. Bounds boot-time scans against
+# pathologically deep trees and symlink loops without a visited-set.
 DEFAULT_MAX_SEARCH_DEPTH = 5
-
-
-def _resolve_discovery_max_depth(engine: Engine) -> int:
-    """Read the operator-configured ``discovery_max_depth`` ceiling for recursive discovery.
-
-    Returns the live `discovery_max_depth` engine setting (overridable via the
-    `GTN_CONFIG_DISCOVERY_MAX_DEPTH` env var), falling back to
-    DEFAULT_MAX_SEARCH_DEPTH only when the setting is absent.
-
-    Args:
-        engine: The engine whose ConfigManager holds the setting.
-    """
-    return engine.config_manager.get_config_value(
-        DISCOVERY_MAX_DEPTH_KEY, default=DEFAULT_MAX_SEARCH_DEPTH, cast_type=int
-    )
 
 
 def atomic_write_bytes(path: Path, data: bytes) -> None:
@@ -255,21 +234,21 @@ async def find_files_recursive(
     directory: Path,
     pattern: str,
     *,
-    engine: Engine,
+    max_depth: int,
     skip_hidden: bool = True,
     max_files: int | None = None,
 ) -> list[Path]:
     """Asynchronously search directory recursively for files matching pattern.
 
     Depth-bounded async finder suitable for the engine boot path: each directory read is
-    offloaded to a worker thread so it never blocks the event loop, and the
-    `discovery_max_depth` setting bounds recursion so a pathologically deep tree
-    or symlink loop can't stall startup.
+    offloaded to a worker thread so it never blocks the event loop, and `max_depth`
+    bounds recursion so a pathologically deep tree or symlink loop can't stall startup.
 
     Args:
         directory: Directory to search in
         pattern: Glob pattern to match file names against (e.g., '*.json')
-        engine: The engine whose ConfigManager supplies the `discovery_max_depth` ceiling.
+        max_depth: Ceiling on recursion depth, supplied by the caller (e.g. an
+            operator-configured setting).
         skip_hidden: If True, skip hidden directories (those starting with .).
             This avoids descending into large hidden trees like .git or .venv.
         max_files: If set, stop and return as soon as this many matches are found.
@@ -289,7 +268,7 @@ async def find_files_recursive(
     params = _AsyncWalkParams(
         pattern=pattern,
         skip_hidden=skip_hidden,
-        max_depth=_resolve_discovery_max_depth(engine),
+        max_depth=max_depth,
         max_files=max_files,
         matches=matches,
     )

--- a/src/griptape_nodes/utils/file_utils.py
+++ b/src/griptape_nodes/utils/file_utils.py
@@ -9,9 +9,15 @@ from dataclasses import dataclass
 from fnmatch import fnmatch
 from functools import partial
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import anyio
 import anyio.to_thread
+
+from griptape_nodes.retained_mode.managers.settings import DISCOVERY_MAX_DEPTH_KEY
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
 
 logger = logging.getLogger(__name__)
 
@@ -21,21 +27,17 @@ logger = logging.getLogger(__name__)
 DEFAULT_MAX_SEARCH_DEPTH = 5
 
 
-def _resolve_discovery_max_depth() -> int:
+def _resolve_discovery_max_depth(engine: Engine) -> int:
     """Read the operator-configured ``discovery_max_depth`` ceiling for recursive discovery.
 
     Returns the live `discovery_max_depth` engine setting (overridable via the
     `GTN_CONFIG_DISCOVERY_MAX_DEPTH` env var), falling back to
     DEFAULT_MAX_SEARCH_DEPTH only when the setting is absent.
-    """
-    # Lazy import: file_utils is a leaf util imported by the managers, so reaching
-    # GriptapeNodes/ConfigManager at module top-level would create a cycle
-    # (file_utils <- managers <- griptape_nodes). config_manager.py breaks the
-    # same cycle the same way.
-    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-    from griptape_nodes.retained_mode.managers.settings import DISCOVERY_MAX_DEPTH_KEY
 
-    return GriptapeNodes.ConfigManager().get_config_value(
+    Args:
+        engine: The engine whose ConfigManager holds the setting.
+    """
+    return engine.config_manager.get_config_value(
         DISCOVERY_MAX_DEPTH_KEY, default=DEFAULT_MAX_SEARCH_DEPTH, cast_type=int
     )
 
@@ -253,6 +255,7 @@ async def find_files_recursive(
     directory: Path,
     pattern: str,
     *,
+    engine: Engine,
     skip_hidden: bool = True,
     max_files: int | None = None,
 ) -> list[Path]:
@@ -266,6 +269,7 @@ async def find_files_recursive(
     Args:
         directory: Directory to search in
         pattern: Glob pattern to match file names against (e.g., '*.json')
+        engine: The engine whose ConfigManager supplies the `discovery_max_depth` ceiling.
         skip_hidden: If True, skip hidden directories (those starting with .).
             This avoids descending into large hidden trees like .git or .venv.
         max_files: If set, stop and return as soon as this many matches are found.
@@ -285,7 +289,7 @@ async def find_files_recursive(
     params = _AsyncWalkParams(
         pattern=pattern,
         skip_hidden=skip_hidden,
-        max_depth=_resolve_discovery_max_depth(),
+        max_depth=_resolve_discovery_max_depth(engine),
         max_files=max_files,
         matches=matches,
     )

--- a/tests/unit/retained_mode/file_metadata/test_sidecar_metadata.py
+++ b/tests/unit/retained_mode/file_metadata/test_sidecar_metadata.py
@@ -3,7 +3,7 @@
 import json
 import logging
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 
@@ -19,8 +19,6 @@ from griptape_nodes.retained_mode.file_metadata.sidecar_metadata import (
     SituationPolicy,
     write_sidecar,
 )
-
-HANDLE_REQUEST_PATH = "griptape_nodes.retained_mode.file_metadata.sidecar_metadata.GriptapeNodes.handle_request"
 
 
 class TestSidecarContentModel:
@@ -59,15 +57,11 @@ class TestWriteSidecarFailurePaths:
         """write_sidecar logs a warning and swallows the exception when no project is loaded."""
         file_path = Path("/workspace/output.txt")
         metadata = SidecarContent()
+        mock_engine = Mock()
+        mock_engine.handle_request.return_value = GetCurrentProjectResultFailure(result_details="no project")
 
-        with (
-            patch(
-                HANDLE_REQUEST_PATH,
-                return_value=GetCurrentProjectResultFailure(result_details="no project"),
-            ),
-            caplog.at_level(logging.WARNING, logger="griptape_nodes"),
-        ):
-            write_sidecar(file_path, metadata)
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+            write_sidecar(file_path, metadata, mock_engine)
 
         assert "Failed to write sidecar metadata" in caplog.text
         assert "output.txt" in caplog.text
@@ -96,11 +90,11 @@ class TestWriteSidecarFailurePaths:
             msg = f"Unexpected request: {request}"
             raise AssertionError(msg)
 
-        with (
-            patch(HANDLE_REQUEST_PATH, side_effect=handle_request),
-            caplog.at_level(logging.WARNING, logger="griptape_nodes"),
-        ):
-            write_sidecar(file_path, metadata)
+        mock_engine = Mock()
+        mock_engine.handle_request.side_effect = handle_request
+
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+            write_sidecar(file_path, metadata, mock_engine)
 
         assert "Failed to write sidecar metadata" in caplog.text
 
@@ -148,11 +142,11 @@ class TestWriteSidecarFailurePaths:
             msg = f"Unexpected request: {request}"
             raise AssertionError(msg)
 
-        with (
-            patch(HANDLE_REQUEST_PATH, side_effect=handle_request),
-            caplog.at_level(logging.WARNING, logger="griptape_nodes"),
-        ):
-            write_sidecar(file_path, metadata)
+        mock_engine = Mock()
+        mock_engine.handle_request.side_effect = handle_request
+
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+            write_sidecar(file_path, metadata, mock_engine)
 
         assert "Failed to write sidecar metadata" in caplog.text
 
@@ -201,8 +195,10 @@ class TestWriteSidecarFailurePaths:
             msg = f"Unexpected request: {request}"
             raise AssertionError(msg)
 
-        with patch(HANDLE_REQUEST_PATH, side_effect=handle_request):
-            write_sidecar(file_path, None)
+        mock_engine = Mock()
+        mock_engine.handle_request.side_effect = handle_request
+
+        write_sidecar(file_path, None, mock_engine)
 
         assert sidecar_path.exists()
         data = json.loads(sidecar_path.read_text())

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -2197,10 +2197,9 @@ class TestInstalledLibraryVersion:
     def _config_manager_for(libraries_dir: Path) -> MagicMock:
         config_manager = MagicMock()
         config_manager.resolved_libraries_root.return_value = libraries_dir
-        # find_files_recursive resolves `discovery_max_depth` through this same
-        # config manager (via engine.config_manager), so it needs a real
-        # int here or the recursive walk's depth comparison blows up on a MagicMock.
-        config_manager.get_config_value.return_value = DEFAULT_MAX_SEARCH_DEPTH
+        # find_files_recursive takes its depth ceiling from `config_manager.discovery_max_depth`,
+        # so it needs a real int here or the recursive walk's depth comparison blows up on a MagicMock.
+        config_manager.discovery_max_depth = DEFAULT_MAX_SEARCH_DEPTH
         return config_manager
 
     @pytest.mark.asyncio
@@ -2341,6 +2340,7 @@ class TestInstalledDownloadVersion:
         # libraries_directory must never be read.
         live_config.get_config_value.return_value = str(tmp_path / "live" / "libraries")
         live_config.workspace_path = str(tmp_path / "live")
+        live_config.discovery_max_depth = DEFAULT_MAX_SEARCH_DEPTH
         with patch.object(engine, "_config_manager", live_config):
             assert await library_manager._installed_download_version(download, target_libs) == "3.3.0"
         live_config.get_config_value.assert_not_called()

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -45,6 +45,7 @@ from griptape_nodes.retained_mode.events.project_events import (
 )
 from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
 from griptape_nodes.retained_mode.managers.project_manager import PROJECTS_TO_REGISTER_KEY, ProjectManager
+from griptape_nodes.utils.file_utils import DEFAULT_MAX_SEARCH_DEPTH
 
 
 def _stub_config_for_listing(mock_config: Mock, *, global_workspace: str = "/global/ws") -> None:
@@ -6048,9 +6049,8 @@ situations:
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
 
         mock_engine = MagicMock()
-        # find_files_recursive reads discovery_max_depth via self.engine.config_manager, so this
-        # mock config manager needs the same fallback-to-default behavior as pm._config_manager.
-        mock_engine.config_manager.get_config_value.side_effect = get_config_value_side_effect
+        # find_files_recursive takes its max_depth from self.engine.config_manager.discovery_max_depth.
+        mock_engine.config_manager.discovery_max_depth = DEFAULT_MAX_SEARCH_DEPTH
         with (
             patch.object(pm, "_engine", mock_engine),
             patch.object(pm, "_register_project_path") as mock_register,

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -6040,14 +6040,17 @@ situations:
         nested_project.write_text(self.VALID_PROJECT_YAML)
         yaml_content = self.VALID_PROJECT_YAML
 
-        def get_config_value_side_effect(key: str, **_: object) -> object:
+        def get_config_value_side_effect(key: str, default: object = None, **_: object) -> object:
             if key == PROJECTS_TO_REGISTER_KEY:
                 return [str(tmp_path)]
-            return []
+            return default
 
         cast("Mock", pm._config_manager).get_config_value.side_effect = get_config_value_side_effect
 
         mock_engine = MagicMock()
+        # find_files_recursive reads discovery_max_depth via self.engine.config_manager, so this
+        # mock config manager needs the same fallback-to-default behavior as pm._config_manager.
+        mock_engine.config_manager.get_config_value.side_effect = get_config_value_side_effect
         with (
             patch.object(pm, "_engine", mock_engine),
             patch.object(pm, "_register_project_path") as mock_register,

--- a/tests/unit/utils/test_file_utils.py
+++ b/tests/unit/utils/test_file_utils.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 import pytest
 
 from griptape_nodes.utils.file_utils import (
+    DEFAULT_MAX_SEARCH_DEPTH,
     _arecurse_find,
     _AsyncWalkParams,
     atomic_write_bytes,
@@ -23,8 +24,6 @@ from griptape_nodes.utils.file_utils import (
 
 if TYPE_CHECKING:
     from collections.abc import Generator
-
-    from griptape_nodes.retained_mode.engine import Engine
 
 
 class _RaisingDirEntry:
@@ -292,34 +291,36 @@ class TestAfindFilesRecursive:
             yield Path(tmpdir)
 
     @pytest.mark.asyncio
-    async def test_when_directory_does_not_exist(self, engine: Engine) -> None:
+    async def test_when_directory_does_not_exist(self) -> None:
         """Empty list is returned when directory doesn't exist."""
-        result = await find_files_recursive(Path("/non/existent/directory"), "*.json", engine=engine)
+        result = await find_files_recursive(
+            Path("/non/existent/directory"), "*.json", max_depth=DEFAULT_MAX_SEARCH_DEPTH
+        )
 
         assert result == []
 
     @pytest.mark.asyncio
-    async def test_when_path_is_not_directory(self, temp_dir: Path, engine: Engine) -> None:
+    async def test_when_path_is_not_directory(self, temp_dir: Path) -> None:
         """Empty list is returned when path is a file, not a directory."""
         test_file = temp_dir / "test.txt"
         test_file.write_text("content")
 
-        result = await find_files_recursive(test_file, "*.json", engine=engine)
+        result = await find_files_recursive(test_file, "*.json", max_depth=DEFAULT_MAX_SEARCH_DEPTH)
 
         assert result == []
 
     @pytest.mark.asyncio
-    async def test_when_no_files_match_pattern(self, temp_dir: Path, engine: Engine) -> None:
+    async def test_when_no_files_match_pattern(self, temp_dir: Path) -> None:
         """Empty list is returned when no files match the pattern."""
         (temp_dir / "test.txt").write_text("content")
         (temp_dir / "another.py").write_text("content")
 
-        result = await find_files_recursive(temp_dir, "*.json", engine=engine)
+        result = await find_files_recursive(temp_dir, "*.json", max_depth=DEFAULT_MAX_SEARCH_DEPTH)
 
         assert result == []
 
     @pytest.mark.asyncio
-    async def test_returns_sorted_results(self, temp_dir: Path, engine: Engine) -> None:
+    async def test_returns_sorted_results(self, temp_dir: Path) -> None:
         """Results are returned in sorted order."""
         file3 = temp_dir / "zebra.json"
         file1 = temp_dir / "apple.json"
@@ -328,12 +329,12 @@ class TestAfindFilesRecursive:
         file1.write_text("{}")
         file2.write_text("{}")
 
-        result = await find_files_recursive(temp_dir, "*.json", engine=engine)
+        result = await find_files_recursive(temp_dir, "*.json", max_depth=DEFAULT_MAX_SEARCH_DEPTH)
 
         assert result == [file1, file2, file3]
 
     @pytest.mark.asyncio
-    async def test_returns_sorted_results_with_subdirectories(self, temp_dir: Path, engine: Engine) -> None:
+    async def test_returns_sorted_results_with_subdirectories(self, temp_dir: Path) -> None:
         """Results from subdirectories are also sorted."""
         subdir_z = temp_dir / "z_dir"
         subdir_a = temp_dir / "a_dir"
@@ -347,12 +348,12 @@ class TestAfindFilesRecursive:
         file2.write_text("{}")
         file3.write_text("{}")
 
-        result = await find_files_recursive(temp_dir, "*.json", engine=engine)
+        result = await find_files_recursive(temp_dir, "*.json", max_depth=DEFAULT_MAX_SEARCH_DEPTH)
 
         assert result == [file1, file3, file2]
 
     @pytest.mark.asyncio
-    async def test_skips_hidden_directories_by_default(self, temp_dir: Path, engine: Engine) -> None:
+    async def test_skips_hidden_directories_by_default(self, temp_dir: Path) -> None:
         """Hidden directories are skipped by default."""
         hidden_dir = temp_dir / ".hidden"
         hidden_dir.mkdir()
@@ -361,12 +362,12 @@ class TestAfindFilesRecursive:
         hidden_file.write_text("{}")
         visible_file.write_text("{}")
 
-        result = await find_files_recursive(temp_dir, "*.json", engine=engine)
+        result = await find_files_recursive(temp_dir, "*.json", max_depth=DEFAULT_MAX_SEARCH_DEPTH)
 
         assert result == [visible_file]
 
     @pytest.mark.asyncio
-    async def test_includes_hidden_directories_when_requested(self, temp_dir: Path, engine: Engine) -> None:
+    async def test_includes_hidden_directories_when_requested(self, temp_dir: Path) -> None:
         """Hidden directories are included when skip_hidden=False."""
         hidden_dir = temp_dir / ".hidden"
         hidden_dir.mkdir()
@@ -375,12 +376,12 @@ class TestAfindFilesRecursive:
         hidden_file.write_text("{}")
         visible_file.write_text("{}")
 
-        result = await find_files_recursive(temp_dir, "*.json", engine=engine, skip_hidden=False)
+        result = await find_files_recursive(temp_dir, "*.json", max_depth=DEFAULT_MAX_SEARCH_DEPTH, skip_hidden=False)
 
         assert set(result) == {hidden_file, visible_file}
 
     @pytest.mark.asyncio
-    async def test_matches_glob_pattern(self, temp_dir: Path, engine: Engine) -> None:
+    async def test_matches_glob_pattern(self, temp_dir: Path) -> None:
         """Files are matched using glob patterns."""
         file1 = temp_dir / "my_library.json"
         file2 = temp_dir / "your_library.json"
@@ -388,26 +389,25 @@ class TestAfindFilesRecursive:
         file1.write_text("{}")
         file2.write_text("{}")
 
-        result = await find_files_recursive(temp_dir, "*library*.json", engine=engine)
+        result = await find_files_recursive(temp_dir, "*library*.json", max_depth=DEFAULT_MAX_SEARCH_DEPTH)
 
         assert result == sorted([file1, file2])
 
     @pytest.mark.asyncio
-    async def test_depth_zero_setting_scans_only_top_level(self, temp_dir: Path, engine: Engine) -> None:
-        """A discovery_max_depth setting of 0 returns only matches directly in the directory."""
+    async def test_depth_zero_setting_scans_only_top_level(self, temp_dir: Path) -> None:
+        """A max_depth of 0 returns only matches directly in the directory."""
         root_file = temp_dir / "root.json"
         nested_file = temp_dir / "sub" / "nested.json"
         nested_file.parent.mkdir()
         root_file.write_text("{}")
         nested_file.write_text("{}")
 
-        with patch("griptape_nodes.utils.file_utils._resolve_discovery_max_depth", return_value=0):
-            result = await find_files_recursive(temp_dir, "*.json", engine=engine)
+        result = await find_files_recursive(temp_dir, "*.json", max_depth=0)
 
         assert result == [root_file]
 
     @pytest.mark.asyncio
-    async def test_depth_setting_excludes_files_below_cap(self, temp_dir: Path, engine: Engine) -> None:
+    async def test_depth_setting_excludes_files_below_cap(self, temp_dir: Path) -> None:
         """Files at the depth cap are included; deeper files are excluded."""
         at_cap = temp_dir / "a" / "at_cap.json"
         below_cap = temp_dir / "a" / "b" / "below_cap.json"
@@ -415,23 +415,22 @@ class TestAfindFilesRecursive:
         at_cap.write_text("{}")
         below_cap.write_text("{}")
 
-        with patch("griptape_nodes.utils.file_utils._resolve_discovery_max_depth", return_value=1):
-            result = await find_files_recursive(temp_dir, "*.json", engine=engine)
+        result = await find_files_recursive(temp_dir, "*.json", max_depth=1)
 
         assert result == [at_cap]
 
     @pytest.mark.asyncio
-    async def test_max_files_limits_results(self, temp_dir: Path, engine: Engine) -> None:
+    async def test_max_files_limits_results(self, temp_dir: Path) -> None:
         """At most max_files matches are returned."""
         for name in ["a.json", "b.json", "c.json", "d.json"]:
             (temp_dir / name).write_text("{}")
 
-        result = await find_files_recursive(temp_dir, "*.json", engine=engine, max_files=2)
+        result = await find_files_recursive(temp_dir, "*.json", max_depth=DEFAULT_MAX_SEARCH_DEPTH, max_files=2)
 
         assert len(result) == 2  # noqa: PLR2004
 
     @pytest.mark.asyncio
-    async def test_follows_symlinked_directories(self, temp_dir: Path, engine: Engine) -> None:
+    async def test_follows_symlinked_directories(self, temp_dir: Path) -> None:
         """A symlinked directory is walked, so a workspace can reach content through a link.
 
         Guards against a walk that skips links (os.walk's default), which would silently
@@ -444,34 +443,34 @@ class TestAfindFilesRecursive:
         scan_root.mkdir()
         (scan_root / "linked").symlink_to(real_dir)
 
-        result = await find_files_recursive(scan_root, "*.json", engine=engine)
+        result = await find_files_recursive(scan_root, "*.json", max_depth=DEFAULT_MAX_SEARCH_DEPTH)
 
         assert result == [scan_root / "linked" / "found.json"]
 
     @pytest.mark.asyncio
-    async def test_symlink_loop_terminates(self, temp_dir: Path, engine: Engine) -> None:
+    async def test_symlink_loop_terminates(self, temp_dir: Path) -> None:
         """A directory symlink pointing back at an ancestor terminates via the depth cap."""
         nested = temp_dir / "a"
         nested.mkdir()
         (nested / "f.json").write_text("{}")
         (nested / "loop").symlink_to(temp_dir)
 
-        result = await find_files_recursive(temp_dir, "*.json", engine=engine)
+        result = await find_files_recursive(temp_dir, "*.json", max_depth=DEFAULT_MAX_SEARCH_DEPTH)
 
         assert nested / "f.json" in result
 
     @pytest.mark.asyncio
-    async def test_broken_symlink_is_skipped(self, temp_dir: Path, engine: Engine) -> None:
+    async def test_broken_symlink_is_skipped(self, temp_dir: Path) -> None:
         """A dangling symlink is neither matched nor fatal to the walk."""
         (temp_dir / "real.json").write_text("{}")
         (temp_dir / "broken.json").symlink_to(temp_dir / "does_not_exist")
 
-        result = await find_files_recursive(temp_dir, "*.json", engine=engine)
+        result = await find_files_recursive(temp_dir, "*.json", max_depth=DEFAULT_MAX_SEARCH_DEPTH)
 
         assert result == [temp_dir / "real.json"]
 
     @pytest.mark.asyncio
-    async def test_unreadable_directory_does_not_abort_walk(self, temp_dir: Path, engine: Engine) -> None:
+    async def test_unreadable_directory_does_not_abort_walk(self, temp_dir: Path) -> None:
         """A directory that cannot be listed is skipped, and its siblings still resolve.
 
         Uses a patched scandir rather than chmod so the case is exercised on Windows too,
@@ -491,12 +490,12 @@ class TestAfindFilesRecursive:
             return real_scandir(path)  # type: ignore[arg-type]
 
         with patch("griptape_nodes.utils.file_utils.os.scandir", side_effect=scandir_denying_one_dir):
-            result = await find_files_recursive(temp_dir, "*.json", engine=engine)
+            result = await find_files_recursive(temp_dir, "*.json", max_depth=DEFAULT_MAX_SEARCH_DEPTH)
 
         assert result == [temp_dir / "sibling" / "found.json"]
 
     @pytest.mark.asyncio
-    async def test_unclassifiable_entry_does_not_abort_directory(self, temp_dir: Path, engine: Engine) -> None:
+    async def test_unclassifiable_entry_does_not_abort_directory(self, temp_dir: Path) -> None:
         """An entry whose type cannot be determined is skipped, not fatal to its siblings.
 
         Mirrors a macOS protected path, where stat-ing one entry raises while the rest of
@@ -517,7 +516,7 @@ class TestAfindFilesRecursive:
             return _FakeScandir(entries)
 
         with patch("griptape_nodes.utils.file_utils.os.scandir", side_effect=scandir_with_one_bad_entry):
-            result = await find_files_recursive(temp_dir, "*.json", engine=engine)
+            result = await find_files_recursive(temp_dir, "*.json", max_depth=DEFAULT_MAX_SEARCH_DEPTH)
 
         assert result == [temp_dir / "good.json"]
 

--- a/tests/unit/utils/test_file_utils.py
+++ b/tests/unit/utils/test_file_utils.py
@@ -24,6 +24,8 @@ from griptape_nodes.utils.file_utils import (
 if TYPE_CHECKING:
     from collections.abc import Generator
 
+    from griptape_nodes.retained_mode.engine import Engine
+
 
 class _RaisingDirEntry:
     """Stands in for a DirEntry whose type cannot be determined.
@@ -290,34 +292,34 @@ class TestAfindFilesRecursive:
             yield Path(tmpdir)
 
     @pytest.mark.asyncio
-    async def test_when_directory_does_not_exist(self) -> None:
+    async def test_when_directory_does_not_exist(self, engine: Engine) -> None:
         """Empty list is returned when directory doesn't exist."""
-        result = await find_files_recursive(Path("/non/existent/directory"), "*.json")
+        result = await find_files_recursive(Path("/non/existent/directory"), "*.json", engine=engine)
 
         assert result == []
 
     @pytest.mark.asyncio
-    async def test_when_path_is_not_directory(self, temp_dir: Path) -> None:
+    async def test_when_path_is_not_directory(self, temp_dir: Path, engine: Engine) -> None:
         """Empty list is returned when path is a file, not a directory."""
         test_file = temp_dir / "test.txt"
         test_file.write_text("content")
 
-        result = await find_files_recursive(test_file, "*.json")
+        result = await find_files_recursive(test_file, "*.json", engine=engine)
 
         assert result == []
 
     @pytest.mark.asyncio
-    async def test_when_no_files_match_pattern(self, temp_dir: Path) -> None:
+    async def test_when_no_files_match_pattern(self, temp_dir: Path, engine: Engine) -> None:
         """Empty list is returned when no files match the pattern."""
         (temp_dir / "test.txt").write_text("content")
         (temp_dir / "another.py").write_text("content")
 
-        result = await find_files_recursive(temp_dir, "*.json")
+        result = await find_files_recursive(temp_dir, "*.json", engine=engine)
 
         assert result == []
 
     @pytest.mark.asyncio
-    async def test_returns_sorted_results(self, temp_dir: Path) -> None:
+    async def test_returns_sorted_results(self, temp_dir: Path, engine: Engine) -> None:
         """Results are returned in sorted order."""
         file3 = temp_dir / "zebra.json"
         file1 = temp_dir / "apple.json"
@@ -326,12 +328,12 @@ class TestAfindFilesRecursive:
         file1.write_text("{}")
         file2.write_text("{}")
 
-        result = await find_files_recursive(temp_dir, "*.json")
+        result = await find_files_recursive(temp_dir, "*.json", engine=engine)
 
         assert result == [file1, file2, file3]
 
     @pytest.mark.asyncio
-    async def test_returns_sorted_results_with_subdirectories(self, temp_dir: Path) -> None:
+    async def test_returns_sorted_results_with_subdirectories(self, temp_dir: Path, engine: Engine) -> None:
         """Results from subdirectories are also sorted."""
         subdir_z = temp_dir / "z_dir"
         subdir_a = temp_dir / "a_dir"
@@ -345,12 +347,12 @@ class TestAfindFilesRecursive:
         file2.write_text("{}")
         file3.write_text("{}")
 
-        result = await find_files_recursive(temp_dir, "*.json")
+        result = await find_files_recursive(temp_dir, "*.json", engine=engine)
 
         assert result == [file1, file3, file2]
 
     @pytest.mark.asyncio
-    async def test_skips_hidden_directories_by_default(self, temp_dir: Path) -> None:
+    async def test_skips_hidden_directories_by_default(self, temp_dir: Path, engine: Engine) -> None:
         """Hidden directories are skipped by default."""
         hidden_dir = temp_dir / ".hidden"
         hidden_dir.mkdir()
@@ -359,12 +361,12 @@ class TestAfindFilesRecursive:
         hidden_file.write_text("{}")
         visible_file.write_text("{}")
 
-        result = await find_files_recursive(temp_dir, "*.json")
+        result = await find_files_recursive(temp_dir, "*.json", engine=engine)
 
         assert result == [visible_file]
 
     @pytest.mark.asyncio
-    async def test_includes_hidden_directories_when_requested(self, temp_dir: Path) -> None:
+    async def test_includes_hidden_directories_when_requested(self, temp_dir: Path, engine: Engine) -> None:
         """Hidden directories are included when skip_hidden=False."""
         hidden_dir = temp_dir / ".hidden"
         hidden_dir.mkdir()
@@ -373,12 +375,12 @@ class TestAfindFilesRecursive:
         hidden_file.write_text("{}")
         visible_file.write_text("{}")
 
-        result = await find_files_recursive(temp_dir, "*.json", skip_hidden=False)
+        result = await find_files_recursive(temp_dir, "*.json", engine=engine, skip_hidden=False)
 
         assert set(result) == {hidden_file, visible_file}
 
     @pytest.mark.asyncio
-    async def test_matches_glob_pattern(self, temp_dir: Path) -> None:
+    async def test_matches_glob_pattern(self, temp_dir: Path, engine: Engine) -> None:
         """Files are matched using glob patterns."""
         file1 = temp_dir / "my_library.json"
         file2 = temp_dir / "your_library.json"
@@ -386,12 +388,12 @@ class TestAfindFilesRecursive:
         file1.write_text("{}")
         file2.write_text("{}")
 
-        result = await find_files_recursive(temp_dir, "*library*.json")
+        result = await find_files_recursive(temp_dir, "*library*.json", engine=engine)
 
         assert result == sorted([file1, file2])
 
     @pytest.mark.asyncio
-    async def test_depth_zero_setting_scans_only_top_level(self, temp_dir: Path) -> None:
+    async def test_depth_zero_setting_scans_only_top_level(self, temp_dir: Path, engine: Engine) -> None:
         """A discovery_max_depth setting of 0 returns only matches directly in the directory."""
         root_file = temp_dir / "root.json"
         nested_file = temp_dir / "sub" / "nested.json"
@@ -400,12 +402,12 @@ class TestAfindFilesRecursive:
         nested_file.write_text("{}")
 
         with patch("griptape_nodes.utils.file_utils._resolve_discovery_max_depth", return_value=0):
-            result = await find_files_recursive(temp_dir, "*.json")
+            result = await find_files_recursive(temp_dir, "*.json", engine=engine)
 
         assert result == [root_file]
 
     @pytest.mark.asyncio
-    async def test_depth_setting_excludes_files_below_cap(self, temp_dir: Path) -> None:
+    async def test_depth_setting_excludes_files_below_cap(self, temp_dir: Path, engine: Engine) -> None:
         """Files at the depth cap are included; deeper files are excluded."""
         at_cap = temp_dir / "a" / "at_cap.json"
         below_cap = temp_dir / "a" / "b" / "below_cap.json"
@@ -414,22 +416,22 @@ class TestAfindFilesRecursive:
         below_cap.write_text("{}")
 
         with patch("griptape_nodes.utils.file_utils._resolve_discovery_max_depth", return_value=1):
-            result = await find_files_recursive(temp_dir, "*.json")
+            result = await find_files_recursive(temp_dir, "*.json", engine=engine)
 
         assert result == [at_cap]
 
     @pytest.mark.asyncio
-    async def test_max_files_limits_results(self, temp_dir: Path) -> None:
+    async def test_max_files_limits_results(self, temp_dir: Path, engine: Engine) -> None:
         """At most max_files matches are returned."""
         for name in ["a.json", "b.json", "c.json", "d.json"]:
             (temp_dir / name).write_text("{}")
 
-        result = await find_files_recursive(temp_dir, "*.json", max_files=2)
+        result = await find_files_recursive(temp_dir, "*.json", engine=engine, max_files=2)
 
         assert len(result) == 2  # noqa: PLR2004
 
     @pytest.mark.asyncio
-    async def test_follows_symlinked_directories(self, temp_dir: Path) -> None:
+    async def test_follows_symlinked_directories(self, temp_dir: Path, engine: Engine) -> None:
         """A symlinked directory is walked, so a workspace can reach content through a link.
 
         Guards against a walk that skips links (os.walk's default), which would silently
@@ -442,34 +444,34 @@ class TestAfindFilesRecursive:
         scan_root.mkdir()
         (scan_root / "linked").symlink_to(real_dir)
 
-        result = await find_files_recursive(scan_root, "*.json")
+        result = await find_files_recursive(scan_root, "*.json", engine=engine)
 
         assert result == [scan_root / "linked" / "found.json"]
 
     @pytest.mark.asyncio
-    async def test_symlink_loop_terminates(self, temp_dir: Path) -> None:
+    async def test_symlink_loop_terminates(self, temp_dir: Path, engine: Engine) -> None:
         """A directory symlink pointing back at an ancestor terminates via the depth cap."""
         nested = temp_dir / "a"
         nested.mkdir()
         (nested / "f.json").write_text("{}")
         (nested / "loop").symlink_to(temp_dir)
 
-        result = await find_files_recursive(temp_dir, "*.json")
+        result = await find_files_recursive(temp_dir, "*.json", engine=engine)
 
         assert nested / "f.json" in result
 
     @pytest.mark.asyncio
-    async def test_broken_symlink_is_skipped(self, temp_dir: Path) -> None:
+    async def test_broken_symlink_is_skipped(self, temp_dir: Path, engine: Engine) -> None:
         """A dangling symlink is neither matched nor fatal to the walk."""
         (temp_dir / "real.json").write_text("{}")
         (temp_dir / "broken.json").symlink_to(temp_dir / "does_not_exist")
 
-        result = await find_files_recursive(temp_dir, "*.json")
+        result = await find_files_recursive(temp_dir, "*.json", engine=engine)
 
         assert result == [temp_dir / "real.json"]
 
     @pytest.mark.asyncio
-    async def test_unreadable_directory_does_not_abort_walk(self, temp_dir: Path) -> None:
+    async def test_unreadable_directory_does_not_abort_walk(self, temp_dir: Path, engine: Engine) -> None:
         """A directory that cannot be listed is skipped, and its siblings still resolve.
 
         Uses a patched scandir rather than chmod so the case is exercised on Windows too,
@@ -489,12 +491,12 @@ class TestAfindFilesRecursive:
             return real_scandir(path)  # type: ignore[arg-type]
 
         with patch("griptape_nodes.utils.file_utils.os.scandir", side_effect=scandir_denying_one_dir):
-            result = await find_files_recursive(temp_dir, "*.json")
+            result = await find_files_recursive(temp_dir, "*.json", engine=engine)
 
         assert result == [temp_dir / "sibling" / "found.json"]
 
     @pytest.mark.asyncio
-    async def test_unclassifiable_entry_does_not_abort_directory(self, temp_dir: Path) -> None:
+    async def test_unclassifiable_entry_does_not_abort_directory(self, temp_dir: Path, engine: Engine) -> None:
         """An entry whose type cannot be determined is skipped, not fatal to its siblings.
 
         Mirrors a macOS protected path, where stat-ing one entry raises while the rest of
@@ -515,7 +517,7 @@ class TestAfindFilesRecursive:
             return _FakeScandir(entries)
 
         with patch("griptape_nodes.utils.file_utils.os.scandir", side_effect=scandir_with_one_bad_entry):
-            result = await find_files_recursive(temp_dir, "*.json")
+            result = await find_files_recursive(temp_dir, "*.json", engine=engine)
 
         assert result == [temp_dir / "good.json"]
 


### PR DESCRIPTION
Continue removing usage of the GriptapeNodes facade in favor of plain ol' engine object.