### PR TITLE
fix: do not resume a session another live engine is serving

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/session_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/session_manager.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
@@ -47,6 +48,12 @@ class SessionData(BaseModel):
     engine_id: str | None = None
     started_at: str
     last_updated: str
+    # PID of the engine process that claimed this session. Used at boot to tell a session
+    # left behind by a process that has since exited (safe to resume) from one another
+    # running engine is still serving (must not be resumed -- see
+    # `_get_or_initialize_active_session`). None on records written before this field
+    # existed, which are treated as unowned.
+    owner_pid: int | None = None
 
 
 class SessionsStorage(BaseModel):
@@ -120,6 +127,7 @@ class SessionManager:
             engine_id=engine_id,
             started_at=datetime.now(tz=UTC).isoformat(),
             last_updated=datetime.now(tz=UTC).isoformat(),
+            owner_pid=os.getpid(),
         )
 
         # Add or update the session
@@ -181,22 +189,59 @@ class SessionManager:
     def _get_or_initialize_active_session(self) -> str | None:
         """Get or initialize the active session ID.
 
-        Falls back to first available session if no active session is set.
+        Resumes the first saved session that no live engine is already serving. Returns
+        None when there is nothing safe to resume, which makes the next
+        AppStartSessionRequest mint a fresh session id.
+
+        Engine identity is itself re-adopted from disk (`engines.json` default_engine_id),
+        so two engines started on one machine land on the same `sessions.json`. Resuming
+        blindly meant both subscribed to `sessions/<id>/request` and BOTH serviced every
+        client request -- harmless for a read, but requests with side effects ran twice,
+        which is how one click on a library's "Open" button produced two file browsers.
 
         Returns:
-            str | None: The active session ID or None if no sessions exist
+            str | None: The session ID to resume, or None if none can be resumed
         """
-        # Fall back to first session if available
-        if self._sessions_data.sessions:
-            first_session = self._sessions_data.sessions[0]
+        for session in self._sessions_data.sessions:
+            if self._is_session_owned_by_live_process(session):
+                logger.info(
+                    "Not resuming session %s: it is still owned by running engine process %s. "
+                    "A new session will be created instead so both engines do not serve the same session.",
+                    session.session_id,
+                    session.owner_pid,
+                )
+                continue
             logger.debug(
-                "Initialized active session to first saved session: %s for engine: %s",
-                first_session.session_id,
-                first_session.engine_id,
+                "Initialized active session to saved session: %s for engine: %s",
+                session.session_id,
+                session.engine_id,
             )
-            return first_session.session_id
+            return session.session_id
 
         return None
