### PR TITLE
fix: stop config writes copying other layers' list entries into the user config

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -115,6 +115,8 @@ class ConfigManager(EngineScoped):
         self._workspace_config_path: Path | None = None
         self._workspace_dir_override: str | None = None
         self._libraries_root_override: str | None = None
+        # Rebuilt by every load_configs(); declared here so the first load has it defined.
+        self._layers_without_user_snapshot: dict = {}
         self.load_configs()
 
         # Once per engine process, before any project YAML is read. See the method docstring for why
@@ -398,6 +400,56 @@ class ConfigManager(EngineScoped):
             logger.error("Error parsing %s config file: %s", label, e)
             return {}
 
+    def _merge_config_layers(self, *, include_user_layer: bool) -> dict:
+        """Merge the already-loaded layers in precedence order (later entries win).
+
+        The single source of truth for layer ordering, so `load_configs` and the
+        user-owned-write calculation in `set_config_value` can never disagree about
+        precedence. Operates purely on the loaded layer dicts and does no file I/O.
+
+        `include_user_layer=False` yields what every layer OTHER than the user's supplies,
+        which is what tells a write whether a value is the user's own contribution or
+        something a project handed them.
+        """
+        merged = merge_dicts({}, self.default_config)
+        if include_user_layer:
+            merged = merge_dicts(merged, self.user_config)
+        merged = merge_dicts(merged, self.project_config)
+        merged = merge_dicts(merged, self.workspace_config)
+        # Runtime workspace override (from ProjectManager's project_workspaces lookup or
+        # auto-default-to-project-dir). Sits above config files but below env vars.
+        if self._workspace_dir_override is not None:
+            merged = merge_dicts(merged, {"workspace_directory": self._workspace_dir_override})
+        return merge_dicts(merged, self.env_config)
+
+    def _user_owned_write_value(self, key: str, value: Any) -> Any:
+        """Strip list entries another layer already supplies, so they are not persisted.
+
+        The editor renders the MERGED config, so a write to a list-valued key hands back
+        the whole merged list. Persisting that verbatim copies entries owned by the project
+        or workspace layer into the user config file, where they outlive the project that
+        supplied them and resurface any time no project layer is loaded to shadow them.
+        That is how a user config ends up registering libraries from a project they no
+        longer have open.
+
+        Non-list values pass through unchanged. For a scalar the merged value IS the user's
+        intent, and a scalar the project also defines is a separate problem: the write
+        persists but the higher layer keeps winning, so the edit looks ignored.
+
+        Reads the snapshot taken at load time rather than recomputing from the live layers.
+        `get_config_value` returns references straight into those layers, and the
+        read-modify-write callers (a library download appending its clone path, for one)
+        mutate the returned list in place. By the time this runs, the live layer dicts can
+        already contain the very entry being added, which would make it look like something
+        another layer supplied and drop it.
+        """
+        if not isinstance(value, list):
+            return value
+        supplied_elsewhere = get_dot_value(self._layers_without_user_snapshot, key, None)
+        if not isinstance(supplied_elsewhere, list):
+            return value
+        return [entry for entry in value if entry not in supplied_elsewhere]
+
     def load_configs(self) -> None:
         """Load and merge configs from all sources in priority order.
 
@@ -406,18 +458,15 @@ class ConfigManager(EngineScoped):
         defaults → user → project-adjacent → workspace → env vars.
         """
         self.default_config = Settings().model_dump()
-        merged_config = self.default_config
 
         if USER_CONFIG_PATH.exists():
             self.user_config = self._load_config_from_file(USER_CONFIG_PATH, "user")
-            merged_config = merge_dicts(merged_config, self.user_config)
         else:
             self.user_config = {}
             logger.debug("User config file not found")
 
         if self._project_config_path is not None:
             self.project_config = self._load_config_from_file(self._project_config_path, "project-adjacent")
-            merged_config = merge_dicts(merged_config, self.project_config)
         else:
             self.project_config = {}
 
