### PR TITLE
feat: add gtn config prune-libraries

### DIFF
--- a/src/griptape_nodes/cli/commands/config.py
+++ b/src/griptape_nodes/cli/commands/config.py
@@ -1,12 +1,22 @@
 """Config command for Griptape Nodes CLI."""
 
 import json
+import shutil
 import sys
+from pathlib import Path
+from typing import Annotated, Any
 
 import typer
 
 from griptape_nodes.cli.shared import console
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+# Imported as a module, not `from ... import USER_CONFIG_PATH`, so the path is read at call
+# time. The engine references it the same way, which is what lets the test suite redirect it
+# to a temp file instead of touching a real user's config.
+from griptape_nodes.retained_mode.managers import config_manager as config_manager_module
+from griptape_nodes.retained_mode.managers.settings import LIBRARIES_TO_REGISTER_KEY
+from griptape_nodes.utils.library_utils import extract_library_path
 
 config_manager = GriptapeNodes.ConfigManager()
 
@@ -34,6 +44,42 @@ def list_configs() -> None:
 def reset() -> None:
     """Reset configuration to defaults."""
     _reset_user_config()
+
+
+@app.command("prune-libraries")
+def prune_libraries(
+    *,
+    remove_outside_root: Annotated[
+        bool,
+        typer.Option(
+            "--remove-outside-root",
+            help="Remove entries whose path is not under the resolved libraries directory.",
+        ),
+    ] = False,
+    remove_path: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--remove-path",
+            help="Remove one specific entry by its path, exactly as listed. Repeatable.",
+        ),
+    ] = None,
+    yes: Annotated[bool, typer.Option("--yes", "-y", help="Skip the confirmation prompt.")] = False,
+) -> None:
+    """Inspect (and optionally clean) libraries_to_register in your USER config.
+
+    Editing library settings used to persist the whole merged list, so a user config can
+    hold library paths that belong to a project opened long ago. Those entries stay inert
+    while a project supplies its own list, then become the engine's library set the moment
+    no project layer is loaded to shadow them.
+
+    Reports by default and changes nothing. Only the user config file is ever touched;
+    project and workspace configs are read-only here.
+    """
+    _prune_user_config_libraries(
+        remove_outside_root=remove_outside_root,
+        remove_paths=remove_path or [],
+        assume_yes=yes,
+    )
 
 
 def _print_user_config(config_path: str | None = None) -> None:
@@ -72,3 +118,106 @@ def _reset_user_config() -> None:
     console.print("[bold]Resetting user configuration to default values...[/bold]")
     config_manager.reset_user_config()
     console.print("[bold green]User configuration reset complete![/bold green]")