+
+    def _is_session_owned_by_live_process(self, session: SessionData) -> bool:
+        """Whether another running process is still serving this session.
+
+        Records written before `owner_pid` existed, and records this very process wrote,
+        both count as unowned: the former carry no ownership information, and the latter
+        are this engine resuming its own session.
+        """
+        owner_pid = session.owner_pid
+        if owner_pid is None or owner_pid == os.getpid():
+            return False
+        try:
+            # Signal 0 performs the permission/existence check without delivering a signal.
+            os.kill(owner_pid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            # The PID is live but owned by another user, so it is not one of our engines.
+            return False
+        except OSError:
+            # Cannot determine liveness; assume free rather than stranding the session.
+            return False
+        return True
 
     def _add_or_update_session(self, session_data: SessionData) -> None:
         """Add or update a session in the sessions data structure.

--- a/tests/unit/retained_mode/managers/test_session_manager_ownership.py
+++ b/tests/unit/retained_mode/managers/test_session_manager_ownership.py
@@ -1,0 +1,119 @@
+"""Tests for session resume ownership.
+
+Engine identity is re-adopted from disk (`engines.json` default_engine_id), so two engines
+started on one machine resolve to the same `engines/<engine_id>/sessions.json`. Resuming the
+saved session unconditionally meant both processes subscribed to `sessions/<id>/request` and
+BOTH serviced every client request. Reads were merely duplicated; requests with side effects
+ran twice, which is how a single click on a library's "Open" button opened two file browsers,
+both resolving the older engine's library path.
+
+A session now records the PID that claimed it, and boot skips any session another live
+process is still serving.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from griptape_nodes.retained_mode.managers import session_manager as session_manager_module
+from griptape_nodes.retained_mode.managers.session_manager import SessionManager
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+SESSION_ID = "b06cea3a68bd4a0ca4fa6e9d205fed46"
+ENGINE_ID = "engine-under-test"
+OTHER_PID = 999_001
+
+
+def _write_sessions(state_home: Path, *, owner_pid: int | None) -> None:
+    """Persist one saved session, optionally stamped with an owning PID."""
+    session: dict[str, object] = {
+        "session_id": SESSION_ID,
+        "engine_id": ENGINE_ID,
+        "started_at": "2026-08-28T14:19:33+00:00",
+        "last_updated": "2026-08-28T14:19:33+00:00",
+    }
+    if owner_pid is not None:
+        session["owner_pid"] = owner_pid
+    sessions_dir = state_home / "griptape_nodes" / "engines" / ENGINE_ID
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    (sessions_dir / "sessions.json").write_text(json.dumps({"sessions": [session]}), encoding="utf-8")
+
+
+@pytest.fixture
+def state_home(tmp_path: Path) -> Path:
+    """Point the manager's XDG state lookup at a temp dir."""
+    return tmp_path / "state"
+
+
+def _build_manager(state_home: Path) -> SessionManager:
+    identity = MagicMock()
+    identity.active_engine_id = ENGINE_ID
+    with patch.object(session_manager_module, "xdg_state_home", return_value=state_home):
+        return SessionManager(identity)
+
+
+class TestSessionResumeOwnership:
+    def test_resumes_a_session_with_no_recorded_owner(self, state_home: Path) -> None:
+        """Records written before owner_pid existed carry no ownership info, so they resume."""
+        _write_sessions(state_home, owner_pid=None)
+
+        manager = _build_manager(state_home)
+
+        assert manager.active_session_id == SESSION_ID
+
+    def test_resumes_a_session_this_process_owns(self, state_home: Path) -> None:
+        """An engine resuming its own session across a reconnect is the normal case."""
+        _write_sessions(state_home, owner_pid=session_manager_module.os.getpid())
+
+        manager = _build_manager(state_home)
+
+        assert manager.active_session_id == SESSION_ID
+
+    def test_resumes_a_session_whose_owner_has_exited(self, state_home: Path) -> None:
+        """The reattach-after-restart case: the previous engine is gone, so resume is safe."""
+        _write_sessions(state_home, owner_pid=OTHER_PID)
+
+        with patch.object(session_manager_module.os, "kill", side_effect=ProcessLookupError):
+            manager = _build_manager(state_home)
+
+        assert manager.active_session_id == SESSION_ID
+
+    def test_does_not_resume_a_session_a_live_process_still_owns(self, state_home: Path) -> None:
+        """The reported failure: a second engine must not join a session already being served.
+
+        Returning None here makes the next AppStartSessionRequest mint a fresh id, so the two
+        engines never share a request topic and side-effecting requests run once.
+        """
+        _write_sessions(state_home, owner_pid=OTHER_PID)
+
+        with patch.object(session_manager_module.os, "kill", return_value=None):
+            manager = _build_manager(state_home)
+
+        assert manager.active_session_id is None
+
+    def test_a_pid_owned_by_another_user_is_not_one_of_our_engines(self, state_home: Path) -> None:
+        """PID reuse by an unrelated process must not strand the session forever."""
+        _write_sessions(state_home, owner_pid=OTHER_PID)
+
+        with patch.object(session_manager_module.os, "kill", side_effect=PermissionError):
+            manager = _build_manager(state_home)
+
+        assert manager.active_session_id == SESSION_ID
+
+    def test_saving_a_session_stamps_the_owning_pid(self, state_home: Path) -> None:
+        """Without the stamp the next engine cannot tell an orphan from a live session."""
+        manager = _build_manager(state_home)
+
+        with patch.object(session_manager_module, "xdg_state_home", return_value=state_home):
+            manager.save_session(SESSION_ID)
+
+        saved = json.loads(
+            (state_home / "griptape_nodes" / "engines" / ENGINE_ID / "sessions.json").read_text(encoding="utf-8")
+        )
+        assert saved["sessions"][0]["owner_pid"] == session_manager_module.os.getpid()


### PR DESCRIPTION
Explains the "Open button opens 2 file browsers" symptom from a reported session.

## Cause

Engine identity is re-adopted from disk: `_get_or_initialize_engine_data` takes `engines.json`'s `default_engine_id` unless `GTN_ENGINE_ID` is set. Two engines started on one machine therefore resolve to the **same** `engines/<engine_id>/sessions.json`, and `_get_or_initialize_active_session` resumed `sessions[0]` unconditionally.

So both processes ended up subscribed to `sessions/<id>/request`, and **both serviced every client request**. Duplicated reads were invisible. Requests with side effects ran twice:

- One click on a library's **Open** button → one `OpenAssociatedFileRequest` → two engines each run `xdg-open` → **two file browsers**.
- Both windows showed the *previous install's* directory: the older engine resolved its own library path, and the newer engine was handed a path from row data that was itself stale.

The engine handler is not at fault — it runs `xdg-open` exactly once per request. Nothing in the GUI sends twice either; `createEvent` publishes a single message and the parent bridge's message listener is correctly torn down. The duplication is entirely in who was listening.

## Change

`SessionData` records the PID that claimed the session. Boot skips any session whose owner process is still running and returns `None`, so the next `AppStartSessionRequest` mints a fresh id and the two engines never share a request topic.

Deliberately permissive in the ambiguous cases, so a session is never stranded:

| Recorded owner | Treated as |
|---|---|
| absent (records predating this field) | unowned → resume |
| this process | unowned → resume |
| a PID that has exited | unowned → resume (this is reattach-after-restart) |
| a PID owned by another user | not one of our engines → resume |
| a live PID | **owned → do not resume** |

## Not covered

This stops two engines from serving one session. It does not stop two engines from *running* — that is the user's choice — and it does not address the stale library/config state those sessions were showing, which is tracked in #5405.

## Verification

Full unit suite passes. Lint, types, format, spell clean. Six new tests cover each row of the table above plus the PID stamp on save.