@@ -425,19 +474,19 @@ class ConfigManager(EngineScoped):
         # (this happens when workspace dir == project dir for self-contained projects).
         if self._workspace_config_path is not None and self._workspace_config_path != self._project_config_path:
             self.workspace_config = self._load_config_from_file(self._workspace_config_path, "workspace")
-            merged_config = merge_dicts(merged_config, self.workspace_config)
         else:
             self.workspace_config = {}
 
-        # Apply runtime workspace override (from ProjectManager's project_workspaces lookup
-        # or auto-default-to-project-dir). Sits above config files but below env vars.
-        if self._workspace_dir_override is not None:
-            merged_config["workspace_directory"] = self._workspace_dir_override
-
         self.env_config = self._load_config_from_env_vars()
         if self.env_config:
-            merged_config = merge_dicts(merged_config, self.env_config)
             logger.debug("Merged config from environment variables: %s", list(self.env_config.keys()))
+
+        merged_config = self._merge_config_layers(include_user_layer=True)
+
+        # Snapshot what the non-user layers supply, deep-copied so later in-place mutation
+        # of a list handed out by get_config_value cannot reach it. See
+        # `_user_owned_write_value`, which relies on this being pristine.
+        self._layers_without_user_snapshot = copy.deepcopy(self._merge_config_layers(include_user_layer=False))
 
         # Re-assign workspace path in case env var or project config overrides it. Uses the shared
         # precedence resolver (WITH the runtime override) so the active workspace and
@@ -738,7 +787,7 @@ class ConfigManager(EngineScoped):
         # Capture old value before making changes (for event emission)
         old_value = self.get_config_value(key, should_load_env_var_if_detected=False)
 
-        delta = set_dot_value({}, key, value)
+        delta = set_dot_value({}, key, self._user_owned_write_value(key, value))
         if key == "log_level":
             self._set_log_level(value)
         elif key == "workspace_directory":

