### PR TITLE
Route libraries with execution dependencies to their worker process

### DIFF
--- a/docs/guides/libraries.md
+++ b/docs/guides/libraries.md
@@ -186,6 +186,28 @@ clashing heavy pins can still be edited side by side.
 Declaring no `pip_dependencies_exec` is always safe: the library
 behaves exactly as it did before the split existed.
 
+#### What declaring execution dependencies changes
+
+A library that declares them runs differently, in three ways:
+
+- **Its nodes execute in the library's own process.** The main
+    engine can show, edit, and save them (it has the edit-time
+    dependencies), but running them happens where the heavy
+    packages live. If that process isn't up yet, running the node
+    reports that rather than failing strangely.
+- **Node code asks the engine for state instead of reading it.**
+    Inside `process()`, reaching for a manager directly (config,
+    secrets, files) raises an error telling you the request to use
+    instead. The library's process holds no settings or secrets of
+    its own, so a direct read would be answering from the wrong
+    place. Saving static files still works normally.
+- **Values that can't leave the process must stay inside it.** If a
+    node outputs something marked `serializable=False` (a live
+    model handle, a tensor), you'll get an error explaining the two
+    ways forward: make the value serializable, or keep it inside
+    the library by caching it library-side and outputting a small
+    descriptor that the next node trades back.
+
 ### Process isolation: the Isolated mode
 
 Running a library **Isolated** (in its own dedicated process,

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -79,6 +79,30 @@ class _EngineRootMeta(type):
         return current_engine()
 
 
+def _forbid_manager_during_worker_execution(manager_name: str, request_hint: str) -> None:
+    """Raise when node code reaches for a manager while executing in a worker process.
+
+    A worker holds no authoritative state: config, secrets, and the filesystem all belong to
+    the orchestrator, and reads that look local would be answered by a process that is not
+    the source of truth. Node code gets there with ``GriptapeNodes.handle_request(...)``,
+    which forwards to the orchestrator, so the value is always the real one.
+
+    Scoped to node execution deliberately: engine boot and library load run in the worker
+    too, and they legitimately need their own managers.
+    """
+    engine = current_engine()
+    if not engine.library_manager.is_worker:
+        return
+    if not engine.event_manager.in_node_execution():
+        return
+    msg = (
+        f"Attempted to use {manager_name} while running in an isolated library process, where "
+        f"it holds no authoritative state. Use GriptapeNodes.handle_request({request_hint}) "
+        f"instead, which asks the main engine and returns the real value."
+    )
+    raise RuntimeError(msg)
+
+
 class GriptapeNodes(metaclass=_EngineRootMeta):
     """Static accessors for the current engine's managers and request handlers."""
 
@@ -157,14 +181,17 @@ class GriptapeNodes(metaclass=_EngineRootMeta):
 
     @classmethod
     def ConfigManager(cls) -> ConfigManager:
+        _forbid_manager_during_worker_execution("ConfigManager", "GetConfigValueRequest(...)")
         return current_engine().config_manager
 
     @classmethod
     def OSManager(cls) -> OSManager:
+        _forbid_manager_during_worker_execution("OSManager", "ReadFileRequest(...) / WriteFileRequest(...)")
         return current_engine().os_manager
 
     @classmethod
     def SecretsManager(cls) -> SecretsManager:
+        _forbid_manager_during_worker_execution("SecretsManager", "GetSecretValueRequest(...)")
         return current_engine().secrets_manager
 
     @classmethod

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -510,6 +510,13 @@ class LibraryManager(EngineScoped):
         # parsed (discovery or lifecycle progression). Absence of the relevant
         # declarations falls through to False.
         requires_worker: bool = False
+        # True when this library's nodes EXECUTE in a dedicated worker process, for either
+        # reason: legacy worker-mode declarations (requires_worker above, which also skips
+        # orchestrator-side loading in favor of stubs) or execution dependencies
+        # (pip_dependencies_exec -- the library loads REAL nodes on the orchestrator and
+        # only its process() runs in the worker, where .venv-exec is on sys.path).
+        # Consumed by execution routing; never by load-time skips.
+        executes_in_worker: bool = False
         # Set when the library enters WORKER_PENDING state. The orchestrator waits on this
         # event before returning RegisterLibraryFromFileResultSuccess so callers see the real
         # fitness once the worker has loaded and reported back.
@@ -750,7 +757,10 @@ class LibraryManager(EngineScoped):
         # Register stub node classes from the worker-reported schemas so the orchestrator
         # can display nodes in the sidebar and recreate them during workflow loading.
         # Skip on the worker itself -- it already has the real node classes registered.
-        if notification.node_schemas and not self._is_worker:
+        # Exec-deps libraries registered REAL node classes locally at load; overwriting
+        # them with schema stubs would throw away converters/validators/traits/hooks.
+        # Only legacy worker-mode libraries (requires_worker) use stub registration.
+        if notification.node_schemas and not self._is_worker and library_info.requires_worker:
             self._register_nodes_from_worker_schemas(notification.library_name, notification.node_schemas)
         # Unblock any code awaiting this library's worker_ready event.
         if library_info.worker_ready is not None:
@@ -776,7 +786,7 @@ class LibraryManager(EngineScoped):
         """
         if library_name:
             library_info = self.get_library_info_by_library_name(library_name)
-            if library_info and library_info.requires_worker:
+            if library_info and library_info.executes_in_worker:
                 wm = self._worker_manager
                 if wm:
                     worker = wm.get_worker_for_key(library_name)
@@ -802,10 +812,15 @@ class LibraryManager(EngineScoped):
         that worker creation is always tied to an active session.
         """
         for library_info in self._library_file_path_to_info.values():
-            if library_info.requires_worker and library_info.library_name and not self._is_worker:
-                library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.WORKER_PENDING
-                # Create (or reset) the worker_ready event for this spawn.
-                library_info.worker_ready = asyncio.Event()
+            if library_info.executes_in_worker and library_info.library_name and not self._is_worker:
+                # Legacy worker-mode libraries load AS the worker confirms (stubs meanwhile),
+                # so their lifecycle gates on the spawn. Exec-deps libraries loaded real
+                # nodes locally already: the worker gates execution availability only, and
+                # registration must not block on it.
+                if library_info.requires_worker:
+                    library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.WORKER_PENDING
+                    # Create (or reset) the worker_ready event for this spawn.
+                    library_info.worker_ready = asyncio.Event()
                 await self.engine.ahandle_request(StartWorkerRequest(library_name=library_info.library_name))
 
     def on_worker_evicted(self, worker_engine_id: str, library_name: str | None) -> None:
@@ -2183,11 +2198,15 @@ class LibraryManager(EngineScoped):
                 )
 
                 # Update or create LibraryInfo
+                executes_in_worker = self._resolve_executes_in_worker(
+                    requires_worker=requires_worker, metadata=metadata_result.library_schema.metadata
+                )
                 if lib_info:
                     lib_info.library_name = library_name
                     lib_info.library_version = metadata_result.library_schema.metadata.library_version
                     lib_info.lifecycle_state = LibraryManager.LibraryLifecycleState.METADATA_LOADED
                     lib_info.requires_worker = requires_worker
+                    lib_info.executes_in_worker = executes_in_worker
                 else:
                     # Create new LibraryInfo since it doesn't exist yet
                     lib_info = LibraryManager.LibraryInfo(
@@ -2199,6 +2218,7 @@ class LibraryManager(EngineScoped):
                         fitness=LibraryManager.LibraryFitness.NOT_EVALUATED,
                         problems=[],
                         requires_worker=requires_worker,
+                        executes_in_worker=executes_in_worker,
                     )
                     self._library_file_path_to_info[file_path] = lib_info
             else:
