### PR TITLE
Derive execution clusters from live nodes and registered libraries

### DIFF
--- a/src/griptape_nodes/common/execution_clusters.py
+++ b/src/griptape_nodes/common/execution_clusters.py
@@ -18,6 +18,7 @@ resulting clusters, but neither is imported here.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass(frozen=True)
@@ -128,3 +129,75 @@ def compute_execution_clusters(
         exec_dependencies: frozenset[str] = frozenset().union(*(deps_by_name[name] for name in members))
         clusters.append(ExecutionCluster(node_names=frozenset(members), exec_dependencies=exec_dependencies))
     return clusters
+
+
+def exec_dependencies_for_library(library_name: str) -> frozenset[str]:
+    """The execution-dependency set a library declares, empty when it declares none.
+
+    This is the placement signal: a node whose library has execution dependencies cannot
+    run its ``process`` where those dependencies are not installed.
+    """
+    # Deferred import: this module is otherwise pure, and library_registry imports widely.
+    from griptape_nodes.node_library.library_registry import LibraryRegistry
+
+    library = LibraryRegistry.get_library(library_name)
+    dependencies = library.get_library_data().metadata.dependencies
+    if dependencies is None or not dependencies.pip_dependencies_exec:
+        return frozenset()
+    return frozenset(dependencies.pip_dependencies_exec)
+
+
+@dataclass(frozen=True)
+class NodeGraphEdge:
+    """A dataflow edge between two live nodes, as the graph layer describes it."""
+
+    source_node_name: str
+    source_parameter: str
+    target_node_name: str
+    target_parameter: str
+
+
+def clusters_for_nodes(
+    nodes: list[Any],
+    edges: list[NodeGraphEdge],
+) -> list[ExecutionCluster]:
+    """Compute execution clusters from live BaseNode instances and their dataflow edges.
+
+    The adapter between real graphs and the pure computation: each node's
+    execution-dependency set comes from its library (``metadata["library"]``), and an
+    edge is unserializable when the source node's output parameter is marked
+    ``serializable=False`` -- the producer's declaration governs, since it is the
+    producer's value that would have to cross a boundary.
+
+    Args:
+        nodes: Live BaseNode instances (typed as Any to keep this module import-light;
+            they need ``.name``, ``.metadata``, and ``.get_parameter_by_name``).
+        edges: Dataflow edges between those nodes.
+    """
+    cluster_nodes = []
+    for node in nodes:
+        library_name = node.metadata.get("library", "")
+        exec_dependencies = exec_dependencies_for_library(library_name) if library_name else frozenset()
+        cluster_nodes.append(ClusterNode(name=node.name, exec_dependencies=exec_dependencies))
+
+    nodes_by_name = {node.name: node for node in nodes}
+    cluster_edges = []
+    for edge in edges:
+        source = nodes_by_name.get(edge.source_node_name)
+        if source is None:
+            msg = (
+                f"Attempted to compute execution clusters, but edge source "
+                f"{edge.source_node_name!r} is not among the given nodes."
+            )
+            raise ValueError(msg)
+        parameter = source.get_parameter_by_name(edge.source_parameter)
+        serializable = parameter.serializable if parameter is not None else True
+        cluster_edges.append(
+            ClusterEdge(
+                source=edge.source_node_name,
+                target=edge.target_node_name,
+                serializable=serializable,
+            )
+        )
+
+    return compute_execution_clusters(cluster_nodes, cluster_edges)

--- a/src/griptape_nodes/common/execution_clusters.py
+++ b/src/griptape_nodes/common/execution_clusters.py
@@ -128,7 +128,7 @@ def compute_execution_clusters(
     for members in members_by_root.values():
         exec_dependencies: frozenset[str] = frozenset().union(*(deps_by_name[name] for name in members))
         clusters.append(ExecutionCluster(node_names=frozenset(members), exec_dependencies=exec_dependencies))
-    return clusters
+    return _closure_over_paths(clusters, nodes, edges)
 
 
 def exec_dependencies_for_library(library_name: str) -> frozenset[str]:
@@ -201,3 +201,85 @@ def clusters_for_nodes(
         )
 
     return compute_execution_clusters(cluster_nodes, cluster_edges)
+
+
+def _closure_over_paths(
+    clusters: list[ExecutionCluster],
+    nodes: list[ClusterNode],
+    edges: list[ClusterEdge],
+) -> list[ExecutionCluster]:
+    """Absorb any node lying on a path between two members of the same cluster.
+
+    A cluster executes atomically, so it must be convex in the DAG: if member U feeds
+    external node X and X feeds member D, then X's value is needed mid-cluster and X's
+    input only exists once the cluster runs. Leaving X outside would deadlock the
+    dispatch, so X is absorbed and the cluster's dependency union grows accordingly.
+    """
+    deps_by_name = {node.name: node.exec_dependencies for node in nodes}
+    forward: dict[str, list[str]] = {node.name: [] for node in nodes}
+    backward: dict[str, list[str]] = {node.name: [] for node in nodes}
+    for edge in edges:
+        forward[edge.source].append(edge.target)
+        backward[edge.target].append(edge.source)
+
+    def descendants(seeds: frozenset[str]) -> set[str]:
+        return _reachable(seeds, forward)
+
+    def ancestors(seeds: frozenset[str]) -> set[str]:
+        return _reachable(seeds, backward)
+
+    current = clusters
+    changed = True
+    while changed:
+        changed = False
+        absorbed_by_cluster: dict[int, set[str]] = {}
+        for index, cluster in enumerate(current):
+            if cluster.runs_in_orchestrator or len(cluster.node_names) == 1:
+                continue
+            # Nodes both downstream of some member and upstream of another lie on a
+            # member -> member path.
+            on_paths = (descendants(cluster.node_names) & ancestors(cluster.node_names)) - cluster.node_names
+            if on_paths:
+                absorbed_by_cluster[index] = on_paths
+        if not absorbed_by_cluster:
+            return current
+
+        changed = True
+        grown = [cluster.node_names | absorbed_by_cluster.get(index, set()) for index, cluster in enumerate(current)]
+        current = [
+            ExecutionCluster(
+                node_names=members,
+                exec_dependencies=frozenset().union(*(deps_by_name[name] for name in members)),
+            )
+            for members in _merge_overlapping(grown)
+        ]
+    return current
+
+
+def _merge_overlapping(member_sets: list[frozenset[str]]) -> list[frozenset[str]]:
+    """Merge any member sets that share a node, keeping every node in exactly one set.
+
+    Absorption can pull the same node into two clusters (it sits between members of both)
+    or steal a node that was another cluster's member. Either way the affected clusters
+    cannot execute separately.
+    """
+    merged: list[frozenset[str]] = []
+    for members in member_sets:
+        combined = members
+        for existing in [candidate for candidate in merged if candidate & combined]:
+            merged.remove(existing)
+            combined = combined | existing
+        merged.append(combined)
+    return merged
+
+
+def _reachable(seeds: frozenset[str], adjacency: dict[str, list[str]]) -> set[str]:
+    """Every node reachable from ``seeds`` (inclusive) over ``adjacency``."""
+    seen = set(seeds)
+    stack = list(seeds)
+    while stack:
+        for neighbor in adjacency[stack.pop()]:
+            if neighbor not in seen:
+                seen.add(neighbor)
+                stack.append(neighbor)
+    return seen

--- a/tests/e2e/test_cluster_adapter.py
+++ b/tests/e2e/test_cluster_adapter.py
@@ -1,0 +1,119 @@
+"""End-to-end tests for deriving execution clusters from real nodes and libraries.
+
+The pure cluster computation takes primitive inputs; this adapter layer produces them from
+live engine state: execution-dependency sets read from each node's registered library, and
+edge serializability read from the producing node's real Parameter metadata. These tests
+register the actual fixture libraries and instantiate actual nodes, so what is proven is
+the full derivation path a dispatching executor will use.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from griptape_nodes.common.execution_clusters import (
+    NodeGraphEdge,
+    clusters_for_nodes,
+    exec_dependencies_for_library,
+)
+from griptape_nodes.node_library.library_registry import LibraryRegistry, LibrarySchema
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.utils.version_utils import engine_version
+from tests.e2e.offline_wheels import build_wheel, offline_install_flags
+
+FIXTURES = Path(__file__).parent / "fixtures"
+NONSERIALIZABLE_LIBRARY = "NonSerializable Library"
+EXEC_DEP_LIBRARY = "Exec Dep Library"
+
+
+def _register_fixture_library(tmp_path: Path, fixture_dir: str, node_files: list[str], **dep_overrides) -> None:
+    """Register a copy of a fixture library patched to current versions."""
+    source = FIXTURES / fixture_dir
+    library_dir = tmp_path / fixture_dir
+    library_dir.mkdir()
+    schema = json.loads((source / "griptape_nodes_library.json").read_text())
+    schema["library_schema_version"] = LibrarySchema.LATEST_SCHEMA_VERSION
+    schema["metadata"]["engine_version"] = engine_version
+    if dep_overrides:
+        schema["metadata"]["dependencies"] = dep_overrides
+    library_json = library_dir / "griptape_nodes_library.json"
+    library_json.write_text(json.dumps(schema, indent=2))
+    for node_file in node_files:
+        shutil.copy(source / node_file, library_dir / node_file)
+    result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    assert isinstance(result, RegisterLibraryFromFileResultSuccess), getattr(result, "result_details", result)
+
+
+@pytest.fixture(autouse=True)
+def _register_libraries(tmp_path: Path) -> None:
+    _register_fixture_library(tmp_path, "nonserializable_library", ["nonserializable_nodes.py"])
+    wheel_dir = tmp_path / "wheels"
+    build_wheel(wheel_dir, "fakeedit", "1.0.0")
+    build_wheel(wheel_dir, "fakeexec", "2.0.0")
+    _register_fixture_library(
+        tmp_path,
+        "exec_dep_library",
+        ["exec_dep_node.py"],
+        pip_dependencies=["fakeedit"],
+        pip_dependencies_exec=["fakeexec"],
+        pip_install_flags=offline_install_flags(wheel_dir),
+    )
+
+
+class TestExecDependencyDerivation:
+    def test_library_with_exec_deps_reports_them(self) -> None:
+        assert exec_dependencies_for_library(EXEC_DEP_LIBRARY) == frozenset({"fakeexec"})
+
+    def test_library_without_exec_deps_reports_empty(self) -> None:
+        assert exec_dependencies_for_library(NONSERIALIZABLE_LIBRARY) == frozenset()
+
+
+class TestClustersFromLiveNodes:
+    def test_live_edge_serializability_and_library_deps_drive_clustering(self) -> None:
+        """Real parameter metadata and real library metadata drive the clustering.
+
+        A real ProducerNode's serializable=False output pins it to its consumer, and a
+        real ExecDepNode's cluster carries its library's execution dependencies.
+        """
+        producer = LibraryRegistry.create_node(
+            node_type="ProducerNode", name="producer", specific_library_name=NONSERIALIZABLE_LIBRARY
+        )
+        consumer = LibraryRegistry.create_node(
+            node_type="ConsumerNode", name="consumer", specific_library_name=NONSERIALIZABLE_LIBRARY
+        )
+        heavy = LibraryRegistry.create_node(
+            node_type="ExecDepNode", name="heavy", specific_library_name=EXEC_DEP_LIBRARY
+        )
+
+        clusters = clusters_for_nodes(
+            [producer, consumer, heavy],
+            [
+                # ProducerNode.session is serializable=False in the real Parameter metadata.
+                NodeGraphEdge("producer", "session", "consumer", "session"),
+                # ConsumerNode.marker is a plain string: a serializable boundary.
+                NodeGraphEdge("consumer", "marker", "heavy", "edit_dep_version"),
+            ],
+        )
+
+        by_membership = {cluster.node_names: cluster for cluster in clusters}
+        assert frozenset({"producer", "consumer"}) in by_membership
+        assert frozenset({"heavy"}) in by_membership
+        assert by_membership[frozenset({"producer", "consumer"})].runs_in_orchestrator
+        heavy_cluster = by_membership[frozenset({"heavy"})]
+        assert heavy_cluster.exec_dependencies == frozenset({"fakeexec"})
+        assert not heavy_cluster.runs_in_orchestrator
+
+    def test_unknown_edge_source_raises(self) -> None:
+        node = LibraryRegistry.create_node(
+            node_type="ProducerNode", name="only", specific_library_name=NONSERIALIZABLE_LIBRARY
+        )
+        with pytest.raises(ValueError, match="is not among the given nodes"):
+            clusters_for_nodes([node], [NodeGraphEdge("ghost", "x", "only", "session")])

--- a/tests/unit/common/test_execution_clusters.py
+++ b/tests/unit/common/test_execution_clusters.py
@@ -164,3 +164,106 @@ class TestValidation:
     def test_edge_referencing_unknown_node_raises(self) -> None:
         with pytest.raises(ValueError, match="references a node not in the graph"):
             compute_execution_clusters([ClusterNode("a")], [ClusterEdge("a", "ghost")])
+
+
+class TestConvexity:
+    """A dispatched cluster must be convex in the DAG.
+
+    Nodes on member->member paths are absorbed, or the dispatch would need a value that
+    only exists mid-cluster.
+    """
+
+    def test_external_node_on_a_member_to_member_path_is_absorbed(self) -> None:
+        """U -> X -> D with U,D pinned by a live edge: X joins the cluster."""
+        nodes = [ClusterNode("u", TORCH), ClusterNode("x"), ClusterNode("d", TORCH)]
+        edges = [
+            ClusterEdge("u", "d", serializable=False),
+            ClusterEdge("u", "x", serializable=True),
+            ClusterEdge("x", "d", serializable=True),
+        ]
+        clusters = compute_execution_clusters(nodes, edges)
+        assert {c.node_names for c in clusters} == {frozenset({"u", "x", "d"})}
+
+    def test_pure_upstream_and_downstream_nodes_are_not_absorbed(self) -> None:
+        """Nodes before or after the cluster stay outside; only in-between nodes join."""
+        nodes = [
+            ClusterNode("before"),
+            ClusterNode("u", TORCH),
+            ClusterNode("d", TORCH),
+            ClusterNode("after"),
+        ]
+        edges = [
+            ClusterEdge("before", "u", serializable=True),
+            ClusterEdge("u", "d", serializable=False),
+            ClusterEdge("d", "after", serializable=True),
+        ]
+        clusters = compute_execution_clusters(nodes, edges)
+        assert {c.node_names for c in clusters} == {
+            frozenset({"before"}),
+            frozenset({"u", "d"}),
+            frozenset({"after"}),
+        }
+
+    def test_absorbed_heavy_node_unions_its_dependencies(self) -> None:
+        """An in-between node from another heavy library grows the cluster's dep union."""
+        nodes = [ClusterNode("u", TORCH), ClusterNode("x", OTHER), ClusterNode("d", TORCH)]
+        edges = [
+            ClusterEdge("u", "d", serializable=False),
+            ClusterEdge("u", "x", serializable=True),
+            ClusterEdge("x", "d", serializable=True),
+        ]
+        clusters = compute_execution_clusters(nodes, edges)
+        assert len(clusters) == 1
+        assert clusters[0].exec_dependencies == TORCH | OTHER
+
+    def test_chained_absorption_reaches_a_fixed_point(self) -> None:
+        """U -> x1 -> x2 -> D: the whole in-between chain is absorbed."""
+        nodes = [ClusterNode("u", TORCH), ClusterNode("x1"), ClusterNode("x2"), ClusterNode("d", TORCH)]
+        edges = [
+            ClusterEdge("u", "d", serializable=False),
+            ClusterEdge("u", "x1", serializable=True),
+            ClusterEdge("x1", "x2", serializable=True),
+            ClusterEdge("x2", "d", serializable=True),
+        ]
+        clusters = compute_execution_clusters(nodes, edges)
+        assert {c.node_names for c in clusters} == {frozenset({"u", "x1", "x2", "d"})}
+
+    def test_light_clusters_are_never_closed(self) -> None:
+        """Convexity only matters for dispatched clusters; orchestrator nodes run per-node."""
+        nodes = [ClusterNode("a"), ClusterNode("x"), ClusterNode("b")]
+        edges = [
+            ClusterEdge("a", "b", serializable=False),
+            ClusterEdge("a", "x", serializable=True),
+            ClusterEdge("x", "b", serializable=True),
+        ]
+        clusters = compute_execution_clusters(nodes, edges)
+        # a-b cluster is light (runs in orchestrator), so x stays outside it.
+        assert frozenset({"x"}) in {c.node_names for c in clusters}
+
+    def test_two_clusters_sharing_an_intermediate_node_merge(self) -> None:
+        """One node between members of TWO clusters merges everything into one.
+
+        The node cannot execute in two places, and every node must land in exactly one
+        cluster.
+        """
+        nodes = [
+            ClusterNode("u1", TORCH),
+            ClusterNode("d1", TORCH),
+            ClusterNode("u2", OTHER),
+            ClusterNode("d2", OTHER),
+            ClusterNode("x"),
+        ]
+        edges = [
+            ClusterEdge("u1", "d1", serializable=False),
+            ClusterEdge("u2", "d2", serializable=False),
+            ClusterEdge("u1", "x", serializable=True),
+            ClusterEdge("x", "d1", serializable=True),
+            ClusterEdge("u2", "x", serializable=True),
+            ClusterEdge("x", "d2", serializable=True),
+        ]
+        clusters = compute_execution_clusters(nodes, edges)
+        seen: set[str] = set()
+        for cluster in clusters:
+            assert not (cluster.node_names & seen), "a node appeared in two clusters"
+            seen |= cluster.node_names
+        assert {c.node_names for c in clusters} == {frozenset({"u1", "d1", "u2", "d2", "x"})}


### PR DESCRIPTION
Fifth PR in the venue-execution stack (design: `venue-execution-plan.md`). **Stacked on #5393** — review only the last commit.

## What

The adapter between real engine state and the pure cluster computation from #5392:

- `exec_dependencies_for_library(name)`: reads a registered library's `pip_dependencies_exec` — the placement signal
- `clusters_for_nodes(nodes, edges)`: derives cluster inputs from live `BaseNode` instances. Exec-dep sets come from each node's library (`metadata["library"]`); edge serializability comes from the **producing node's real `Parameter.serializable`** metadata, since it is the producer's value that would have to cross a boundary

This completes the derivation path a dispatching executor will use: real graph in, placement-and-grouping decision out. What remains before end-to-end workflow dispatch is the executor integration itself (routing a computed non-orchestrator cluster through `ExecuteClusterRequest` from #5393).

## Testing

4 e2e tests that register the actual fixture libraries and instantiate actual nodes — no mocked metadata anywhere: exec-dep derivation for both library kinds; a real `serializable=False` output pinning producer to consumer while a heavy node clusters alone carrying `fakeexec`; unknown-edge validation.

Full gate: 4675 unit / 56 e2e / 9 integration passed, `make check` clean.