### PR TITLE
Add ExecuteClusterRequest: execute a cluster with live intra-cluster values

### DIFF
--- a/src/griptape_nodes/common/cluster_execution.py
+++ b/src/griptape_nodes/common/cluster_execution.py
@@ -1,0 +1,141 @@
+"""Execute a dispatched cluster of nodes in this process.
+
+The cluster is the dispatch unit for isolated execution: nodes joined by unserializable
+values must run in one process (see ``common/execution_clusters.py`` for how clusters are
+computed), so they arrive as one ``ExecuteClusterRequest``. Members are constructed fresh,
+boundary inputs are hydrated from the wire, and execution proceeds in dependency order with
+intra-cluster values handed off as **live references** -- the entire reason the cluster
+exists. Only serializable outputs of the requested output nodes go back over the wire.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from griptape_nodes.common.parameter_hydration import hydrate_parameter_values
+from griptape_nodes.exe_types.node_types import aprocess_scope
+from griptape_nodes.node_library.library_registry import LibraryRegistry
+from griptape_nodes.retained_mode.events.execution_events import (
+    ExecuteClusterRequest,
+    ExecuteClusterResultFailure,
+    ExecuteClusterResultSuccess,
+)
+
+if TYPE_CHECKING:
+    from griptape_nodes.exe_types.node_types import BaseNode
+    from griptape_nodes.retained_mode.events.base_events import ResultPayload
+    from griptape_nodes.retained_mode.managers.event_manager import EventManager
+
+logger = logging.getLogger("griptape_nodes")
+
+
+def _topological_order(request: ExecuteClusterRequest) -> list[str] | None:
+    """Return member names in dependency order, or None when the edges form a cycle."""
+    names = [spec.node_name for spec in request.nodes]
+    incoming_count = dict.fromkeys(names, 0)
+    targets_by_source: dict[str, list[str]] = {name: [] for name in names}
+    for edge in request.edges:
+        incoming_count[edge.target_node] += 1
+        targets_by_source[edge.source_node].append(edge.target_node)
+
+    ready = [name for name in names if incoming_count[name] == 0]
+    order = []
+    while ready:
+        name = ready.pop(0)
+        order.append(name)
+        for target in targets_by_source[name]:
+            incoming_count[target] -= 1
+            if incoming_count[target] == 0:
+                ready.append(target)
+
+    if len(order) != len(names):
+        return None
+    return order
+
+
+def _validate(request: ExecuteClusterRequest) -> str | None:
+    """Return a user-facing failure detail for a malformed cluster, or None when well-formed."""
+    names = [spec.node_name for spec in request.nodes]
+    if not names:
+        return "Attempted to execute a cluster with no nodes."
+    if len(set(names)) != len(names):
+        return "Attempted to execute a cluster with duplicate node names."
+    known = set(names)
+    for edge in request.edges:
+        if edge.source_node not in known or edge.target_node not in known:
+            return (
+                f"Attempted to execute a cluster, but edge {edge.source_node!r} -> "
+                f"{edge.target_node!r} references a node that is not in the cluster."
+            )
+    for name in request.output_nodes:
+        if name not in known:
+            return f"Attempted to execute a cluster, but output node {name!r} is not in the cluster."
+    return None
+
+
+def _serializable_outputs(node: BaseNode) -> dict[str, Any]:
+    """The node's outputs that may cross a process boundary.
+
+    A serializable=False output is by definition consumed inside the cluster (or not at
+    all); returning it would hand the orchestrator a value it cannot hold.
+    """
+    outputs = {}
+    for parameter_name, value in node.parameter_output_values.items():
+        parameter = node.get_parameter_by_name(parameter_name)
+        if parameter is not None and parameter.serializable:
+            outputs[parameter_name] = value
+    return outputs
+
+
+async def execute_cluster(request: ExecuteClusterRequest, event_manager: EventManager) -> ResultPayload:
+    """Construct, hydrate, and run a cluster's members in dependency order."""
+    validation_failure = _validate(request)
+    if validation_failure is not None:
+        return ExecuteClusterResultFailure(result_details=validation_failure)
+
+    order = _topological_order(request)
+    if order is None:
+        return ExecuteClusterResultFailure(result_details="Attempted to execute a cluster, but its edges form a cycle.")
+
+    nodes: dict[str, BaseNode] = {}
+    for spec in request.nodes:
+        try:
+            node = LibraryRegistry.create_node(
+                node_type=spec.node_type,
+                name=spec.node_name,
+                metadata=spec.node_metadata or None,
+                specific_library_name=spec.library_name,
+            )
+        except KeyError as e:
+            details = (
+                f"Attempted to execute a cluster containing node {spec.node_name!r} of type "
+                f"{spec.node_type!r} from library {spec.library_name!r}. Failed due to: {e}"
+            )
+            return ExecuteClusterResultFailure(failed_node=spec.node_name, result_details=details)
+        for parameter_name, value in hydrate_parameter_values(spec.parameter_values).items():
+            node.set_parameter_value(parameter_name, value)
+        nodes[spec.node_name] = node
+
+    edges_by_source: dict[str, list[Any]] = {}
+    for edge in request.edges:
+        edges_by_source.setdefault(edge.source_node, []).append(edge)
+
+    for name in order:
+        node = nodes[name]
+        try:
+            with event_manager.worker_node_execution_scope(), aprocess_scope(request.variables):
+                await node.aprocess()
+        except Exception as e:
+            details = f"Attempted to execute node {name!r} in a cluster of {len(nodes)}. Failed due to: {e}"
+            logger.exception(details)
+            return ExecuteClusterResultFailure(failed_node=name, result_details=details)
+        for edge in edges_by_source.get(name, []):
+            # The whole point of the cluster: values on internal edges are handed to the
+            # consumer as live references, never serialized.
+            value = node.parameter_output_values.get(edge.source_parameter)
+            nodes[edge.target_node].set_parameter_value(edge.target_parameter, value)
+
+    outputs = {name: _serializable_outputs(nodes[name]) for name in request.output_nodes}
+    details = f"Executed cluster of {len(nodes)} nodes"
+    return ExecuteClusterResultSuccess(parameter_output_values=outputs, result_details=details)

