### PR TITLE
refactor(drivers): give the storage drivers a workspace source, not the facade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,10 +178,6 @@ ignore = [
 #
 # Group 2 -- not yet migrated. Each of these should eventually receive an Engine instead.
 # Deleting an entry from this list is the definition of done; do not add new entries.
-# GriptapeCloudStorageDriver is constructed from inside exe_types
-# (param_components/artifact_url/public_artifact_url_parameter.py), which has no Engine of its own
-# yet, so drivers cannot come off this list until exe_types does.
-"src/griptape_nodes/drivers/**" = ["TID251"]
 "src/griptape_nodes/exe_types/**" = ["TID251"]
 # WorkflowRegistry is still a process-global fake singleton reaching the facade for config.
 # Making it engine-owned is its own change, since it alters what node libraries import.

--- a/src/griptape_nodes/drivers/storage/base_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/base_storage_driver.py
@@ -1,12 +1,18 @@
+from __future__ import annotations
+
 import logging
 from abc import ABC, abstractmethod
-from pathlib import Path
-from typing import TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 import httpx
 
 from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
-from griptape_nodes.retained_mode.file_metadata.sidecar_metadata import SidecarContent
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from griptape_nodes.retained_mode.file_metadata.sidecar_metadata import SidecarContent
+    from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -28,26 +34,22 @@ class BaseStorageDriver(ABC):
     converting absolute paths to workspace-relative before calling driver methods.
     """
 
-    def __init__(self, workspace_directory: Path) -> None:  # noqa: B027
-        """Initialize the storage driver with a workspace directory.
+    def __init__(self, config_manager: ConfigManager) -> None:
+        """Initialize the storage driver.
 
         Args:
-            workspace_directory: The base workspace directory path (unused, kept for API compatibility).
-                Drivers now fetch the current workspace dynamically via the workspace_directory property.
+            config_manager: Reports the current workspace directory.
         """
-        # workspace_directory parameter is ignored - the property reads from ConfigManager instead.
-        # This ensures drivers always use the current workspace, even if it changes after initialization.
+        self._config_manager = config_manager
 
     @property
     def workspace_directory(self) -> Path:
-        """Get the current workspace directory from ConfigManager.
+        """Get the workspace directory in force right now.
 
         Returns the workspace path fresh on each access to handle dynamic workspace
         changes (e.g., project switches, workspace_dir overrides).
         """
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-        return GriptapeNodes.ConfigManager().workspace_path
+        return self._config_manager.workspace_path
 
     @abstractmethod
     def create_signed_upload_url(

--- a/src/griptape_nodes/drivers/storage/griptape_cloud_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/griptape_cloud_storage_driver.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 import logging
 import os
-from collections.abc import Callable
 from http import HTTPStatus
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin, urlparse
 
 import httpx
@@ -12,8 +13,13 @@ from griptape_nodes.drivers.cloud_credentials import resolve_cloud_credential
 from griptape_nodes.drivers.storage.base_storage_driver import BaseStorageDriver, CreateSignedUploadUrlResponse
 from griptape_nodes.files.path_utils import get_workspace_relative_path
 from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
-from griptape_nodes.retained_mode.file_metadata.sidecar_metadata import SidecarContent
 from griptape_nodes.utils.http_utils import request_with_retry, retry_on_transient_error
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from griptape_nodes.retained_mode.file_metadata.sidecar_metadata import SidecarContent
+    from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -23,7 +29,7 @@ class GriptapeCloudStorageDriver(BaseStorageDriver):
 
     def __init__(
         self,
-        workspace_directory: Path,
+        config_manager: ConfigManager,
         *,
         bucket_id: str,
         api_key: str | None = None,
@@ -32,13 +38,13 @@ class GriptapeCloudStorageDriver(BaseStorageDriver):
         """Initialize the GriptapeCloudStorageDriver.
 
         Args:
-            workspace_directory: The base workspace directory path.
+            config_manager: Reports the current workspace directory.
             bucket_id: The ID of the bucket to use. Required.
             api_key: The credential for authentication. If not provided, it is resolved from the Griptape Nodes License, then "GT_CLOUD_API_KEY".
             static_files_directory: The directory path prefix for static files. If provided, file names will be prefixed with this path.
             **kwargs: Additional keyword arguments including base_url and headers.
         """
-        super().__init__(workspace_directory)
+        super().__init__(config_manager)
 
         self.base_url = kwargs.get("base_url") or os.environ.get("GT_CLOUD_BASE_URL", "https://cloud.griptape.ai")
         self.api_key = api_key if api_key is not None else resolve_cloud_credential()

--- a/src/griptape_nodes/drivers/storage/local_storage_driver.py
+++ b/src/griptape_nodes/drivers/storage/local_storage_driver.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import logging
 import time
 from http import HTTPStatus
 from pathlib import Path
+from typing import TYPE_CHECKING
 from urllib.parse import urljoin
 
 import httpx
@@ -9,9 +12,12 @@ import httpx
 from griptape_nodes.drivers.storage.base_storage_driver import BaseStorageDriver, CreateSignedUploadUrlResponse
 from griptape_nodes.files.path_utils import canonicalize_to_posix, strip_windows_long_path_prefix
 from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy, WriteFileRequest, WriteFileResultSuccess
-from griptape_nodes.retained_mode.file_metadata.sidecar_metadata import SidecarContent
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.utils import resolve_workspace_path
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.file_metadata.sidecar_metadata import SidecarContent
+    from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
+    from griptape_nodes.retained_mode.managers.os_manager import OSManager
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -19,14 +25,21 @@ logger = logging.getLogger("griptape_nodes")
 class LocalStorageDriver(BaseStorageDriver):
     """Stores files using the engine's local static server."""
 
-    def __init__(self, workspace_directory: Path, base_url: str | None = None) -> None:
+    def __init__(
+        self,
+        config_manager: ConfigManager,
+        os_manager: OSManager,
+        base_url: str | None = None,
+    ) -> None:
         """Initialize the LocalStorageDriver.
 
         Args:
-            workspace_directory: The base workspace directory path.
+            config_manager: Reports the current workspace directory.
+            os_manager: Performs the policy-aware writes this driver delegates to.
             base_url: The base URL for the static file server. If not provided, it will be constructed
         """
-        super().__init__(workspace_directory)
+        super().__init__(config_manager)
+        self._os_manager = os_manager
 
         from griptape_nodes.servers.static import (
             STATIC_SERVER_ENABLED,
@@ -54,18 +67,17 @@ class LocalStorageDriver(BaseStorageDriver):
         # on_write_file_request seems to work most reliably with an absolute path.
         absolute_path = resolve_workspace_path(path, self.workspace_directory)
 
-        # Always delegate to OSManager for file path resolution and policy handling.
+        # Always delegate the write for file path resolution and policy handling.
         # Creating an empty file before the upload url gives us a chance to claim ownership
         # of that particular file when creating the upload url. The file policy is not
         # checked when actually uploading the file, it will always overwrite.
-        os_manager = GriptapeNodes.OSManager()
         write_request = WriteFileRequest(
             file_path=str(absolute_path),
             content=b"",  # Empty content for URL generation
             existing_file_policy=existing_file_policy,
             skip_metadata_injection=True,
         )
-        result = os_manager.on_write_file_request(write_request)
+        result = self._os_manager.on_write_file_request(write_request)
 
         if not result.succeeded():
             msg = f"WriteFileRequest failed: {result.result_details}"
@@ -130,7 +142,7 @@ class LocalStorageDriver(BaseStorageDriver):
         """
         absolute_path = resolve_workspace_path(path, self.workspace_directory)
 
-        result = GriptapeNodes.OSManager().on_write_file_request(
+        result = self._os_manager.on_write_file_request(
             WriteFileRequest(
                 file_path=str(absolute_path),
                 content=file_content,

--- a/src/griptape_nodes/exe_types/param_components/artifact_url/public_artifact_url_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/artifact_url/public_artifact_url_parameter.py
@@ -63,7 +63,7 @@ class PublicArtifactUrlParameter:
 
         base = os.getenv("GT_CLOUD_BASE_URL", "https://cloud.griptape.ai")
         self._storage_driver = GriptapeCloudStorageDriver(
-            workspace_directory=GriptapeNodes.ConfigManager().workspace_path,
+            GriptapeNodes.ConfigManager(),
             bucket_id=self._get_bucket_id(base, api_key, timeout=self._request_timeout),
             api_key=api_key,
             base_url=base,

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -98,7 +98,6 @@ class StaticFilesManager(EngineScoped):
         self.secrets_manager = secrets_manager
 
         self.storage_backend = config_manager.get_config_value("storage_backend", default=StorageBackend.LOCAL)
-        workspace_directory = config_manager.workspace_path
 
         # Where the workspace is served, resolved in on_app_initialization_complete. Staying None
         # until then is also what tells that handler it has not settled this yet, so a second
@@ -121,7 +120,7 @@ class StaticFilesManager(EngineScoped):
                     logger.warning(
                         "GT_CLOUD_BUCKET_ID secret is not available, falling back to local storage. Run `gtn init` to set it up."
                     )
-                    self.storage_driver = LocalStorageDriver(workspace_directory, base_url=base_url)
+                    self.storage_driver = LocalStorageDriver(config_manager, self.engine.os_manager, base_url=base_url)
                 elif not cloud_credential:
                     # Without this the driver would send "Bearer None" and every
                     # upload would fail with an opaque 401 instead of naming the
@@ -130,19 +129,19 @@ class StaticFilesManager(EngineScoped):
                         "Falling back to local storage because %s",
                         MISSING_CREDENTIAL_MESSAGE,
                     )
-                    self.storage_driver = LocalStorageDriver(workspace_directory, base_url=base_url)
+                    self.storage_driver = LocalStorageDriver(config_manager, self.engine.os_manager, base_url=base_url)
                 else:
                     static_files_directory = config_manager.get_config_value(
                         "static_files_directory", default="staticfiles"
                     )
                     self.storage_driver = GriptapeCloudStorageDriver(
-                        workspace_directory,
+                        config_manager,
                         bucket_id=bucket_id,
                         api_key=cloud_credential,
                         static_files_directory=static_files_directory,
                     )
             case StorageBackend.LOCAL:
-                self.storage_driver = LocalStorageDriver(workspace_directory, base_url=base_url)
+                self.storage_driver = LocalStorageDriver(config_manager, self.engine.os_manager, base_url=base_url)
             case _:
                 msg = f"Invalid storage backend: {self.storage_backend}"
                 raise ValueError(msg)
@@ -319,11 +318,10 @@ class StaticFilesManager(EngineScoped):
         if not api_key:
             return None
 
-        workspace_directory = self.config_manager.workspace_path
         static_files_directory = self.config_manager.get_config_value("static_files_directory", default="staticfiles")
 
         return GriptapeCloudStorageDriver(
-            workspace_directory,
+            self.config_manager,
             bucket_id=bucket_id,
             api_key=api_key,
             static_files_directory=static_files_directory,

--- a/src/griptape_nodes/retained_mode/managers/sync_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/sync_manager.py
@@ -227,10 +227,8 @@ class SyncManager(EngineScoped):
             msg = f"Attempted to reach cloud storage. Failed because {MISSING_CREDENTIAL_MESSAGE}"
             raise RuntimeError(msg)
 
-        workspace_directory = self._config_manager.workspace_path
-
         return GriptapeCloudStorageDriver(
-            workspace_directory,
+            self._config_manager,
             bucket_id=bucket_id,
             base_url=base_url,
             api_key=api_key,

--- a/tests/unit/drivers/storage/test_base_storage_driver.py
+++ b/tests/unit/drivers/storage/test_base_storage_driver.py
@@ -1,4 +1,3 @@
-from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 from unittest.mock import Mock, patch
@@ -64,16 +63,7 @@ class TestBaseStorageDriverUploadFile:
     @pytest.fixture
     def base_storage_driver(self) -> ConcreteStorageDriver:
         """Create a concrete BaseStorageDriver instance for testing."""
-        return self.ConcreteStorageDriver(Path("/workspace"))
-
-    @pytest.fixture
-    def mock_workspace_path(self) -> Generator[None, None, None]:
-        """Mock ConfigManager to return /workspace for all tests."""
-        with patch("griptape_nodes.retained_mode.griptape_nodes.GriptapeNodes") as mock_griptape:
-            mock_config_manager = Mock()
-            mock_config_manager.workspace_path = Path("/workspace")
-            mock_griptape.ConfigManager.return_value = mock_config_manager
-            yield
+        return self.ConcreteStorageDriver(Mock(workspace_path=Path("/workspace")))
 
     @pytest.fixture
     def mock_upload_response(self) -> dict[str, Any]:
@@ -88,7 +78,6 @@ class TestBaseStorageDriverUploadFile:
     def test_upload_file_passes_existing_file_policy_to_create_signed_upload_url(
         self,
         base_storage_driver: ConcreteStorageDriver,
-        mock_workspace_path: Any,  # noqa: ARG002
     ) -> None:
         """Test line 95: upload_file passes existing_file_policy to create_signed_upload_url."""
         with (
@@ -115,7 +104,6 @@ class TestBaseStorageDriverUploadFile:
     def test_upload_file_default_policy_is_overwrite(
         self,
         base_storage_driver: ConcreteStorageDriver,
-        mock_workspace_path: Any,  # noqa: ARG002
     ) -> None:
         """Test line 95: upload_file defaults to OVERWRITE policy when not specified."""
         with (
@@ -142,7 +130,6 @@ class TestBaseStorageDriverUploadFile:
     def test_upload_file_create_new_policy(
         self,
         base_storage_driver: ConcreteStorageDriver,
-        mock_workspace_path: Any,  # noqa: ARG002
     ) -> None:
         """Test line 95: upload_file passes CREATE_NEW policy correctly."""
         with (
@@ -166,9 +153,9 @@ class TestBaseStorageDriverUploadFile:
             # Verify create_signed_upload_url was called with CREATE_NEW policy (line 95)
             mock_create_url.assert_called_once_with(TEST_FILE_PATH, ExistingFilePolicy.CREATE_NEW)
 
-    def test_upload_file_uses_timeout_parameter(self, mock_workspace_path: Any) -> None:  # noqa: ARG002
+    def test_upload_file_uses_timeout_parameter(self) -> None:
         """upload_file should pass timeout parameter to httpx.request."""
-        driver = self.ConcreteStorageDriver(Path("/workspace"))
+        driver = self.ConcreteStorageDriver(Mock(workspace_path=Path("/workspace")))
 
         with (
             patch.object(driver, "create_signed_upload_url") as mock_create_url,

--- a/tests/unit/drivers/storage/test_griptape_cloud_storage_driver.py
+++ b/tests/unit/drivers/storage/test_griptape_cloud_storage_driver.py
@@ -24,7 +24,7 @@ class TestGriptapeCloudStorageDriverCreateSignedUploadUrl:
     def cloud_storage_driver(self) -> GriptapeCloudStorageDriver:
         """Create GriptapeCloudStorageDriver instance for testing."""
         return GriptapeCloudStorageDriver(
-            workspace_directory=Path("/workspace"),
+            Mock(workspace_path=Path("/workspace")),
             bucket_id=TEST_BUCKET_ID,
             api_key=TEST_API_KEY,
         )
@@ -131,7 +131,7 @@ class TestGriptapeCloudStorageDriverParseCloudAssetPath:
     def cloud_storage_driver(self) -> GriptapeCloudStorageDriver:
         """Create GriptapeCloudStorageDriver instance for testing."""
         return GriptapeCloudStorageDriver(
-            workspace_directory=Path("/workspace"),
+            Mock(workspace_path=Path("/workspace")),
             bucket_id="test-bucket-123",
             api_key="test-api-key",
             base_url="https://cloud.griptape.ai",
@@ -227,7 +227,7 @@ class TestGriptapeCloudStorageDriverUploadTimeout:
     def test_upload_file_uses_timeout_parameter(self) -> None:
         """upload_file should pass timeout parameter to signed URL upload request."""
         driver = GriptapeCloudStorageDriver(
-            workspace_directory=Path("/workspace"),
+            Mock(workspace_path=Path("/workspace")),
             bucket_id=TEST_BUCKET_ID,
             api_key=TEST_API_KEY,
         )
@@ -490,7 +490,7 @@ class TestGriptapeCloudStorageDriverDeleteFile:
     @pytest.fixture
     def cloud_storage_driver(self) -> GriptapeCloudStorageDriver:
         return GriptapeCloudStorageDriver(
-            workspace_directory=Path("/workspace"),
+            Mock(workspace_path=Path("/workspace")),
             bucket_id=TEST_BUCKET_ID,
             api_key=TEST_API_KEY,
         )

--- a/tests/unit/drivers/storage/test_local_storage_driver.py
+++ b/tests/unit/drivers/storage/test_local_storage_driver.py
@@ -1,5 +1,4 @@
 import platform
-from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 from unittest.mock import Mock, patch
@@ -27,23 +26,14 @@ class TestLocalStorageDriverCreateSignedUploadUrl:
     """Test LocalStorageDriver.create_signed_upload_url() method with ExistingFilePolicy support."""
 
     @pytest.fixture
-    def local_storage_driver(self) -> LocalStorageDriver:
-        """Create LocalStorageDriver instance for testing."""
-        return LocalStorageDriver(Path("/workspace"))
-
-    @pytest.fixture
-    def mock_workspace_path(self) -> Generator[None, None, None]:
-        """Mock ConfigManager to return /workspace for all tests."""
-        with patch("griptape_nodes.retained_mode.griptape_nodes.GriptapeNodes") as mock_griptape:
-            mock_config_manager = Mock()
-            mock_config_manager.workspace_path = Path("/workspace")
-            mock_griptape.ConfigManager.return_value = mock_config_manager
-            yield
-
-    @pytest.fixture
     def mock_os_manager(self) -> Mock:
         """Mock OSManager for testing."""
         return Mock()
+
+    @pytest.fixture
+    def local_storage_driver(self, mock_os_manager: Mock) -> LocalStorageDriver:
+        """Create LocalStorageDriver instance for testing."""
+        return LocalStorageDriver(Mock(workspace_path=Path("/workspace")), mock_os_manager)
 
     @pytest.fixture
     def mock_write_success_result(self) -> WriteFileResultSuccess:
@@ -70,15 +60,10 @@ class TestLocalStorageDriverCreateSignedUploadUrl:
         local_storage_driver: LocalStorageDriver,
         mock_os_manager: Mock,
         mock_write_success_result: Any,
-        mock_workspace_path: Any,  # noqa: ARG002
     ) -> None:
         """Test that create_signed_upload_url delegates to OSManager with correct policy."""
-        with (
-            patch("griptape_nodes.drivers.storage.local_storage_driver.GriptapeNodes") as mock_griptape,
-            patch("griptape_nodes.drivers.storage.local_storage_driver.httpx.post") as mock_post,
-        ):
+        with patch("griptape_nodes.drivers.storage.local_storage_driver.httpx.post") as mock_post:
             # Setup mocks
-            mock_griptape.OSManager.return_value = mock_os_manager
             mock_os_manager.on_write_file_request.return_value = mock_write_success_result
             mock_post_response = Mock()
             mock_post_response.raise_for_status.return_value = None
@@ -104,15 +89,10 @@ class TestLocalStorageDriverCreateSignedUploadUrl:
         local_storage_driver: LocalStorageDriver,
         mock_os_manager: Mock,
         mock_write_success_result: Any,
-        mock_workspace_path: Any,  # noqa: ARG002
     ) -> None:
         """Test that create_signed_upload_url uses resolved filename from OSManager."""
-        with (
-            patch("griptape_nodes.drivers.storage.local_storage_driver.GriptapeNodes") as mock_griptape,
-            patch("griptape_nodes.drivers.storage.local_storage_driver.httpx.post") as mock_post,
-        ):
+        with patch("griptape_nodes.drivers.storage.local_storage_driver.httpx.post") as mock_post:
             # Setup mocks
-            mock_griptape.OSManager.return_value = mock_os_manager
             mock_os_manager.on_write_file_request.return_value = mock_write_success_result
             mock_post_response = Mock()
             mock_post_response.raise_for_status.return_value = None
@@ -132,35 +112,26 @@ class TestLocalStorageDriverCreateSignedUploadUrl:
         local_storage_driver: LocalStorageDriver,
         mock_os_manager: Mock,
         mock_write_failure_result: Any,
-        mock_workspace_path: Any,  # noqa: ARG002
     ) -> None:
         """Test that create_signed_upload_url raises FileExistsError when WriteFileRequest fails."""
-        with patch("griptape_nodes.drivers.storage.local_storage_driver.GriptapeNodes") as mock_griptape:
-            # Setup mocks
-            mock_griptape.OSManager.return_value = mock_os_manager
-            mock_os_manager.on_write_file_request.return_value = mock_write_failure_result
+        mock_os_manager.on_write_file_request.return_value = mock_write_failure_result
 
-            # Call create_signed_upload_url with FAIL policy on existing file
-            with pytest.raises(FileExistsError, match="WriteFileRequest failed"):
-                local_storage_driver.create_signed_upload_url(TEST_FILE_PATH, ExistingFilePolicy.FAIL)
+        # Call create_signed_upload_url with FAIL policy on existing file
+        with pytest.raises(FileExistsError, match="WriteFileRequest failed"):
+            local_storage_driver.create_signed_upload_url(TEST_FILE_PATH, ExistingFilePolicy.FAIL)
 
-            # Verify OSManager was called but HTTP request was not made
-            mock_os_manager.on_write_file_request.assert_called_once()
+        # Verify OSManager was called but HTTP request was not made
+        mock_os_manager.on_write_file_request.assert_called_once()
 
     def test_create_signed_upload_url_default_overwrite_policy(
         self,
         local_storage_driver: LocalStorageDriver,
         mock_os_manager: Mock,
         mock_write_success_result: Any,
-        mock_workspace_path: Any,  # noqa: ARG002
     ) -> None:
         """Test that create_signed_upload_url defaults to OVERWRITE policy."""
-        with (
-            patch("griptape_nodes.drivers.storage.local_storage_driver.GriptapeNodes") as mock_griptape,
-            patch("griptape_nodes.drivers.storage.local_storage_driver.httpx.post") as mock_post,
-        ):
+        with patch("griptape_nodes.drivers.storage.local_storage_driver.httpx.post") as mock_post:
             # Setup mocks
-            mock_griptape.OSManager.return_value = mock_os_manager
             mock_os_manager.on_write_file_request.return_value = mock_write_success_result
             mock_post_response = Mock()
             mock_post_response.raise_for_status.return_value = None
@@ -182,21 +153,11 @@ class TestLocalStorageDriverCreateSignedDownloadUrl:
     @pytest.fixture
     def local_storage_driver(self) -> LocalStorageDriver:
         """Create LocalStorageDriver instance for testing."""
-        return LocalStorageDriver(Path("/workspace"))
-
-    @pytest.fixture
-    def mock_workspace_path(self) -> Generator[None, None, None]:
-        """Mock ConfigManager to return /workspace for all tests."""
-        with patch("griptape_nodes.retained_mode.griptape_nodes.GriptapeNodes") as mock_griptape:
-            mock_config_manager = Mock()
-            mock_config_manager.workspace_path = Path("/workspace")
-            mock_griptape.ConfigManager.return_value = mock_config_manager
-            yield
+        return LocalStorageDriver(Mock(workspace_path=Path("/workspace")), Mock())
 
     def test_internal_file_uses_workspace_relative_url(
         self,
         local_storage_driver: LocalStorageDriver,
-        mock_workspace_path: Any,  # noqa: ARG002
     ) -> None:
         """Internal files should produce a workspace-relative URL."""
         with patch("griptape_nodes.drivers.storage.local_storage_driver.time") as mock_time:
@@ -208,7 +169,6 @@ class TestLocalStorageDriverCreateSignedDownloadUrl:
     def test_external_unix_file_uses_external_url(
         self,
         local_storage_driver: LocalStorageDriver,
-        mock_workspace_path: Any,  # noqa: ARG002
     ) -> None:
         """External Unix files should produce a /external/ URL with forward slashes."""
         with (
@@ -225,7 +185,6 @@ class TestLocalStorageDriverCreateSignedDownloadUrl:
     def test_external_windows_file_uses_forward_slashes_in_url(
         self,
         local_storage_driver: LocalStorageDriver,
-        mock_workspace_path: Any,  # noqa: ARG002
     ) -> None:
         """External Windows-style files should produce a URL with forward slashes, not backslashes."""
         with patch("griptape_nodes.drivers.storage.local_storage_driver.time") as mock_time:
@@ -251,7 +210,6 @@ class TestLocalStorageDriverCreateSignedDownloadUrl:
     def test_external_long_path_prefixed_file_matches_clean_spelling(
         self,
         local_storage_driver: LocalStorageDriver,
-        mock_workspace_path: Any,  # noqa: ARG002
     ) -> None:
         r"""A ``\\?\``-prefixed path must produce the same URL as the unprefixed one.
 
@@ -281,18 +239,12 @@ class TestLocalStorageDriverCreateSignedDownloadUrl:
         ``relative_to`` read a file sitting in the workspace as outside it and the URL was
         built from the absolute path.
         """
-        driver = LocalStorageDriver(Path("C:/ws"))
+        driver = LocalStorageDriver(Mock(workspace_path=Path("C:/ws")), Mock())
 
-        # The workspace comes from ConfigManager on every access, so it has to be patched
-        # there rather than passed to the constructor.
         with (
-            patch("griptape_nodes.retained_mode.griptape_nodes.GriptapeNodes") as mock_griptape,
             patch("griptape_nodes.drivers.storage.local_storage_driver.time") as mock_time,
             patch("griptape_nodes.drivers.storage.local_storage_driver.resolve_workspace_path") as mock_resolve,
         ):
-            mock_config_manager = Mock()
-            mock_config_manager.workspace_path = Path("C:/ws")
-            mock_griptape.ConfigManager.return_value = mock_config_manager
             mock_time.time.return_value = 1000
             mock_resolve.return_value = Path(r"\\?\C:\ws\images\photo.png")
             url = driver.create_signed_download_url(Path(r"C:\ws\images\photo.png"))
@@ -312,20 +264,9 @@ class TestSignedDownloadUrlRoundTrip:
     https://github.com/griptape-ai/griptape-nodes-engine/issues/5283
     """
 
-    @pytest.fixture
-    def mock_workspace_path(self) -> Generator[None, None, None]:
-        with patch("griptape_nodes.retained_mode.griptape_nodes.GriptapeNodes") as mock_griptape:
-            mock_config_manager = Mock()
-            mock_config_manager.workspace_path = Path("/workspace")
-            mock_griptape.ConfigManager.return_value = mock_config_manager
-            yield
-
-    def test_workspace_file_round_trips(
-        self,
-        mock_workspace_path: Any,  # noqa: ARG002
-    ) -> None:
+    def test_workspace_file_round_trips(self) -> None:
         """An in-workspace file survives path -> URL -> path unchanged."""
-        driver = LocalStorageDriver(Path("/workspace"))
+        driver = LocalStorageDriver(Mock(workspace_path=Path("/workspace")), Mock())
         original = Path("/workspace/staticfiles/clip.mp4")
 
         with patch("griptape_nodes.drivers.storage.local_storage_driver.time") as mock_time:
@@ -334,12 +275,9 @@ class TestSignedDownloadUrlRoundTrip:
 
         assert parse_static_server_url(url, Path("/workspace")) == original
 
-    def test_nested_workspace_file_round_trips(
-        self,
-        mock_workspace_path: Any,  # noqa: ARG002
-    ) -> None:
+    def test_nested_workspace_file_round_trips(self) -> None:
         """Nested subdirectories survive the round trip."""
-        driver = LocalStorageDriver(Path("/workspace"))
+        driver = LocalStorageDriver(Mock(workspace_path=Path("/workspace")), Mock())
         original = Path("/workspace/outputs/shots/010/clip.mp4")
 
         with patch("griptape_nodes.drivers.storage.local_storage_driver.time") as mock_time:
@@ -348,15 +286,12 @@ class TestSignedDownloadUrlRoundTrip:
 
         assert parse_static_server_url(url, Path("/workspace")) == original
 
-    def test_cachebuster_does_not_reach_the_filename(
-        self,
-        mock_workspace_path: Any,  # noqa: ARG002
-    ) -> None:
+    def test_cachebuster_does_not_reach_the_filename(self) -> None:
         """The ``?t=`` the builder appends must not survive into the resolved path.
 
         It rode along into the filename in the original bug, so no such file existed.
         """
-        driver = LocalStorageDriver(Path("/workspace"))
+        driver = LocalStorageDriver(Mock(workspace_path=Path("/workspace")), Mock())
 
         with patch("griptape_nodes.drivers.storage.local_storage_driver.time") as mock_time:
             mock_time.time.return_value = 1000
@@ -384,28 +319,19 @@ class TestLocalStorageDriverGetAssetUrl:
     """
 
     @pytest.fixture
-    def mock_workspace_path(self) -> Generator[None, None, None]:
-        """Mock ConfigManager to return /workspace for all tests."""
-        with patch("griptape_nodes.retained_mode.griptape_nodes.GriptapeNodes") as mock_griptape:
-            mock_config_manager = Mock()
-            mock_config_manager.workspace_path = Path("/workspace")
-            mock_griptape.ConfigManager.return_value = mock_config_manager
-            yield
+    def local_storage_driver(self) -> LocalStorageDriver:
+        """Create LocalStorageDriver instance for testing."""
+        return LocalStorageDriver(Mock(workspace_path=Path("/workspace")), Mock())
 
-    def test_relative_path_keeps_its_directory(
-        self,
-        mock_workspace_path: Any,  # noqa: ARG002
-    ) -> None:
+    def test_relative_path_keeps_its_directory(self, local_storage_driver: LocalStorageDriver) -> None:
         """A workspace-relative path resolves in place, not re-derived from the filename."""
-        driver = LocalStorageDriver(Path("/workspace"))
-
-        url = driver.get_asset_url(Path(".griptape-nodes-thumbnails/thumb.png"))
+        url = local_storage_driver.get_asset_url(Path(".griptape-nodes-thumbnails/thumb.png"))
 
         assert url == str((Path("/workspace") / ".griptape-nodes-thumbnails/thumb.png").resolve())
 
     def test_absolute_path_is_returned_resolved(self) -> None:
         """An absolute path passes through untouched apart from normalization."""
-        driver = LocalStorageDriver(Path("/workspace"))
+        driver = LocalStorageDriver(Mock(workspace_path=Path("/workspace")), Mock())
 
         url = driver.get_asset_url(Path("/elsewhere/media/photo.png"))
 
@@ -434,7 +360,7 @@ class TestLocalStorageDriverDeleteFile:
         return Mock(return_value=response)
 
     def test_deletes_through_static_files_endpoint(self) -> None:
-        driver = LocalStorageDriver(Path("/workspace"))
+        driver = LocalStorageDriver(Mock(workspace_path=Path("/workspace")), Mock())
         delete_mock = self._delete_mock(None)
 
         with patch(f"{self.MODULE}.httpx.delete", delete_mock):
@@ -444,13 +370,13 @@ class TestLocalStorageDriverDeleteFile:
         assert args[0].endswith("/static-files/artifact_url_storage/abc/video.mp4")
 
     def test_absent_file_is_a_no_op(self) -> None:
-        driver = LocalStorageDriver(Path("/workspace"))
+        driver = LocalStorageDriver(Mock(workspace_path=Path("/workspace")), Mock())
 
         with patch(f"{self.MODULE}.httpx.delete", self._delete_mock(404)):
             driver.delete_file(TEST_FILE_PATH)
 
     def test_raises_on_server_error(self) -> None:
-        driver = LocalStorageDriver(Path("/workspace"))
+        driver = LocalStorageDriver(Mock(workspace_path=Path("/workspace")), Mock())
 
         with (
             patch(f"{self.MODULE}.httpx.delete", self._delete_mock(500)),


### PR DESCRIPTION
More facade removal. This one was a little trickier.