### PR TITLE
feat: report whether each library metadata entry is in the registry

### DIFF
--- a/src/griptape_nodes/retained_mode/events/library_events.py
+++ b/src/griptape_nodes/retained_mode/events/library_events.py
@@ -433,6 +433,25 @@ class LoadLibraryMetadataFromFileResultSuccess(WorkflowNotAlteredMixin, ResultPa
         git_remote: The git remote URL if the library is in a git repository, None otherwise.
         git_ref: The current git reference (branch, tag, or commit) if the library is in a git repository, None otherwise.
         enabled: If the current library is enabled or disabled by the user at the time of the request.
+        is_registered: Whether a library of this name is in the LibraryRegistry right now.
+
+                       Metadata is read from whatever `libraries_to_register` currently
+                       resolves to, while the registry holds what was actually loaded. Those
+                       two can disagree: config changes after boot (a settings write, a
+                       project switch) are not applied to the registry until libraries
+                       reload, so metadata can describe a library the engine cannot answer
+                       any other question about. Without this flag that difference is
+                       invisible, and a client reasonably follows a metadata entry with a
+                       name-keyed call (CheckLibraryUpdate, GetAllInfoForLibrary) that then
+                       fails with "no Library with that name was registered".
+
+                       False means "declared but not loaded": show it as pending a library
+                       refresh rather than querying it. Keyed on name, not path, because the
+                       follow-up requests are name-keyed too, so a second copy of an
+                       already-loaded name reports True.
+
+                       Distinct from `enabled` (the user's config flag) and from
+                       `registered_path` (the verbatim config path, not a membership answer).
     """
 
     library_schema: LibrarySchema
@@ -440,6 +459,7 @@ class LoadLibraryMetadataFromFileResultSuccess(WorkflowNotAlteredMixin, ResultPa
     git_remote: str | None
     git_ref: str | None
     enabled: bool
+    is_registered: bool
     registered_path: str | None = None
 
 

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -1367,8 +1367,20 @@ class LibraryManager(EngineScoped):
             git_remote=git_remote,
             git_ref=git_ref,
             enabled=enabled,
+            is_registered=self._is_library_name_registered(library_data.name),
             result_details=details,
         )
+
+    @staticmethod
+    def _is_library_name_registered(library_name: str) -> bool:
+        """Whether a library of this name is in the registry right now.
+
+        Metadata is derived from config while the registry holds what actually loaded, so the
+        two can disagree until libraries reload. Keyed on name because the requests a client
+        makes off the back of metadata (CheckLibraryUpdate, GetAllInfoForLibrary) are
+        name-keyed: if the name resolves, those calls succeed regardless of which copy loaded.
+        """
+        return library_name in LibraryRegistry.list_libraries()
 
     async def load_metadata_for_all_libraries_request(
         self,
@@ -1422,6 +1434,7 @@ class LibraryManager(EngineScoped):
                         git_remote=None,
                         git_ref=None,
                         enabled=True,
+                        is_registered=self._is_library_name_registered(scan_result.library_schema.name),
                         result_details=scan_result.result_details,
                     )
                 # else: Keep the load failure result
@@ -1583,6 +1596,7 @@ class LibraryManager(EngineScoped):
             git_remote=git_remote,
             git_ref=git_ref,
             enabled=True,
+            is_registered=self._is_library_name_registered(library_schema.name),
             result_details=details,
         )
 

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -709,6 +709,7 @@ class TestLibraryManagerRegisterLibraryFromFile:
                 git_remote=None,
                 git_ref=None,
                 enabled=True,
+                is_registered=False,
                 result_details=ResultDetails(message="Success", level=20),
             )
             mock_venv.return_value.exists.return_value = True
@@ -748,6 +749,7 @@ class TestLibraryManagerRegisterLibraryFromFile:
                     git_remote=None,
                     git_ref=None,
                     enabled=True,
+                    is_registered=False,
                     result_details=ResultDetails(message="OK", level=20),
                 ),
             ),
@@ -776,6 +778,7 @@ class TestLibraryManagerInstallLibraryDependencies:
             git_remote=None,
             git_ref=None,
             enabled=True,
+            is_registered=False,
             result_details=ResultDetails(message="OK", level=20),
         )
 

--- a/tests/unit/retained_mode/managers/test_library_manager_deps.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_deps.py
@@ -128,6 +128,7 @@ def _metadata_success(schema: MagicMock) -> LoadLibraryMetadataFromFileResultSuc
         git_remote=None,
         git_ref=None,
         enabled=True,
+        is_registered=False,
         result_details=ResultDetails(message="OK", level=20),
     )
 

--- a/tests/unit/retained_mode/managers/test_library_metadata_registry_membership.py
+++ b/tests/unit/retained_mode/managers/test_library_metadata_registry_membership.py
@@ -1,0 +1,204 @@
+"""Metadata reports whether each library is actually in the registry.
+
+Metadata is derived from whatever `libraries_to_register` currently resolves to, while the
+registry holds what was actually loaded. Those two disagree whenever config changes after
+boot without a library reload: a settings write updates config and only marks a refresh as
+pending, so until the user acts on it the engine advertises libraries it cannot answer any
+other question about.
+
+Nothing in the response used to expose that. A client would follow a metadata entry with a
+name-keyed call and get `no Library with that name was registered` back, which is what
+produced a wall of errors in a reported session. `is_registered` makes the difference
+visible so those entries can be shown as pending a refresh instead of being queried.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.node_library.library_registry import (
+    LibraryMetadata,
+    LibraryRegistry,
+    LibrarySchema,
+)
+from griptape_nodes.retained_mode.events.library_events import (
+    CheckLibraryUpdateRequest,
+    CheckLibraryUpdateResultFailure,
+    LoadMetadataForAllLibrariesRequest,
+    LoadMetadataForAllLibrariesResultSuccess,
+)
+from griptape_nodes.retained_mode.managers.settings import (
+    LIBRARIES_TO_DOWNLOAD_KEY,
+    LIBRARIES_TO_REGISTER_KEY,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator
+    from pathlib import Path
+
+    from griptape_nodes.retained_mode.engine import Engine
+
+LOADED_LIBRARY = "Nuke Nodes Library"
+DECLARED_BUT_NOT_LOADED = "Griptape Nodes VOID Library"
+
+
+def _library_json(name: str) -> str:
+    schema = LibrarySchema(
+        name=name,
+        library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+        metadata=LibraryMetadata(
+            author="test",
+            description=f"{name} manifest",
+            library_version="0.1.0",
+            engine_version="0.98.0",
+            tags=[],
+        ),
+        categories=[],
+        nodes=[],
+    )
+    return json.dumps(schema.model_dump(mode="json"))
+
+
+def _write_library(directory: Path, name: str) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    manifest = directory / "griptape_nodes_library.json"
+    manifest.write_text(_library_json(name), encoding="utf-8")
+    return manifest
+
+
+def _register_only_config(libraries: object) -> Callable[..., object]:
+    """A `get_config_value` side effect serving only `libraries_to_register`."""
+
+    def get_config_value(key: str, *, default: object = None, **_: object) -> object:
+        if key == LIBRARIES_TO_REGISTER_KEY:
+            return libraries
+        if key == LIBRARIES_TO_DOWNLOAD_KEY:
+            return []
+        return default
+
+    return get_config_value
+
+
+def _register_in_registry(name: str) -> None:
+    LibraryRegistry.generate_new_library(
+        library_data=LibrarySchema(
+            name=name,
+            library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+            metadata=LibraryMetadata(
+                author="test",
+                description="loaded at boot",
+                library_version="0.1.0",
+                engine_version="0.98.0",
+                tags=[],
+            ),
+            categories=[],
+            nodes=[],
+        )
+    )
+
+
+class TestMetadataReportsRegistryMembership:
+    @pytest.fixture(autouse=True)
+    def _clean_registry(self) -> Generator[None, None, None]:
+        LibraryRegistry._clear()
+        yield
+        LibraryRegistry._clear()
+
+    @pytest.fixture
+    def two_declared_libraries(self, tmp_path: Path) -> list[str]:
+        """Two libraries in config; only one of them will be registered."""
+        return [
+            str(_write_library(tmp_path / "loaded", LOADED_LIBRARY)),
+            str(_write_library(tmp_path / "declared-only", DECLARED_BUT_NOT_LOADED)),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_declared_but_unloaded_libraries_are_flagged(
+        self, engine: Engine, two_declared_libraries: list[str]
+    ) -> None:
+        """The exact divergence from the report: config has both, the registry has one."""
+        library_manager = engine.library_manager
+        _register_in_registry(LOADED_LIBRARY)
+
+        with pytest.MonkeyPatch.context() as patcher:
+            patcher.setattr(engine.config_manager, "get_config_value", _register_only_config(two_declared_libraries))
+            result = await library_manager.load_metadata_for_all_libraries_request(LoadMetadataForAllLibrariesRequest())
+
+        assert isinstance(result, LoadMetadataForAllLibrariesResultSuccess)
+        by_name = {entry.library_schema.name: entry for entry in result.successful_libraries}
+
+        assert by_name[LOADED_LIBRARY].is_registered is True
+        assert by_name[DECLARED_BUT_NOT_LOADED].is_registered is False
+
+    @pytest.mark.asyncio
+    async def test_the_flag_predicts_whether_a_name_keyed_call_will_work(
+        self, engine: Engine, two_declared_libraries: list[str]
+    ) -> None:
+        """The point of the flag: it tells a client which entries are safe to ask about.
+
+        Every entry reporting is_registered False is exactly an entry whose follow-up call
+        fails with "no Library with that name was registered", so a client that skips them
+        never provokes that error.
+        """
+        library_manager = engine.library_manager
+        _register_in_registry(LOADED_LIBRARY)
+
+        with pytest.MonkeyPatch.context() as patcher:
+            patcher.setattr(engine.config_manager, "get_config_value", _register_only_config(two_declared_libraries))
+            metadata = await library_manager.load_metadata_for_all_libraries_request(
+                LoadMetadataForAllLibrariesRequest()
+            )
+            assert isinstance(metadata, LoadMetadataForAllLibrariesResultSuccess)
+
+            for entry in metadata.successful_libraries:
+                name = entry.library_schema.name
+                update_result = await library_manager.check_library_update_request(
+                    CheckLibraryUpdateRequest(library_name=name)
+                )
+                disowned = isinstance(update_result, CheckLibraryUpdateResultFailure) and (
+                    "no Library with that name was registered" in str(update_result.result_details)
+                )
+                assert disowned is not entry.is_registered
+
+    @pytest.mark.asyncio
+    async def test_a_second_copy_of_a_loaded_name_reports_registered(self, engine: Engine, tmp_path: Path) -> None:
+        """Keyed on name, not path, because the follow-up requests are name-keyed too.
+
+        Two manifests for one library name: only one copy loads, but a query for that name
+        succeeds either way, so both entries report True.
+        """
+        library_manager = engine.library_manager
+        _register_in_registry(LOADED_LIBRARY)
+
+        copies = [
+            str(_write_library(tmp_path / "copy-a", LOADED_LIBRARY)),
+            str(_write_library(tmp_path / "copy-b", LOADED_LIBRARY)),
+        ]
+
+        with pytest.MonkeyPatch.context() as patcher:
+            patcher.setattr(engine.config_manager, "get_config_value", _register_only_config(copies))
+            result = await library_manager.load_metadata_for_all_libraries_request(LoadMetadataForAllLibrariesRequest())
+
+        assert isinstance(result, LoadMetadataForAllLibrariesResultSuccess)
+        assert [entry.is_registered for entry in result.successful_libraries] == [True, True]
+
+    @pytest.mark.asyncio
+    async def test_is_registered_is_independent_of_enabled(self, engine: Engine, tmp_path: Path) -> None:
+        """`enabled` is the user's config flag; this is a registry answer. Different things."""
+        library_manager = engine.library_manager
+        manifest = str(_write_library(tmp_path / "loaded", LOADED_LIBRARY))
+        _register_in_registry(LOADED_LIBRARY)
+
+        with pytest.MonkeyPatch.context() as patcher:
+            patcher.setattr(engine.config_manager, "get_config_value", _register_only_config([manifest]))
+            result = await library_manager.load_metadata_for_all_libraries_request(LoadMetadataForAllLibrariesRequest())
+
+        assert isinstance(result, LoadMetadataForAllLibrariesResultSuccess)
+        entry = result.successful_libraries[0]
+        # Nothing disabled it, and it is in the registry: the two flags are set from
+        # unrelated sources and must not be conflated by callers.
+        assert entry.enabled is True
+        assert entry.is_registered is True


### PR DESCRIPTION
Makes a config/registry divergence visible instead of fatal. This is the change that closes the `no Library with that name was registered` spam from a reported session; the GUI half follows in griptape-vsl-gui.

## Cause

Library metadata is derived from whatever `libraries_to_register` currently resolves to. The registry holds what was actually **loaded**. Those two diverge whenever config changes after boot without a library reload, and a settings write is exactly that case: `set_config_value` updates config and the editor only marks a refresh as *pending*, so until the user acts on that banner the engine advertises libraries it cannot answer any other question about.

Nothing in the response exposed the difference, so a client would reasonably follow a metadata entry with a name-keyed call (`CheckLibraryUpdate`, `GetAllInfoForLibrary`) and get `no Library with that name was registered` back. One entry per stale library, every sweep.

Worth noting activation does *not* cause this: a project switch trips `library_config_changed` and reloads, so config and registry end up agreeing. It is specifically the write-without-reload path.

## Change

`LoadLibraryMetadataFromFileResultSuccess` gains `is_registered`. `False` means "declared but not loaded": show it as pending a library refresh rather than querying it.

Keyed on **name**, not path, because the follow-up requests are name-keyed too — so a second copy of an already-loaded name reports `True`, since a query for that name succeeds regardless of which copy loaded.

Two deliberate choices:

- **Required, not defaulted.** A wrong value here is silently wrong, so every construction site has to state it. That is why four test constructors and three production sites are touched.
- **Named `is_registered`, not `registered`.** `registered_path` already exists and means the verbatim config path, not a membership answer. Adjacent fields differing by one word would be a reading hazard.

It is also independent of `enabled`, which is the user's config flag. A test pins that they are not interchangeable.

## The test that matters

`test_the_flag_predicts_whether_a_name_keyed_call_will_work` asserts, for every advertised entry, that `is_registered is False` holds exactly when a follow-up `CheckLibraryUpdate` fails with that error string. So the flag cannot drift from the behaviour it exists to describe: if the registry lookup or the error path changes, this fails.

## Verification

Full unit suite: 4667 passed, 13 skipped. Lint, types, format, spell clean.

## Follow-ups

The engine now reports it; the editor still has to act on it (skip update checks and `getLibrarySourceInfo` for unregistered entries, badge those rows as pending refresh). That is a separate PR in griptape-vsl-gui and degrades gracefully against an older engine, where the field is absent and everything is treated as registered exactly as today.

Related: griptape-nodes-engine#5401 stops new pollution of the user config, and a `gtn config prune-libraries` command is still needed for configs already polluted.
