### PR TITLE
Add execution-cluster computation: union-find over unserializable edges

### DIFF
--- a/src/griptape_nodes/common/execution_clusters.py
+++ b/src/griptape_nodes/common/execution_clusters.py
@@ -1,0 +1,130 @@
+"""Compute execution clusters: which nodes must run together, and where.
+
+Nodes connected by an unserializable value MUST run in the same process, because that value
+cannot cross a process boundary (a live tensor, an open pipeline). That is a correctness
+constraint the user cannot see, so clusters are computed from the graph rather than authored:
+
+1. Union two nodes across any edge whose value cannot serialize.
+2. Union adjacent nodes that require the same non-empty execution-dependency set, so a chain
+   from one heavy library does not pay a boundary crossing between every pair of nodes.
+3. A cluster whose execution-dependency union is empty runs in the orchestrator. A cluster
+   with execution dependencies is a dispatch unit for a venue that has them installed.
+
+The inputs are deliberately primitive (names, dependency sets, edge flags) so this module
+stays pure: the DAG builder describes its graph in these terms, and dispatch consumes the
+resulting clusters, but neither is imported here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ClusterNode:
+    """A node as the cluster computation sees it.
+
+    exec_dependencies is the execution-dependency set of the node's library
+    (``pip_dependencies_exec``), empty for a library that declares none.
+    """
+
+    name: str
+    exec_dependencies: frozenset[str] = frozenset()
+
+
+@dataclass(frozen=True)
+class ClusterEdge:
+    """A dataflow edge between two nodes.
+
+    serializable is False when the value on this edge cannot cross a process boundary
+    (``Parameter.serializable`` is static metadata, so this is known without running).
+    """
+
+    source: str
+    target: str
+    serializable: bool = True
+
+
+@dataclass(frozen=True)
+class ExecutionCluster:
+    """A set of nodes that execute together, and the execution deps their venue needs."""
+
+    node_names: frozenset[str]
+    exec_dependencies: frozenset[str]
+
+    @property
+    def runs_in_orchestrator(self) -> bool:
+        """True when no member needs execution dependencies, so no venue is required."""
+        return not self.exec_dependencies
+
+
+class _UnionFind:
+    """Union-find over node names, path-compressed."""
+
+    def __init__(self, names: list[str]) -> None:
+        self._parent: dict[str, str] = {name: name for name in names}
+
+    def find(self, name: str) -> str:
+        root = name
+        while self._parent[root] != root:
+            root = self._parent[root]
+        # Path compression: point every node on the walk directly at the root.
+        while self._parent[name] != root:
+            self._parent[name], name = root, self._parent[name]
+        return root
+
+    def union(self, a: str, b: str) -> None:
+        self._parent[self.find(a)] = self.find(b)
+
+
+def compute_execution_clusters(
+    nodes: list[ClusterNode],
+    edges: list[ClusterEdge],
+) -> list[ExecutionCluster]:
+    """Partition a dataflow graph into execution clusters.
+
+    Args:
+        nodes: Every node in the control-flow step's DAG.
+        edges: Every dataflow edge between those nodes.
+
+    Returns:
+        Clusters covering every input node, each with the union of its members'
+        execution dependencies. Order follows first appearance in ``nodes``.
+
+    Raises:
+        ValueError: If an edge references a node that is not in ``nodes``; the DAG
+            builder handing us an edge for a missing node is a caller bug, not a
+            graph shape.
+    """
+    known_names = {node.name for node in nodes}
+    for edge in edges:
+        if edge.source not in known_names or edge.target not in known_names:
+            msg = (
+                f"Attempted to compute execution clusters, but edge "
+                f"{edge.source!r} -> {edge.target!r} references a node not in the graph."
+            )
+            raise ValueError(msg)
+
+    deps_by_name = {node.name: node.exec_dependencies for node in nodes}
+    union_find = _UnionFind([node.name for node in nodes])
+
+    for edge in edges:
+        if not edge.serializable:
+            # An unserializable value pins producer and consumer into one process.
+            union_find.union(edge.source, edge.target)
+            continue
+        source_deps = deps_by_name[edge.source]
+        if source_deps and source_deps == deps_by_name[edge.target]:
+            # Same heavy library on both ends: crossing a boundary here would serialize a
+            # value just to land in an identical environment. Merge to avoid the round trip.
+            union_find.union(edge.source, edge.target)
+
+    members_by_root: dict[str, list[str]] = {}
+    for node in nodes:
+        members_by_root.setdefault(union_find.find(node.name), []).append(node.name)
+
+    clusters = []
+    for members in members_by_root.values():
+        exec_dependencies: frozenset[str] = frozenset().union(*(deps_by_name[name] for name in members))
+        clusters.append(ExecutionCluster(node_names=frozenset(members), exec_dependencies=exec_dependencies))
+    return clusters

--- a/tests/unit/common/test_execution_clusters.py
+++ b/tests/unit/common/test_execution_clusters.py
@@ -1,0 +1,166 @@
+"""Unit tests for execution-cluster computation.
+
+The shapes here mirror the shipped diffusers templates: latent chains that must co-locate,
+light passthrough nodes absorbed into heavy clusters, and multi-stage graphs whose stages
+communicate through serializable values.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from griptape_nodes.common.execution_clusters import (
+    ClusterEdge,
+    ClusterNode,
+    ExecutionCluster,
+    compute_execution_clusters,
+)
+
+TORCH = frozenset({"torch==2.7.0", "diffusers==0.39.0"})
+OTHER = frozenset({"torch==2.4.0"})
+
+
+def _cluster_of(clusters: list[ExecutionCluster], name: str) -> ExecutionCluster:
+    matches = [c for c in clusters if name in c.node_names]
+    assert len(matches) == 1
+    return matches[0]
+
+
+class TestPlacement:
+    def test_light_nodes_run_in_orchestrator(self) -> None:
+        clusters = compute_execution_clusters(
+            [ClusterNode("a"), ClusterNode("b")],
+            [ClusterEdge("a", "b", serializable=True)],
+        )
+        assert all(c.runs_in_orchestrator for c in clusters)
+        assert {c.node_names for c in clusters} == {frozenset({"a"}), frozenset({"b"})}  # nothing forces them together
+
+    def test_lone_heavy_node_is_a_single_node_cluster(self) -> None:
+        clusters = compute_execution_clusters([ClusterNode("gen", TORCH)], [])
+        assert clusters == [ExecutionCluster(frozenset({"gen"}), TORCH)]
+        assert not clusters[0].runs_in_orchestrator
+
+
+class TestUnserializableEdges:
+    def test_latent_chain_merges(self) -> None:
+        """Loader -> generate -> decode over live values is one cluster."""
+        nodes = [ClusterNode("loader", TORCH), ClusterNode("generate", TORCH), ClusterNode("decode", TORCH)]
+        edges = [
+            ClusterEdge("loader", "generate", serializable=False),
+            ClusterEdge("generate", "decode", serializable=False),
+        ]
+        clusters = compute_execution_clusters(nodes, edges)
+        assert len(clusters) == 1
+        assert clusters[0].node_names == {"loader", "generate", "decode"}
+
+    def test_light_passthrough_is_absorbed_into_the_heavy_cluster(self) -> None:
+        """A base-only node in a latent chain runs in the venue with everyone else."""
+        nodes = [ClusterNode("gen", TORCH), ClusterNode("note", frozenset()), ClusterNode("decode", TORCH)]
+        edges = [
+            ClusterEdge("gen", "note", serializable=False),
+            ClusterEdge("note", "decode", serializable=False),
+        ]
+        clusters = compute_execution_clusters(nodes, edges)
+        assert len(clusters) == 1
+        assert clusters[0].exec_dependencies == TORCH
+
+    def test_two_libraries_joined_by_live_value_union_their_deps(self) -> None:
+        """The merged cluster carries both dependency sets.
+
+        Whether they co-resolve is the environment builder's question, not ours.
+        """
+        clusters = compute_execution_clusters(
+            [ClusterNode("a", TORCH), ClusterNode("b", OTHER)],
+            [ClusterEdge("a", "b", serializable=False)],
+        )
+        assert len(clusters) == 1
+        assert clusters[0].exec_dependencies == TORCH | OTHER
+
+
+class TestSerializableBoundaries:
+    def test_serializable_edge_between_different_dep_sets_does_not_merge(self) -> None:
+        clusters = compute_execution_clusters(
+            [ClusterNode("a", TORCH), ClusterNode("b", OTHER)],
+            [ClusterEdge("a", "b", serializable=True)],
+        )
+        assert {c.node_names for c in clusters} == {frozenset({"a"}), frozenset({"b"})}
+
+    def test_same_heavy_deps_across_serializable_edge_merge_to_avoid_a_round_trip(self) -> None:
+        clusters = compute_execution_clusters(
+            [ClusterNode("stage1", TORCH), ClusterNode("stage2", TORCH)],
+            [ClusterEdge("stage1", "stage2", serializable=True)],
+        )
+        assert len(clusters) == 1
+
+    def test_light_nodes_across_serializable_edges_never_merge(self) -> None:
+        """The same-deps optimization only applies to non-empty dependency sets.
+
+        Light nodes stay individually placeable in the orchestrator.
+        """
+        clusters = compute_execution_clusters(
+            [ClusterNode("a"), ClusterNode("b")],
+            [ClusterEdge("a", "b", serializable=True)],
+        )
+        assert {c.node_names for c in clusters} == {frozenset({"a"}), frozenset({"b"})}
+
+
+class TestGraphShapes:
+    def test_multi_stage_template_shape(self) -> None:
+        """Two latent stages joined by a serializable image dispatch as one cluster.
+
+        Same library on both stages, so the same-deps rule merges them -- matching how
+        MultistageText2Image should dispatch.
+        """
+        nodes = [
+            ClusterNode("s1_gen", TORCH),
+            ClusterNode("s1_decode", TORCH),
+            ClusterNode("s2_encode", TORCH),
+            ClusterNode("s2_gen", TORCH),
+        ]
+        edges = [
+            ClusterEdge("s1_gen", "s1_decode", serializable=False),
+            ClusterEdge("s1_decode", "s2_encode", serializable=True),
+            ClusterEdge("s2_encode", "s2_gen", serializable=False),
+        ]
+        clusters = compute_execution_clusters(nodes, edges)
+        assert len(clusters) == 1
+
+    def test_diamond_with_mixed_edges(self) -> None:
+        nodes = [
+            ClusterNode("src"),
+            ClusterNode("left", TORCH),
+            ClusterNode("right", OTHER),
+            ClusterNode("sink"),
+        ]
+        edges = [
+            ClusterEdge("src", "left", serializable=True),
+            ClusterEdge("src", "right", serializable=True),
+            ClusterEdge("left", "sink", serializable=True),
+            ClusterEdge("right", "sink", serializable=True),
+        ]
+        clusters = compute_execution_clusters(nodes, edges)
+        assert {c.node_names for c in clusters} == {
+            frozenset({"src"}),
+            frozenset({"left"}),
+            frozenset({"right"}),
+            frozenset({"sink"}),
+        }
+        assert _cluster_of(clusters, "left").exec_dependencies == TORCH
+        assert _cluster_of(clusters, "right").exec_dependencies == OTHER
+        assert _cluster_of(clusters, "src").runs_in_orchestrator
+
+    def test_every_node_lands_in_exactly_one_cluster(self) -> None:
+        nodes = [ClusterNode(f"n{i}", TORCH if i % 2 else frozenset()) for i in range(10)]
+        edges = [ClusterEdge(f"n{i}", f"n{i + 1}", serializable=(i % 3 != 0)) for i in range(9)]
+        clusters = compute_execution_clusters(nodes, edges)
+        seen: set[str] = set()
+        for cluster in clusters:
+            assert not (cluster.node_names & seen)
+            seen |= cluster.node_names
+        assert seen == {node.name for node in nodes}
+
+
+class TestValidation:
+    def test_edge_referencing_unknown_node_raises(self) -> None:
+        with pytest.raises(ValueError, match="references a node not in the graph"):
+            compute_execution_clusters([ClusterNode("a")], [ClusterEdge("a", "ghost")])