--- a/src/griptape_nodes/retained_mode/events/execution_events.py
+++ b/src/griptape_nodes/retained_mode/events/execution_events.py
@@ -567,3 +567,94 @@ class CancelExecuteNodeResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSucce
 @PayloadRegistry.register
 class CancelExecuteNodeResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     """Cancellation could not be delivered."""
+
+
+@dataclass
+class ClusterNodeSpec:
+    """One node of a dispatched execution cluster.
+
+    Args:
+        node_name: Name the node carries inside this cluster (unique within the request).
+        node_type: Registered node class name.
+        library_name: Library that owns the node type.
+        parameter_values: Boundary input values for this node. Values arriving over the wire
+            are serializable by definition; values produced inside the cluster travel through
+            edges instead and never appear here.
+        node_metadata: Node metadata (node_type/library plus optional extras).
+    """
+
+    node_name: str
+    node_type: str
+    library_name: str
+    parameter_values: dict[str, Any] = field(default_factory=dict)
+    node_metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ClusterEdgeSpec:
+    """A dataflow edge internal to a dispatched cluster.
+
+    Values crossing these edges stay in the executing process as live references. This is the
+    reason clusters exist: a serializable=False value cannot cross a process boundary, so its
+    producer and consumer are dispatched together and hand it off locally.
+    """
+
+    source_node: str
+    source_parameter: str
+    target_node: str
+    target_parameter: str
+
+
+@dataclass
+@PayloadRegistry.register
+class ExecuteClusterRequest(RequestPayload):
+    """Execute a cluster of nodes together in this process.
+
+    The cluster is the dispatch unit for isolated execution: nodes joined by unserializable
+    values must run in one process, so they are sent as one request. Nodes are constructed
+    fresh, boundary inputs hydrated, and members executed in dependency order with
+    intra-cluster values handed off as live references. A single-node cluster with no edges
+    degenerates to ExecuteNodeRequest's worker path, which this request supersedes.
+
+    Args:
+        nodes: The cluster's members. Any order; execution order is derived from edges.
+        edges: Intra-cluster dataflow edges.
+        output_nodes: Names of members whose outputs should be returned. Only serializable
+            outputs return; a serializable=False output is by definition consumed inside the
+            cluster or not at all.
+        variables: Workflow variable dict for inline {VAR} substitution (see
+            ExecuteNodeRequest.variables).
+
+    Results: ExecuteClusterResultSuccess | ExecuteClusterResultFailure
+    """
+
+    nodes: list[ClusterNodeSpec] = field(default_factory=list)
+    edges: list[ClusterEdgeSpec] = field(default_factory=list)
+    output_nodes: list[str] = field(default_factory=list)
+    variables: dict[str, str | int] = field(default_factory=dict)
+
+
+@dataclass
+@PayloadRegistry.register
+class ExecuteClusterResultSuccess(ResultPayloadSuccess):
+    """Successful result from executing a cluster.
+
+    Args:
+        parameter_output_values: node_name -> parameter -> value, for the requested
+            output_nodes, restricted to serializable parameters.
+    """
+
+    parameter_output_values: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+
+@dataclass
+@PayloadRegistry.register
+class ExecuteClusterResultFailure(ResultPayloadFailure):
+    """Failed result from executing a cluster.
+
+    Args:
+        failed_node: Name of the member whose execution raised, when the failure came from
+            node execution rather than cluster validation.
+    """
+
+    failed_node: str | None = None

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -10,6 +10,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
 from uuid import uuid4
 