--- a/tests/unit/retained_mode/managers/test_config_user_owned_writes.py
+++ b/tests/unit/retained_mode/managers/test_config_user_owned_writes.py
@@ -1,0 +1,158 @@
+"""Tests that a config write does not copy other layers' list entries into the user config.
+
+The editor renders the MERGED config, so a write to a list-valued key hands the whole
+merged list back to `set_config_value`. Persisting that verbatim wrote entries owned by the
+project or workspace layer into the user config file, where they outlive the project that
+supplied them: the next time no project layer is loaded to shadow them (system defaults, for
+instance) they become the engine's effective library set. That is how a user config ends up
+registering libraries from a project the user no longer has open, which then get advertised
+to the editor and reported as unregistered when the registry disagrees.
+
+Only the user's own contribution is persisted now.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
+from griptape_nodes.retained_mode.managers.settings import LIBRARIES_TO_REGISTER_KEY
+
+PROJECT_LIBRARY = "/show/project/libraries/griptape-nodes-library-nuke/griptape_nodes_library.json"
+OTHER_PROJECT_LIBRARY = "/show/project/libraries/griptape-nodes-library-void/griptape_nodes_library.json"
+MY_OWN_LIBRARY = "/home/me/libraries/my-library/griptape_nodes_library.json"
+
+
+def _register_list_config(libraries: list[str]) -> str:
+    return json.dumps({"app_events": {"on_app_initialization_complete": {"libraries_to_register": libraries}}})
+
+
+def _read_user_layer(user_config_path: Path) -> list[str]:
+    """The `libraries_to_register` actually persisted to the user config file."""
+    raw = json.loads(user_config_path.read_text(encoding="utf-8"))
+    return raw.get("app_events", {}).get("on_app_initialization_complete", {}).get("libraries_to_register", [])
+
+
+class TestUserOwnedWrites:
+    def test_a_project_supplied_list_is_not_copied_into_the_user_config(self, isolate_user_config: Path) -> None:
+        """Saving the rendered list back must not adopt the project's entries.
+
+        This is the write the editor performs whenever a row is toggled or removed: it sends
+        the array it is rendering, which is the merged one.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_dir = Path(temp_dir)
+            (project_dir / "griptape_nodes_config.json").write_text(
+                _register_list_config([PROJECT_LIBRARY, OTHER_PROJECT_LIBRARY])
+            )
+
+            with patch.dict(os.environ, {}, clear=True):
+                manager = ConfigManager()
+                manager.load_project_config(project_dir)
+
+                rendered = manager.get_config_value(LIBRARIES_TO_REGISTER_KEY)
+                assert rendered == [PROJECT_LIBRARY, OTHER_PROJECT_LIBRARY]
+
+                # The editor saves the list it is rendering.
+                manager.set_config_value(LIBRARIES_TO_REGISTER_KEY, list(rendered))
+
+                # Nothing of the project's landed in the user config.
+                assert _read_user_layer(isolate_user_config) == []
+
+    def test_the_users_own_addition_is_persisted(self, isolate_user_config: Path) -> None:
+        """Stripping foreign entries must not strip the entry the user actually added."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_dir = Path(temp_dir)
+            (project_dir / "griptape_nodes_config.json").write_text(_register_list_config([PROJECT_LIBRARY]))
+
+            with patch.dict(os.environ, {}, clear=True):
+                manager = ConfigManager()
+                manager.load_project_config(project_dir)
+
+                manager.set_config_value(LIBRARIES_TO_REGISTER_KEY, [PROJECT_LIBRARY, MY_OWN_LIBRARY])
+
+                assert _read_user_layer(isolate_user_config) == [MY_OWN_LIBRARY]
+
+    def test_with_no_project_layer_the_write_is_unchanged(self, isolate_user_config: Path) -> None:
+        """The common case must behave exactly as before: nothing else supplies the key."""
+        with patch.dict(os.environ, {}, clear=True):
+            manager = ConfigManager()
+
+            manager.set_config_value(LIBRARIES_TO_REGISTER_KEY, [MY_OWN_LIBRARY, PROJECT_LIBRARY])
+
+            assert _read_user_layer(isolate_user_config) == [MY_OWN_LIBRARY, PROJECT_LIBRARY]
+
+    def test_in_place_mutation_of_a_read_value_does_not_drop_the_new_entry(self, isolate_user_config: Path) -> None:
+        """Guards the read-modify-write callers, which mutate the list they were handed.
+
+        `get_config_value` returns references straight into the config layers, so appending
+        to what it returns mutates those layers in place. A shadow check that recomputed
+        from the live layers would then see the new entry as something another layer already
+        supplied and drop it, silently losing a library download's registration.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_dir = Path(temp_dir)
+            (project_dir / "griptape_nodes_config.json").write_text(_register_list_config([PROJECT_LIBRARY]))
+
+            with patch.dict(os.environ, {}, clear=True):
+                manager = ConfigManager()
+                manager.load_project_config(project_dir)
+
+                # Exactly what download_library_request does: read, append in place, write.
+                entries = manager.get_config_value(LIBRARIES_TO_REGISTER_KEY, default=[])
+                entries.append(MY_OWN_LIBRARY)
+                manager.set_config_value(LIBRARIES_TO_REGISTER_KEY, entries)
+
+                assert _read_user_layer(isolate_user_config) == [MY_OWN_LIBRARY]
+
+    def test_scalars_are_left_alone(self, isolate_user_config: Path) -> None:
+        """Only list keys are filtered; a scalar write still persists verbatim.
+
+        A scalar the project also defines stays a separate problem: the write lands in the
+        user layer but the project keeps winning, so the edit reads as ignored.
+        """
+        with patch.dict(os.environ, {}, clear=True):
+            manager = ConfigManager()
+
+            manager.set_config_value("log_level", "DEBUG")
+
+            raw = json.loads(isolate_user_config.read_text(encoding="utf-8"))
+            assert raw["log_level"] == "DEBUG"
+
+
+class TestLayerOrderingStaysInSync:
+    def test_merge_helper_agrees_with_the_loaded_merged_config(self, isolate_user_config: Path) -> None:
+        """`_merge_config_layers` is the ordering used by load_configs, not a second copy.
+
+        If someone adds a layer to one and not the other, the shadow check starts consulting
+        a different precedence than the engine actually resolves.
+        """
+        isolate_user_config.write_text(_register_list_config([MY_OWN_LIBRARY]))
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_dir = Path(temp_dir)
+            (project_dir / "griptape_nodes_config.json").write_text(_register_list_config([PROJECT_LIBRARY]))
+
+            with patch.dict(os.environ, {"GTN_CONFIG_STORAGE_BACKEND": "gtc"}, clear=True):
+                manager = ConfigManager()
+                manager.load_project_config(project_dir)
+
+                assert manager._merge_config_layers(include_user_layer=True) == manager.merged_config
+
+    def test_excluding_the_user_layer_drops_only_the_user_layer(self, isolate_user_config: Path) -> None:
+        isolate_user_config.write_text(_register_list_config([MY_OWN_LIBRARY]))
+
+        with patch.dict(os.environ, {}, clear=True):
+            manager = ConfigManager()
+
+            with_user = manager._merge_config_layers(include_user_layer=True)
+            without_user = manager._merge_config_layers(include_user_layer=False)
+
+            from griptape_nodes.utils.dict_utils import get_dot_value
+
+            assert get_dot_value(with_user, LIBRARIES_TO_REGISTER_KEY, None) == [MY_OWN_LIBRARY]
+            assert get_dot_value(without_user, LIBRARIES_TO_REGISTER_KEY, None) == []