### PR DESCRIPTION
Third PR in the venue-execution stack (design: `venue-execution-plan.md`). **Stacked on #5391** — review only the last commit.

## What

The pure cluster-computation module: given a DAG's nodes (with their libraries' execution-dependency sets) and dataflow edges (with `Parameter.serializable` flags), partition into execution clusters.

Rules, per the design:
1. Union across any `serializable=False` edge — an unserializable value (live tensor, open pipeline) pins producer and consumer into one process.
2. Union across serializable edges whose endpoints require the same non-empty exec-dep set — a heavy library's chain shouldn't pay a serialization round trip between every node pair.
3. Empty dep-union → runs in the orchestrator. Non-empty → dispatch unit for a venue holding that union.

Clusters are **computed, never authored**: the constraint is invisible to users, and the shipped diffusers templates contain no subflows to hang it on.

## Deliberately out of scope here

- DAG-builder integration (the module takes primitive inputs precisely so it stays pure)
- Dispatch and venue lifecycle (next in the stack)
- Co-resolution checking of a merged cluster's dep union — that's the environment builder's question; this module just reports the union

## Testing

12 unit tests covering the template shapes: latent chains merge; a base-only passthrough node in a latent chain is absorbed into the heavy cluster; two libraries joined by a live value union their deps; serializable edges between different dep sets do NOT merge; multi-stage same-library graphs merge into one dispatch; diamonds partition correctly; every node lands in exactly one cluster; unknown-node edges raise.

Full gate: 4675 unit / 43 e2e passed, `make check` clean.