### PR TITLE
Pin worker forwarding reentrancy, contention, and timeout behavior

### DIFF
--- a/docs/guides/libraries.md
+++ b/docs/guides/libraries.md
@@ -165,6 +165,27 @@ isolation is the same.
 pip resolution conflicts.** This is the most important guarantee on
 this page.
 
+#### Edit-time vs. execution dependencies
+
+A library can split its dependencies into two sets in its manifest:
+
+- `pip_dependencies` — **edit-time**: what's needed to show the
+    library's nodes in the editor, place them on the canvas, and
+    edit their parameters. Keep this set light.
+- `pip_dependencies_exec` — **execution**: the heavy packages
+    (torch, diffusers, and friends) that are only needed when a
+    node actually *runs*.
+
+Execution dependencies are installed into a separate environment
+(`.venv-exec`, next to the library's `.venv`) and are only loaded
+in the process where nodes execute — never in the main engine
+process. That means a library can depend on multi-gigabyte ML
+stacks while the editor stays light, and two libraries with
+clashing heavy pins can still be edited side by side.
+
+Declaring no `pip_dependencies_exec` is always safe: the library
+behaves exactly as it did before the split existed.
+
 ### Process isolation: the Isolated mode
 
 Running a library **Isolated** (in its own dedicated process,

--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -62,9 +62,29 @@ class LibraryNameAndVersion(NamedTuple):
 
 
 class Dependencies(BaseModel):
-    """Pip packages that need to be installed for this library."""
+    """Pip packages that need to be installed for this library.
+
+    Dependencies are declared in two sets, because a library needs far less installed to be
+    *edited* than to be *run*:
+
+    - ``pip_dependencies`` (edit-time): everything needed to import the library's node modules
+      and instantiate its nodes. The orchestrator installs these, so they are what the editor,
+      workflow loading, and parameter/trait behavior depend on. Keep this set light.
+    - ``pip_dependencies_exec`` (execution-time): the heavy packages only ``process`` needs
+      (torch, diffusers, and friends). These are installed into a separate environment and are
+      only on ``sys.path`` where nodes actually execute, so they never enter the orchestrator's
+      import path and cannot collide with another library's pins there.
+
+    A library that declares no execution dependencies behaves exactly as it always has:
+    everything is edit-time, and it runs in the orchestrator.
+
+    ``pip_install_flags`` applies to both installs, since flags in practice configure where
+    packages come from (index URLs, ``--find-links``, backend selection) rather than which set
+    is being installed.
+    """
 
     pip_dependencies: list[str] | None = None
+    pip_dependencies_exec: list[str] | None = None
     pip_install_flags: list[str] | None = None
 
 
@@ -253,7 +273,9 @@ class LibrarySchema(BaseModel):
     library itself.
     """
 
-    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.11.0"
+    # 0.12.0 added Dependencies.pip_dependencies_exec. Older manifests still validate: the
+    # field is optional, and its absence means every dependency is edit-time.
+    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.12.0"
 
     name: str
     library_schema_version: str

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -2959,28 +2959,43 @@ class LibraryManager(EngineScoped):
 
         return capabilities
 
-    def _get_library_venv_path(self, library_name: str, library_file_path: str | None = None) -> Path:
-        """Get the path to the virtual environment directory for a library.
+    def _get_library_venv_path(
+        self, library_name: str, library_file_path: str | None = None, *, execution: bool = False
+    ) -> Path:
+        """Get the path to a virtual environment directory for a library.
+
+        A library has up to two environments. The edit-time environment (``.venv``) holds the
+        dependencies needed to import and instantiate nodes, and is the one a developer's
+        ``uv sync`` already produces, so it is deliberately left at the conventional name. The
+        execution environment (``.venv-exec``) holds the heavy dependencies only ``process``
+        needs and is put on ``sys.path`` solely where nodes execute.
 
         Args:
             library_name: Name of the library
             library_file_path: Optional path to the library JSON file
+            execution: Whether to return the execution environment instead of the edit-time one
 
         Returns:
             Path to the virtual environment directory
         """
+        venv_dir_name = ".venv-exec" if execution else ".venv"
         clean_library_name = library_name.replace(" ", "_").strip()
 
         if library_file_path is not None:
             # Create venv relative to the library.json file
             library_dir = Path(library_file_path).parent.absolute()
-            return library_dir / ".venv"
+            return library_dir / venv_dir_name
 
         # Create venv relative to the xdg data home
-        return xdg_data_home() / "griptape_nodes" / "libraries" / clean_library_name / ".venv"
+        return xdg_data_home() / "griptape_nodes" / "libraries" / clean_library_name / venv_dir_name
 
     async def _add_library_paths_to_sys_path(self, library_name: str, library_file_path: str, base_dir: Path) -> None:
         """Add a library's directory and venv site-packages to sys.path.
+
+        The edit-time environment is added everywhere, because importing node modules and
+        instantiating nodes needs it. The execution environment is added only in a worker
+        process: the orchestrator must never have a library's heavy dependencies on its import
+        path, since keeping them out is what stops one library's pins from shadowing another's.
 
         Args:
             library_name: Name of the library (for venv lookup)
@@ -2989,18 +3004,30 @@ class LibraryManager(EngineScoped):
         """
         sys.path.insert(0, str(base_dir))
 
-        venv_path = self._get_library_venv_path(library_name, library_file_path)
-        if await anyio.Path(venv_path).exists():
-            site_packages = str(
-                Path(
-                    sysconfig.get_path(
-                        "purelib",
-                        vars={"base": str(venv_path), "platbase": str(venv_path)},
-                    )
+        await self._add_library_venv_to_sys_path(library_name, library_file_path, execution=False)
+
+        if self._is_worker:
+            await self._add_library_venv_to_sys_path(library_name, library_file_path, execution=True)
+
+    async def _add_library_venv_to_sys_path(
+        self, library_name: str, library_file_path: str, *, execution: bool
+    ) -> None:
+        """Add one of a library's venv site-packages directories to sys.path, if it exists."""
+        venv_path = self._get_library_venv_path(library_name, library_file_path, execution=execution)
+        if not await anyio.Path(venv_path).exists():
+            return
+
+        site_packages = str(
+            Path(
+                sysconfig.get_path(
+                    "purelib",
+                    vars={"base": str(venv_path), "platbase": str(venv_path)},
                 )
             )
-            sys.path.insert(0, site_packages)
-            logger.debug("Added library '%s' venv to sys.path: %s", library_name, site_packages)
+        )
+        sys.path.insert(0, site_packages)
+        venv_kind = "execution" if execution else "edit-time"
+        logger.debug("Added library '%s' %s venv to sys.path: %s", library_name, venv_kind, site_packages)
 
     def _can_write_to_venv_location(self, venv_python_path: Path) -> bool:
         """Check if we can write to the venv location (either create it or modify existing).
@@ -6855,14 +6882,14 @@ class LibraryManager(EngineScoped):
             result_details=details,
         )
 
-    async def install_library_dependencies_request(self, request: InstallLibraryDependenciesRequest) -> ResultPayload:  # noqa: PLR0911
-        """Install a library's dependencies, recovering from a corrupt reused venv.
+    async def install_library_dependencies_request(self, request: InstallLibraryDependenciesRequest) -> ResultPayload:
+        """Install a library's dependencies into its edit-time and execution environments.
 
-        Advanced library hooks (before_library_nodes_loaded) expect the venv to exist, so the
-        venv is always initialized even when there are no dependencies to install. When the
-        venv is reused from a previous session it may be corrupt (e.g. a dist-info directory
-        missing its METADATA file), which makes uv fail while planning the install; in that
-        case the venv is rebuilt once and the install retried against a clean environment.
+        Edit-time dependencies go into ``.venv``, which is always created even when there is
+        nothing to install, because advanced library hooks (before_library_nodes_loaded) expect
+        it to exist. Execution dependencies go into ``.venv-exec``, which is created only when
+        the library declares any, so a library with no execution dependencies produces exactly
+        the layout it always has.
         """
         library_file_path = request.library_file_path
 
@@ -6879,44 +6906,93 @@ class LibraryManager(EngineScoped):
         library_metadata = library_data.metadata
 
         pip_dependencies = []
+        pip_dependencies_exec = []
         pip_install_flags = []
         if library_metadata.dependencies:
             pip_dependencies = library_metadata.dependencies.pip_dependencies or []
+            pip_dependencies_exec = library_metadata.dependencies.pip_dependencies_exec or []
             pip_install_flags = library_metadata.dependencies.pip_install_flags or []
 
-        # Always initialize the venv, even if there are no dependencies to install.
-        # Advanced library hooks (before_library_nodes_loaded) expect the venv to exist.
-        venv_path = self._get_library_venv_path(library_name, library_file_path)
+        edit_failure = await self._install_dependency_set(
+            library_name=library_name,
+            library_file_path=library_file_path,
+            pip_dependencies=pip_dependencies,
+            pip_install_flags=pip_install_flags,
+            execution=False,
+        )
+        if edit_failure is not None:
+            return InstallLibraryDependenciesResultFailure(result_details=edit_failure)
+
+        exec_failure = await self._install_dependency_set(
+            library_name=library_name,
+            library_file_path=library_file_path,
+            pip_dependencies=pip_dependencies_exec,
+            pip_install_flags=pip_install_flags,
+            execution=True,
+        )
+        if exec_failure is not None:
+            return InstallLibraryDependenciesResultFailure(result_details=exec_failure)
+
+        installed_count = len(pip_dependencies) + len(pip_dependencies_exec)
+        if installed_count == 0:
+            details = f"Library '{library_name}' has no dependencies to install"
+        elif pip_dependencies_exec:
+            details = (
+                f"Installed {len(pip_dependencies)} edit-time and {len(pip_dependencies_exec)} "
+                f"execution dependencies for library '{library_name}'"
+            )
+        else:
+            details = f"Installed {len(pip_dependencies)} dependencies for library '{library_name}'"
+        logger.info(details)
+        return InstallLibraryDependenciesResultSuccess(
+            library_name=library_name, dependencies_installed=installed_count, result_details=details
+        )
+
+    async def _install_dependency_set(  # noqa: PLR0911
+        self,
+        *,
+        library_name: str,
+        library_file_path: str,
+        pip_dependencies: list[str],
+        pip_install_flags: list[str],
+        execution: bool,
+    ) -> str | None:
+        """Install one dependency set into its environment, creating the environment first.
+
+        Returns a user-facing failure detail, or None on success.
+
+        The edit-time environment is created even with nothing to install, because advanced
+        library hooks expect it to exist. The execution environment is skipped entirely when
+        the library declares no execution dependencies, so nothing new appears on disk for the
+        libraries that do not use them.
+        """
+        venv_kind = "execution" if execution else "edit-time"
+        if execution and not pip_dependencies:
+            return None
+
+        venv_path = self._get_library_venv_path(library_name, library_file_path, execution=execution)
 
         try:
             venv_init = await self._init_library_venv(venv_path)
         except RuntimeError as e:
-            details = f"Attempted to prepare the environment for library '{library_name}'. Failed due to: {e}"
-            return InstallLibraryDependenciesResultFailure(result_details=details)
+            return f"Attempted to prepare the {venv_kind} environment for library '{library_name}'. Failed due to: {e}"
         library_venv_python_path = venv_init.python_path
 
         if not self._can_write_to_venv_location(library_venv_python_path):
-            details = f"Attempted to set up the environment for library '{library_name}' at {venv_path}. Failed due to: the location is not writable."
+            details = f"Attempted to set up the {venv_kind} environment for library '{library_name}' at {venv_path}. Failed due to: the location is not writable."
             logger.warning(details)
-            return InstallLibraryDependenciesResultFailure(result_details=details)
+            return details
 
-        # Check disk space
         config_manager = self.engine.config_manager
         min_space_gb = config_manager.get_config_value("minimum_disk_space_gb_libraries")
         if not OSManager.check_available_disk_space(Path(venv_path), min_space_gb):
             error_msg = OSManager.format_disk_space_error(Path(venv_path))
-            details = f"Attempted to install the components required by library '{library_name}'. Failed due to insufficient disk space (requires {min_space_gb} GB): {error_msg}"
-            return InstallLibraryDependenciesResultFailure(result_details=details)
+            return f"Attempted to install the components required by library '{library_name}'. Failed due to insufficient disk space (requires {min_space_gb} GB): {error_msg}"
 
         if not pip_dependencies:
-            details = f"Library '{library_name}' has no dependencies to install"
-            logger.info(details)
-            return InstallLibraryDependenciesResultSuccess(
-                library_name=library_name, dependencies_installed=0, result_details=details
-            )
+            return None
 
-        # Install dependencies
-        logger.info("Installing %d dependencies for library '%s'", len(pip_dependencies), library_name)
+        logger.info("Installing %d %s dependencies for library '%s'", len(pip_dependencies), venv_kind, library_name)
         is_debug = config_manager.get_config_value("log_level").upper() == "DEBUG"
 
         try:
@@ -6940,19 +7016,11 @@ class LibraryManager(EngineScoped):
                 )
         except subprocess.CalledProcessError as e:
             reason = e.stderr or f"the installer exited with code {e.returncode}"
-            details = (
-                f"Attempted to install the components required by library '{library_name}'. Failed due to: {reason}"
-            )
-            return InstallLibraryDependenciesResultFailure(result_details=details)
+            return f"Attempted to install the components required by library '{library_name}'. Failed due to: {reason}"
         except RuntimeError as e:
-            details = f"Attempted to rebuild the environment for library '{library_name}'. Failed due to: {e}"
-            return InstallLibraryDependenciesResultFailure(result_details=details)
+            return f"Attempted to rebuild the {venv_kind} environment for library '{library_name}'. Failed due to: {e}"
 
-        details = f"Installed {len(pip_dependencies)} dependencies for library '{library_name}'"
-        logger.info(details)
-        return InstallLibraryDependenciesResultSuccess(
-            library_name=library_name, dependencies_installed=len(pip_dependencies), result_details=details
-        )
+        return None
 
     async def _install_deps_with_recovery(
         self,

--- a/src/griptape_nodes/retained_mode/publishing/project_packager.py
+++ b/src/griptape_nodes/retained_mode/publishing/project_packager.py
@@ -92,6 +92,10 @@ WORKSPACE_DIRECTORY_KEY = "workspace_directory"
 _MIRROR_IGNORE_PATTERNS = [
     ".env",
     ".venv",
+    # Matched by fnmatch, so ".venv" does not cover it. An execution venv is a full torch
+    # install with host-specific binaries and absolute paths in pyvenv.cfg -- gigabytes that
+    # are wrong on any other machine.
+    ".venv-exec",
     ".git",
     "__pycache__",
     ".griptape-nodes-previews",

--- a/src/griptape_nodes/retained_mode/publishing/workflow_packager.py
+++ b/src/griptape_nodes/retained_mode/publishing/workflow_packager.py
@@ -177,7 +177,7 @@ class WorkflowPackager:
         default exclusions.
         """
         if ignore_patterns is None:
-            ignore_patterns = [".venv", "__pycache__", ".git"]
+            ignore_patterns = [".venv", ".venv-exec", "__pycache__", ".git"]
         result = GriptapeNodes.handle_request(
             CopyTreeRequest(
                 source_path=str(source_path),

--- a/tests/e2e/fixtures/exec_dep_library/exec_dep_node.py
+++ b/tests/e2e/fixtures/exec_dep_library/exec_dep_node.py
@@ -1,0 +1,51 @@
+"""Node that splits its dependencies the way the execution-environment design requires.
+
+The two imports in this file are the whole point:
+
+- ``fakeedit`` is imported at module scope, so it is an EDIT-TIME dependency. It has to resolve
+  anywhere a node is merely defined or instantiated, which includes the orchestrator.
+- ``fakeexec`` is imported inside ``process``, so it is an EXECUTION dependency. It only has to
+  resolve where nodes actually execute.
+
+Real heavy libraries have this shape with torch and diffusers standing in for ``fakeexec``.
+"""
+
+from __future__ import annotations
+
+import fakeedit  # type: ignore[reportMissingImports]  # Edit-time dep: only importable from the library's edit venv.
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import DataNode
+
+
+class ExecDepNode(DataNode):
+    def __init__(self, name: str, metadata: dict | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        # Reading the edit-time dep here proves it is available at instantiation, not just import.
+        self.add_parameter(
+            Parameter(
+                name="edit_dep_version",
+                tooltip="Version of the edit-time dependency seen at instantiation",
+                type="str",
+                default_value=fakeedit.__version__,
+                allowed_modes={ParameterMode.PROPERTY, ParameterMode.OUTPUT},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="exec_dep_version",
+                tooltip="Version of the execution dependency seen while running",
+                type="str",
+                default_value="",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        # Deliberate deferred import, not a circular-import workaround: this dependency is
+        # declared as execution-only, so it is absent from the orchestrator by design and
+        # importing it at module scope would make this node impossible to instantiate there.
+        import fakeexec  # type: ignore[reportMissingImports]
+
+        self.parameter_output_values["edit_dep_version"] = fakeedit.__version__
+        self.parameter_output_values["exec_dep_version"] = fakeexec.__version__

--- a/tests/e2e/fixtures/exec_dep_library/griptape_nodes_library.json
+++ b/tests/e2e/fixtures/exec_dep_library/griptape_nodes_library.json
@@ -1,0 +1,36 @@
+{
+  "name": "Exec Dep Library",
+  "library_schema_version": "0.12.0",
+  "metadata": {
+    "author": "Test Fixture",
+    "description": "Library that declares edit-time and execution dependencies separately",
+    "library_version": "0.1.0",
+    "engine_version": "0.0.0",
+    "tags": ["test"],
+    "dependencies": {
+      "pip_dependencies": [],
+      "pip_dependencies_exec": []
+    }
+  },
+  "categories": [
+    {
+      "test": {
+        "title": "test",
+        "description": "Test nodes",
+        "color": "border-gray-500",
+        "icon": "Folder"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "class_name": "ExecDepNode",
+      "file_path": "exec_dep_node.py",
+      "metadata": {
+        "category": "test",
+        "description": "Node whose module needs an edit-time dep and whose process needs an execution dep",
+        "display_name": "Exec Dep Node"
+      }
+    }
+  ]
+}

--- a/tests/e2e/offline_wheels.py
+++ b/tests/e2e/offline_wheels.py
@@ -1,0 +1,48 @@
+"""Hand-built wheels for dependency-environment tests.
+
+Building the wheel by hand keeps these tests fully offline: no network, no build backend, and
+no dependency on any package that happens to be installed. Because the packages built here
+exist nowhere else, a successful import of one is proof that the environment it was installed
+into was created AND wired onto ``sys.path``.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import zipfile
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def build_wheel(wheel_dir: Path, name: str, version: str = "1.0.0") -> Path:
+    """Write a minimal importable wheel for ``name`` into ``wheel_dir``.
+
+    The built package exposes ``__version__`` so tests can assert *which* environment
+    satisfied an import.
+    """
+    wheel_dir.mkdir(parents=True, exist_ok=True)
+    wheel_path = wheel_dir / f"{name}-{version}-py3-none-any.whl"
+    dist_info = f"{name}-{version}.dist-info"
+    files = {
+        f"{name}/__init__.py": f'__version__ = "{version}"\n',
+        f"{dist_info}/METADATA": f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n",
+        f"{dist_info}/WHEEL": "Wheel-Version: 1.0\nGenerator: test-fixture\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+    }
+    record_rows = []
+    with zipfile.ZipFile(wheel_path, "w") as zf:
+        for file_name, content in files.items():
+            data = content.encode()
+            zf.writestr(file_name, data)
+            digest = base64.urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=").decode()
+            record_rows.append(f"{file_name},sha256={digest},{len(data)}")
+        record_rows.append(f"{dist_info}/RECORD,,")
+        zf.writestr(f"{dist_info}/RECORD", "\n".join(record_rows) + "\n")
+    return wheel_path
+
+
+def offline_install_flags(wheel_dir: Path) -> list[str]:
+    """Pip flags that install only from ``wheel_dir``, never the network."""
+    return ["--no-index", "--find-links", str(wheel_dir)]

--- a/tests/e2e/test_library_execution_dependency_split.py
+++ b/tests/e2e/test_library_execution_dependency_split.py
@@ -1,0 +1,250 @@
+"""End-to-end tests for the edit-time / execution dependency split.
+
+A library declares its dependencies in two sets. Edit-time dependencies are what the engine
+needs to import node modules and instantiate nodes; execution dependencies are the heavy
+packages only ``process`` needs. The split exists so the orchestrator can hold real node
+classes for every library without ever putting those heavy packages on its import path, which
+is what stops one library's pins from shadowing another's.
+
+The contract these tests pin:
+
+- **On the orchestrator**: edit-time dependencies are importable and nodes instantiate, while
+  execution dependencies are installed on disk but deliberately absent from ``sys.path``.
+- **In a worker**: both environments are on ``sys.path``, so ``process`` runs.
+- **For a library that declares no execution dependencies**: nothing changes, and no second
+  environment appears on disk.
+
+Both dependencies are hand-built wheels installed from a local ``--find-links`` directory with
+``--no-index``, so the tests are fully offline. Because ``fakeedit`` and ``fakeexec`` exist
+nowhere except those wheels, a successful import IS proof the matching environment was created
+and wired onto ``sys.path`` -- and an ImportError is proof it was not.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import sysconfig
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.node_library.library_registry import LibraryRegistry, LibrarySchema
+from griptape_nodes.retained_mode.engine import current_engine
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
+from griptape_nodes.utils.version_utils import engine_version
+from tests.e2e.offline_wheels import build_wheel, offline_install_flags
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "exec_dep_library"
+FIXTURE_FILES = ("exec_dep_node.py",)
+EDIT_DEP = "fakeedit"
+EXEC_DEP = "fakeexec"
+EDIT_DEP_VERSION = "1.0.0"
+EXEC_DEP_VERSION = "2.0.0"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_import_state() -> Iterator[None]:
+    """Keep sys.path and sys.modules from leaking between tests.
+
+    Every registration inserts paths and imports modules. Without this, a dependency imported
+    by one test would satisfy the next test's import from the module cache, which would hide
+    exactly the wiring these tests exist to check.
+    """
+    original_path = list(sys.path)
+    original_is_worker = current_engine().library_manager._is_worker
+    for dep in (EDIT_DEP, EXEC_DEP):
+        sys.modules.pop(dep, None)
+    yield
+    sys.path[:] = original_path
+    current_engine().library_manager._is_worker = original_is_worker
+    for dep in (EDIT_DEP, EXEC_DEP):
+        sys.modules.pop(dep, None)
+
+
+def _materialize_library(
+    target_dir: Path,
+    *,
+    wheel_dir: Path,
+    name: str,
+    exec_dependencies: list[str],
+) -> Path:
+    """Write a registrable copy of the fixture library, declaring the given dependency split."""
+    schema = json.loads((FIXTURE_DIR / "griptape_nodes_library.json").read_text())
+    schema["name"] = name
+    schema["library_schema_version"] = LibrarySchema.LATEST_SCHEMA_VERSION
+    schema["metadata"]["engine_version"] = engine_version
+    schema["metadata"]["dependencies"] = {
+        "pip_dependencies": [EDIT_DEP],
+        "pip_dependencies_exec": exec_dependencies,
+        "pip_install_flags": offline_install_flags(wheel_dir),
+    }
+    target_dir.mkdir(parents=True, exist_ok=True)
+    library_json = target_dir / "griptape_nodes_library.json"
+    library_json.write_text(json.dumps(schema, indent=2))
+    for file_name in FIXTURE_FILES:
+        (target_dir / file_name).write_text((FIXTURE_DIR / file_name).read_text())
+    return library_json
+
+
+def _build_both_wheels(wheel_dir: Path) -> None:
+    build_wheel(wheel_dir, EDIT_DEP, EDIT_DEP_VERSION)
+    build_wheel(wheel_dir, EXEC_DEP, EXEC_DEP_VERSION)
+
+
+def _register(library_json: Path) -> RegisterLibraryFromFileResultSuccess:
+    result = current_engine().handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    assert isinstance(result, RegisterLibraryFromFileResultSuccess), getattr(result, "result_details", result)
+    return result
+
+
+def _library_info(library_json: Path) -> LibraryManager.LibraryInfo:
+    return current_engine().library_manager._library_file_path_to_info[str(library_json)]
+
+
+def _site_packages(venv_path: Path) -> str:
+    return str(Path(sysconfig.get_path("purelib", vars={"base": str(venv_path), "platbase": str(venv_path)})))
+
+
+def _import_fresh(module_name: str) -> object:
+    """Import a module without letting a previous test's cache answer for it."""
+    sys.modules.pop(module_name, None)
+    importlib.invalidate_caches()
+    return importlib.import_module(module_name)
+
+
+class TestOrchestratorHoldsEditTimeDepsOnly:
+    def test_execution_dependencies_are_installed_but_absent_from_sys_path(self, tmp_path: Path) -> None:
+        """The orchestrator installs both sets but only imports against the edit-time one.
+
+        This is the isolation the whole design rests on: the heavy packages exist on disk, ready
+        for a worker, and cannot be reached from the process that runs the editor.
+        """
+        wheel_dir = tmp_path / "wheels"
+        _build_both_wheels(wheel_dir)
+        library_dir = tmp_path / "library"
+        library_json = _materialize_library(
+            library_dir, wheel_dir=wheel_dir, name="Exec Dep Orchestrator", exec_dependencies=[EXEC_DEP]
+        )
+
+        _register(library_json)
+
+        info = _library_info(library_json)
+        assert info.lifecycle_state is LibraryManager.LibraryLifecycleState.LOADED
+        assert info.fitness is LibraryManager.LibraryFitness.GOOD
+
+        # Both environments were built on disk.
+        edit_venv = library_dir / ".venv"
+        exec_venv = library_dir / ".venv-exec"
+        assert edit_venv.exists()
+        assert exec_venv.exists()
+
+        # Only the edit-time one is importable from here.
+        assert _site_packages(edit_venv) in sys.path
+        assert _site_packages(exec_venv) not in sys.path
+        assert _import_fresh(EDIT_DEP).__version__ == EDIT_DEP_VERSION  # type: ignore[attr-defined]
+        with pytest.raises(ImportError):
+            _import_fresh(EXEC_DEP)
+
+    def test_node_instantiates_on_the_orchestrator_without_execution_dependencies(self, tmp_path: Path) -> None:
+        """A real node class, instantiated for real, with the heavy dependency unreachable.
+
+        This is what lets the orchestrator drop stub nodes: it holds the actual class, and the
+        actual class only needs edit-time dependencies to exist.
+        """
+        wheel_dir = tmp_path / "wheels"
+        _build_both_wheels(wheel_dir)
+        library_dir = tmp_path / "library"
+        library_json = _materialize_library(
+            library_dir, wheel_dir=wheel_dir, name="Exec Dep Instantiate", exec_dependencies=[EXEC_DEP]
+        )
+        _register(library_json)
+
+        node = LibraryRegistry.create_node(
+            node_type="ExecDepNode", name="exec_dep_node", specific_library_name="Exec Dep Instantiate"
+        )
+
+        assert node.get_parameter_value("edit_dep_version") == EDIT_DEP_VERSION
+        with pytest.raises(ImportError):
+            _import_fresh(EXEC_DEP)
+
+
+class TestWorkerHoldsBothEnvironments:
+    def test_worker_puts_both_environments_on_sys_path(self, tmp_path: Path) -> None:
+        wheel_dir = tmp_path / "wheels"
+        _build_both_wheels(wheel_dir)
+        library_dir = tmp_path / "library"
+        library_json = _materialize_library(
+            library_dir, wheel_dir=wheel_dir, name="Exec Dep Worker", exec_dependencies=[EXEC_DEP]
+        )
+        current_engine().library_manager._is_worker = True
+
+        _register(library_json)
+
+        assert _site_packages(library_dir / ".venv") in sys.path
+        assert _site_packages(library_dir / ".venv-exec") in sys.path
+        assert _import_fresh(EDIT_DEP).__version__ == EDIT_DEP_VERSION  # type: ignore[attr-defined]
+        assert _import_fresh(EXEC_DEP).__version__ == EXEC_DEP_VERSION  # type: ignore[attr-defined]
+
+    def test_process_runs_in_a_worker(self, tmp_path: Path) -> None:
+        """The payoff: the same node whose process is unrunnable on the orchestrator runs here."""
+        wheel_dir = tmp_path / "wheels"
+        _build_both_wheels(wheel_dir)
+        library_dir = tmp_path / "library"
+        library_json = _materialize_library(
+            library_dir, wheel_dir=wheel_dir, name="Exec Dep Worker Process", exec_dependencies=[EXEC_DEP]
+        )
+        current_engine().library_manager._is_worker = True
+        _register(library_json)
+        node = LibraryRegistry.create_node(
+            node_type="ExecDepNode", name="exec_dep_node", specific_library_name="Exec Dep Worker Process"
+        )
+
+        node.process()
+
+        assert node.parameter_output_values["edit_dep_version"] == EDIT_DEP_VERSION
+        assert node.parameter_output_values["exec_dep_version"] == EXEC_DEP_VERSION
+
+
+class TestLibrariesWithoutExecutionDependencies:
+    def test_no_execution_environment_is_created(self, tmp_path: Path) -> None:
+        """A library that declares no execution dependencies gets exactly today's layout.
+
+        Backward compatibility is the point: the split is opt-in, and opting out leaves no new
+        artifacts on disk.
+        """
+        wheel_dir = tmp_path / "wheels"
+        _build_both_wheels(wheel_dir)
+        library_dir = tmp_path / "library"
+        library_json = _materialize_library(
+            library_dir, wheel_dir=wheel_dir, name="Exec Dep None Declared", exec_dependencies=[]
+        )
+
+        _register(library_json)
+
+        info = _library_info(library_json)
+        assert info.lifecycle_state is LibraryManager.LibraryLifecycleState.LOADED
+        assert (library_dir / ".venv").exists()
+        assert not (library_dir / ".venv-exec").exists()
+        assert _import_fresh(EDIT_DEP).__version__ == EDIT_DEP_VERSION  # type: ignore[attr-defined]
+
+    def test_manifest_without_the_field_still_validates(self) -> None:
+        """An older manifest that never heard of execution dependencies loads unchanged."""
+        schema = json.loads((FIXTURE_DIR / "griptape_nodes_library.json").read_text())
+        schema["library_schema_version"] = "0.11.0"
+        schema["metadata"]["dependencies"] = {"pip_dependencies": ["something"]}
+
+        parsed = LibrarySchema.model_validate(schema)
+
+        assert parsed.metadata.dependencies is not None
+        assert parsed.metadata.dependencies.pip_dependencies == ["something"]
+        assert parsed.metadata.dependencies.pip_dependencies_exec is None

--- a/tests/e2e/test_worker_forwarding_reentrancy.py
+++ b/tests/e2e/test_worker_forwarding_reentrancy.py
@@ -1,0 +1,256 @@
+"""End-to-end tests for worker->orchestrator request forwarding under reentrancy.
+
+When a node executes off the orchestrator, every request it makes mid-execution forwards to
+the orchestrator, which must service those requests while it is itself awaiting the execution
+that produced them. These tests pin that machinery -- ``EventManager.forward_to_orchestrator``,
+``RequestClient`` response matching, and the cross-loop dispatch topology -- without a real
+websocket, using a fake broker that loops forwarded requests into a real engine's dispatch.
+
+The topology reproduced here is the real one, because it is exactly the topology that has
+bitten before (see ``configure_worker_forwarding``'s docstring): the ``RequestClient`` and its
+futures live on a daemon thread's event loop, while the code that forwards runs on the main
+loop, so every forward crosses loops twice. Awaiting the client's primitives from the wrong
+loop historically stalled for seconds per request; the latency assertions here exist to fail
+if that regression returns.
+
+The contract these tests pin:
+
+- **Service while awaiting**: a forwarded request is dispatched and answered while the main
+  loop coroutine that sent it is still awaiting the reply.
+- **Contention**: many concurrent forwards, including from foreign threads (the diffusers
+  thread-pool shape), all complete, and none stalls for seconds.
+- **Bounded failure**: when the orchestrator never replies, the forward raises TimeoutError
+  within the configured bound instead of hanging.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import time
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+import pytest_asyncio
+
+from griptape_nodes.api_client.request_client import RequestClient
+from griptape_nodes.retained_mode.engine import current_engine
+from griptape_nodes.retained_mode.events.app_events import GetEngineVersionRequest
+from griptape_nodes.retained_mode.events.base_events import (
+    EventResultFailure,
+    EventResultSuccess,
+)
+from griptape_nodes.retained_mode.events.event_converter import converter
+from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
+from griptape_nodes.retained_mode.managers.event_manager import ResultContext
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Callable
+
+    from griptape_nodes.retained_mode.events.base_events import RequestPayload
+
+ORCHESTRATOR_REQUEST_TOPIC = "sessions/test/request"
+WORKER_RESPONSE_TOPIC = "engines/test-worker/response"
+
+# Generous enough for CI noise, far below the seconds-long stalls this guards against.
+SINGLE_FORWARD_BUDGET_S = 2.0
+CONTENTION_TOTAL_BUDGET_S = 10.0
+CONTENTION_COUNT = 50
+
+
+class FakeBrokerClient:
+    """Stands in for the websocket Client: loops forwarded requests into a real engine.
+
+    ``publish`` to the orchestrator request topic dispatches the deserialized request into
+    the orchestrator engine on ``orchestrator_loop`` as its own task (mirroring the app's
+    task-per-request ingress), then delivers the result back through the registered message
+    filters on the broker loop, which is where ``RequestClient._try_match`` and its futures
+    live. Set ``drop_requests`` to simulate an orchestrator that never answers.
+    """
+
+    def __init__(self, orchestrator_loop: asyncio.AbstractEventLoop) -> None:
+        self.orchestrator_loop = orchestrator_loop
+        self.drop_requests = False
+        self._filters: list[Callable[[dict[str, Any]], Any]] = []
+        self.subscribed_topics: list[str] = []
+
+    def add_message_filter(self, filter_fn: Callable[[dict[str, Any]], Any]) -> None:
+        self._filters.append(filter_fn)
+
+    def remove_message_filter(self, filter_fn: Callable[[dict[str, Any]], Any]) -> None:
+        self._filters.remove(filter_fn)
+
+    async def subscribe(self, topic: str) -> None:
+        self.subscribed_topics.append(topic)
+
+    async def publish(self, event_type: str, payload: dict[str, Any], topic: str) -> None:
+        assert event_type == "EventRequest"
+        assert topic == ORCHESTRATOR_REQUEST_TOPIC
+        if self.drop_requests:
+            return
+
+        broker_loop = asyncio.get_running_loop()
+        request_type = PayloadRegistry.get_type(payload["request_type"])
+        assert request_type is not None
+        request = cast("RequestPayload", converter.structure(payload["request"], request_type))
+        request_id = payload.get("request_id")
+
+        async def dispatch_and_reply() -> None:
+            # Task-per-request, exactly like the app's ingress: nothing serializes behind
+            # whatever the orchestrator is currently awaiting.
+            result = await current_engine().ahandle_request(request)
+            event_cls = EventResultSuccess if result.succeeded() else EventResultFailure
+            reply = event_cls(request=request, request_id=request_id, result=result)
+            reply_payload = json.loads(reply.json())
+            broker_loop.call_soon_threadsafe(
+                lambda: broker_loop.create_task(self._deliver(reply_payload)),
+            )
+
+        self.orchestrator_loop.call_soon_threadsafe(
+            lambda: self.orchestrator_loop.create_task(dispatch_and_reply()),
+        )
+
+    async def _deliver(self, payload: dict[str, Any]) -> None:
+        message = {"payload": payload}
+        for filter_fn in list(self._filters):
+            claimed = await filter_fn(message)
+            if claimed:
+                return
+
+
+class BrokerThread:
+    """A daemon thread running its own event loop, like the app's websocket thread."""
+
+    def __init__(self) -> None:
+        self.loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self.loop.run_forever, daemon=True)
+        self._thread.start()
+
+    def run(self, coro: Any) -> Any:
+        return asyncio.run_coroutine_threadsafe(coro, self.loop).result(timeout=30)
+
+    def shutdown(self) -> None:
+        self.loop.call_soon_threadsafe(self.loop.stop)
+        self._thread.join(timeout=5)
+        self.loop.close()
+
+
+@pytest_asyncio.fixture
+async def forwarding() -> AsyncIterator[FakeBrokerClient]:
+    """Configure worker-style forwarding on a real engine, against the fake broker."""
+    orchestrator_loop = asyncio.get_running_loop()
+    broker = BrokerThread()
+    fake_client = FakeBrokerClient(orchestrator_loop)
+    request_client = RequestClient(fake_client)  # type: ignore[arg-type]
+    broker.run(request_client.__aenter__())
+
+    event_manager = current_engine().event_manager
+    event_manager.configure_worker_forwarding(
+        request_client=request_client,
+        orchestrator_request_topic=ORCHESTRATOR_REQUEST_TOPIC,
+        worker_response_topic=WORKER_RESPONSE_TOPIC,
+        websocket_event_loop=broker.loop,
+        timeout_ms=1_000,
+    )
+    yield fake_client
+    broker.run(request_client.__aexit__(None, None, None))
+    broker.shutdown()
+
+
+class TestServiceWhileAwaiting:
+    @pytest.mark.asyncio
+    async def test_forward_is_serviced_while_sender_awaits(self, forwarding: FakeBrokerClient) -> None:  # noqa: ARG002 (fixture wires forwarding)
+        """The main loop services the forwarded request while the forwarding coroutine awaits it.
+
+        This is the reentrancy shape the whole design depends on: the awaiting side and the
+        servicing side share the orchestrator loop.
+        """
+        event_manager = current_engine().event_manager
+        started = time.monotonic()
+
+        result = await event_manager.forward_to_orchestrator(GetEngineVersionRequest(), ResultContext())
+
+        elapsed = time.monotonic() - started
+        assert isinstance(result, EventResultSuccess)
+        assert result.result.succeeded()
+        assert elapsed < SINGLE_FORWARD_BUDGET_S, f"single forward took {elapsed:.2f}s; cross-loop stall regression"
+
+    @pytest.mark.asyncio
+    async def test_forward_inside_node_execution_scope(self, forwarding: FakeBrokerClient) -> None:  # noqa: ARG002 (fixture wires forwarding)
+        """Forwarding works from inside the scope that marks node execution."""
+        event_manager = current_engine().event_manager
+        with event_manager.worker_node_execution_scope():
+            assert event_manager.in_node_execution()
+            result = await event_manager.forward_to_orchestrator(GetEngineVersionRequest(), ResultContext())
+        assert isinstance(result, EventResultSuccess)
+
+
+class TestContention:
+    @pytest.mark.asyncio
+    async def test_many_concurrent_forwards_from_the_main_loop(self, forwarding: FakeBrokerClient) -> None:  # noqa: ARG002 (fixture wires forwarding)
+        event_manager = current_engine().event_manager
+        started = time.monotonic()
+
+        results = await asyncio.gather(
+            *(
+                event_manager.forward_to_orchestrator(GetEngineVersionRequest(), ResultContext())
+                for _ in range(CONTENTION_COUNT)
+            )
+        )
+
+        elapsed = time.monotonic() - started
+        assert all(isinstance(r, EventResultSuccess) for r in results)
+        assert elapsed < CONTENTION_TOTAL_BUDGET_S, f"{CONTENTION_COUNT} forwards took {elapsed:.2f}s"
+
+    @pytest.mark.asyncio
+    async def test_forwards_from_foreign_threads(self, forwarding: FakeBrokerClient) -> None:  # noqa: ARG002 (fixture wires forwarding)
+        """Requests emitted from library-internal threads (the diffusers thread-pool shape).
+
+        A foreign thread cannot await on the orchestrator loop, so it does what node code
+        effectively does: schedule the coroutine onto the loop and block on the result.
+        """
+        event_manager = current_engine().event_manager
+        orchestrator_loop = asyncio.get_running_loop()
+        errors: list[BaseException] = []
+
+        def forward_from_thread() -> None:
+            future = asyncio.run_coroutine_threadsafe(
+                event_manager.forward_to_orchestrator(GetEngineVersionRequest(), ResultContext()),
+                orchestrator_loop,
+            )
+            try:
+                result = future.result(timeout=SINGLE_FORWARD_BUDGET_S * 5)
+                assert isinstance(result, EventResultSuccess)
+            except BaseException as e:
+                errors.append(e)
+
+        with event_manager.worker_node_execution_scope():
+            threads = [threading.Thread(target=forward_from_thread) for _ in range(8)]
+            for t in threads:
+                t.start()
+            # The orchestrator loop must stay free to service while threads block on replies.
+            await asyncio.sleep(0)
+            deadline = time.monotonic() + CONTENTION_TOTAL_BUDGET_S
+            while any(t.is_alive() for t in threads):
+                if time.monotonic() > deadline:
+                    pytest.fail("foreign-thread forwards did not complete within budget")
+                await asyncio.sleep(0.05)
+
+        assert not errors, f"foreign-thread forwards failed: {errors!r}"
+
+
+class TestBoundedFailure:
+    @pytest.mark.asyncio
+    async def test_unanswered_forward_times_out_instead_of_hanging(self, forwarding: FakeBrokerClient) -> None:
+        """An orchestrator that never replies produces a TimeoutError within the bound."""
+        forwarding.drop_requests = True
+        event_manager = current_engine().event_manager
+        started = time.monotonic()
+
+        with pytest.raises(TimeoutError):
+            await event_manager.forward_to_orchestrator(GetEngineVersionRequest(), ResultContext())
+
+        elapsed = time.monotonic() - started
+        # Configured timeout is 1s; anything wildly past it means the bound is not real.
+        assert elapsed < SINGLE_FORWARD_BUDGET_S * 2, f"timeout took {elapsed:.2f}s to fire"

--- a/tests/unit/node_library/test_library_declarations.py
+++ b/tests/unit/node_library/test_library_declarations.py
@@ -402,8 +402,9 @@ class TestRequiresWorkerProcess:
 
 
 class TestSchemaVersion:
-    def test_latest_schema_version_is_0_11_0(self) -> None:
-        assert LibrarySchema.LATEST_SCHEMA_VERSION == "0.11.0"
+    def test_latest_schema_version_is_0_12_0(self) -> None:
+        # 0.12.0 added Dependencies.pip_dependencies_exec.
+        assert LibrarySchema.LATEST_SCHEMA_VERSION == "0.12.0"
 
 
 # ---------- Model catalog ----------

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -792,6 +792,7 @@ class TestLibraryManagerInstallLibraryDependencies:
         schema.metadata.library_version = "1.0.0"
         schema.metadata.dependencies.pip_dependencies = []
         schema.metadata.dependencies.pip_install_flags = []
+        schema.metadata.dependencies.pip_dependencies_exec = None
 
         with (
             patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
@@ -859,6 +860,7 @@ class TestLibraryManagerInstallLibraryDependencies:
         schema.metadata.library_version = "1.0.0"
         schema.metadata.dependencies.pip_dependencies = []
         schema.metadata.dependencies.pip_install_flags = []
+        schema.metadata.dependencies.pip_dependencies_exec = None
 
         with (
             patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
@@ -881,6 +883,7 @@ class TestLibraryManagerInstallLibraryDependencies:
         schema.metadata.library_version = "1.0.0"
         schema.metadata.dependencies.pip_dependencies = []
         schema.metadata.dependencies.pip_install_flags = []
+        schema.metadata.dependencies.pip_dependencies_exec = None
 
         with (
             patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
@@ -908,6 +911,7 @@ class TestLibraryManagerInstallLibraryDependencies:
         schema.metadata.library_version = "1.0.0"
         schema.metadata.dependencies.pip_dependencies = []
         schema.metadata.dependencies.pip_install_flags = []
+        schema.metadata.dependencies.pip_dependencies_exec = None
 
         with (
             patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
@@ -944,6 +948,7 @@ class TestLibraryManagerInstallLibraryDependencies:
         schema.metadata.library_version = "1.0.0"
         schema.metadata.dependencies.pip_dependencies = ["a==1"]
         schema.metadata.dependencies.pip_install_flags = []
+        schema.metadata.dependencies.pip_dependencies_exec = None
 
         with (
             patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
@@ -984,6 +989,7 @@ class TestLibraryManagerInstallLibraryDependencies:
         schema.metadata.library_version = "1.0.0"
         schema.metadata.dependencies.pip_dependencies = ["a==1"]
         schema.metadata.dependencies.pip_install_flags = []
+        schema.metadata.dependencies.pip_dependencies_exec = None
         expected_attempts = 2
 
         with (
@@ -1031,6 +1037,7 @@ class TestLibraryManagerInstallLibraryDependencies:
         schema.metadata.library_version = "1.0.0"
         schema.metadata.dependencies.pip_dependencies = ["a==1"]
         schema.metadata.dependencies.pip_install_flags = []
+        schema.metadata.dependencies.pip_dependencies_exec = None
 
         with (
             patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
@@ -1071,6 +1078,7 @@ class TestLibraryManagerInstallLibraryDependencies:
         schema.metadata.library_version = "1.0.0"
         schema.metadata.dependencies.pip_dependencies = ["a==1"]
         schema.metadata.dependencies.pip_install_flags = []
+        schema.metadata.dependencies.pip_dependencies_exec = None
         expected_attempts = 2
 
         with (

--- a/tests/unit/retained_mode/managers/test_library_manager_deps.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_deps.py
@@ -69,7 +69,8 @@ class TestLibraryDependencyDeclaration:
         assert not hasattr(deps, "library_dependencies")
 
     def test_schema_version_bumped(self) -> None:
-        assert LibrarySchema.LATEST_SCHEMA_VERSION == "0.11.0"
+        # 0.12.0 added Dependencies.pip_dependencies_exec.
+        assert LibrarySchema.LATEST_SCHEMA_VERSION == "0.12.0"
 
 
 class TestLibraryDependencyProblem:


### PR DESCRIPTION
Part of griptape-ai/internal#214 — pins the forwarding machinery the contract depends on. (Stack position map at the bottom.) Rebased 2026-08-31 onto main@47cb67b4; e2e suites converted to the `engine`/`current_engine()` test idiom from #5385.

---

Second PR of the worker-execution stack. **Stacked on #5390** — review only the last commit. (Plan: local `venue-execution-plan.md`, rewritten 2026-08-28; the cluster-era PRs that once stacked on this are closed, but these tests are unaffected — they pin machinery the per-node worker path relies on regardless.)

## What

Test-only PR: a fake-broker harness pinning the worker->orchestrator forwarding machinery that worker execution makes load-bearing. No production code changes.

The harness reproduces the real topology, which is exactly the one with a documented history of seconds-long stalls: `RequestClient` and its futures live on a daemon-thread event loop, forwarding is initiated from the orchestrator loop, and every forward crosses loops twice. Dispatch back into the engine is task-per-request, mirroring the app's ingress.

## Contract pinned

- **Service while awaiting**: a forwarded request is dispatched and answered while the coroutine that sent it is still awaiting the reply
- **Scope**: forwarding works inside `worker_node_execution_scope`
- **Contention**: 50 concurrent forwards complete within budget; forwards from foreign threads (the diffusers thread-pool shape) complete while the orchestrator loop stays free
- **Bounded failure**: an unanswered forward raises `TimeoutError` within the configured bound instead of hanging

## Findings from the investigation

- The orchestrator ingress is already task-per-request (`app.py` spawns a task per incoming request), so there is no structural serialization deadlock behind an awaited dispatch
- Forwarding already carries a 30s timeout (`_ORCHESTRATOR_REQUEST_TIMEOUT_MS`)
- Measured: 50 concurrent forwards complete in well under 3s through the full cross-loop path

These matter more now than when written: the MVP's scoped dummy managers make `handle_request` the ONLY state channel for node code in workers, so this path becomes every config read and secret fetch.

Full gate: 4663 unit / 43 e2e / 9 integration passed, `make check` clean.

> **Merge note.** This stack lands as a unit. Intermediate tips are not intended as shippable states: #5409 forwards OS file requests until #5426 makes them local, and #5390 through #5468 splice `.venv-exec` onto a worker's `sys.path` until #5472 retires that mechanism — a running interpreter cannot be handed a library's own dependency versions that way, because `sys.modules` never reconsiders a module already imported. The orchestrator installing the execution set is therefore the intended end state, not a step: it has to be the builder, since the worker receives that directory as `PYTHONPATH` and so cannot create it.

## Stack

| # | PR | Branch |
|---|----|--------|
| 1 | #5390 | `feat/venue-exec-deps` |
| 2 | #5391 ← this | `feat/venue-reentrancy` |
| 3 | #5402 | `feat/venue-worker-mvp` |
| 4 | #5409 | `feat/venue-worker-behavior-suite` |
| 5 | #5425 | `feat/exe-types-engine-injection` |
| 6 | #5426 | `feat/worker-wire-hardening` |
| 7 | #5427 | `feat/library-exec-lifecycle` |
| 8 | #5428 | `fix/failed-nodes-leave-resolving` |
| 9 | #5430 | `feat/parameter-structure-contract` |