@@ -2316,6 +2336,10 @@ class LibraryManager(EngineScoped):
                     library_info.requires_worker = self._resolve_requires_worker(
                         library_info.registered_path,
                         metadata_result.library_schema.metadata.declarations,
+                    )
+                    library_info.executes_in_worker = self._resolve_executes_in_worker(
+                        requires_worker=library_info.requires_worker,
+                        metadata=metadata_result.library_schema.metadata,
                     )
                     library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.METADATA_LOADED
 
@@ -5115,6 +5139,14 @@ class LibraryManager(EngineScoped):
         registered node type to extract its parameter layout, so the orchestrator
         can create stub classes without importing the library's Python modules.
         """
+        # Only a legacy worker-mode library is stubbed on the orchestrator: an
+        # execution-dependency library is loaded there for real (its node modules are
+        # base-clean by contract), and stub registration is gated on `requires_worker`.
+        # The two stub-loss detectors below are gated on the same fact, or they warn that
+        # converters, traits and hooks "will not execute on the orchestrator stub" for a
+        # library that has no stub -- sending an author to fix code that is already correct.
+        library_info = self.get_library_info_by_library_name(library_name)
+        will_be_stubbed = library_info is None or library_info.requires_worker
         try:
             library = LibraryRegistry.get_library(library_name)
         except KeyError:
@@ -5158,8 +5190,9 @@ class LibraryManager(EngineScoped):
                 # Run the parameter-behavior-drop and inert-hook detectors
                 # inside the scope so warnings attach to the same LOAD_PROBE
                 # scope that owns the probe attempt.
-                self._report_parameter_behavior_losses(probe)
-                self._report_inert_worker_hooks(probe)
+                if will_be_stubbed:
+                    self._report_parameter_behavior_losses(probe)
+                    self._report_inert_worker_hooks(probe)
 
             # Drop the class only when a rule flagged drops_class_from_schema
             # fired. Severity is a logging concern; drops_class_from_schema is
@@ -5437,6 +5470,18 @@ class LibraryManager(EngineScoped):
 
         return manifest_default
 
+    @staticmethod
+    def _resolve_executes_in_worker(*, requires_worker: bool, metadata: LibraryMetadata) -> bool:
+        """Whether this library's nodes execute in a dedicated worker process.
+
+        True for legacy worker-mode libraries (requires_worker) and for libraries that
+        declare execution dependencies: their heavy packages live in .venv-exec, which is
+        only on sys.path in a worker, so process() can only run there.
+        """
+        dependencies = metadata.dependencies
+        has_exec_dependencies = bool(dependencies and dependencies.pip_dependencies_exec)
+        return requires_worker or has_exec_dependencies
+
     def _remove_missing_libraries_from_config(self, config_category: str) -> None:
         # Now remove all libraries that were missing from the user's config.
         config_mgr = self.engine.config_manager
@@ -5691,6 +5736,7 @@ class LibraryManager(EngineScoped):
         library_name = None
         library_version = None
         requires_worker = False
+        executes_in_worker = False
         lifecycle_state = LibraryManager.LibraryLifecycleState.DISCOVERED
 
         if isinstance(metadata_result, LoadLibraryMetadataFromFileResultSuccess):
@@ -5699,6 +5745,9 @@ class LibraryManager(EngineScoped):
             requires_worker = self._resolve_requires_worker(
                 registered_path,
                 metadata_result.library_schema.metadata.declarations,
+            )
+            executes_in_worker = self._resolve_executes_in_worker(
+                requires_worker=requires_worker, metadata=metadata_result.library_schema.metadata
             )
             lifecycle_state = LibraryManager.LibraryLifecycleState.METADATA_LOADED
 
@@ -5715,6 +5764,7 @@ class LibraryManager(EngineScoped):
             library_version=library_version,
             registered_path=registered_path,
             requires_worker=requires_worker,
+            executes_in_worker=executes_in_worker,
         )
 
     async def discover_libraries_request(

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -804,6 +804,37 @@ class LibraryManager(EngineScoped):
                 raise RuntimeError(msg)
         return None
 
+    async def wait_for_worker_library_load(self, library_name: str) -> None:
+        """Block until this library's worker has reported the library fully loaded, if one is expected.
+
+        A worker registers with the orchestrator at process start, BEFORE it has loaded its
+        library -- so a node executed in that window would reach a worker that cannot create
+        it yet. The worker's LibraryLoadedNotification is what "loaded" means, exactly as it
+        did for legacy worker-mode libraries; this waits for it, bounded by the same startup
+        grace the boot-time wait uses. Returns immediately for a library with no spawned
+        worker. An eviction during the wait also releases it: the reason is recorded, and
+        get_worker_for_library reports it to the caller.
+
+        Raises:
+            RuntimeError: If the worker did not report the library loaded within the grace
+                period.
+        """
+        library_info = self.get_library_info_by_library_name(library_name)
+        if library_info is None or library_info.worker_ready is None or library_info.worker_ready.is_set():
+            return
+        config_mgr = self.engine.config_manager
+        wait_seconds = config_mgr.get_config_value(WORKER_HEARTBEAT_STARTUP_GRACE_KEY, default=600.0, cast_type=float)
+        logger.info("Waiting for library '%s' to finish loading in its worker before running the node", library_name)
+        try:
+            with anyio.fail_after(wait_seconds):
+                await library_info.worker_ready.wait()
+        except TimeoutError:
+            msg = (
+                f"Attempted to run a node from library '{library_name}'. Failed because its worker "
+                f"process did not finish loading the library within {wait_seconds:.0f} seconds."
+            )
+            raise RuntimeError(msg) from None
+
     async def _start_workers(self) -> None:
         """Issue StartWorkerRequest for every library that requires a dedicated worker.
 
@@ -819,8 +850,13 @@ class LibraryManager(EngineScoped):
                 # registration must not block on it.
                 if library_info.requires_worker:
                     library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.WORKER_PENDING
-                    # Create (or reset) the worker_ready event for this spawn.
-                    library_info.worker_ready = asyncio.Event()
+                # Create (or reset) the worker_ready event for this spawn -- for EVERY spawned
+                # worker, not only legacy ones. A worker registers with the orchestrator at
+                # process start, BEFORE it has loaded its library, so registration alone cannot
+                # gate execution: a node routed in that window fails in the worker with
+                # "Library not found". This event is set by the worker's LibraryLoadedNotification,
+                # and the execute path waits on it (wait_for_worker_library_load).
+                library_info.worker_ready = asyncio.Event()
                 await self.engine.ahandle_request(StartWorkerRequest(library_name=library_info.library_name))
 
     def on_worker_evicted(self, worker_engine_id: str, library_name: str | None) -> None:
@@ -835,12 +871,15 @@ class LibraryManager(EngineScoped):
         library_info = self.get_library_info_by_library_name(library_name)
         if library_info is None:
             return
+        # Unblock any code awaiting this library's worker_ready event, whatever the
+        # lifecycle: an exec-deps library stays LOADED through an eviction, and a waiter
+        # on the execute path would otherwise hold on for the full grace period for a
+        # worker that is already gone.
+        if library_info.worker_ready is not None:
+            library_info.worker_ready.set()
         if library_info.lifecycle_state == LibraryManager.LibraryLifecycleState.WORKER_PENDING:
             library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.FAILURE
             library_info.fitness = LibraryManager.LibraryFitness.UNUSABLE