+from griptape_nodes.common.cluster_execution import execute_cluster
 from griptape_nodes.common.parameter_hydration import hydrate_parameter_values
 from griptape_nodes.common.strict_mode import (
     STRICT_MODE,
@@ -89,6 +90,7 @@ from griptape_nodes.retained_mode.events.execution_events import (
     CancelExecuteNodeRequest,
     CancelExecuteNodeResultSuccess,
     CancelFlowRequest,
+    ExecuteClusterRequest,
     ExecuteNodeRequest,
     ExecuteNodeResultFailure,
     ExecuteNodeResultSuccess,
@@ -408,6 +410,7 @@ class NodeManager(EngineScoped):
             BatchSetNodeLockStateRequest, self.on_batch_set_lock_node_state_request
         )
         event_manager.assign_manager_to_request_type(ExecuteNodeRequest, self.on_execute_node_request)
+        event_manager.assign_manager_to_request_type(ExecuteClusterRequest, self.on_execute_cluster_request)
         event_manager.assign_manager_to_request_type(CancelExecuteNodeRequest, self.on_cancel_execute_node_request)
 
     def handle_node_rename(self, old_name: str, new_name: str) -> None:
@@ -3098,6 +3101,10 @@ class NodeManager(EngineScoped):
         # callers do not have to poll check_for_existing_running_flow() themselves.
         details = f'Starting to resolve "{node_name}" in "{flow_name}"'
         return ResolveNodeResultSuccess(result_details=details)
+
+    async def on_execute_cluster_request(self, request: ExecuteClusterRequest) -> ResultPayload:
+        """Execute a dispatched cluster of nodes in this process (see common/cluster_execution.py)."""
+        return await execute_cluster(request, self.engine.event_manager)
 
     async def on_execute_node_request(self, request: ExecuteNodeRequest) -> ResultPayload:
         """Execute a node. Orchestrator path is lookup-only; worker path is a pure RPC.

--- a/tests/e2e/test_execute_cluster.py
+++ b/tests/e2e/test_execute_cluster.py
@@ -1,0 +1,172 @@
+"""End-to-end tests for cluster execution (ExecuteClusterRequest).
+
+A cluster is the dispatch unit for isolated execution: nodes joined by a serializable=False
+value must run in one process, so they are sent as one request and hand that value off as a
+live reference. These tests execute real clusters against a real engine using the
+nonserializable_library fixture, whose ProducerNode emits a live ``Session`` object that
+cannot cross a process boundary and whose ConsumerNode reads a string out of it.
+
+The contract pinned here:
+
+- An intra-cluster serializable=False edge delivers the live value to the consumer.
+- Returned outputs are restricted to serializable parameters: the live Session never
+  appears in the result, the string extracted from it does.
+- Execution order follows edges, not request order.
+- Malformed clusters (unknown edge targets, cycles, unknown node types) fail with a
+  diagnostic naming the problem, and a node that raises fails the cluster naming the node.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from griptape_nodes.node_library.library_registry import LibrarySchema
+from griptape_nodes.retained_mode.events.execution_events import (
+    ClusterEdgeSpec,
+    ClusterNodeSpec,
+    ExecuteClusterRequest,
+    ExecuteClusterResultFailure,
+    ExecuteClusterResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+FIXTURE_JSON = Path(__file__).parent / "fixtures" / "nonserializable_library" / "griptape_nodes_library.json"
+LIBRARY = "NonSerializable Library"
+EXPECTED_MARKER = "live-session-marker"
+
+
+@pytest.fixture(autouse=True)
+def _register_library(tmp_path: Path) -> None:
+    """Register a copy of the fixture library patched to the current schema/engine versions."""
+    from griptape_nodes.utils.version_utils import engine_version
+
+    library_dir = tmp_path / "nonserializable_library"
+    library_dir.mkdir()
+    schema = json.loads(FIXTURE_JSON.read_text())
+    schema["library_schema_version"] = LibrarySchema.LATEST_SCHEMA_VERSION
+    schema["metadata"]["engine_version"] = engine_version
+    library_json = library_dir / "griptape_nodes_library.json"
+    library_json.write_text(json.dumps(schema, indent=2))
+    shutil.copy(FIXTURE_JSON.parent / "nonserializable_nodes.py", library_dir / "nonserializable_nodes.py")
+    result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    assert isinstance(result, RegisterLibraryFromFileResultSuccess), getattr(result, "result_details", result)
+
+
+def _producer(name: str = "producer") -> ClusterNodeSpec:
+    return ClusterNodeSpec(node_name=name, node_type="ProducerNode", library_name=LIBRARY)
+
+
+def _consumer(name: str = "consumer") -> ClusterNodeSpec:
+    return ClusterNodeSpec(node_name=name, node_type="ConsumerNode", library_name=LIBRARY)
+
+
+def _session_edge(source: str = "producer", target: str = "consumer") -> ClusterEdgeSpec:
+    return ClusterEdgeSpec(
+        source_node=source, source_parameter="session", target_node=target, target_parameter="session"
+    )
+
+
+class TestLiveValueHandoff:
+    def test_live_value_crosses_the_intra_cluster_edge(self) -> None:
+        """The consumer reads the producer's live Session and extracts its marker.
+
+        This is the design's core claim: the serializable=False value flowed
+        producer -> consumer without ever being serialized.
+        """
+        result = GriptapeNodes.handle_request(
+            ExecuteClusterRequest(
+                nodes=[_producer(), _consumer()],
+                edges=[_session_edge()],
+                output_nodes=["consumer"],
+            )
+        )
+
+        assert isinstance(result, ExecuteClusterResultSuccess), getattr(result, "result_details", result)
+        assert result.parameter_output_values["consumer"]["marker"] == EXPECTED_MARKER
+
+    def test_unserializable_outputs_never_return_over_the_boundary(self) -> None:
+        """The producer's live Session is not in the result even when requested."""
+        result = GriptapeNodes.handle_request(
+            ExecuteClusterRequest(
+                nodes=[_producer(), _consumer()],
+                edges=[_session_edge()],
+                output_nodes=["producer", "consumer"],
+            )
+        )
+
+        assert isinstance(result, ExecuteClusterResultSuccess)
+        assert "session" not in result.parameter_output_values["producer"]
+        assert result.parameter_output_values["consumer"] == {"marker": EXPECTED_MARKER}
+
+    def test_execution_order_follows_edges_not_request_order(self) -> None:
+        """Consumer listed first still runs after the producer that feeds it."""
+        result = GriptapeNodes.handle_request(
+            ExecuteClusterRequest(
+                nodes=[_consumer(), _producer()],
+                edges=[_session_edge()],
+                output_nodes=["consumer"],
+            )
+        )
+
+        assert isinstance(result, ExecuteClusterResultSuccess)
+        assert result.parameter_output_values["consumer"]["marker"] == EXPECTED_MARKER
+
+    def test_single_node_cluster_degenerates_to_per_node_execution(self) -> None:
+        result = GriptapeNodes.handle_request(
+            ExecuteClusterRequest(nodes=[_producer()], edges=[], output_nodes=["producer"])
+        )
+
+        assert isinstance(result, ExecuteClusterResultSuccess)
+        # Its only output is unserializable, so nothing crosses back -- by design.
+        assert result.parameter_output_values["producer"] == {}
+
+
+class TestBoundedFailure:
+    def test_node_that_raises_fails_the_cluster_naming_the_node(self) -> None:
+        """A consumer with no incoming session raises inside process(); the failure says who."""
+        result = GriptapeNodes.handle_request(
+            ExecuteClusterRequest(nodes=[_consumer("lonely")], edges=[], output_nodes=["lonely"])
+        )
+
+        assert isinstance(result, ExecuteClusterResultFailure)
+        assert result.failed_node == "lonely"
+
+    def test_unknown_node_type_fails_with_diagnostic(self) -> None:
+        result = GriptapeNodes.handle_request(
+            ExecuteClusterRequest(
+                nodes=[ClusterNodeSpec(node_name="ghost", node_type="NoSuchNode", library_name=LIBRARY)],
+            )
+        )
+
+        assert isinstance(result, ExecuteClusterResultFailure)
+        assert result.failed_node == "ghost"
+
+    def test_edge_to_unknown_node_fails_validation(self) -> None:
+        result = GriptapeNodes.handle_request(
+            ExecuteClusterRequest(nodes=[_producer()], edges=[_session_edge("producer", "ghost")])
+        )
+
+        assert isinstance(result, ExecuteClusterResultFailure)
+
+    def test_cycle_fails_validation(self) -> None:
+        result = GriptapeNodes.handle_request(
+            ExecuteClusterRequest(
+                nodes=[_producer("a"), _consumer("b")],
+                edges=[_session_edge("a", "b"), _session_edge("b", "a")],
+            )
+        )
+
+        assert isinstance(result, ExecuteClusterResultFailure)
+
+    def test_empty_cluster_fails_validation(self) -> None:
+        result = GriptapeNodes.handle_request(ExecuteClusterRequest())
+
+        assert isinstance(result, ExecuteClusterResultFailure)


### PR DESCRIPTION
Fourth PR in the venue-execution stack (design: `venue-execution-plan.md`). **Stacked on #5392** — review only the last commit.

## What

The execution half of clustering: `ExecuteClusterRequest` runs a set of nodes together in one process.

- Members constructed fresh via `LibraryRegistry.create_node`, boundary inputs hydrated from the wire
- Execution in dependency order (topological sort over the cluster's edges, not request order)
- **Values on intra-cluster edges are handed off as live references, never serialized** — the reason clusters exist
- Only serializable outputs of the requested `output_nodes` return, enforced against `Parameter.serializable`
- A single-node cluster with no edges degenerates to `ExecuteNodeRequest`'s worker path, which this supersedes (deletion comes in the demolition step)

Failures are bounded and attributed: validation failures (empty cluster, duplicate names, unknown edge endpoints, cycles, unknown node types) name the problem; a member that raises fails the cluster naming the node.

Core logic lives in `common/cluster_execution.py` as a pure-ish module; `NodeManager` registers a thin delegate.

## Testing

9 e2e tests against the existing `nonserializable_library` fixture, whose ProducerNode emits a live `Session` (`serializable=False`) and whose ConsumerNode extracts a string from it:

- the live value crosses the producer→consumer edge unserialized (the design's core claim)
- the live value never appears in returned outputs, even when its node is requested
- execution order follows edges, not request order
- single-node degenerate case; empty/cycle/unknown-node/unknown-edge validation; raise-inside-process attribution

Full gate: 4675 unit / 52 e2e / 9 integration passed, `make check` clean.