### PR DESCRIPTION
Stops new pollution of the user config. This is the write that put another project's libraries into a reported user's config in the first place, and it is the root cause behind #5405 and the "editor edit appears to do nothing" report from the ALT VFX thread.

## Cause

The editor renders the **merged** config (`on_handle_get_config_category_request` returns `merged_config`), so a write to a list-valued key hands the whole merged list back to `set_config_value`. That was persisted verbatim: `set_dot_value({}, key, value)` built a delta holding the merged list, and `_write_user_config_delta` merged it with `merge_lists=False`, replacing the user config's array with the merged one.

Result: entries owned by the project or workspace layer got copied into the **user** layer, where they outlive the project that supplied them. The next time no project layer is loaded to shadow them (system defaults, for instance) they become the engine's effective library set, get advertised to the editor, and are reported `no Library with that name was registered` when the registry disagrees.

Toggling a single library's enabled switch was enough to adopt a project's entire library list.

## Change

`set_config_value` persists only the caller's own contribution for list keys: entries another layer already supplies are dropped. With no project layer present nothing else supplies the key, so the common case is byte-identical to before.

Non-list values are untouched. A scalar a project also defines stays a separate problem: the write lands in the user layer but the higher layer keeps winning, so the edit still reads as ignored. Fixing that means either writing to the owning layer (often a shared, possibly read-only file on a network share) or refusing the write, and neither belongs in this change.

Layer ordering moves into `_merge_config_layers`, so `load_configs` and this calculation cannot drift apart on precedence. A test asserts the helper reproduces the loaded `merged_config` exactly.

## A landmine found on the way

The check reads a deep-copied snapshot taken at load time rather than recomputing from the live layers, because `get_config_value` returns references **straight into** the layer dicts and the read-modify-write callers mutate what they are handed. `download_library_request` appends its clone path to the list it just read, which mutates `default_config` in place; recomputing from live layers therefore saw the brand-new entry as something another layer already supplied and dropped it, silently losing the registration. That surfaced as a failing test before the snapshot went in, and there is now a test pinning it.

The aliasing itself is a real foot gun for any caller and is left for a separate change.

## Verification

Full unit suite passes. Lint, types, format, spell clean.

## How this fits with the rest of the batch

This stops new pollution. It does not clean a config that is already polluted, and it does not make an existing config/registry divergence harmless. Those are covered elsewhere:

- **Existing divergence is made harmless** by #5405, which adds `is_registered` to library metadata, and griptape-vsl-gui#2883, which stops the editor querying libraries the engine has not loaded and marks those rows as pending a refresh.
- **Cleaning an already-polluted config** is handled by a one-off script sent to the affected customer, not by a shipped command. Only configs written before this PR can be polluted, so that population never grows, and the one heuristic a built-in command would need ("remove entries outside the libraries directory") misfires on any normal setup that registers libraries from a checkout.

