### PR TITLE
Route heavy clusters through ExecuteClusterRequest in the DAG executor

### DIFF
--- a/src/griptape_nodes/common/execution_clusters.py
+++ b/src/griptape_nodes/common/execution_clusters.py
@@ -283,3 +283,48 @@ def _reachable(seeds: frozenset[str], adjacency: dict[str, list[str]]) -> set[st
                 seen.add(neighbor)
                 stack.append(neighbor)
     return seen
+
+
+def heavy_clusters_by_node(
+    nodes: list[Any],
+    connections: Any,
+) -> dict[str, ExecutionCluster]:
+    """Map node name -> the heavy cluster it belongs to, for a set of live nodes.
+
+    Derives dataflow edges from the engine's Connections indices (control edges are not
+    dataflow and are skipped), computes clusters, and returns only the ones that need a
+    dispatch: clusters with execution dependencies and more than zero members. Nodes in
+    light clusters are absent from the map, which is the executor's signal to run them
+    exactly as today.
+    """
+    # Deferred import: keeps the module importable without the exe_types tree.
+    from griptape_nodes.exe_types.core_types import ParameterTypeBuiltin
+
+    names = {node.name for node in nodes}
+    edges = []
+    for node in nodes:
+        outgoing = connections.outgoing_index.get(node.name, {})
+        for parameter_name, connection_ids in outgoing.items():
+            parameter = node.get_parameter_by_name(parameter_name)
+            if parameter is None or parameter.output_type == ParameterTypeBuiltin.CONTROL_TYPE.value:
+                continue
+            for connection_id in connection_ids:
+                connection = connections.connections.get(connection_id)
+                if connection is None or connection.target_node.name not in names:
+                    continue
+                edges.append(
+                    NodeGraphEdge(
+                        source_node_name=node.name,
+                        source_parameter=parameter_name,
+                        target_node_name=connection.target_node.name,
+                        target_parameter=connection.target_parameter.name,
+                    )
+                )
+
+    by_node: dict[str, ExecutionCluster] = {}
+    for cluster in clusters_for_nodes(list(nodes), edges):
+        if cluster.runs_in_orchestrator:
+            continue
+        for member in cluster.node_names:
+            by_node[member] = cluster
+    return by_node

--- a/src/griptape_nodes/common/node_executor.py
+++ b/src/griptape_nodes/common/node_executor.py
@@ -50,10 +50,14 @@ from griptape_nodes.retained_mode.events.connection_events import (
     ListConnectionsForNodeResultSuccess,
 )
 from griptape_nodes.retained_mode.events.execution_events import (
+    ClusterEdgeSpec,
+    ClusterNodeSpec,
     ControlFlowCancelledEvent,
     ControlFlowResolvedEvent,
     CurrentControlNodeEvent,
     CurrentDataNodeEvent,
+    ExecuteClusterRequest,
+    ExecuteClusterResultSuccess,
     ExecuteNodeRequest,
     ExecuteNodeResultSuccess,
     GriptapeEvent,
@@ -122,6 +126,7 @@ from griptape_nodes.retained_mode.variable_types import VariableScope
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from griptape_nodes.common.execution_clusters import ExecutionCluster
     from griptape_nodes.retained_mode.events.node_events import SerializedNodeCommands
     from griptape_nodes.retained_mode.managers.event_manager import EventManager
     from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
@@ -226,15 +231,31 @@ class NodeExecutor(EngineScoped):
         msg = f"Could not find PublishWorkflowRequest handler for library {library_name}"
         raise ValueError(msg)
 
-    async def execute(self, node: BaseNode) -> None:
+    async def execute(  # noqa: C901, PLR0911 (a dispatch ladder: each node kind exits on its own branch)
+        self,
+        node: BaseNode,
+        cluster: ExecutionCluster | None = None,
+        cluster_executed: set[str] | None = None,
+    ) -> None:
         """Execute the given node.
 
         Args:
             node: The BaseNode to execute
-            library_name: The library that the execute method should come from.
+            cluster: The heavy execution cluster this node belongs to, if any. The first
+                member to execute dispatches the whole cluster in one request; the rest
+                are no-ops whose outputs were already applied.
+            cluster_executed: Run-scoped set of node names already executed via a cluster
+                dispatch. Owned by the resolution context; mutated here.
         """
+        if cluster_executed is not None and node.name in cluster_executed:
+            # This member already ran inside its cluster's dispatch; its outputs are
+            # already on the node. Completing without re-executing is the contract.
+            return
         token = current_executing_node_name.set(node.name)
         try:
+            if cluster is not None and not cluster.runs_in_orchestrator:
+                await self._execute_cluster(node, cluster, cluster_executed if cluster_executed is not None else set())
+                return
             # Handle while-loop node groups (RetryGroup, etc.)
             # Check this BEFORE SubflowNodeGroup since BaseWhileNodeGroup extends SubflowNodeGroup
             if isinstance(node, BaseWhileNodeGroup):
@@ -297,6 +318,84 @@ class NodeExecutor(EngineScoped):
                 node.parameter_output_values[name] = value
         finally:
             current_executing_node_name.reset(token)
+
+    async def _execute_cluster(self, node: BaseNode, cluster: ExecutionCluster, cluster_executed: set[str]) -> None:
+        """Dispatch a heavy cluster as one ExecuteClusterRequest and apply all outputs.
+
+        Nodes joined by unserializable values must run in one process, so the whole
+        cluster goes as one request; intra-cluster values are handed off inside the
+        executing process as live references. Restricted to single-library clusters until
+        venues are keyed on dependency sets: a multi-library live-value chain fails here,
+        loudly, naming the libraries.
+        """
+        object_manager = self.engine.object_manager
+        members: list[BaseNode] = []
+        for member_name in sorted(cluster.node_names):
+            member = object_manager.attempt_get_object_by_name_as_type(member_name, BaseNode)
+            if member is None:
+                msg = f"Attempted to execute a node cluster, but member '{member_name}' no longer exists."
+                raise RuntimeError(msg)
+            members.append(member)
+
+        libraries = {str(member.metadata.get("library", "")) for member in members}
+        if len(libraries) > 1:
+            msg = (
+                f"Attempted to execute nodes {sorted(cluster.node_names)} together because a value "
+                f"that cannot leave its process connects them, but they come from different "
+                f"libraries ({sorted(libraries)}). Running two libraries' nodes in one isolated "
+                f"process is not supported yet: split the chain so the value stays within one library."
+            )
+            raise RuntimeError(msg)
+
+        result = await self.engine.ahandle_request(
+            ExecuteClusterRequest(
+                nodes=[
+                    ClusterNodeSpec(
+                        node_name=member.name,
+                        node_type=str(member.metadata.get("node_type", type(member).__name__)),
+                        library_name=str(member.metadata.get("library", "")),
+                        parameter_values=dict(member.parameter_values),
+                        node_metadata=dict(member.metadata),
+                    )
+                    for member in members
+                ],
+                edges=self._intra_cluster_edges(cluster, members),
+                output_nodes=[member.name for member in members],
+                variables=self._resolve_variables_for_node(node.name),
+            )
+        )
+        if not isinstance(result, ExecuteClusterResultSuccess):
+            failed = getattr(result, "failed_node", None) or node.name
+            msg = self._format_node_failure_message(failed, result, getattr(result, "exception", None))
+            raise RuntimeError(msg)  # noqa: TRY004 (failure result, not a type error; matches the single-node path)
+
+        # Apply every member's outputs with the same idempotent copy-back discipline as
+        # the single-node path (see the comment in execute()).
+        for member in members:
+            for name, value in result.parameter_output_values.get(member.name, {}).items():
+                member.parameter_output_values[name] = value
+            cluster_executed.add(member.name)
+
+    def _intra_cluster_edges(self, cluster: ExecutionCluster, members: list[BaseNode]) -> list[ClusterEdgeSpec]:
+        """Dataflow edges between cluster members, from the live connection indices."""
+        connections = self.engine.flow_manager.get_connections()
+        edges = []
+        for member in members:
+            outgoing = connections.outgoing_index.get(member.name, {})
+            for parameter_name, connection_ids in outgoing.items():
+                for connection_id in connection_ids:
+                    connection = connections.connections.get(connection_id)
+                    if connection is None or connection.target_node.name not in cluster.node_names:
+                        continue
+                    edges.append(
+                        ClusterEdgeSpec(
+                            source_node=member.name,
+                            source_parameter=parameter_name,
+                            target_node=connection.target_node.name,
+                            target_parameter=connection.target_parameter.name,
+                        )
+                    )
+        return edges
 
     def _resolve_variables_for_node(self, node_name: str) -> dict[str, str | int]:
         """Resolve the variable dict for a node's flow on the orchestrator.

--- a/src/griptape_nodes/machines/parallel_resolution.py
+++ b/src/griptape_nodes/machines/parallel_resolution.py
@@ -5,6 +5,7 @@ import contextlib
 import logging
 from typing import TYPE_CHECKING, NamedTuple
 
+from griptape_nodes.common.execution_clusters import ExecutionCluster, heavy_clusters_by_node
 from griptape_nodes.exe_types.base_iterative_nodes import BaseIterativeEndNode, BaseIterativeStartNode
 from griptape_nodes.exe_types.connections import Direction
 from griptape_nodes.exe_types.core_types import Parameter, ParameterTypeBuiltin
@@ -97,6 +98,13 @@ class ParallelResolutionContext(EngineScoped):
         self.task_to_node = {}
         self.generation = 0
         self.new_work_event = asyncio.Event()
+        # Heavy execution clusters (nodes pinned together by unserializable values whose
+        # libraries declare execution dependencies). Computed once when DAG execution
+        # starts; nodes absent from the map run exactly as they always have.
+        self.heavy_cluster_by_node: dict[str, ExecutionCluster] = {}
+        # Members already executed via a cluster dispatch this run: their outputs are
+        # applied, so their own execution is a no-op completion.
+        self.cluster_executed_nodes: set[str] = set()
 
     @property
     def node_to_reference(self) -> dict[str, DagNode]:
@@ -544,12 +552,49 @@ class ExecuteDagState(State):
                 ExecuteDagState._try_queue_waiting_node(context, leaf_node)
 
     @staticmethod
-    async def execute_node(engine: Engine, current_node: DagNode) -> None:
+    async def execute_node(engine: Engine, current_node: DagNode, context: ParallelResolutionContext) -> None:
         executor = engine.flow_manager.node_executor
-        await executor.execute(current_node.node_reference)
+        await executor.execute(
+            current_node.node_reference,
+            cluster=context.heavy_cluster_by_node.get(current_node.node_reference.name),
+            cluster_executed=context.cluster_executed_nodes,
+        )
+
+    @staticmethod
+    def _compute_heavy_clusters(context: ParallelResolutionContext) -> None:
+        """Compute the run's heavy clusters from the completed DAG."""
+        nodes = [dag_node.node_reference for dag_node in context.node_to_reference.values()]
+        connections = context.engine.flow_manager.get_connections()
+        context.heavy_cluster_by_node = heavy_clusters_by_node(nodes, connections)
+        context.cluster_executed_nodes = set()
+
+    @staticmethod
+    def _cluster_is_dispatchable(context: ParallelResolutionContext, cluster: ExecutionCluster) -> bool:
+        """True when every member's EXTERNAL dataflow inputs are resolved.
+
+        A cluster executes atomically, so it cannot start until every value entering it
+        from outside exists. Intra-cluster sources are exempt: those values are produced
+        by the dispatch itself.
+        """
+        connections = context.engine.flow_manager.get_connections()
+        for member_name in cluster.node_names:
+            incoming = connections.incoming_index.get(member_name, {})
+            for connection_ids in incoming.values():
+                for connection_id in connection_ids:
+                    connection = connections.connections.get(connection_id)
+                    if connection is None:
+                        continue
+                    source_name = connection.source_node.name
+                    if source_name in cluster.node_names:
+                        continue
+                    source_dag_node = context.node_to_reference.get(source_name)
+                    if source_dag_node is not None and source_dag_node.node_state != NodeState.DONE:
+                        return False
+        return True
 
     @staticmethod
     async def on_enter(context: ParallelResolutionContext) -> type[State] | None:
+        ExecuteDagState._compute_heavy_clusters(context)
         # Start DAG execution after resolution is complete
         for node in context.node_to_reference.values():
             # Only queue nodes that are waiting - preserve state of already processed nodes.
@@ -614,6 +659,23 @@ class ExecuteDagState(State):
                 context.running_tasks_count -= 1  # Decrement since we're skipping
                 continue
 
+            # A member of a heavy cluster cannot start until the WHOLE cluster can: it
+            # executes atomically with its co-members, so every value entering the
+            # cluster from outside must exist first. Requeue and stop this drain pass;
+            # the completion that resolves the missing input signals new work and the
+            # drain runs again. (Never parks a task: with max_nodes_in_parallel slots,
+            # parking cluster sources could starve the very externals they wait for.)
+            gating_cluster = context.heavy_cluster_by_node.get(node)
+            if (
+                gating_cluster is not None
+                and node not in context.cluster_executed_nodes
+                and not ExecuteDagState._cluster_is_dispatchable(context, gating_cluster)
+            ):
+                context.running_tasks_count -= 1
+                node_reference.node_state = NodeState.QUEUED
+                context.node_priority_queue.add_node(node_reference)
+                break
+
             # Collect parameter values from upstream nodes before executing
             try:
                 await ExecuteDagState.collect_values_from_upstream_nodes(context.engine, node_reference)
@@ -643,9 +705,16 @@ class ExecuteDagState(State):
                 return None
 
             # Clear all of the current output values but don't broadcast the clearing.
-            # to avoid any flickering in subscribers (UI).
-            node_reference.node_reference.parameter_output_values.silent_clear()
-            exceptions = node_reference.node_reference.validate_before_node_run()
+            # to avoid any flickering in subscribers (UI). Members already executed by a
+            # cluster dispatch keep their applied outputs: their task below is a no-op
+            # completion, and clearing here would wipe the dispatch's results.
+            if node not in context.cluster_executed_nodes:
+                node_reference.node_reference.parameter_output_values.silent_clear()
+            exceptions = (
+                []
+                if node in context.cluster_executed_nodes
+                else node_reference.node_reference.validate_before_node_run()
+            )
             if exceptions:
                 context.running_tasks_count -= 1  # Decrement on error
                 validation_node_name = node_reference.node_reference.name
@@ -710,7 +779,7 @@ class ExecuteDagState(State):
             node_reference.node_state = NodeState.PROCESSING
             node_reference.node_reference.state = NodeResolutionState.RESOLVING
 
-            node_task = asyncio.create_task(ExecuteDagState.execute_node(context.engine, node_reference))
+            node_task = asyncio.create_task(ExecuteDagState.execute_node(context.engine, node_reference, context))
             context.task_to_node[node_task] = node_reference
             node_reference.task_reference = node_task
 

--- a/tests/e2e/test_cluster_flow_dispatch.py
+++ b/tests/e2e/test_cluster_flow_dispatch.py
@@ -1,0 +1,156 @@
+"""End-to-end test: a real flow run dispatches a heavy cluster as one request.
+
+This is the keystone proof for venue execution. A library that declares execution
+dependencies has two nodes joined by a serializable=False value (a live Session). Running
+the flow through the REAL machinery (CreateFlow/CreateNode/CreateConnection/StartFlow, the
+DAG builder, the parallel resolution machine) must:
+
+- compute the two nodes into one heavy cluster,
+- gate the cluster until its external inputs are resolved (trivially true here),
+- dispatch it as exactly ONE ExecuteClusterRequest,
+- hand the live Session across the intra-cluster edge without serialization,
+- apply outputs back onto the orchestrator's real nodes, and
+- complete the second member as a no-op so both end RESOLVED.
+
+A light library running the same shape must dispatch ZERO cluster requests: the gate is
+inert for everything that has no execution dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+import griptape_nodes.retained_mode.managers.node_manager as node_manager_module
+from griptape_nodes.exe_types.node_types import NodeResolutionState
+from griptape_nodes.node_library.library_registry import LibrarySchema
+from griptape_nodes.retained_mode.events.execution_events import (
+    ExecuteClusterRequest,
+    StartFlowRequest,
+    StartFlowResultSuccess,
+)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.utils.version_utils import engine_version
+from tests.e2e.offline_wheels import build_wheel, offline_install_flags
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from griptape_nodes.retained_mode.events.base_events import ResultPayload
+    from griptape_nodes.retained_mode.managers.event_manager import EventManager
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "nonserializable_library"
+EXPECTED_MARKER = "live-session-marker"
+
+
+@pytest.fixture
+def cluster_dispatches(monkeypatch: pytest.MonkeyPatch) -> list[ExecuteClusterRequest]:
+    """Count ExecuteClusterRequest dispatches by wrapping the handler's core."""
+    dispatched: list[ExecuteClusterRequest] = []
+    original = node_manager_module.execute_cluster
+
+    async def counting(request: ExecuteClusterRequest, event_manager: EventManager) -> ResultPayload:
+        dispatched.append(request)
+        return await original(request, event_manager)
+
+    monkeypatch.setattr(node_manager_module, "execute_cluster", counting)
+    return dispatched
+
+
+def _register_library(tmp_path: Path, *, name: str, heavy: bool) -> None:
+    """Register the producer/consumer fixture, optionally declaring execution deps."""
+    library_dir = tmp_path / name.replace(" ", "_")
+    library_dir.mkdir()
+    schema = json.loads((FIXTURE_DIR / "griptape_nodes_library.json").read_text())
+    schema["name"] = name
+    schema["library_schema_version"] = LibrarySchema.LATEST_SCHEMA_VERSION
+    schema["metadata"]["engine_version"] = engine_version
+    if heavy:
+        wheel_dir = tmp_path / "wheels"
+        build_wheel(wheel_dir, "fakeexec", "2.0.0")
+        schema["metadata"]["dependencies"] = {
+            "pip_dependencies": [],
+            "pip_dependencies_exec": ["fakeexec"],
+            "pip_install_flags": offline_install_flags(wheel_dir),
+        }
+    library_json = library_dir / "griptape_nodes_library.json"
+    library_json.write_text(json.dumps(schema, indent=2))
+    shutil.copy(FIXTURE_DIR / "nonserializable_nodes.py", library_dir / "nonserializable_nodes.py")
+    result = GriptapeNodes.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    assert isinstance(result, RegisterLibraryFromFileResultSuccess), getattr(result, "result_details", result)
+
+
+async def _run_producer_consumer_flow(
+    library_name: str,
+    create_node: Callable[..., str],
+    connect: Callable[..., None],
+) -> None:
+    GriptapeNodes.ContextManager().push_workflow(workflow_name=f"wf_{library_name}")
+    flow_result = GriptapeNodes.handle_request(
+        CreateFlowRequest(parent_flow_name=None, flow_name="ClusterFlow", set_as_new_context=False)
+    )
+    assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
+
+    create_node("ProducerNode", "Producer", flow_result.flow_name, library_name=library_name)
+    create_node("ConsumerNode", "Consumer", flow_result.flow_name, library_name=library_name)
+    connect("Producer", "session", "Consumer", "session")
+
+    run_result = await GriptapeNodes.ahandle_request(
+        StartFlowRequest(
+            flow_name=flow_result.flow_name,
+            flow_node_name="Consumer",
+            wait_for_completion=True,
+            completion_timeout_ms=30_000,
+        )
+    )
+    assert isinstance(run_result, StartFlowResultSuccess), getattr(run_result, "result_details", run_result)
+
+
+class TestHeavyClusterFlowDispatch:
+    @pytest.mark.asyncio
+    async def test_flow_run_dispatches_the_cluster_once_and_resolves_all_members(
+        self,
+        tmp_path: Path,
+        create_node: Callable[..., str],
+        connect: Callable[..., None],
+        cluster_dispatches: list[ExecuteClusterRequest],
+    ) -> None:
+        _register_library(tmp_path, name="Heavy Cluster Library", heavy=True)
+
+        await _run_producer_consumer_flow("Heavy Cluster Library", create_node, connect)
+
+        assert len(cluster_dispatches) == 1, "the producer/consumer pair must dispatch as ONE cluster"
+        node_manager = GriptapeNodes.NodeManager()
+        producer = node_manager.get_node_by_name("Producer")
+        consumer = node_manager.get_node_by_name("Consumer")
+        assert producer.state == NodeResolutionState.RESOLVED
+        assert consumer.state == NodeResolutionState.RESOLVED
+        # The live value crossed inside the dispatch; the derived string landed back on
+        # the orchestrator's real node.
+        assert consumer.parameter_output_values.get("marker") == EXPECTED_MARKER
+
+    @pytest.mark.asyncio
+    async def test_light_library_never_dispatches_a_cluster(
+        self,
+        tmp_path: Path,
+        create_node: Callable[..., str],
+        connect: Callable[..., None],
+        cluster_dispatches: list[ExecuteClusterRequest],
+    ) -> None:
+        """The same graph shape without execution deps runs exactly as it always has."""
+        _register_library(tmp_path, name="Light Cluster Library", heavy=False)
+
+        await _run_producer_consumer_flow("Light Cluster Library", create_node, connect)
+
+        assert len(cluster_dispatches) == 0
+        consumer = GriptapeNodes.NodeManager().get_node_by_name("Consumer")
+        assert consumer.parameter_output_values.get("marker") == EXPECTED_MARKER

--- a/tests/unit/machines/conftest.py
+++ b/tests/unit/machines/conftest.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -12,6 +12,16 @@ from griptape_nodes.machines.parallel_resolution import ExecuteDagState
 
 if TYPE_CHECKING:
     from griptape_nodes.machines.dag_builder import DagNode
+
+
+@pytest.fixture(autouse=True)
+def _no_cluster_derivation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub cluster derivation for every scheduler test.
+
+    It reads real node metadata and connections, which these tests stub out; they care
+    about who drives the machine and when nodes dispatch, never about placement.
+    """
+    monkeypatch.setattr(ExecuteDagState, "_compute_heavy_clusters", MagicMock())
 
 
 @pytest.fixture
@@ -28,7 +38,7 @@ def held_node_execution(monkeypatch: pytest.MonkeyPatch) -> asyncio.Event:
 
     hold = asyncio.Event()
 
-    async def _hold_until_released(_engine: object, _dag_node: DagNode) -> None:
+    async def _hold_until_released(_engine: object, _dag_node: DagNode, _context: object = None) -> None:
         await hold.wait()
 
     monkeypatch.setattr(ExecuteDagState, "execute_node", _hold_until_released)

--- a/tests/unit/machines/test_parallel_resolution_single_driver.py
+++ b/tests/unit/machines/test_parallel_resolution_single_driver.py
@@ -64,6 +64,7 @@ def _stub_handle_done_nodes(monkeypatch: pytest.MonkeyPatch) -> None:
     Stub it so these stay focused scheduler tests; they only care about who is
     allowed to drive the machine, not what happens after a node finishes.
     """
+    monkeypatch.setattr(ExecuteDagState, "_compute_heavy_clusters", MagicMock())
     monkeypatch.setattr(ExecuteDagState, "handle_done_nodes", AsyncMock())
 
 


### PR DESCRIPTION
Sixth PR in the venue-execution stack (design: `venue-execution-plan.md`). **Stacked on #5394** — review only the last commit.

## What

The keystone: a real flow run now executes heavy clusters through the venue wire.

- **Cluster map at resolution start**: `ExecuteDagState.on_enter` computes heavy clusters from the completed DAG via the #5394 adapter. Nodes in light clusters never enter the map — everything without execution deps runs exactly as it always has.
- **Gate at the queue-pull site**: a heavy-cluster member cannot start until every value entering the cluster from outside exists (it executes atomically with its co-members). The gate **requeues rather than parks**: with `max_nodes_in_parallel` slots (default 5), parking cluster sources could starve the very externals they wait for.
- **One dispatch, no-op members**: the first member through the gate dispatches the whole cluster as one `ExecuteClusterRequest` (#5393); outputs land on all members' real orchestrator nodes via the existing idempotent copy-back discipline; remaining members flow through the machine normally as instant no-op completions. Members already executed skip `silent_clear`/validation, since clearing would wipe the dispatch's outputs.
- **Single-library v1**: a multi-library live-value chain fails loudly naming both libraries and the remedy (split the chain), per design.

## Testing

The keystone e2e runs a REAL flow (CreateFlow/CreateNode/CreateConnection/StartFlow through the DAG builder and resolution machine) against a fixture library with a `serializable=False` producer→consumer edge and declared exec deps:

- exactly ONE cluster dispatch (counted by wrapping the handler core)
- the live Session crosses inside the dispatch; the derived string lands on the orchestrator's real consumer node; both members end RESOLVED
- the identical graph through a **light** library dispatches ZERO clusters — the gate is provably inert for existing workflows

Scheduler unit tests stub cluster derivation via an autouse fixture in the machines conftest, consistent with their existing stubs.

Full gate: 4681 unit / 58 e2e / 9 integration passed, `make check` clean.

## Known limitation (deliberate, next in stack)

In-process dispatch executes the cluster via the local handler (transient nodes). Worker routing — heavy clusters to a worker process only, hard failure when none — lands next, alongside dummy managers.