-            # Unblock any code awaiting this library's worker_ready event.
-            if library_info.worker_ready is not None:
-                library_info.worker_ready.set()
             logger.warning(
                 "Worker '%s' evicted before confirming load of library '%s'; library marked as FAILURE.",
                 worker_engine_id,
@@ -4463,10 +4502,16 @@ class LibraryManager(EngineScoped):
         the orchestrator ceiling stays aligned with the worker self-timeout; first-time
         installs of large libraries can easily exceed the default heartbeat timeout.
         """
+        # Only legacy WORKER_PENDING libraries gate BOOT: their nodes arrive as stubs from
+        # the worker, so nothing exists until it reports. An exec-deps library has real node
+        # classes locally and its worker gates execution only -- blocking startup on its
+        # worker's heavy imports would put torch back on the boot path.
         pending_events = [
             info.worker_ready
             for info in self._library_file_path_to_info.values()
-            if info.worker_ready is not None and not info.worker_ready.is_set()
+            if info.worker_ready is not None
+            and not info.worker_ready.is_set()
+            and info.lifecycle_state == LibraryManager.LibraryLifecycleState.WORKER_PENDING
         ]
         if not pending_events:
             return

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -3146,6 +3146,12 @@ class NodeManager(EngineScoped):
         # scope, not ours. Decide forwarding first; only open a local scope when
         # this process is actually going to execute the node.
         if not is_worker:
+            # The worker registers before it has loaded its library; routing in that window
+            # fails in the worker with "Library not found". Wait for the worker's
+            # LibraryLoadedNotification first -- immediate for any library without a
+            # spawned worker.
+            if library_name:
+                await library_manager.wait_for_worker_library_load(library_name)
             worker = library_manager.get_worker_for_library(library_name) if library_name else None
             wm = self.engine.worker_manager
             if wm is not None and worker is not None:

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -3359,7 +3359,7 @@ class NodeManager(EngineScoped):
         # installed (register_remote_handlers is worker-only), so opening the
         # scope there would just bump a refcount that nothing reads. Skip it
         # to keep the depth counter accurate to its name.
-        is_worker = self.engine.library_manager._is_worker
+        is_worker = self.engine.library_manager.is_worker
         scope_cm = self.engine.event_manager.worker_node_execution_scope() if is_worker else contextlib.nullcontext()
         with scope_cm:
             # Rehydrate serialized artifacts that crossed the orchestrator->worker JSON boundary.
@@ -3411,10 +3411,38 @@ class NodeManager(EngineScoped):
                     result_details=f"Attempted to execute node '{node_name}'. Failed with error: {e}",
                     exception=e,
                 )
+        if self.engine.library_manager.is_worker:
+            unshippable = self._unshippable_output_names(node)
+            if unshippable:
+                library_name = node.metadata.get("library", "its library")
+                details = (
+                    f"Node '{node_name}' produced {', '.join(unshippable)}, which cannot leave "
+                    f"'{library_name}'s isolated process. Either make the value serializable, or keep "
+                    f"it inside the library: cache it library-side and output a small serializable "
+                    f"descriptor that the consuming node trades back."
+                )
+                return ExecuteNodeResultFailure(result_details=details)
+
         return ExecuteNodeResultSuccess(
             parameter_output_values=dict(node.parameter_output_values),
             result_details=f"Node '{node_name}' executed successfully.",
         )
+
+    @staticmethod
+    def _unshippable_output_names(node: BaseNode) -> list[str]:
+        """Output parameter names holding values that cannot cross the process boundary.
+
+        ``serializable=False`` is the author declaring the value unreasonable to move (a live
+        tensor, an open pipeline). In a worker those outputs would be dropped or mangled on
+        the wire, so producing one is a failure with an actionable message rather than a
+        silent hole in the graph.
+        """
+        names = []
+        for parameter_name in node.parameter_output_values:
+            parameter = node.get_parameter_by_name(parameter_name)
+            if parameter is not None and not parameter.serializable:
+                names.append(f"'{parameter_name}'")
+        return names
 
     def on_validate_node_dependencies_request(self, request: ValidateNodeDependenciesRequest) -> ResultPayload:
         node_name = request.node_name

--- a/tests/e2e/fixtures/behavior_preservation_library/behavior_preservation_node.py
+++ b/tests/e2e/fixtures/behavior_preservation_library/behavior_preservation_node.py
@@ -1,0 +1,102 @@
+"""Node carrying everything a schema stub drops, for a library routed to a worker.
+
+The point of this fixture is the combination: the library declares execution dependencies, so
+its execution goes to a worker -- and yet the ORCHESTRATOR holds this real class, so the
+parameter behaviors that only exist in Python survive. A stub rebuilt from
+``WorkerParameterSchema`` carries scalar fields and ``ui_options`` only, so all three of these
+would be gone:
+
+- a ``Button`` trait, whose click handler lives on the trait rather than on the node. This is
+  the worst of the family, because ``ui_options`` DO serialize, so the button renders and
+  looks clickable while being guaranteed to fail (griptape-nodes-engine#5420).
+- a converter, which rewrites an incoming value.
+- a validator, which refuses one.
+- a value hook and a connection hook override, which a stub class does not carry at all.
+
+Module scope stays clean of the execution dependency on purpose: that is the contract that
+lets the orchestrator import this at all.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import NodeMessageResult, Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import DataNode
+from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
+
+CLICK_ACKNOWLEDGEMENT = "the node's own handler ran on the orchestrator"
+
+
+def _shout(value: Any) -> Any:
+    if isinstance(value, str):
+        return value.upper()
+    return value
+
+
+def _reject_forbidden(parameter: Parameter, value: Any) -> None:  # noqa: ARG001
+    if value == "FORBIDDEN":
+        msg = "forbidden value"
+        raise ValueError(msg)
+
+
+class BehaviorPreservationNode(DataNode):
+    BUTTON_PARAMETER = "model_manager"
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        button = Button(full_width=True)
+        button.on_click_callback = self._on_button_clicked
+        self.add_parameter(
+            Parameter(
+                name=self.BUTTON_PARAMETER,
+                type="str",
+                default_value="",
+                tooltip="Opens the model manager",
+                allowed_modes={ParameterMode.PROPERTY},
+                traits={button},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="mode",
+                type="str",
+                default_value="plain",
+                tooltip="Converted to upper case; refuses FORBIDDEN",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                converters=[_shout],
+                validators=[_reject_forbidden],
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="observed_mode",
+                type="str",
+                default_value="",
+                tooltip="",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def _on_button_clicked(self, _button: Button, _details: ButtonDetailsMessagePayload) -> NodeMessageResult:
+        return NodeMessageResult(success=True, details=CLICK_ACKNOWLEDGEMENT)
+
+    def after_value_set(self, parameter: Parameter, value: Any) -> None:
+        """Overridden so the value-hook detector has something to find."""
+        super().after_value_set(parameter, value)
+
+    def after_incoming_connection(
+        self,
+        source_node: Any,
+        source_parameter: Parameter,
+        target_parameter: Parameter,
+    ) -> None:
+        """Overridden so the connection-hook detector has something to find."""
+        super().after_incoming_connection(source_node, source_parameter, target_parameter)
+
+    def process(self) -> None:
+        # Deferred on purpose: this library declares it as execution-only, so it is absent
+        # from the orchestrator by design.
+        import fakeexec  # type: ignore[reportMissingImports]  # noqa: F401
+
+        self.parameter_output_values["observed_mode"] = self.get_parameter_value("mode")

--- a/tests/e2e/fixtures/behavior_preservation_library/griptape_nodes_library.json
+++ b/tests/e2e/fixtures/behavior_preservation_library/griptape_nodes_library.json
@@ -1,0 +1,38 @@
+{
+  "name": "Behavior Preservation Library",
+  "library_schema_version": "0.12.0",
+  "metadata": {
+    "author": "Test Fixture",
+    "description": "Library whose nodes carry traits, converters and validators",
+    "library_version": "0.1.0",
+    "engine_version": "0.0.0",
+    "tags": [
+      "test"
+    ],
+    "dependencies": {
+      "pip_dependencies": [],
+      "pip_dependencies_exec": []
+    }
+  },
+  "categories": [
+    {
+      "test": {
+        "title": "test",
+        "description": "Test nodes",
+        "color": "border-gray-500",
+        "icon": "Folder"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "class_name": "BehaviorPreservationNode",
+      "file_path": "behavior_preservation_node.py",
+      "metadata": {
+        "category": "test",
+        "description": "Node carrying a Button trait, a converter and a validator",
+        "display_name": "Behavior Preservation Node"
+      }
+    }
+  ]
+}

--- a/tests/e2e/test_exec_dep_worker_routing.py
+++ b/tests/e2e/test_exec_dep_worker_routing.py
@@ -1,0 +1,461 @@
+"""End-to-end tests for the exec-dep worker MVP.
+
+A library that declares execution dependencies (``pip_dependencies_exec``) gets a different
+deal than either mode that exists today:
+
+- It loads REAL node classes on the orchestrator (not schema stubs), because its node
+  modules import with edit-time deps only.
+- Its nodes EXECUTE in its dedicated worker process, where ``.venv-exec`` is on
+  ``sys.path``.
+- While executing there, node code cannot reach orchestrator-owned managers directly; it
+  asks the orchestrator with a request instead.
+- A value it produces that cannot leave that process fails loudly with instructions.
+
+These tests pin those four behaviors, plus the crucial negative: a library that declares no
+execution dependencies is untouched by any of it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+from pathlib import Path
+
+import pytest
+
+from griptape_nodes.node_library.library_registry import LibraryRegistry, LibrarySchema
+from griptape_nodes.retained_mode.engine import current_engine
+from griptape_nodes.retained_mode.events.app_events import LibraryLoadedNotification
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.events.node_events import (
+    SendNodeMessageRequest,
+    SendNodeMessageResultSuccess,
+)
+
+# The facade import survives for the dummy-manager guard tests, whose subject it is.
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes  # noqa: TID251
+from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
+from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
+from griptape_nodes.utils.version_utils import engine_version
+from tests.e2e.fixtures.behavior_preservation_library.behavior_preservation_node import CLICK_ACKNOWLEDGEMENT
+from tests.e2e.offline_wheels import build_wheel, offline_install_flags
+
+EXEC_FIXTURE = Path(__file__).parent / "fixtures" / "exec_dep_library"
+NONSERIALIZABLE_FIXTURE = Path(__file__).parent / "fixtures" / "nonserializable_library"
+BEHAVIOR_FIXTURE = Path(__file__).parent / "fixtures" / "behavior_preservation_library"
+
+
+def _register(  # noqa: PLR0913 (a test-library builder; each knob is one manifest field)
+    tmp_path: Path,
+    *,
+    fixture_dir: Path,
+    node_file: str,
+    name: str,
+    exec_dependencies: list[str] | None = None,
+    edit_dependencies: list[str] | None = None,
+) -> str:
+    """Register a fixture library, optionally declaring execution dependencies."""
+    library_dir = tmp_path / name.replace(" ", "_")
+    library_dir.mkdir(parents=True, exist_ok=True)
+    schema = json.loads((fixture_dir / "griptape_nodes_library.json").read_text())
+    schema["name"] = name
+    schema["library_schema_version"] = LibrarySchema.LATEST_SCHEMA_VERSION
+    schema["metadata"]["engine_version"] = engine_version
+    dependencies: dict[str, list[str]] = {"pip_dependencies": list(edit_dependencies or [])}
+    if exec_dependencies:
+        wheel_dir = tmp_path / "wheels"
+        for dep in [*(edit_dependencies or []), *exec_dependencies]:
+            build_wheel(wheel_dir, dep, "1.0.0")
+        dependencies["pip_dependencies_exec"] = exec_dependencies
+        dependencies["pip_install_flags"] = offline_install_flags(wheel_dir)
+    elif edit_dependencies:
+        wheel_dir = tmp_path / "wheels"
+        for dep in edit_dependencies:
+            build_wheel(wheel_dir, dep, "1.0.0")
+        dependencies["pip_install_flags"] = offline_install_flags(wheel_dir)
+    schema["metadata"]["dependencies"] = dependencies
+    library_json = library_dir / "griptape_nodes_library.json"
+    library_json.write_text(json.dumps(schema, indent=2))
+    shutil.copy(fixture_dir / node_file, library_dir / node_file)
+    result = current_engine().handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    assert isinstance(result, RegisterLibraryFromFileResultSuccess), getattr(result, "result_details", result)
+    return str(library_json)
+
+
+def _library_info(library_json: str) -> LibraryManager.LibraryInfo:
+    return current_engine().library_manager._library_file_path_to_info[library_json]
+
+
+class TestRoutingFact:
+    def test_exec_dependencies_mean_execution_in_a_worker(self, tmp_path: Path) -> None:
+        """Declaring exec deps routes execution to a worker WITHOUT the legacy stub path."""
+        library_json = _register(
+            tmp_path,
+            fixture_dir=EXEC_FIXTURE,
+            node_file="exec_dep_node.py",
+            name="Routing Heavy",
+            edit_dependencies=["fakeedit"],
+            exec_dependencies=["fakeexec"],
+        )
+
+        info = _library_info(library_json)
+        assert info.executes_in_worker is True
+        # Crucially NOT the legacy worker mode: no stub path, no WORKER_PENDING gating.
+        assert info.requires_worker is False
+        assert info.lifecycle_state is LibraryManager.LibraryLifecycleState.LOADED
+
+    def test_no_exec_dependencies_means_no_worker(self, tmp_path: Path) -> None:
+        library_json = _register(
+            tmp_path,
+            fixture_dir=NONSERIALIZABLE_FIXTURE,
+            node_file="nonserializable_nodes.py",
+            name="Routing Light",
+        )
+
+        info = _library_info(library_json)
+        assert info.executes_in_worker is False
+        assert info.requires_worker is False
+
+    def test_worker_is_required_once_declared(self, tmp_path: Path) -> None:
+        """With no worker registered, routing raises instead of silently running locally.
+
+        Falling back to in-process execution would run the node in the one process that
+        deliberately lacks its execution dependencies.
+        """
+        _register(
+            tmp_path,
+            fixture_dir=EXEC_FIXTURE,
+            node_file="exec_dep_node.py",
+            name="Routing Guard",
+            edit_dependencies=["fakeedit"],
+            exec_dependencies=["fakeexec"],
+        )
+
+        with pytest.raises(RuntimeError, match="requires a dedicated worker"):
+            current_engine().library_manager.get_worker_for_library("Routing Guard")
+
+
+class TestRealNodesOnOrchestrator:
+    def test_orchestrator_holds_real_node_classes_not_stubs(self, tmp_path: Path) -> None:
+        """The point of the dep split: real classes in the editor, heavy deps elsewhere.
+
+        The node instantiates here with its edit-time dependency importable and its
+        execution dependency absent from this process.
+        """
+        _register(
+            tmp_path,
+            fixture_dir=EXEC_FIXTURE,
+            node_file="exec_dep_node.py",
+            name="Real Nodes",
+            edit_dependencies=["fakeedit"],
+            exec_dependencies=["fakeexec"],
+        )
+
+        node = LibraryRegistry.create_node(node_type="ExecDepNode", name="real", specific_library_name="Real Nodes")
+
+        # A stub would carry parameter shape only; this is the real class, so its
+        # __init__ ran and read its edit-time dependency.
+        assert node.get_parameter_value("edit_dep_version") == "1.0.0"
+        assert type(node).__name__ == "ExecDepNode"
+        assert type(node).__module__ != "griptape_nodes.retained_mode.managers.library_manager"
+
+
+class TestParameterBehaviorsSurviveOnRealClasses:
+    """What a schema stub drops, and what these libraries keep by not being stubbed.
+
+    A stub is rebuilt from ``WorkerParameterSchema``, which carries scalar fields and
+    ``ui_options`` only. Traits, converters and validators live in Python and cannot travel,
+    so a worker-mode library loses all of them on the orchestrator -- see
+    griptape-nodes-engine#5420 for the trait case, which is the worst of the family because
+    ``ui_options`` DO serialize: the button renders, looks clickable, and cannot work.
+
+    An execution-dependency library sets ``executes_in_worker`` WITHOUT setting
+    ``requires_worker``, and stub registration is gated on the latter, so these libraries keep
+    the real class. ``test_the_orchestrator_refuses_worker_schemas_that_would_clobber_real_classes``
+    is the one that drives that gate; the rest cover what survives on the class itself.
+    """
+
+    def _register_behavior_library(self, tmp_path: Path) -> str:
+        return _register(
+            tmp_path,
+            fixture_dir=BEHAVIOR_FIXTURE,
+            node_file="behavior_preservation_node.py",
+            name="Behavior Library",
+            exec_dependencies=["fakeexec"],
+        )
+
+    def test_a_button_trait_survives_and_its_click_resolves(self, tmp_path: Path) -> None:
+        """The #5420 case: the trait is present, so the click reaches the node's handler."""
+        self._register_behavior_library(tmp_path)
+        node = LibraryRegistry.create_node(
+            node_type="BehaviorPreservationNode", name="behaviors", specific_library_name="Behavior Library"
+        )
+        current_engine().object_manager.add_object_by_name("behaviors", node)
+
+        parameter = node.get_parameter_by_name("model_manager")
+        assert parameter is not None
+        assert list(parameter.find_elements_by_type(Button)), "the Button trait did not survive"
+
+        result = current_engine().handle_request(
+            SendNodeMessageRequest(
+                node_name="behaviors",
+                optional_element_name="model_manager",
+                message_type="on_click",
+                message=ButtonDetailsMessagePayload(label="Open", variant="default", size="md", state="ready"),
+            )
+        )
+
+        assert isinstance(result, SendNodeMessageResultSuccess), getattr(result, "result_details", result)
+        # The trait's bound callback is what produced this, so the string proves the node's own
+        # handler ran rather than something merely accepting the message.
+        assert CLICK_ACKNOWLEDGEMENT in str(result.result_details)
+
+    @pytest.mark.asyncio
+    async def test_the_orchestrator_refuses_worker_schemas_that_would_clobber_real_classes(
+        self, tmp_path: Path
+    ) -> None:
+        """Drive the gate itself: a worker's schemas must not replace real classes.
+
+        The tests above load a library in-process, which is true of any library and never
+        reaches the gate. The clobber happens later and elsewhere: the worker sends a
+        LibraryLoadedNotification carrying serialized schemas, and the ORCHESTRATOR decides
+        whether to build stub classes from them. `Library.register_new_node_type` overwrites
+        unconditionally, so a gate keyed on the wrong flag silently swaps this library's real
+        classes -- traits and all -- for stubs after load.
+        """
+        self._register_behavior_library(tmp_path)
+        library_manager = current_engine().library_manager
+        library_info = library_manager.get_library_info_by_library_name("Behavior Library")
+        assert library_info is not None
+        assert library_info.executes_in_worker is True, "the library must be worker-routed for this to mean anything"
+        assert library_info.requires_worker is False, "...but not via the legacy stub path"
+
+        # Exactly what a worker broadcasts after loading the library.
+        schemas = await library_manager._serialize_library_node_schemas("Behavior Library")
+        await library_manager._on_library_loaded_notification(
+            LibraryLoadedNotification(
+                library_name="Behavior Library",
+                fitness=LibraryManager.LibraryFitness.GOOD,
+                node_schemas=schemas,
+            )
+        )
+
+        node = LibraryRegistry.create_node(
+            node_type="BehaviorPreservationNode", name="post_notification", specific_library_name="Behavior Library"
+        )
+        parameter = node.get_parameter_by_name("model_manager")
+        assert parameter is not None
+        assert list(parameter.find_elements_by_type(Button)), (
+            "the worker's schemas replaced the real class with a stub, dropping the Button trait"
+        )
+
+    def test_converters_and_validators_survive(self, tmp_path: Path) -> None:
+        """The quieter half of the same family: both only exist as Python callables."""
+        self._register_behavior_library(tmp_path)
+        node = LibraryRegistry.create_node(
+            node_type="BehaviorPreservationNode", name="callables", specific_library_name="Behavior Library"
+        )
+
+        node.set_parameter_value("mode", "expand")
+        assert node.get_parameter_value("mode") == "EXPAND", "the converter did not run"
+
+        with pytest.raises(ValueError, match="forbidden"):
+            node.set_parameter_value("mode", "FORBIDDEN")
+
+    @pytest.mark.asyncio
+    async def test_the_stub_loss_warnings_stay_quiet_for_a_library_that_is_not_stubbed(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The detectors describe what a stub loses, so they must not fire when there is none.
+
+        Both fire from the worker-side schema probe, which runs for every library a worker
+        loads -- including execution-dependency libraries, whose schemas the orchestrator
+        then ignores. Ungated, this node's converter, validator and trait each produced a
+        warning saying they "will not execute on the orchestrator stub", for a library whose
+        orchestrator copy is the real class. That sends an author to fix correct code.
+        """
+        self._register_behavior_library(tmp_path)
+        library_manager = current_engine().library_manager
+
+        with caplog.at_level(logging.WARNING):
+            await library_manager._serialize_library_node_schemas("Behavior Library")
+
+        assert "will not execute on the orchestrator stub" not in caplog.text
+        assert "parameter-behaviors-dropped-in-schema" not in caplog.text
+        # The other two gated rules carry their own wording; assert each, or half the gate
+        # can be reverted with nothing failing.
+        assert "connection hooks run on the orchestrator against a stub" not in caplog.text
+        assert "these fire only during" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_the_stub_loss_warnings_still_fire_for_a_legacy_worker_mode_library(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The other direction: a library that IS stubbed still gets told what it loses."""
+        self._register_behavior_library(tmp_path)
+        library_manager = current_engine().library_manager
+        library_info = library_manager.get_library_info_by_library_name("Behavior Library")
+        assert library_info is not None
+        library_info.requires_worker = True
+
+        with caplog.at_level(logging.WARNING):
+            await library_manager._serialize_library_node_schemas("Behavior Library")
+
+        assert "will not execute on the orchestrator stub" in caplog.text
+        assert "connection hooks run on the orchestrator against a stub" in caplog.text
+        assert "these fire only during" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_the_stub_path_these_libraries_avoid_would_drop_the_button(self, tmp_path: Path) -> None:
+        """Negative control: the same parameters through stub synthesis lose the trait.
+
+        Without this, the test above passes for any ordinary library and proves nothing about
+        the routing decision. Driving the real serializer and stub builder shows the loss is in
+        stub synthesis, and reproduces the reported failure message exactly.
+        """
+        self._register_behavior_library(tmp_path)
+        library_manager = current_engine().library_manager
+
+        schemas = await library_manager._serialize_library_node_schemas("Behavior Library")
+        node_schema = next(s for s in schemas if s.class_name == "BehaviorPreservationNode")
+        stub_class = library_manager._make_worker_stub_class("BehaviorPreservationNode", node_schema.parameters)
+        stub = stub_class(name="stubbed")
+        current_engine().object_manager.add_object_by_name("stubbed", stub)
+
+        stub_parameter = stub.get_parameter_by_name("model_manager")
+        assert stub_parameter is not None, "the parameter itself should survive -- only its trait is lost"
+        assert not list(stub_parameter.find_elements_by_type(Button))
+
+        result = current_engine().handle_request(
+            SendNodeMessageRequest(
+                node_name="stubbed",
+                optional_element_name="model_manager",
+                message_type="on_click",
+                message=ButtonDetailsMessagePayload(label="Open", variant="default", size="md", state="ready"),
+            )
+        )
+
+        assert not isinstance(result, SendNodeMessageResultSuccess)
+        assert "no handler was available" in str(result.result_details)
+
+
+class TestUnshippableOutputGuardrail:
+    @pytest.mark.asyncio
+    async def test_worker_producing_an_unshippable_value_fails_with_instructions(self, tmp_path: Path) -> None:
+        """A serializable=False output cannot cross the boundary, so say so usefully."""
+        from griptape_nodes.retained_mode.events.execution_events import (
+            ExecuteNodeRequest,
+            ExecuteNodeResultFailure,
+        )
+
+        _register(
+            tmp_path,
+            fixture_dir=NONSERIALIZABLE_FIXTURE,
+            node_file="nonserializable_nodes.py",
+            name="Guardrail Library",
+        )
+        library_manager = current_engine().library_manager
+        library_manager._is_worker = True
+        node = LibraryRegistry.create_node(
+            node_type="ProducerNode", name="Producer", specific_library_name="Guardrail Library"
+        )
+        current_engine().object_manager.add_object_by_name("Producer", node)
+
+        result = await current_engine().ahandle_request(
+            ExecuteNodeRequest(
+                node_name="Producer",
+                node_metadata={"node_type": "ProducerNode", "library": "Guardrail Library"},
+            )
+        )
+
+        assert isinstance(result, ExecuteNodeResultFailure)
+        details = str(result.result_details)
+        assert "'session'" in details
+        assert "cannot leave" in details
+        # The message must teach the way forward, not just refuse.
+        assert "descriptor" in details
+
+    @pytest.mark.asyncio
+    async def test_serializable_outputs_are_unaffected(self, tmp_path: Path) -> None:
+        from griptape_nodes.retained_mode.events.execution_events import (
+            ExecuteNodeRequest,
+            ExecuteNodeResultSuccess,
+        )
+
+        _register(
+            tmp_path,
+            fixture_dir=EXEC_FIXTURE,
+            node_file="exec_dep_node.py",
+            name="Guardrail Serializable",
+            edit_dependencies=["fakeedit"],
+        )
+        current_engine().library_manager._is_worker = True
+        node = LibraryRegistry.create_node(
+            node_type="ExecDepNode", name="Fine", specific_library_name="Guardrail Serializable"
+        )
+        current_engine().object_manager.add_object_by_name("Fine", node)
+
+        result = await current_engine().ahandle_request(
+            ExecuteNodeRequest(
+                node_name="Fine",
+                node_metadata={"node_type": "ExecDepNode", "library": "Guardrail Serializable"},
+            )
+        )
+
+        # fakeexec is not importable here, so process() raises -- but on the exec dep, NOT
+        # on the guardrail. What matters is the guardrail did not fire for its string outputs.
+        if isinstance(result, ExecuteNodeResultSuccess):
+            assert result.parameter_output_values["edit_dep_version"] == "1.0.0"
+        else:
+            assert "cannot leave" not in str(result.result_details)
+
+
+class TestManagerAccessDuringWorkerExecution:
+    def test_config_manager_is_refused_inside_worker_execution(self) -> None:
+        """In a worker, node code must ask the orchestrator rather than read local state."""
+        library_manager = current_engine().library_manager
+        library_manager._is_worker = True
+        event_manager = current_engine().event_manager
+
+        with event_manager.worker_node_execution_scope(), pytest.raises(RuntimeError) as excinfo:
+            GriptapeNodes.ConfigManager()
+
+        message = str(excinfo.value)
+        assert "ConfigManager" in message
+        assert "GetConfigValueRequest" in message
+
+    def test_secrets_and_os_managers_are_refused_too(self) -> None:
+        current_engine().library_manager._is_worker = True
+        event_manager = current_engine().event_manager
+
+        with event_manager.worker_node_execution_scope():
+            with pytest.raises(RuntimeError, match="GetSecretValueRequest"):
+                GriptapeNodes.SecretsManager()
+            with pytest.raises(RuntimeError, match="ReadFileRequest"):
+                GriptapeNodes.OSManager()
+
+    def test_managers_work_outside_node_execution_in_a_worker(self) -> None:
+        """Engine boot and library load happen in the worker too, and need real managers."""
+        current_engine().library_manager._is_worker = True
+
+        assert GriptapeNodes.ConfigManager() is not None
+        assert GriptapeNodes.SecretsManager() is not None
+
+    def test_managers_work_during_execution_on_the_orchestrator(self) -> None:
+        """The refusal is about being in a worker, not about executing."""
+        event_manager = current_engine().event_manager
+
+        with event_manager.worker_node_execution_scope():
+            assert GriptapeNodes.ConfigManager() is not None
+
+    def test_static_files_manager_stays_available(self) -> None:
+        """Storage is the one local capability: media bytes cannot cross the boundary."""
+        current_engine().library_manager._is_worker = True
+        event_manager = current_engine().event_manager
+
+        with event_manager.worker_node_execution_scope():
+            assert GriptapeNodes.StaticFilesManager() is not None

--- a/tests/unit/retained_mode/managers/test_execute_node.py
+++ b/tests/unit/retained_mode/managers/test_execute_node.py
@@ -36,6 +36,9 @@ def _make_mock_library_manager(*, is_worker: bool) -> MagicMock:
     lib_mgr.is_worker = is_worker
     lib_mgr._is_worker = is_worker
     lib_mgr.get_worker_for_library.return_value = None
+    # The execute path awaits this before consulting get_worker_for_library; a plain
+    # MagicMock attribute is not awaitable.
+    lib_mgr.wait_for_worker_library_load = AsyncMock()
     return lib_mgr
 
 
@@ -371,6 +374,7 @@ class TestExecuteNodeWorkerRoute:
         lib_mgr = MagicMock()
         lib_mgr.is_worker = False
         lib_mgr._is_worker = False
+        lib_mgr.wait_for_worker_library_load = AsyncMock()
         lib_mgr.get_worker_for_library.return_value = ("eng-id", "topic")
 
         node_manager = _make_node_manager(object_manager=mock_obj_mgr, library_manager=lib_mgr, worker_manager=wm)
@@ -402,6 +406,7 @@ class TestExecuteNodeWorkerRoute:
         lib_mgr = MagicMock()
         lib_mgr.is_worker = False
         lib_mgr._is_worker = False
+        lib_mgr.wait_for_worker_library_load = AsyncMock()
         lib_mgr.get_worker_for_library.return_value = ("eng-id", "topic")
 
         node_manager = _make_node_manager(object_manager=mock_obj_mgr, library_manager=lib_mgr, worker_manager=wm)

--- a/tests/unit/retained_mode/managers/test_library_worker_config.py
+++ b/tests/unit/retained_mode/managers/test_library_worker_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any, cast
 from unittest.mock import MagicMock
 
@@ -218,3 +219,95 @@ class TestResolveExecutesInWorker:
             requires_worker=True, metadata=self._metadata(exec_deps=None)
         )
         assert result is True
+
+
+class TestExecuteWaitsForTheWorkerLibraryLoad:
+    """Routing must gate on the worker's LibraryLoadedNotification, not on registration.
+
+    A worker registers at process start, BEFORE it has loaded its library -- with eager
+    execution-module imports, seconds before. A node routed in that window failed in the
+    worker with "Library 'X' not found". The old worker system never had this window:
+    stub nodes did not exist until the worker confirmed the load, so nothing could execute.
+    """
+
+    def _spawned_info(self, *, loaded: bool) -> LibraryManager.LibraryInfo:
+        info = LibraryManager.LibraryInfo(
+            lifecycle_state=LibraryManager.LibraryLifecycleState.LOADED,
+            fitness=LibraryManager.LibraryFitness.GOOD,
+            library_path="/some/path.json",
+            is_sandbox=False,
+            library_name="Lib",
+            executes_in_worker=True,
+        )
+        info.worker_ready = asyncio.Event()
+        if loaded:
+            info.worker_ready.set()
+        return info
+
+    @pytest.mark.asyncio
+    async def test_the_wait_releases_when_the_notification_arrives(self) -> None:
+        mgr = _make_library_manager()
+        info = self._spawned_info(loaded=False)
+        mgr._library_file_path_to_info["/some/path.json"] = info
+        order: list[str] = []
+
+        async def executes() -> None:
+            await mgr.wait_for_worker_library_load("Lib")
+            order.append("routed")
+
+        async def worker_finishes_loading() -> None:
+            order.append("loaded")
+            await mgr._on_library_loaded_notification(LibraryLoadedNotification(library_name="Lib", fitness="GOOD"))
+
+        await asyncio.gather(executes(), worker_finishes_loading())
+
+        assert order == ["loaded", "routed"], "execution routed before the worker reported the library loaded"
+
+    @pytest.mark.asyncio
+    async def test_an_already_loaded_library_does_not_wait(self) -> None:
+        mgr = _make_library_manager()
+        mgr._library_file_path_to_info["/some/path.json"] = self._spawned_info(loaded=True)
+
+        await mgr.wait_for_worker_library_load("Lib")
+
+    @pytest.mark.asyncio
+    async def test_a_library_with_no_spawned_worker_does_not_wait(self) -> None:
+        mgr = _make_library_manager()
+        info = self._spawned_info(loaded=False)
+        info.worker_ready = None
+        mgr._library_file_path_to_info["/some/path.json"] = info
+
+        await mgr.wait_for_worker_library_load("Lib")
+
+    @pytest.mark.asyncio
+    async def test_the_timeout_names_the_library_and_the_ceiling(self) -> None:
+        mgr = _make_library_manager()
+        mgr._library_file_path_to_info["/some/path.json"] = self._spawned_info(loaded=False)
+        mgr._engine = MagicMock()  # type: ignore[assignment]
+        mgr._engine.config_manager.get_config_value.return_value = 0.01
+
+        with pytest.raises(RuntimeError, match="Lib"):
+            await mgr.wait_for_worker_library_load("Lib")
+
+    @pytest.mark.asyncio
+    async def test_an_eviction_during_the_wait_releases_it(self) -> None:
+        """The waiter must not hold on for the full grace for a worker that is already gone."""
+        mgr = _make_library_manager()
+        info = self._spawned_info(loaded=False)
+        mgr._library_file_path_to_info["/some/path.json"] = info
+        order: list[str] = []
+
+        async def executes() -> None:
+            await mgr.wait_for_worker_library_load("Lib")
+            order.append("released")
+
+        async def worker_dies() -> None:
+            order.append("evicted")
+            mgr.on_worker_evicted("worker-1", "Lib")
+
+        await asyncio.gather(executes(), worker_dies())
+
+        assert order == ["evicted", "released"]
+        assert info.lifecycle_state is LibraryManager.LibraryLifecycleState.LOADED, (
+            "an exec-deps library must stay editable through an eviction"
+        )

--- a/tests/unit/retained_mode/managers/test_library_worker_config.py
+++ b/tests/unit/retained_mode/managers/test_library_worker_config.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from griptape_nodes.node_library.library_registry import LibraryMetadata
+from griptape_nodes.node_library.library_registry import Dependencies, LibraryMetadata
 from griptape_nodes.retained_mode.events.app_events import LibraryLoadedNotification
 from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
 
@@ -69,6 +69,7 @@ class TestGetWorkerForLibrary:
             is_sandbox=False,
             library_name="my_lib",
             requires_worker=True,
+            executes_in_worker=True,
         )
 
         cast("MagicMock", mgr._worker_manager).get_worker_for_key.return_value = (
@@ -106,6 +107,7 @@ class TestGetWorkerForLibrary:
             is_sandbox=False,
             library_name="my_lib",
             requires_worker=True,
+            executes_in_worker=True,
         )
 
         cast("MagicMock", mgr._worker_manager).get_worker_for_key.return_value = None
@@ -174,3 +176,45 @@ class TestRegisterPreReloadCallback:
         mgr.register_pre_reload_callback(second)
 
         assert mgr._pre_reload_callbacks == [*baseline, first, second]
+
+
+class TestResolveExecutesInWorker:
+    """Execution placement is a fact about dependencies, derived not declared."""
+
+    def _metadata(self, *, exec_deps: list[str] | None) -> LibraryMetadata:
+        dependencies = None
+        if exec_deps is not None:
+            dependencies = Dependencies(pip_dependencies=["pillow"], pip_dependencies_exec=exec_deps)
+        return LibraryMetadata(
+            author="t",
+            description="d",
+            library_version="1.0.0",
+            engine_version="0.0.0",
+            tags=[],
+            dependencies=dependencies,
+        )
+
+    def test_exec_dependencies_require_a_worker(self) -> None:
+        result = LibraryManager._resolve_executes_in_worker(
+            requires_worker=False, metadata=self._metadata(exec_deps=["torch"])
+        )
+        assert result is True
+
+    def test_no_dependencies_section_means_no_worker(self) -> None:
+        result = LibraryManager._resolve_executes_in_worker(
+            requires_worker=False, metadata=self._metadata(exec_deps=None)
+        )
+        assert result is False
+
+    def test_empty_exec_dependencies_mean_no_worker(self) -> None:
+        result = LibraryManager._resolve_executes_in_worker(
+            requires_worker=False, metadata=self._metadata(exec_deps=[])
+        )
+        assert result is False
+
+    def test_legacy_worker_mode_still_executes_in_a_worker(self) -> None:
+        """The two reasons are independent: declaring worker mode is sufficient alone."""
+        result = LibraryManager._resolve_executes_in_worker(
+            requires_worker=True, metadata=self._metadata(exec_deps=None)
+        )
+        assert result is True

--- a/tests/unit/retained_mode/managers/test_node_manager_strict_mode.py
+++ b/tests/unit/retained_mode/managers/test_node_manager_strict_mode.py
@@ -69,6 +69,9 @@ class TestExecuteNodeStrictMode:
         m.is_worker = is_worker
         m._is_worker = is_worker
         m.get_worker_for_library.return_value = None
+        # Awaited on the orchestrator route before a node is routed, so it has to be a coroutine
+        # rather than a plain MagicMock attribute.
+        m.wait_for_worker_library_load = AsyncMock(return_value=None)
         return m
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Part of griptape-ai/internal#215 AND griptape-ai/internal#214 — routes exec-deps libraries to a worker (#215) and replaces lossy stubs with real classes plus the first guarded managers (#214). (Stack position map at the bottom.) Rebased 2026-08-31 onto main@47cb67b4; e2e suites converted to the `engine`/`current_engine()` test idiom from #5385.

---

Third PR of the worker-execution stack. **Stacked on #5391** — review only the last commit.

## What

Makes `pip_dependencies_exec` (from #5390) actually do something: a library that declares execution dependencies executes its nodes in its dedicated worker process, while the orchestrator holds its **real node classes** rather than schema stubs.

The mechanism is separating two facts that were conflated:

| Fact | Meaning |
|---|---|
| `requires_worker` (existing) | Legacy worker mode: skip orchestrator-side loading, register stubs, gate the lifecycle on worker confirmation |
| `executes_in_worker` (new) | **Routing**: this library's `process()` runs in a worker. True for either reason. |

`get_worker_for_library` and worker spawning now consult the routing fact. Because the three load-time skips still gate on `requires_worker`, exec-deps libraries flow down the normal path — install deps, load the advanced module, register real classes — with no additional change. One subtlety handled: `LibraryLoadedNotification` no longer overwrites those real classes with worker-reported stubs (that would discard converters, validators, traits, and hooks).

## Two guardrails

Both make the boundary honest rather than silently wrong, and both were written to teach:

1. **Unshippable outputs.** A `serializable=False` output produced in a worker fails with the parameter named and both remedies stated: make the value serializable, or cache it library-side and output a small descriptor the consuming node trades back. (That descriptor idiom is the plan of record for live values — the heavy libraries already use it for pipelines.)
2. **Manager access during execution.** `ConfigManager`, `SecretsManager`, and `OSManager` raise inside worker node execution, naming the request to use instead. A worker holds no authoritative state, so those reads would answer from the wrong process. Deliberately scoped: engine boot and library load also run in the worker and legitimately need real managers, and `StaticFilesManager` stays real because media bytes cannot cross the boundary.

This PR guards the three managers real node code demonstrably reaches (config, secrets, files) -- the evidence-driven starting set. The widening to every accessor happens up-stack in #5426, after the exe_types migration (#5425) took the last engine-internal facade users out of the worker execution path; the plan locked guard breadth as BROAD on 2026-08-31.

## Testing

e2e tests across two suites: the routing fact both ways; hard failure (never local fall-through) when no worker is up; real-classes-not-stubs proven by instantiating the node and reading a value its `__init__` computed from its edit-time dependency; both guardrails including the message content; and the negatives that keep the guards narrow — managers work outside node execution in a worker, and work during execution on the orchestrator. Plus 4 unit tests on the placement decision.

Libraries declaring no execution dependencies are untouched throughout, pinned by tests on both sides.

Full gate: 4667 unit / 54 e2e / 9 integration passed, `make check` clean. `docs/guides/libraries.md` updated with the three behavior changes in artist-facing language.

## Not in this PR

Live-value sharing between two worker-side nodes (the diffusers case). Plan of record: libraries own their value stores using the cache-plus-descriptor idiom they already built for pipelines; the guardrail above points there. Engine-level resident references remain designed but unbuilt, pending evidence that the library-owned pattern is painful.


<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--5402.org.readthedocs.build/en/5402/

<!-- readthedocs-preview griptape-nodes end -->

## Parameter behaviors that a stub would drop

Refs #5420. A schema stub is rebuilt from `WorkerParameterSchema`, which carries scalar fields and `ui_options` only — so traits, converters and validators cannot travel. The trait case is the worst of that family: `ui_options` *do* serialize, so a `Button` renders and looks clickable while being guaranteed to fail with *"no handler was available"*, which names the element rather than the cause.

Execution-dependency libraries avoid this because declaring `pip_dependencies_exec` sets `executes_in_worker` **without** setting `requires_worker`, and stub registration is gated on the latter. `TestParameterBehaviorsSurviveOnRealClasses` pins that gate with a new fixture whose node carries a `Button` trait, a converter and a validator:

- the trait survives and an `on_click` reaches the node's own handler
- the converter and validator still run
- **negative control**: the same parameters driven through the real `_serialize_library_node_schemas` + `_make_worker_stub_class` lose the trait and reproduce the reported failure message verbatim — so the test proves the routing decision, not merely that buttons work on ordinary libraries

This does not close #5420: legacy `worker_mode_override` libraries take the stub path unchanged and still have the bug. It resolves per-library on migration.

The same fact fixes a false positive this PR would otherwise introduce. The stub-loss detectors (`parameter-behaviors-dropped-in-schema`, `value-hooks-execute-only-on-worker`, `connection-hooks-inert-on-worker`) run from the worker-side schema probe, which fires for every library a worker loads — including execution-dependency libraries, whose schemas the orchestrator then ignores. Ungated, this fixture's converter, validator and trait each produced a warning saying they "will not execute on the orchestrator stub" for a library whose orchestrator copy is the real class, sending an author to fix code that is already correct. All three are now gated on the same `requires_worker` fact that gates stubbing, with tests pinning both directions.

> **Merge note.** This stack lands as a unit. Intermediate tips are not intended as shippable states: #5409 forwards OS file requests until #5426 makes them local, and #5390 through #5468 splice `.venv-exec` onto a worker's `sys.path` until #5472 retires that mechanism — a running interpreter cannot be handed a library's own dependency versions that way, because `sys.modules` never reconsiders a module already imported. The orchestrator installing the execution set is therefore the intended end state, not a step: it has to be the builder, since the worker receives that directory as `PYTHONPATH` and so cannot create it.

## Stack

| # | PR | Branch |
|---|----|--------|
| 1 | #5390 | `feat/venue-exec-deps` |
| 2 | #5391 | `feat/venue-reentrancy` |
| 3 | #5402 ← this | `feat/venue-worker-mvp` |
| 4 | #5409 | `feat/venue-worker-behavior-suite` |
| 5 | #5425 | `feat/exe-types-engine-injection` |
| 6 | #5426 | `feat/worker-wire-hardening` |
| 7 | #5427 | `feat/library-exec-lifecycle` |
| 8 | #5428 | `fix/failed-nodes-leave-resolving` |
| 9 | #5430 | `feat/parameter-structure-contract` |
