### PR TITLE
fix: stop the engine serving stale library state

### DIFF
--- a/src/griptape_nodes/retained_mode/events/library_events.py
+++ b/src/griptape_nodes/retained_mode/events/library_events.py
@@ -433,6 +433,25 @@ class LoadLibraryMetadataFromFileResultSuccess(WorkflowNotAlteredMixin, ResultPa
         git_remote: The git remote URL if the library is in a git repository, None otherwise.
         git_ref: The current git reference (branch, tag, or commit) if the library is in a git repository, None otherwise.
         enabled: If the current library is enabled or disabled by the user at the time of the request.
+        is_registered: Whether a library of this name is in the LibraryRegistry right now.
+
+                       Metadata is read from whatever `libraries_to_register` currently
+                       resolves to, while the registry holds what was actually loaded. Those
+                       two can disagree: config changes after boot (a settings write, a
+                       project switch) are not applied to the registry until libraries
+                       reload, so metadata can describe a library the engine cannot answer
+                       any other question about. Without this flag that difference is
+                       invisible, and a client reasonably follows a metadata entry with a
+                       name-keyed call (CheckLibraryUpdate, GetAllInfoForLibrary) that then
+                       fails with "no Library with that name was registered".
+
+                       False means "declared but not loaded": show it as pending a library
+                       refresh rather than querying it. Keyed on name, not path, because the
+                       follow-up requests are name-keyed too, so a second copy of an
+                       already-loaded name reports True.
+
+                       Distinct from `enabled` (the user's config flag) and from
+                       `registered_path` (the verbatim config path, not a membership answer).
     """
 
     library_schema: LibrarySchema
@@ -440,6 +459,7 @@ class LoadLibraryMetadataFromFileResultSuccess(WorkflowNotAlteredMixin, ResultPa
     git_remote: str | None
     git_ref: str | None
     enabled: bool
+    is_registered: bool
     registered_path: str | None = None
 
 

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -660,7 +660,9 @@ class LibraryManager(EngineScoped):
             GetLibraryMetadataRequest,
             self.get_library_metadata_request,
         )
-        event_manager.assign_manager_to_request_type(GetAllInfoForLibraryRequest, self.get_all_info_for_library_request)
+        event_manager.assign_manager_to_request_type(
+            GetAllInfoForLibraryRequest, self.on_get_all_info_for_library_request
+        )
         event_manager.assign_manager_to_request_type(
             GetAllInfoForAllLibrariesRequest, self.on_get_all_info_for_all_libraries_request
         )
@@ -3083,6 +3085,19 @@ class LibraryManager(EngineScoped):
         await self._libraries_loading_complete.wait()
         return await asyncio.to_thread(self.get_all_info_for_all_libraries_request, request)
 
+    async def on_get_all_info_for_library_request(self, request: GetAllInfoForLibraryRequest) -> ResultPayload:
+        """Async handler for GetAllInfoForLibraryRequest that waits for library loading to complete.
+
+        The registered entry point for this request. Mirrors the all-libraries handler
+        above: without the wait, a request arriving mid-reload reports the library as
+        unregistered even though the reload re-registers it moments later.
+        `get_all_info_for_library_request` stays synchronous because
+        `get_all_info_for_all_libraries_request` calls it directly per library, after
+        having already waited on the gate itself.
+        """
+        await self._libraries_loading_complete.wait()
+        return await asyncio.to_thread(self.get_all_info_for_library_request, request)
+
     def get_all_info_for_library_request(self, request: GetAllInfoForLibraryRequest) -> ResultPayload:  # noqa: PLR0911, PLR0912, PLR0915, C901
         # Does this library exist?
         try:
@@ -3653,6 +3668,22 @@ class LibraryManager(EngineScoped):
                 )
             )
 
+    def _close_libraries_loading_gate(self) -> None:
+        """Close the gate that library queries wait on while the registry is being rebuilt.
+
+        Recreates the Event rather than calling .clear(): an Event created by a previous
+        asyncio.run() call raises RuntimeError when awaited from a new loop (asyncio.Event
+        objects are bound to the loop they were created on).
+
+        An already-closed gate is left alone. A reload closes the gate before it unloads
+        libraries, so by the time load_all_libraries_from_config runs there may already be
+        callers suspended on this Event; replacing it would orphan them, because the
+        matching set() would fire on a different object.
+        """
+        if not self._libraries_loading_complete.is_set():
+            return
+        self._libraries_loading_complete = asyncio.Event()
+
     async def load_all_libraries_from_config(self, target_library_names: list[str] | None = None) -> list[str]:
         """Reconcile sourced libraries, then discover and load every enabled library.
 
@@ -3666,54 +3697,54 @@ class LibraryManager(EngineScoped):
 
         Returns the reconcile failure details (empty list on success).
         """
-        # Recreate the event bound to the current event loop. Calling .clear() on an event
-        # created by a previous asyncio.run() call raises RuntimeError when awaited from
-        # the new loop (asyncio.Event objects are bound to the loop they were created on).
-        self._libraries_loading_complete = asyncio.Event()
+        # Close the gate for the duration of the rebuild. A reload has already closed it
+        # before unloading, in which case this is a no-op and its waiters are preserved.
+        # The finally below reopens it on every exit path, so "closed" always means a load
+        # is in flight on the current loop.
+        self._close_libraries_loading_gate()
+        try:
+            reconcile_failures = await self._reconcile_libraries_from_config()
 
-        reconcile_failures = await self._reconcile_libraries_from_config()
+            # Discover all available libraries (config + sandbox)
+            discover_result = await self.discover_libraries_request(DiscoverLibrariesRequest())
+            if isinstance(discover_result, DiscoverLibrariesResultFailure):
+                logger.error("Failed to discover libraries: %s", discover_result.result_details)
+                return reconcile_failures
 
-        # Discover all available libraries (config + sandbox)
-        discover_result = await self.discover_libraries_request(DiscoverLibrariesRequest())
-        if isinstance(discover_result, DiscoverLibrariesResultFailure):
-            logger.error("Failed to discover libraries: %s", discover_result.result_details)
-            self._libraries_loading_complete.set()
+            # Build list of library paths to load
+            libraries_to_load = []
+            for discovered_lib in discover_result.libraries_discovered:
+                lib_path = str(discovered_lib.path)
+                lib_info = self._library_file_path_to_info.get(lib_path)
+
+                if lib_info and lib_info.lifecycle_state != LibraryManager.LibraryLifecycleState.DISABLED:
+                    libraries_to_load.append(lib_path)
+
+            if not libraries_to_load:
+                logger.info("No libraries found in configuration.")
+                return reconcile_failures
+
+            # Calculate total libraries for progress tracking
+            total_libraries = len(libraries_to_load)
+
+            for current_library_index, lib_path in enumerate(libraries_to_load, start=1):
+                # When running as a dedicated library worker, skip libraries that don't match the target.
+                # library_name is already populated in _library_file_path_to_info from the discovery phase.
+                lib_info = self._library_file_path_to_info.get(lib_path)
+                if target_library_names is not None and (
+                    lib_info is None or lib_info.library_name not in target_library_names
+                ):
+                    continue
+
+                await self._load_and_track_library(lib_path, current_library_index, total_libraries)
+
+            # Remove any missing libraries AFTER we've loaded them for the user.
+            user_libraries_section = LIBRARIES_TO_REGISTER_KEY
+            self._remove_missing_libraries_from_config(config_category=user_libraries_section)
+
             return reconcile_failures
-
-        # Build list of library paths to load
-        libraries_to_load = []
-        for discovered_lib in discover_result.libraries_discovered:
-            lib_path = str(discovered_lib.path)
-            lib_info = self._library_file_path_to_info.get(lib_path)
-
-            if lib_info and lib_info.lifecycle_state != LibraryManager.LibraryLifecycleState.DISABLED:
-                libraries_to_load.append(lib_path)
-
-        if not libraries_to_load:
-            logger.info("No libraries found in configuration.")
+        finally:
             self._libraries_loading_complete.set()
-            return reconcile_failures
-
-        # Calculate total libraries for progress tracking
-        total_libraries = len(libraries_to_load)
-
-        for current_library_index, lib_path in enumerate(libraries_to_load, start=1):
-            # When running as a dedicated library worker, skip libraries that don't match the target.
-            # library_name is already populated in _library_file_path_to_info from the discovery phase.
-            lib_info = self._library_file_path_to_info.get(lib_path)
-            if target_library_names is not None and (
-                lib_info is None or lib_info.library_name not in target_library_names
-            ):
-                continue
-
-            await self._load_and_track_library(lib_path, current_library_index, total_libraries)
-
-        # Remove any missing libraries AFTER we've loaded them for the user.
-        user_libraries_section = LIBRARIES_TO_REGISTER_KEY
-        self._remove_missing_libraries_from_config(config_category=user_libraries_section)
-
-        self._libraries_loading_complete.set()
-        return reconcile_failures
 
     async def on_preview_project_provisioning_request(
         self, request: PreviewProjectProvisioningRequest
@@ -5480,6 +5511,11 @@ class LibraryManager(EngineScoped):
             return await self._run_reload_libraries(request)
         finally:
             self._is_initializing = False
+            # load_all_libraries_from_config reopens the gate on its own way out, but a
+            # reload that bails between closing it and getting there (a failed unload, say)
+            # would otherwise leave every gated query waiting for the life of the process.
+            # Once the reload request is done, loading is definitively not in progress.
+            self._libraries_loading_complete.set()
 
     async def _run_reload_libraries(self, request: ReloadAllLibrariesRequest) -> ResultPayload:  # noqa: ARG002
         # Start with a clean slate.
@@ -5496,6 +5532,15 @@ class LibraryManager(EngineScoped):
             details = "When preparing to reload all libraries, failed to get registered libraries."
             logger.error(details)
             return ReloadAllLibrariesResultFailure(result_details=details)
+
+        # Close the loading gate before the registry is actually emptied, and not any
+        # earlier: the enumeration above goes through on_list_registered_libraries_request,
+        # which waits on this same gate, so closing it first would deadlock the reload
+        # against itself. Everything from here on mutates the registry, so a query that
+        # waits now sees the rebuilt registry rather than an empty one. Closing it only in
+        # load_all_libraries_from_config would leave this whole unload window uncovered,
+        # which is what produced the "no Library with that name was registered" spam.
+        self._close_libraries_loading_gate()
 
         for library_name in all_libraries_result.libraries:
             unload_library_request = UnloadLibraryFromRegistryRequest(library_name=library_name)
@@ -6081,6 +6126,11 @@ class LibraryManager(EngineScoped):
     async def check_library_update_request(self, request: CheckLibraryUpdateRequest) -> ResultPayload:  # noqa: C901, PLR0911, PLR0912, PLR0915
         """Check if a library has updates available via git."""
         library_name = request.library_name
+
+        # A reload unregisters every library before re-registering them one at a time, so a
+        # check landing in that window would report a perfectly healthy library as
+        # unregistered. Wait for the rebuild to finish first.
+        await self._libraries_loading_complete.wait()
 
         # Check if the library exists
         try:

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -1367,8 +1367,20 @@ class LibraryManager(EngineScoped):
             git_remote=git_remote,
             git_ref=git_ref,
             enabled=enabled,
+            is_registered=self._is_library_name_registered(library_data.name),
             result_details=details,
         )
+
+    @staticmethod
+    def _is_library_name_registered(library_name: str) -> bool:
+        """Whether a library of this name is in the registry right now.
+
+        Metadata is derived from config while the registry holds what actually loaded, so the
+        two can disagree until libraries reload. Keyed on name because the requests a client
+        makes off the back of metadata (CheckLibraryUpdate, GetAllInfoForLibrary) are
+        name-keyed: if the name resolves, those calls succeed regardless of which copy loaded.
+        """
+        return library_name in LibraryRegistry.list_libraries()
 
     async def load_metadata_for_all_libraries_request(
         self,
@@ -1422,6 +1434,7 @@ class LibraryManager(EngineScoped):
                         git_remote=None,
                         git_ref=None,
                         enabled=True,
+                        is_registered=self._is_library_name_registered(scan_result.library_schema.name),
                         result_details=scan_result.result_details,
                     )
                 # else: Keep the load failure result
@@ -1583,6 +1596,7 @@ class LibraryManager(EngineScoped):
             git_remote=git_remote,
             git_ref=git_ref,
             enabled=True,
+            is_registered=self._is_library_name_registered(library_schema.name),
             result_details=details,
         )
 

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -5511,11 +5511,6 @@ class LibraryManager(EngineScoped):
             return await self._run_reload_libraries(request)
         finally:
             self._is_initializing = False
-            # load_all_libraries_from_config reopens the gate on its own way out, but a
-            # reload that bails between closing it and getting there (a failed unload, say)
-            # would otherwise leave every gated query waiting for the life of the process.
-            # Once the reload request is done, loading is definitively not in progress.
-            self._libraries_loading_complete.set()
 
     async def _run_reload_libraries(self, request: ReloadAllLibrariesRequest) -> ResultPayload:  # noqa: ARG002
         # Start with a clean slate.
@@ -5540,27 +5535,43 @@ class LibraryManager(EngineScoped):
         # waits now sees the rebuilt registry rather than an empty one. Closing it only in
         # load_all_libraries_from_config would leave this whole unload window uncovered,
         # which is what produced the "no Library with that name was registered" spam.
+        #
+        # A single flag cannot describe two rebuilds at once, so overlapping reloads are not
+        # supported: the second shares this Event and the first to finish reopens it. The
+        # reopen below is deliberately conditional for the same reason -- it must not force
+        # open a gate that another rebuild is relying on.
         self._close_libraries_loading_gate()
 
-        for library_name in all_libraries_result.libraries:
-            unload_library_request = UnloadLibraryFromRegistryRequest(library_name=library_name)
-            unload_library_result = self.engine.handle_request(unload_library_request)
-            if not unload_library_result.succeeded():
-                details = f"When preparing to reload all libraries, failed to unload library '{library_name}'."
-                logger.error(details)
-                return ReloadAllLibrariesResultFailure(result_details=details)
+        try:
+            for library_name in all_libraries_result.libraries:
+                unload_library_request = UnloadLibraryFromRegistryRequest(library_name=library_name)
+                unload_library_result = self.engine.handle_request(unload_library_request)
+                if not unload_library_result.succeeded():
+                    details = f"When preparing to reload all libraries, failed to unload library '{library_name}'."
+                    logger.error(details)
+                    return ReloadAllLibrariesResultFailure(result_details=details)
 
-        # Notify pre-reload callbacks (e.g. to terminate worker processes) before
-        # load_all_libraries_from_config runs so that workers can be cleanly restarted.
-        for callback in self._pre_reload_callbacks:
-            try:
-                await callback()
-            except Exception as e:
-                logger.warning("Pre-reload callback raised an exception: %s", e)
+            # Notify pre-reload callbacks (e.g. to terminate worker processes) before
+            # load_all_libraries_from_config runs so that workers can be cleanly restarted.
+            for callback in self._pre_reload_callbacks:
+                try:
+                    await callback()
+                except Exception as e:
+                    logger.warning("Pre-reload callback raised an exception: %s", e)
 
-        # Load (or reload, which should trigger a hot reload) all libraries.
-        # Pass _target_library_names so workers reload only their designated libraries.
-        reconcile_failures = await self.load_all_libraries_from_config(target_library_names=self._target_library_names)
+            # Load (or reload, which should trigger a hot reload) all libraries. This reopens
+            # the gate itself on every exit path.
+            reconcile_failures = await self.load_all_libraries_from_config(
+                target_library_names=self._target_library_names
+            )
+        finally:
+            # Bailing out above (a failed unload, or a raise) would otherwise leave the gate
+            # closed and every gated query waiting for the life of the process. Only reopen a
+            # gate still closed at this point: once load_all_libraries_from_config has run,
+            # it has already reopened this one, and re-setting it could open a gate a
+            # concurrent rebuild closed after that.
+            if not self._libraries_loading_complete.is_set():
+                self._libraries_loading_complete.set()
 
         # Re-spawn workers for libraries that require them; reset_workers terminated them above.
         await self._maybe_start_workers_for_existing_session()

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -709,6 +709,7 @@ class TestLibraryManagerRegisterLibraryFromFile:
                 git_remote=None,
                 git_ref=None,
                 enabled=True,
+                is_registered=False,
                 result_details=ResultDetails(message="Success", level=20),
             )
             mock_venv.return_value.exists.return_value = True
@@ -748,6 +749,7 @@ class TestLibraryManagerRegisterLibraryFromFile:
                     git_remote=None,
                     git_ref=None,
                     enabled=True,
+                    is_registered=False,
                     result_details=ResultDetails(message="OK", level=20),
                 ),
             ),
@@ -776,6 +778,7 @@ class TestLibraryManagerInstallLibraryDependencies:
             git_remote=None,
             git_ref=None,
             enabled=True,
+            is_registered=False,
             result_details=ResultDetails(message="OK", level=20),
         )
 

--- a/tests/unit/retained_mode/managers/test_library_manager_deps.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_deps.py
@@ -128,6 +128,7 @@ def _metadata_success(schema: MagicMock) -> LoadLibraryMetadataFromFileResultSuc
         git_remote=None,
         git_ref=None,
         enabled=True,
+        is_registered=False,
         result_details=ResultDetails(message="OK", level=20),
     )
 

--- a/tests/unit/retained_mode/managers/test_library_metadata_registry_membership.py
+++ b/tests/unit/retained_mode/managers/test_library_metadata_registry_membership.py
@@ -1,0 +1,204 @@
+"""Metadata reports whether each library is actually in the registry.
+
+Metadata is derived from whatever `libraries_to_register` currently resolves to, while the
+registry holds what was actually loaded. Those two disagree whenever config changes after
+boot without a library reload: a settings write updates config and only marks a refresh as
+pending, so until the user acts on it the engine advertises libraries it cannot answer any
+other question about.
+
+Nothing in the response used to expose that. A client would follow a metadata entry with a
+name-keyed call and get `no Library with that name was registered` back, which is what
+produced a wall of errors in a reported session. `is_registered` makes the difference
+visible so those entries can be shown as pending a refresh instead of being queried.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.node_library.library_registry import (
+    LibraryMetadata,
+    LibraryRegistry,
+    LibrarySchema,
+)
+from griptape_nodes.retained_mode.events.library_events import (
+    CheckLibraryUpdateRequest,
+    CheckLibraryUpdateResultFailure,
+    LoadMetadataForAllLibrariesRequest,
+    LoadMetadataForAllLibrariesResultSuccess,
+)
+from griptape_nodes.retained_mode.managers.settings import (
+    LIBRARIES_TO_DOWNLOAD_KEY,
+    LIBRARIES_TO_REGISTER_KEY,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator
+    from pathlib import Path
+
+    from griptape_nodes.retained_mode.engine import Engine
+
+LOADED_LIBRARY = "Nuke Nodes Library"
+DECLARED_BUT_NOT_LOADED = "Griptape Nodes VOID Library"
+
+
+def _library_json(name: str) -> str:
+    schema = LibrarySchema(
+        name=name,
+        library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+        metadata=LibraryMetadata(
+            author="test",
+            description=f"{name} manifest",
+            library_version="0.1.0",
+            engine_version="0.98.0",
+            tags=[],
+        ),
+        categories=[],
+        nodes=[],
+    )
+    return json.dumps(schema.model_dump(mode="json"))
+
+
+def _write_library(directory: Path, name: str) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    manifest = directory / "griptape_nodes_library.json"
+    manifest.write_text(_library_json(name), encoding="utf-8")
+    return manifest
+
+
+def _register_only_config(libraries: object) -> Callable[..., object]:
+    """A `get_config_value` side effect serving only `libraries_to_register`."""
+
+    def get_config_value(key: str, *, default: object = None, **_: object) -> object:
+        if key == LIBRARIES_TO_REGISTER_KEY:
+            return libraries
+        if key == LIBRARIES_TO_DOWNLOAD_KEY:
+            return []
+        return default
+
+    return get_config_value
+
+
+def _register_in_registry(name: str) -> None:
+    LibraryRegistry.generate_new_library(
+        library_data=LibrarySchema(
+            name=name,
+            library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+            metadata=LibraryMetadata(
+                author="test",
+                description="loaded at boot",
+                library_version="0.1.0",
+                engine_version="0.98.0",
+                tags=[],
+            ),
+            categories=[],
+            nodes=[],
+        )
+    )
+
+
+class TestMetadataReportsRegistryMembership:
+    @pytest.fixture(autouse=True)
+    def _clean_registry(self) -> Generator[None, None, None]:
+        LibraryRegistry._clear()
+        yield
+        LibraryRegistry._clear()
+
+    @pytest.fixture
+    def two_declared_libraries(self, tmp_path: Path) -> list[str]:
+        """Two libraries in config; only one of them will be registered."""
+        return [
+            str(_write_library(tmp_path / "loaded", LOADED_LIBRARY)),
+            str(_write_library(tmp_path / "declared-only", DECLARED_BUT_NOT_LOADED)),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_declared_but_unloaded_libraries_are_flagged(
+        self, engine: Engine, two_declared_libraries: list[str]
+    ) -> None:
+        """The exact divergence from the report: config has both, the registry has one."""
+        library_manager = engine.library_manager
+        _register_in_registry(LOADED_LIBRARY)
+
+        with pytest.MonkeyPatch.context() as patcher:
+            patcher.setattr(engine.config_manager, "get_config_value", _register_only_config(two_declared_libraries))
+            result = await library_manager.load_metadata_for_all_libraries_request(LoadMetadataForAllLibrariesRequest())
+
+        assert isinstance(result, LoadMetadataForAllLibrariesResultSuccess)
+        by_name = {entry.library_schema.name: entry for entry in result.successful_libraries}
+
+        assert by_name[LOADED_LIBRARY].is_registered is True
+        assert by_name[DECLARED_BUT_NOT_LOADED].is_registered is False
+
+    @pytest.mark.asyncio
+    async def test_the_flag_predicts_whether_a_name_keyed_call_will_work(
+        self, engine: Engine, two_declared_libraries: list[str]
+    ) -> None:
+        """The point of the flag: it tells a client which entries are safe to ask about.
+
+        Every entry reporting is_registered False is exactly an entry whose follow-up call
+        fails with "no Library with that name was registered", so a client that skips them
+        never provokes that error.
+        """
+        library_manager = engine.library_manager
+        _register_in_registry(LOADED_LIBRARY)
+
+        with pytest.MonkeyPatch.context() as patcher:
+            patcher.setattr(engine.config_manager, "get_config_value", _register_only_config(two_declared_libraries))
+            metadata = await library_manager.load_metadata_for_all_libraries_request(
+                LoadMetadataForAllLibrariesRequest()
+            )
+            assert isinstance(metadata, LoadMetadataForAllLibrariesResultSuccess)
+
+            for entry in metadata.successful_libraries:
+                name = entry.library_schema.name
+                update_result = await library_manager.check_library_update_request(
+                    CheckLibraryUpdateRequest(library_name=name)
+                )
+                disowned = isinstance(update_result, CheckLibraryUpdateResultFailure) and (
+                    "no Library with that name was registered" in str(update_result.result_details)
+                )
+                assert disowned is not entry.is_registered
+
+    @pytest.mark.asyncio
+    async def test_a_second_copy_of_a_loaded_name_reports_registered(self, engine: Engine, tmp_path: Path) -> None:
+        """Keyed on name, not path, because the follow-up requests are name-keyed too.
+
+        Two manifests for one library name: only one copy loads, but a query for that name
+        succeeds either way, so both entries report True.
+        """
+        library_manager = engine.library_manager
+        _register_in_registry(LOADED_LIBRARY)
+
+        copies = [
+            str(_write_library(tmp_path / "copy-a", LOADED_LIBRARY)),
+            str(_write_library(tmp_path / "copy-b", LOADED_LIBRARY)),
+        ]
+
+        with pytest.MonkeyPatch.context() as patcher:
+            patcher.setattr(engine.config_manager, "get_config_value", _register_only_config(copies))
+            result = await library_manager.load_metadata_for_all_libraries_request(LoadMetadataForAllLibrariesRequest())
+
+        assert isinstance(result, LoadMetadataForAllLibrariesResultSuccess)
+        assert [entry.is_registered for entry in result.successful_libraries] == [True, True]
+
+    @pytest.mark.asyncio
+    async def test_is_registered_is_independent_of_enabled(self, engine: Engine, tmp_path: Path) -> None:
+        """`enabled` is the user's config flag; this is a registry answer. Different things."""
+        library_manager = engine.library_manager
+        manifest = str(_write_library(tmp_path / "loaded", LOADED_LIBRARY))
+        _register_in_registry(LOADED_LIBRARY)
+
+        with pytest.MonkeyPatch.context() as patcher:
+            patcher.setattr(engine.config_manager, "get_config_value", _register_only_config([manifest]))
+            result = await library_manager.load_metadata_for_all_libraries_request(LoadMetadataForAllLibrariesRequest())
+
+        assert isinstance(result, LoadMetadataForAllLibrariesResultSuccess)
+        entry = result.successful_libraries[0]
+        # Nothing disabled it, and it is in the registry: the two flags are set from
+        # unrelated sources and must not be conflated by callers.
+        assert entry.enabled is True
+        assert entry.is_registered is True

--- a/tests/unit/retained_mode/managers/test_library_reload_query_race.py
+++ b/tests/unit/retained_mode/managers/test_library_reload_query_race.py
@@ -50,6 +50,7 @@ from griptape_nodes.retained_mode.events.library_events import (
 if TYPE_CHECKING:
     from collections.abc import Generator
 
+    from griptape_nodes.retained_mode.events.base_events import RequestPayload, ResultPayload
     from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 # A library the engine had registered before the reload and re-registers after it.
@@ -219,11 +220,12 @@ class TestQueriesDuringLibraryReload:
         LibraryRegistry.generate_new_library(library_data=_schema(LIBRARY_NAME))
 
         failed_unload = ReloadAllLibrariesResultFailure(result_details="unload failed")
+        real_handle_request = griptape_nodes.handle_request
 
-        def refuse_unload(request: object) -> object:
+        def refuse_unload(request: RequestPayload) -> ResultPayload:
             if isinstance(request, UnloadLibraryFromRegistryRequest):
                 return failed_unload
-            return griptape_nodes.handle_request(request)
+            return real_handle_request(request)
 
         with (
             patch.object(library_manager, "load_all_libraries_from_config", AsyncMock(return_value=[])) as load_all,

--- a/tests/unit/retained_mode/managers/test_library_reload_query_race.py
+++ b/tests/unit/retained_mode/managers/test_library_reload_query_race.py
@@ -50,8 +50,8 @@ from griptape_nodes.retained_mode.events.library_events import (
 if TYPE_CHECKING:
     from collections.abc import Generator
 
+    from griptape_nodes.retained_mode.engine import Engine
     from griptape_nodes.retained_mode.events.base_events import RequestPayload, ResultPayload
-    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 # A library the engine had registered before the reload and re-registers after it.
 # Mirrors 'Sendgrid Library' / 'Topaz Labs' from the log: fine before, fine after,
@@ -85,26 +85,26 @@ class TestQueriesDuringLibraryReload:
         LibraryRegistry._clear()
 
     @staticmethod
-    def _enter_reload_window(griptape_nodes: GriptapeNodes) -> None:
+    def _enter_reload_window(engine: Engine) -> None:
         """Put the manager in the state `_run_reload_libraries` creates mid-flight.
 
         The registry has been emptied by the unload loop and `load_all_libraries_from_config`
         has not finished re-registering, so the loading gate is closed.
         """
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         LibraryRegistry._clear()
         library_manager._libraries_loading_complete = asyncio.Event()
 
     @pytest.mark.asyncio
-    async def test_check_library_update_waits_for_the_reload(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_check_library_update_waits_for_the_reload(self, engine: Engine) -> None:
         """An update check mid-reload waits instead of reporting the library missing."""
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         LibraryRegistry.generate_new_library(library_data=_schema(LIBRARY_NAME))
 
         # Before the reload the library answers normally: it is in the registry.
         assert LIBRARY_NAME in set(LibraryRegistry.list_libraries())
 
-        self._enter_reload_window(griptape_nodes)
+        self._enter_reload_window(engine)
 
         pending = asyncio.create_task(
             library_manager.check_library_update_request(CheckLibraryUpdateRequest(library_name=LIBRARY_NAME))
@@ -123,17 +123,17 @@ class TestQueriesDuringLibraryReload:
         assert "no Library with that name was registered" not in str(result.result_details)
 
     @pytest.mark.asyncio
-    async def test_both_get_all_info_entry_points_wait_on_the_gate(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_both_get_all_info_entry_points_wait_on_the_gate(self, engine: Engine) -> None:
         """The per-library and all-libraries entry points now agree about the reload window.
 
         `get_all_info_for_library_request` stays synchronous and ungated because
         `get_all_info_for_all_libraries_request` calls it directly once it has already
         waited. The registered entry point is the async wrapper, which waits.
         """
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         LibraryRegistry.generate_new_library(library_data=_schema(LIBRARY_NAME))
 
-        self._enter_reload_window(griptape_nodes)
+        self._enter_reload_window(engine)
 
         singular = asyncio.create_task(
             library_manager.on_get_all_info_for_library_request(GetAllInfoForLibraryRequest(library=LIBRARY_NAME))
@@ -155,7 +155,7 @@ class TestQueriesDuringLibraryReload:
         assert not isinstance(singular_result, GetAllInfoForLibraryResultFailure)
 
     @pytest.mark.asyncio
-    async def test_reload_closes_the_gate_before_emptying_the_registry(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_reload_closes_the_gate_before_emptying_the_registry(self, engine: Engine) -> None:
         """The gate must cover the whole reload, including the unload loop.
 
         `_run_reload_libraries` empties the registry (ClearAllObjectState + the unload loop)
@@ -163,7 +163,7 @@ class TestQueriesDuringLibraryReload:
         registry would already be empty while the gate still read "loaded", and a handler
         awaiting it would sail through onto an empty registry. So the gate closes first.
         """
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         LibraryRegistry.generate_new_library(library_data=_schema(LIBRARY_NAME))
 
         observed: dict[str, object] = {}
@@ -190,12 +190,12 @@ class TestQueriesDuringLibraryReload:
         )
 
     @pytest.mark.asyncio
-    async def test_reload_reopens_the_gate_even_when_loading_raises(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_reload_reopens_the_gate_even_when_loading_raises(self, engine: Engine) -> None:
         """A failed rebuild must not leave the gate closed forever.
 
         Otherwise every gated query would hang for the life of the process.
         """
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         failure = RuntimeError("discovery blew up")
 
         async def boom(*_args: object, **_kwargs: object) -> list[str]:
@@ -210,17 +210,17 @@ class TestQueriesDuringLibraryReload:
         assert library_manager._libraries_loading_complete.is_set()
 
     @pytest.mark.asyncio
-    async def test_reload_reopens_the_gate_when_it_bails_before_loading(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_reload_reopens_the_gate_when_it_bails_before_loading(self, engine: Engine) -> None:
         """A reload that fails between closing the gate and loading must not wedge queries.
 
         The gate closes just before the unload loop, so an early return from that loop would
         otherwise leave every gated query waiting for the life of the process.
         """
-        library_manager = griptape_nodes.LibraryManager()
+        library_manager = engine.library_manager
         LibraryRegistry.generate_new_library(library_data=_schema(LIBRARY_NAME))
 
         failed_unload = ReloadAllLibrariesResultFailure(result_details="unload failed")
-        real_handle_request = griptape_nodes.handle_request
+        real_handle_request = engine.handle_request
 
         def refuse_unload(request: RequestPayload) -> ResultPayload:
             if isinstance(request, UnloadLibraryFromRegistryRequest):
@@ -240,14 +240,14 @@ class TestQueriesDuringLibraryReload:
         )
 
     @pytest.mark.asyncio
-    async def test_gated_handler_would_have_returned_the_right_answer(self, griptape_nodes: GriptapeNodes) -> None:
+    async def test_gated_handler_would_have_returned_the_right_answer(self, engine: Engine) -> None:
         """Waiting is the correct behavior: the library is present once the reload ends.
 
         This is what makes the failures above spurious rather than informative -- nothing
         was actually wrong with the library.
         """
-        library_manager = griptape_nodes.LibraryManager()
-        self._enter_reload_window(griptape_nodes)
+        library_manager = engine.library_manager
+        self._enter_reload_window(engine)
 
         pending = asyncio.create_task(
             library_manager.on_get_all_info_for_all_libraries_request(GetAllInfoForAllLibrariesRequest())

--- a/tests/unit/retained_mode/managers/test_library_reload_query_race.py
+++ b/tests/unit/retained_mode/managers/test_library_reload_query_race.py
@@ -1,0 +1,230 @@
+"""Regression tests for the "refresh libraries produces more errors" race.
+
+Reloading libraries is not atomic. `_run_reload_libraries` empties the registry
+(ClearAllObjectState, then an unload loop) and only afterwards calls
+`load_all_libraries_from_config`, which re-registers libraries one at a time. In the
+reported session that window was ~29s wide: the reload began at 14:27:16 and finished at
+14:27:45, and the editor's update sweep landed inside it at 14:27:26-31, producing one
+hard failure per library that had not yet been re-registered:
+
+    ERROR  Attempted to get all library info for a Library named 'Sendgrid Library'.
+           Failed because no Library with that name was registered.
+    ERROR  Attempted to check for updates for Library 'Topaz Labs'.
+           Failed because no Library with that name was registered.
+
+Every one of those libraries registered successfully seconds later, so the failures were
+purely an artifact of being asked mid-reload.
+
+Two things had to change. `_libraries_loading_complete` -- the asyncio.Event that
+`on_list_registered_libraries_request`, `on_get_library_source_info_request` and
+`on_get_all_info_for_all_libraries_request` already awaited -- is now also awaited by the
+two GUI-facing handlers that produced the errors above. And the gate now closes before the
+unload loop rather than inside `load_all_libraries_from_config`, so it actually covers the
+window where the registry is empty; closing it any earlier would deadlock the reload
+against its own `ListRegisteredLibrariesRequest`, which waits on the same gate.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from griptape_nodes.node_library.library_registry import (
+    LibraryMetadata,
+    LibraryRegistry,
+    LibrarySchema,
+)
+from griptape_nodes.retained_mode.events.library_events import (
+    CheckLibraryUpdateRequest,
+    GetAllInfoForAllLibrariesRequest,
+    GetAllInfoForLibraryRequest,
+    GetAllInfoForLibraryResultFailure,
+    ReloadAllLibrariesRequest,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+# A library the engine had registered before the reload and re-registers after it.
+# Mirrors 'Sendgrid Library' / 'Topaz Labs' from the log: fine before, fine after,
+# "not registered" only while the reload is in flight.
+LIBRARY_NAME = "Sendgrid Library"
+
+
+def _schema(name: str) -> LibrarySchema:
+    return LibrarySchema(
+        name=name,
+        library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+        metadata=LibraryMetadata(
+            author="test",
+            description="library that is mid-reload",
+            library_version="0.1.0",
+            engine_version="0.98.0",
+            tags=[],
+        ),
+        categories=[],
+        nodes=[],
+    )
+
+
+class TestQueriesDuringLibraryReload:
+    """GUI-facing library queries wait for the reload instead of failing hard."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_registry(self) -> Generator[None, None, None]:
+        LibraryRegistry._clear()
+        yield
+        LibraryRegistry._clear()
+
+    @staticmethod
+    def _enter_reload_window(griptape_nodes: GriptapeNodes) -> None:
+        """Put the manager in the state `_run_reload_libraries` creates mid-flight.
+
+        The registry has been emptied by the unload loop and `load_all_libraries_from_config`
+        has not finished re-registering, so the loading gate is closed.
+        """
+        library_manager = griptape_nodes.LibraryManager()
+        LibraryRegistry._clear()
+        library_manager._libraries_loading_complete = asyncio.Event()
+
+    @pytest.mark.asyncio
+    async def test_check_library_update_waits_for_the_reload(self, griptape_nodes: GriptapeNodes) -> None:
+        """An update check mid-reload waits instead of reporting the library missing."""
+        library_manager = griptape_nodes.LibraryManager()
+        LibraryRegistry.generate_new_library(library_data=_schema(LIBRARY_NAME))
+
+        # Before the reload the library answers normally: it is in the registry.
+        assert LIBRARY_NAME in set(LibraryRegistry.list_libraries())
+
+        self._enter_reload_window(griptape_nodes)
+
+        pending = asyncio.create_task(
+            library_manager.check_library_update_request(CheckLibraryUpdateRequest(library_name=LIBRARY_NAME))
+        )
+        await asyncio.sleep(0)
+        assert not pending.done(), "the update check should wait on the loading gate, not fail"
+
+        # The reload re-registers the library and reopens the gate.
+        LibraryRegistry.generate_new_library(library_data=_schema(LIBRARY_NAME))
+        library_manager._libraries_loading_complete.set()
+
+        result = await pending
+
+        # It no longer claims the library was never registered. (It still fails, because the
+        # temp library is not a git repo -- a different, honest reason.)
+        assert "no Library with that name was registered" not in str(result.result_details)
+
+    @pytest.mark.asyncio
+    async def test_both_get_all_info_entry_points_wait_on_the_gate(self, griptape_nodes: GriptapeNodes) -> None:
+        """The per-library and all-libraries entry points now agree about the reload window.
+
+        `get_all_info_for_library_request` stays synchronous and ungated because
+        `get_all_info_for_all_libraries_request` calls it directly once it has already
+        waited. The registered entry point is the async wrapper, which waits.
+        """
+        library_manager = griptape_nodes.LibraryManager()
+        LibraryRegistry.generate_new_library(library_data=_schema(LIBRARY_NAME))
+
+        self._enter_reload_window(griptape_nodes)
+
+        singular = asyncio.create_task(
+            library_manager.on_get_all_info_for_library_request(GetAllInfoForLibraryRequest(library=LIBRARY_NAME))
+        )
+        plural = asyncio.create_task(
+            library_manager.on_get_all_info_for_all_libraries_request(GetAllInfoForAllLibrariesRequest())
+        )
+        await asyncio.sleep(0)
+        assert not singular.done(), "the per-library handler is expected to wait on the loading gate"
+        assert not plural.done(), "the all-libraries handler is expected to wait on the loading gate"
+
+        # Finish the reload the way load_all_libraries_from_config does: re-register the
+        # library, then reopen the gate. Both queries then see the rebuilt registry.
+        LibraryRegistry.generate_new_library(library_data=_schema(LIBRARY_NAME))
+        library_manager._libraries_loading_complete.set()
+        singular_result = await singular
+        await plural
+
+        assert not isinstance(singular_result, GetAllInfoForLibraryResultFailure)
+
+    @pytest.mark.asyncio
+    async def test_reload_closes_the_gate_before_emptying_the_registry(self, griptape_nodes: GriptapeNodes) -> None:
+        """The gate must cover the whole reload, including the unload loop.
+
+        `_run_reload_libraries` empties the registry (ClearAllObjectState + the unload loop)
+        before `load_all_libraries_from_config` runs. If the gate only closed there, the
+        registry would already be empty while the gate still read "loaded", and a handler
+        awaiting it would sail through onto an empty registry. So the gate closes first.
+        """
+        library_manager = griptape_nodes.LibraryManager()
+        LibraryRegistry.generate_new_library(library_data=_schema(LIBRARY_NAME))
+
+        observed: dict[str, object] = {}
+
+        async def spy_load_all_libraries_from_config(*_args: object, **_kwargs: object) -> list[str]:
+            # Sampled at the moment reload hands off to the loading phase.
+            observed["gate_was_open"] = library_manager._libraries_loading_complete.is_set()
+            observed["registry_was_empty"] = set(LibraryRegistry.list_libraries()) == set()
+            return []
+
+        with (
+            patch.object(
+                library_manager, "load_all_libraries_from_config", side_effect=spy_load_all_libraries_from_config
+            ),
+            patch.object(library_manager, "_maybe_start_workers_for_existing_session", AsyncMock()),
+            patch.object(library_manager, "_await_pending_workers", AsyncMock()),
+        ):
+            await library_manager._run_reload_libraries(ReloadAllLibrariesRequest())
+
+        assert observed["registry_was_empty"] is True, "the unload loop should have emptied the registry"
+        assert observed["gate_was_open"] is False, (
+            "the gate must already be closed by the time the registry is empty, so queries "
+            "wait for the rebuild instead of seeing a registry with nothing in it"
+        )
+
+    @pytest.mark.asyncio
+    async def test_reload_reopens_the_gate_even_when_loading_raises(self, griptape_nodes: GriptapeNodes) -> None:
+        """A failed rebuild must not leave the gate closed forever.
+
+        Otherwise every gated query would hang for the life of the process.
+        """
+        library_manager = griptape_nodes.LibraryManager()
+        failure = RuntimeError("discovery blew up")
+
+        async def boom(*_args: object, **_kwargs: object) -> list[str]:
+            raise failure
+
+        with (
+            patch.object(library_manager, "_reconcile_libraries_from_config", side_effect=boom),
+            pytest.raises(RuntimeError, match="discovery blew up"),
+        ):
+            await library_manager.load_all_libraries_from_config()
+
+        assert library_manager._libraries_loading_complete.is_set()
+
+    @pytest.mark.asyncio
+    async def test_gated_handler_would_have_returned_the_right_answer(self, griptape_nodes: GriptapeNodes) -> None:
+        """Waiting is the correct behavior: the library is present once the reload ends.
+
+        This is what makes the failures above spurious rather than informative -- nothing
+        was actually wrong with the library.
+        """
+        library_manager = griptape_nodes.LibraryManager()
+        self._enter_reload_window(griptape_nodes)
+
+        pending = asyncio.create_task(
+            library_manager.on_get_all_info_for_all_libraries_request(GetAllInfoForAllLibrariesRequest())
+        )
+        await asyncio.sleep(0)
+        assert not pending.done()
+
+        # The reload re-registers the library, then opens the gate.
+        LibraryRegistry.generate_new_library(library_data=_schema(LIBRARY_NAME))
+        library_manager._libraries_loading_complete.set()
+
+        await pending
+        assert LIBRARY_NAME in set(LibraryRegistry.list_libraries())

--- a/tests/unit/retained_mode/managers/test_library_reload_query_race.py
+++ b/tests/unit/retained_mode/managers/test_library_reload_query_race.py
@@ -43,6 +43,8 @@ from griptape_nodes.retained_mode.events.library_events import (
     GetAllInfoForLibraryRequest,
     GetAllInfoForLibraryResultFailure,
     ReloadAllLibrariesRequest,
+    ReloadAllLibrariesResultFailure,
+    UnloadLibraryFromRegistryRequest,
 )
 
 if TYPE_CHECKING:
@@ -205,6 +207,35 @@ class TestQueriesDuringLibraryReload:
             await library_manager.load_all_libraries_from_config()
 
         assert library_manager._libraries_loading_complete.is_set()
+
+    @pytest.mark.asyncio
+    async def test_reload_reopens_the_gate_when_it_bails_before_loading(self, griptape_nodes: GriptapeNodes) -> None:
+        """A reload that fails between closing the gate and loading must not wedge queries.
+
+        The gate closes just before the unload loop, so an early return from that loop would
+        otherwise leave every gated query waiting for the life of the process.
+        """
+        library_manager = griptape_nodes.LibraryManager()
+        LibraryRegistry.generate_new_library(library_data=_schema(LIBRARY_NAME))
+
+        failed_unload = ReloadAllLibrariesResultFailure(result_details="unload failed")
+
+        def refuse_unload(request: object) -> object:
+            if isinstance(request, UnloadLibraryFromRegistryRequest):
+                return failed_unload
+            return griptape_nodes.handle_request(request)
+
+        with (
+            patch.object(library_manager, "load_all_libraries_from_config", AsyncMock(return_value=[])) as load_all,
+            patch.object(library_manager.engine, "handle_request", side_effect=refuse_unload),
+        ):
+            result = await library_manager._run_reload_libraries(ReloadAllLibrariesRequest())
+
+        assert isinstance(result, ReloadAllLibrariesResultFailure)
+        load_all.assert_not_called()
+        assert library_manager._libraries_loading_complete.is_set(), (
+            "a reload that bailed before loading must reopen the gate it closed"
+        )
 
     @pytest.mark.asyncio
     async def test_gated_handler_would_have_returned_the_right_answer(self, griptape_nodes: GriptapeNodes) -> None:


### PR DESCRIPTION
Stacked on #5395.

Reloading libraries is not atomic. `_run_reload_libraries` empties the registry (`ClearAllObjectState` plus an unload loop) and only then re-registers libraries one at a time. In a reported session that window was 29s wide, and the editor update sweep landed inside it:

```
ERROR  Attempted to get all library info for a Library named "Sendgrid Library".
       Failed because no Library with that name was registered.
ERROR  Attempted to check for updates for Library "Topaz Labs".
       Failed because no Library with that name was registered.
```

Every one of those libraries registered successfully seconds later, so the failures were purely an artifact of being asked mid-reload. This is the one symptom from that report that these changes close outright.

## Changes

**Gate the two handlers that produced the errors.** `check_library_update_request` and `GetAllInfoForLibraryRequest` now await `_libraries_loading_complete`, the gate that `on_list_registered_libraries_request`, `on_get_library_source_info_request` and `on_get_all_info_for_all_libraries_request` already waited on. The per-library request gets an async wrapper as its registered entry point, mirroring its all-libraries sibling two lines above it; the sync method stays ungated because the all-libraries handler calls it directly after waiting itself.

**Close the gate before the unload loop**, not inside `load_all_libraries_from_config`, so it covers the window where the registry is actually empty. Gating the handlers alone was not sufficient: a handler awaiting a gate that was still open would sail straight through onto an empty registry.

It cannot close any earlier than it now does. The reload enumerates registered libraries through a request whose handler waits on this same gate, so closing it at the top deadlocks the reload against itself. That deadlock showed up as a hung test run during development.

**Reopen the gate conditionally.** `load_all_libraries_from_config` reopens it in a `finally`. `_run_reload_libraries` also reopens it, but only if it is still closed — so a reload that bails between closing the gate and reaching the load cannot wedge every gated query, while a completing reload cannot force open a gate another rebuild is relying on.

## Known limitation

A single flag cannot describe two rebuilds at once, so overlapping reloads are unsupported: the second shares the Event and the first to finish reopens it. That predates this change and is now documented at the call site rather than fixed.

## Verification

Full unit suite: 4675 passed, 13 skipped. Lint, types, format, spell clean.