+
+
+def _classify_user_library_entry(path: str, libraries_root: Path) -> str:
+    """Describe why a user-config library entry might not belong there.
+
+    Returns a short reason, or an empty string when nothing looks off. These are signals
+    rather than proof: registering a library by absolute path from anywhere is legitimate,
+    which is why nothing is removed without being asked for explicitly.
+    """
+    if not path:
+        return "no path"
+    resolved = Path(path).expanduser()
+    if not resolved.exists():
+        # The engine already drops these on every load, so seeing one means it has not
+        # loaded since the path disappeared.
+        return "missing on disk"
+    if not resolved.is_relative_to(libraries_root):
+        return "outside the libraries directory"
+    return ""
+
+
+def _prune_user_config_libraries(*, remove_outside_root: bool, remove_paths: list[str], assume_yes: bool) -> None:
+    """Report, and optionally clean, `libraries_to_register` in the user config."""
+    user_entries: list[Any] = (
+        config_manager.get_config_value(LIBRARIES_TO_REGISTER_KEY, config_source="user_config", default=[]) or []
+    )
+    if not user_entries:
+        console.print(
+            "[bold green]No libraries_to_register entries in your user config. Nothing to prune.[/bold green]"
+        )
+        return
+
+    libraries_root = config_manager.resolved_libraries_root()
+
+    # Whatever the other layers supply for this key. Because merge_dicts replaces lists
+    # rather than merging them, a project or workspace list does not combine with the
+    # user's: it replaces it wholesale, so every entry below is inert while that layer is
+    # loaded. Asked through the same helper load_configs uses, so this cannot disagree with
+    # the precedence the engine actually resolves.
+    shadowing_list = config_manager.get_config_value(
+        LIBRARIES_TO_REGISTER_KEY,
+        config_source="merged_without_user_config",
+        default=[],
+    )
+    is_shadowed = isinstance(shadowing_list, list) and len(shadowing_list) > 0
+
+    user_config_path = config_manager_module.USER_CONFIG_PATH
+    console.print(f"[bold]User config:[/bold] {user_config_path}")
+    console.print(f"[bold]Libraries directory:[/bold] {libraries_root}\n")
+
+    if is_shadowed:
+        console.print(
+            "[yellow]The active project (or workspace) declares its own libraries_to_register, "
+            "so none of the entries below are currently in effect. They take over as soon as no "
+            "project layer is loaded.[/yellow]\n"
+        )
+
+    paths = [extract_library_path(entry) for entry in user_entries]
+    reasons = [_classify_user_library_entry(path, libraries_root) for path in paths]
+
+    console.print("[bold]Entries in your user config:[/bold]")
+    for path, reason in zip(paths, reasons, strict=True):
+        annotation = f"  [yellow]<- {reason}[/yellow]" if reason else ""
+        console.print(f"  {path or '(no path)'}{annotation}")
+
+    doomed = {
+        path
+        for path, reason in zip(paths, reasons, strict=True)
+        if (remove_outside_root and reason == "outside the libraries directory") or path in set(remove_paths)
+    }
+
+    unmatched = sorted(set(remove_paths) - set(paths))
+    for missing_request in unmatched:
+        console.print(f"\n[bold red]--remove-path '{missing_request}' matches no entry.[/bold red]")
+
+    if not doomed:
+        if not remove_outside_root and not remove_paths:
+            console.print(
+                "\nNothing changed. Re-run with [bold]--remove-outside-root[/bold] to drop the entries "
+                "flagged above, or [bold]--remove-path <path>[/bold] to drop one exactly."
+            )
+        else:
+            console.print("\nNothing matched, so nothing was removed.")
+        return
+
+    console.print("\n[bold]Would remove:[/bold]")
+    for path in sorted(doomed):
+        console.print(f"  [red]{path}[/red]")
+
+    if not assume_yes and not typer.confirm(f"\nRemove {len(doomed)} entry/entries from {user_config_path}?"):
+        console.print("[bold]Left unchanged.[/bold]")
+        return
+
+    backup_path = user_config_path.with_suffix(".prune.bak")
+    shutil.copyfile(user_config_path, backup_path)
+
+    kept = [entry for entry, path in zip(user_entries, paths, strict=True) if path not in doomed]
+    if not config_manager.set_config_value(LIBRARIES_TO_REGISTER_KEY, kept):
+        console.print(f"[bold red]Failed to write the user config. It is unchanged; backup at {backup_path}[/bold red]")
+        sys.exit(1)
+
+    console.print(f"[bold green]Removed {len(doomed)} entry/entries.[/bold green]")
+    console.print(f"Backup of the previous user config: {backup_path}")

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -688,7 +688,12 @@ class ConfigManager(EngineScoped):
         *,
         should_load_env_var_if_detected: bool = True,
         config_source: Literal[
-            "user_config", "project_config", "workspace_config", "default_config", "merged_config"
+            "user_config",
+            "project_config",
+            "workspace_config",
+            "default_config",
+            "merged_config",
+            "merged_without_user_config",
         ] = "merged_config",
         default: Any | None = None,
         cast_type: type[bool] | type[int] | type[float] | type[str] | None = None,
@@ -701,7 +706,12 @@ class ConfigManager(EngineScoped):
             key: The configuration key to get. Can use dot notation for nested keys (e.g., 'category.subcategory.key').
                  If the key refers to a category (dictionary), returns the entire category.
             should_load_env_var_if_detected: If True, and the value starts with a $, it will be pulled from the environment variables.
-            config_source: The source of the configuration to use. Can be 'user_config', 'project_config', 'default_config', or 'merged_config'.
+            config_source: Which configuration to read. The layer names read that layer alone.
+                'merged_config' is the effective value the engine resolves.
+                'merged_without_user_config' is the effective value the engine WOULD resolve if
+                the user layer did not exist, which answers "is this value the user's own, or
+                something a project handed them?". Computed on demand rather than cached, so
+                unlike the others it reflects any layer mutation since the last load.
             default: The default value to return if the key is not found in the configuration.
             cast_type: Optional type to coerce the value to (bool, int, float, or str). Useful for environment
                        variables which are always strings (e.g., "false" -> False when cast_type=bool).
@@ -709,14 +719,19 @@ class ConfigManager(EngineScoped):
         Returns:
             The value associated with the key, or the entire category if key points to a dict.
         """
-        config_source_map = {
-            "user_config": self.user_config,
-            "project_config": self.project_config,
-            "workspace_config": self.workspace_config,
-            "merged_config": self.merged_config,
-            "default_config": self.default_config,
-        }
-        config = config_source_map.get(config_source, self.merged_config)
+        if config_source == "merged_without_user_config":
+            # Computed rather than looked up, and deliberately not part of the map below so
+            # the merge only runs for callers that ask for it. get_config_value is hot.
+            config = self._merge_config_layers(include_user_layer=False)
+        else:
+            config_source_map = {
+                "user_config": self.user_config,
+                "project_config": self.project_config,
+                "workspace_config": self.workspace_config,
+                "merged_config": self.merged_config,
+                "default_config": self.default_config,
+            }
+            config = config_source_map.get(config_source, self.merged_config)
         value = get_dot_value(config, key, default)
 
         if value is None:

--- a/tests/unit/cli/commands/test_config_prune_libraries.py
+++ b/tests/unit/cli/commands/test_config_prune_libraries.py
@@ -1,0 +1,223 @@
+"""Tests for `gtn config prune-libraries`.
+
+Editing library settings used to persist the whole MERGED list into the user config, so a
+user config can hold library paths belonging to a project opened long ago. Those entries are
+inert while a project supplies its own list (lists replace rather than merge) and become the
+engine's library set the moment no project layer is loaded to shadow them.
+
+The command reports by default and removes nothing without being asked, because "outside the
+libraries directory" is a signal and not proof: registering a library by absolute path from
+anywhere is legitimate.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from griptape_nodes.cli.commands import config as config_cli
+from griptape_nodes.retained_mode.managers.settings import LIBRARIES_TO_REGISTER_KEY
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def libraries_root(tmp_path: Path) -> Path:
+    """The resolved libraries directory entries are measured against."""
+    root = tmp_path / "libraries"
+    root.mkdir()
+    return root
+
+
+def _make_library(directory: Path, name: str) -> str:
+    """Create a library manifest on disk and return its path as config would hold it."""
+    lib_dir = directory / name
+    lib_dir.mkdir(parents=True, exist_ok=True)
+    manifest = lib_dir / "griptape_nodes_library.json"
+    manifest.write_text("{}", encoding="utf-8")
+    return str(manifest)
+
+
+@pytest.fixture
+def fake_config_manager(monkeypatch: pytest.MonkeyPatch, libraries_root: Path) -> MagicMock:
+    """Stand in for the module-level ConfigManager the CLI builds at import time."""
+    manager = MagicMock()
+    manager.resolved_libraries_root.return_value = libraries_root
+    manager.set_config_value.return_value = True
+    monkeypatch.setattr(config_cli, "config_manager", manager)
+    return manager
+
+
+def _configure(manager: MagicMock, *, user_entries: list, shadowing: list | None = None) -> None:
+    """Wire get_config_value to answer per config_source, as the real manager does."""
+
+    def get_config_value(
+        key: str, *, config_source: str = "merged_config", default: object = None, **_: object
+    ) -> object:
+        if key != LIBRARIES_TO_REGISTER_KEY:
+            return default
+        if config_source == "user_config":
+            return user_entries
+        if config_source == "merged_without_user_config":
+            return shadowing if shadowing is not None else []
+        return default
+
+    manager.get_config_value.side_effect = get_config_value
+
+
+@pytest.fixture
+def user_config_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Redirect the CLI's view of the user config to a temp file it may back up."""
+    path = tmp_path / "griptape_nodes_config.json"
+    path.write_text(json.dumps({}), encoding="utf-8")
+    monkeypatch.setattr(config_cli.config_manager_module, "USER_CONFIG_PATH", path)
+    return path
+
+
+class TestClassifyUserLibraryEntry:
+    def test_an_entry_inside_the_libraries_root_is_unremarkable(self, libraries_root: Path) -> None:
+        path = _make_library(libraries_root, "mine")
+        assert config_cli._classify_user_library_entry(path, libraries_root) == ""
+
+    def test_an_entry_outside_the_libraries_root_is_flagged(self, libraries_root: Path, tmp_path: Path) -> None:
+        path = _make_library(tmp_path / "some-other-tree", "theirs")
+        assert config_cli._classify_user_library_entry(path, libraries_root) == "outside the libraries directory"
+
+    def test_a_nonexistent_path_is_flagged(self, libraries_root: Path) -> None:
+        assert (
+            config_cli._classify_user_library_entry(str(libraries_root / "gone.json"), libraries_root)
+            == "missing on disk"
+        )
+
+    def test_an_entry_with_no_path_is_flagged(self, libraries_root: Path) -> None:
+        assert config_cli._classify_user_library_entry("", libraries_root) == "no path"
+
+
+class TestPruneReportsWithoutChanging:
+    def test_an_empty_user_list_writes_nothing(self, fake_config_manager: MagicMock) -> None:
+        _configure(fake_config_manager, user_entries=[])
+
+        config_cli._prune_user_config_libraries(remove_outside_root=False, remove_paths=[], assume_yes=True)
+
+        fake_config_manager.set_config_value.assert_not_called()
+
+    def test_the_default_run_changes_nothing(
+        self, fake_config_manager: MagicMock, libraries_root: Path, tmp_path: Path
+    ) -> None:
+        """Reporting must be safe to run: no writes, even with flaggable entries present."""
+        stale = _make_library(tmp_path / "previous-project", "stale")
+        _configure(fake_config_manager, user_entries=[_make_library(libraries_root, "mine"), stale])
+
+        config_cli._prune_user_config_libraries(remove_outside_root=False, remove_paths=[], assume_yes=True)
+
+        fake_config_manager.set_config_value.assert_not_called()
+
+
+class TestPruneRemovals:
+    @pytest.mark.usefixtures("user_config_file")
+    def test_remove_outside_root_keeps_entries_under_the_root(
+        self, fake_config_manager: MagicMock, libraries_root: Path, tmp_path: Path
+    ) -> None:
+        mine = _make_library(libraries_root, "mine")
+        stale = _make_library(tmp_path / "previous-project", "stale")
+        _configure(fake_config_manager, user_entries=[mine, stale])
+
+        config_cli._prune_user_config_libraries(remove_outside_root=True, remove_paths=[], assume_yes=True)
+
+        fake_config_manager.set_config_value.assert_called_once_with(LIBRARIES_TO_REGISTER_KEY, [mine])
+
+    @pytest.mark.usefixtures("user_config_file")
+    def test_remove_path_removes_exactly_that_entry(self, fake_config_manager: MagicMock, libraries_root: Path) -> None:
+        """The surgical option, for an entry inside the root that the user still wants gone."""
+        keep = _make_library(libraries_root, "keep")
+        drop = _make_library(libraries_root, "drop")
+        _configure(fake_config_manager, user_entries=[keep, drop])
+
+        config_cli._prune_user_config_libraries(remove_outside_root=False, remove_paths=[drop], assume_yes=True)
+
+        fake_config_manager.set_config_value.assert_called_once_with(LIBRARIES_TO_REGISTER_KEY, [keep])
+
+    @pytest.mark.usefixtures("user_config_file")
+    def test_dict_shaped_entries_survive_intact(
+        self, fake_config_manager: MagicMock, libraries_root: Path, tmp_path: Path
+    ) -> None:
+        """Entries carrying `enabled` / `worker_mode_override` must be kept whole, not flattened."""
+        mine = {"path": _make_library(libraries_root, "mine"), "enabled": False, "worker_mode_override": "WORKER"}
+        stale = {"path": _make_library(tmp_path / "previous-project", "stale"), "enabled": True}
+        _configure(fake_config_manager, user_entries=[mine, stale])
+
+        config_cli._prune_user_config_libraries(remove_outside_root=True, remove_paths=[], assume_yes=True)
+
+        fake_config_manager.set_config_value.assert_called_once_with(LIBRARIES_TO_REGISTER_KEY, [mine])
+
+    def test_a_backup_is_written_before_the_config_changes(
+        self, fake_config_manager: MagicMock, user_config_file: Path, tmp_path: Path
+    ) -> None:
+        user_config_file.write_text(json.dumps({"marker": "original"}), encoding="utf-8")
+        _configure(fake_config_manager, user_entries=[_make_library(tmp_path / "previous-project", "stale")])
+
+        config_cli._prune_user_config_libraries(remove_outside_root=True, remove_paths=[], assume_yes=True)
+
+        backup = user_config_file.with_suffix(".prune.bak")
+        assert json.loads(backup.read_text(encoding="utf-8")) == {"marker": "original"}
+
+    @pytest.mark.usefixtures("user_config_file")
+    def test_a_failed_write_exits_nonzero(self, fake_config_manager: MagicMock, tmp_path: Path) -> None:
+        """A write that did not land must not be reported as a successful prune."""
+        _configure(fake_config_manager, user_entries=[_make_library(tmp_path / "previous-project", "stale")])
+        fake_config_manager.set_config_value.return_value = False
+
+        with pytest.raises(SystemExit) as exit_info:
+            config_cli._prune_user_config_libraries(remove_outside_root=True, remove_paths=[], assume_yes=True)
+
+        assert exit_info.value.code == 1
+
+    def test_an_unmatched_remove_path_removes_nothing(
+        self, fake_config_manager: MagicMock, libraries_root: Path
+    ) -> None:
+        keep = _make_library(libraries_root, "keep")
+        _configure(fake_config_manager, user_entries=[keep])
+
+        config_cli._prune_user_config_libraries(
+            remove_outside_root=False, remove_paths=["/not/in/the/list.json"], assume_yes=True
+        )
+
+        fake_config_manager.set_config_value.assert_not_called()
+
+
+def _rendered(capsys: pytest.CaptureFixture[str]) -> str:
+    """Captured console text with whitespace collapsed.
+
+    The console hard-wraps to the terminal width, so a phrase can be split across lines.
+    Asserting on the raw capture makes these tests fail on layout rather than content.
+    """
+    return " ".join(capsys.readouterr().out.split())
+
+
+class TestShadowingIsSurfaced:
+    def test_a_project_supplied_list_is_reported_as_shadowing(
+        self, fake_config_manager: MagicMock, libraries_root: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The user needs to know their entries are inert right now but will not stay that way."""
+        _configure(
+            fake_config_manager,
+            user_entries=[_make_library(libraries_root, "mine")],
+            shadowing=["/show/project/libraries/whatever/griptape_nodes_library.json"],
+        )
+
+        config_cli._prune_user_config_libraries(remove_outside_root=False, remove_paths=[], assume_yes=True)
+
+        assert "none of the entries below are currently in effect" in _rendered(capsys)
+
+    def test_no_shadowing_note_when_no_other_layer_supplies_the_key(
+        self, fake_config_manager: MagicMock, libraries_root: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _configure(fake_config_manager, user_entries=[_make_library(libraries_root, "mine")], shadowing=[])
+
+        config_cli._prune_user_config_libraries(remove_outside_root=False, remove_paths=[], assume_yes=True)
+
+        assert "none of the entries below are currently in effect" not in _rendered(capsys)


### PR DESCRIPTION
Stacked on #5401, which stops *new* pollution. This cleans up configs already holding it.

## Why it is needed

Editing library settings used to persist the whole **merged** `libraries_to_register` into the user layer, so a user config accumulates library paths belonging to projects opened long ago. Those entries are inert while a project supplies its own list (lists replace rather than merge) and become the engine's library set the moment no project layer is loaded to shadow them.

#5401 stops the accumulation. Nothing existed to undo it, and `_remove_missing_libraries_from_config` does not help because the stale paths usually still exist on disk.

## Usage

```
gtn config prune-libraries                      # report, changes nothing
gtn config prune-libraries --remove-outside-root
gtn config prune-libraries --remove-path <path> # repeatable, exact
```

Only the user config file is written, and a `.prune.bak` copy is taken first. Project and workspace configs are read-only here.

## Report-only by default, deliberately

Registering a library by absolute path from anywhere is legitimate. Running this against my own machine makes the point:

```
Libraries directory: /Users/cjkindel/nodes/GriptapeNodes/libraries

Entries in your user config:
  /Users/cjkindel/nodes/griptape-nodes-library-template/griptape-nodes-library.json  <- outside the libraries directory
  /Users/cjkindel/nodes/griptape-nodes-library-standard/griptape_nodes_library.json  <- outside the libraries directory
  ... 3 more
```

All five are dev checkouts I registered on purpose. An auto-prune would have deleted every one. So "outside the libraries directory" is a signal for a human to judge, never grounds to act, and removal stays opt-in with a confirmation prompt.

## Shadowing is surfaced

When another layer supplies the key, the report says so up front: the entries are not in effect *right now*, but will be as soon as no project layer is loaded. That is the part users cannot see today and the reason the entries look harmless.

This is read through a new `merged_without_user_config` source on `get_config_value`, which routes through the same `_merge_config_layers` helper `load_configs` uses — so the report cannot disagree with the precedence the engine actually resolves. It is computed on demand rather than added to the eager source map, since `get_config_value` is hot.

## One small change worth noting

The CLI reads `USER_CONFIG_PATH` through its module rather than importing the value, matching how the engine itself references it. Without that the path is bound at import and the tests could not redirect it, so they would have had to touch a real user's config to exercise the backup and write paths.

## Verification

Full unit suite: 4684 passed, 13 skipped. Lint, types, format, spell clean. 14 new tests, including that dict-shaped entries carrying `enabled` / `worker_mode_override` survive intact rather than being flattened to bare paths, and that a failed write exits non-zero rather than reporting a successful prune.
