### PR TITLE
fix: publish CurrentProjectChanged so connected clients receive it

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -3067,19 +3067,8 @@ class ProjectManager(EngineScoped):
         # re-derives the same project), so emit only post-init and only when the
         # project actually changed. A worker that boots like the orchestrator has the
         # same registry, so the id resolves there too.
-        # Published, not broadcast. broadcast_app_event only walks this process's
-        # _app_event_listeners, so a connected editor never heard the switch and kept
-        # rendering the previous project's config. Publishing is what reaches a client:
-        # the app layer's queue drain re-broadcasts in-process AND forwards to every
-        # transport, so the worker adoption listener registered above still fires
-        # exactly once.
-        #
-        # broadcast_app_event cannot simply be taught to publish, because it is the
-        # terminal in-process step of that same drain: publishing from it would enqueue
-        # the event it was called to deliver, and recurse. A broadcast does reach a
-        # client only where something registers a relay listener that publishes by hand,
-        # as app.py does for LibraryLoadedNotification on a worker. Nothing relays this
-        # event, and a per-event relay is the thing worth avoiding.
+        # Published, not broadcast: publishing reaches in-process listeners and every IPC
+        # transport, so connected clients see the switch too.
         if self._initialization_complete and previous_project_id != resolved_project_id:
             self._event_manager.put_event(AppEvent(payload=CurrentProjectChanged(project_id=resolved_project_id)))
         return result

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -3067,8 +3067,6 @@ class ProjectManager(EngineScoped):
         # re-derives the same project), so emit only post-init and only when the
         # project actually changed. A worker that boots like the orchestrator has the
         # same registry, so the id resolves there too.
-        # Published, not broadcast: publishing reaches in-process listeners and every IPC
-        # transport, so connected clients see the switch too.
         if self._initialization_complete and previous_project_id != resolved_project_id:
             self._event_manager.put_event(AppEvent(payload=CurrentProjectChanged(project_id=resolved_project_id)))
         return result

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -54,6 +54,7 @@ from griptape_nodes.files.path_utils import (
 from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
 from griptape_nodes.retained_mode.engine import EngineScoped
 from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete, CurrentProjectChanged
+from griptape_nodes.retained_mode.events.base_events import AppEvent
 from griptape_nodes.retained_mode.events.library_events import (
     ReloadAllLibrariesRequest,
     ReloadAllLibrariesResultFailure,
@@ -3066,8 +3067,13 @@ class ProjectManager(EngineScoped):
         # re-derives the same project), so emit only post-init and only when the
         # project actually changed. A worker that boots like the orchestrator has the
         # same registry, so the id resolves there too.
+        # Published rather than broadcast in-process: broadcast_app_event only reaches
+        # listeners inside this process, so an editor never saw the switch and kept
+        # rendering the previous project's config. Publishing wraps it in an AppEvent,
+        # which the app layer fans out to both the in-process listeners (the worker
+        # adoption above) and every IPC transport.
         if self._initialization_complete and previous_project_id != resolved_project_id:
-            self._event_manager.broadcast_app_event(CurrentProjectChanged(project_id=resolved_project_id))
+            self._event_manager.put_event(AppEvent(payload=CurrentProjectChanged(project_id=resolved_project_id)))
         return result
 
     def _refuse_unresolvable_declared_paths(

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -3067,11 +3067,19 @@ class ProjectManager(EngineScoped):
         # re-derives the same project), so emit only post-init and only when the
         # project actually changed. A worker that boots like the orchestrator has the
         # same registry, so the id resolves there too.
-        # Published rather than broadcast in-process: broadcast_app_event only reaches
-        # listeners inside this process, so an editor never saw the switch and kept
-        # rendering the previous project's config. Publishing wraps it in an AppEvent,
-        # which the app layer fans out to both the in-process listeners (the worker
-        # adoption above) and every IPC transport.
+        # Published, not broadcast. broadcast_app_event only walks this process's
+        # _app_event_listeners, so a connected editor never heard the switch and kept
+        # rendering the previous project's config. Publishing is what reaches a client:
+        # the app layer's queue drain re-broadcasts in-process AND forwards to every
+        # transport, so the worker adoption listener registered above still fires
+        # exactly once.
+        #
+        # broadcast_app_event cannot simply be taught to publish, because it is the
+        # terminal in-process step of that same drain: publishing from it would enqueue
+        # the event it was called to deliver, and recurse. A broadcast does reach a
+        # client only where something registers a relay listener that publishes by hand,
+        # as app.py does for LibraryLoadedNotification on a worker. Nothing relays this
+        # event, and a per-event relay is the thing worth avoiding.
         if self._initialization_complete and previous_project_id != resolved_project_id:
             self._event_manager.put_event(AppEvent(payload=CurrentProjectChanged(project_id=resolved_project_id)))
         return result

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -12621,3 +12621,81 @@ variables:
             assert result.variable.value == "sc042"
         finally:
             self._unload(engine, project_id)
+
+
+class TestCurrentProjectChangedReachesClients:
+    """A project switch has to tell out-of-process listeners, not just in-process ones.
+
+    ``broadcast_app_event`` only walks ``EventManager._app_event_listeners``, which live
+    in this process. An editor learns about a switch from an ``AppEvent`` on the wire, so
+    a switch announced only by broadcast leaves every connected client rendering the
+    previous project's config until it remounts and refetches.
+    """
+
+    @staticmethod
+    def _load(engine: Engine, tmp_path: Path) -> str:
+        from griptape_nodes.retained_mode.events.project_events import (
+            LoadProjectTemplateRequest,
+            LoadProjectTemplateResultSuccess,
+        )
+
+        project_yml = tmp_path / "project_template.yml"
+        project_yml.write_text(DEFAULT_PROJECT_TEMPLATE.to_overlay_yaml(DEFAULT_PROJECT_TEMPLATE))
+        load_result = engine.handle_request(LoadProjectTemplateRequest(project_path=project_yml))
+        assert isinstance(load_result, LoadProjectTemplateResultSuccess)
+        return load_result.project_id
+
+    @staticmethod
+    def _published_project_changes(published: list[Any]) -> list[Any]:
+        """The CurrentProjectChanged payloads among published events."""
+        from griptape_nodes.retained_mode.events.app_events import CurrentProjectChanged
+        from griptape_nodes.retained_mode.events.base_events import AppEvent
+
+        return [
+            event.payload
+            for event in published
+            if isinstance(event, AppEvent) and isinstance(event.payload, CurrentProjectChanged)
+        ]
+
+    def test_switch_publishes_the_change_so_clients_receive_it(self, engine: Engine, tmp_path: Path) -> None:
+        """The switch is handed to the publish path, which is what feeds the IPC transports."""
+        from griptape_nodes.retained_mode.events.project_events import SetCurrentProjectRequest
+
+        project_id = self._load(engine, tmp_path)
+        original_workspace = engine.config_manager.workspace_path
+        # The broadcast is gated on initialization being complete; a real engine has
+        # finished booting long before a user switches projects.
+        engine.project_manager._initialization_complete = True
+
+        published: list[Any] = []
+        try:
+            with patch.object(engine.event_manager, "put_event", side_effect=published.append):
+                engine.handle_request(SetCurrentProjectRequest(project_id=project_id))
+
+            changes = self._published_project_changes(published)
+            assert len(changes) == 1, "a project switch must publish exactly one CurrentProjectChanged"
+            assert changes[0].project_id == project_id
+        finally:
+            engine.project_manager._initialization_complete = False
+            engine.handle_request(SetCurrentProjectRequest(project_id=None))
+            engine.config_manager.workspace_path = original_workspace
+
+    def test_switch_to_the_same_project_publishes_nothing(self, engine: Engine, tmp_path: Path) -> None:
+        """Re-activating the current project is not a change, so clients are left alone."""
+        from griptape_nodes.retained_mode.events.project_events import SetCurrentProjectRequest
+
+        project_id = self._load(engine, tmp_path)
+        original_workspace = engine.config_manager.workspace_path
+        engine.project_manager._initialization_complete = True
+
+        published: list[Any] = []
+        try:
+            engine.handle_request(SetCurrentProjectRequest(project_id=project_id))
+            with patch.object(engine.event_manager, "put_event", side_effect=published.append):
+                engine.handle_request(SetCurrentProjectRequest(project_id=project_id))
+
+            assert self._published_project_changes(published) == []
+        finally:
+            engine.project_manager._initialization_complete = False
+            engine.handle_request(SetCurrentProjectRequest(project_id=None))
+            engine.config_manager.workspace_path = original_workspace


### PR DESCRIPTION
A project switch was announced only inside the engine process, so no connected editor ever heard about it. Found by running the desktop app against a local engine, not by reading code: the switch succeeded, `workspace_directory` changed, and of 103 frames the editor received, **zero** mentioned `CurrentProjectChanged`.

## Cause

`ProjectManager` announced the switch with `broadcast_app_event`, which walks `EventManager._app_event_listeners` and stops there. Those listeners are all in-process (the worker-adoption hook is the only one). Nothing puts the event on the event queue, so it never becomes an `AppEvent` frame and never reaches an IPC transport.

Every other client-visible app event is published instead, e.g. `sync_manager.py` for `SyncComplete`. This one was the outlier.

## Change

Publish it: `put_event(AppEvent(payload=CurrentProjectChanged(...)))`.

That keeps both audiences, without double-dispatch. The app layer's `_process_app_event` calls `abroadcast_app_event(event.payload)` **and** `broadcast_to_all(event)`, so in-process listeners still fire exactly once and every transport now gets a copy. Emitting both calls from `ProjectManager` instead would deliver the in-process broadcast twice, and the worker adoption path is not idempotent enough to want that.

The gate is unchanged: still post-initialization only, and still only when the project id actually changed.

## Why no test caught it

The existing coverage asserted that the broadcast happens, which it did. The defect was that a broadcast is the wrong delivery mechanism for an out-of-process audience, and nothing asserted the event was reachable from outside the process.

`TestCurrentProjectChangedReachesClients` asserts against the publish path, which is what feeds the transports. It fails on `main` (`assert 0 == 1`) and passes with this change. Its sibling pins the no-op case, so re-activating the current project still tells clients nothing.

## What this unblocks

griptape-vsl-gui#2883 has both `FileSystemSettings` and `Libraries` subscribe to `CurrentProjectChanged` to refetch after a switch. Without this change those subscriptions are dead code, and the reported symptom (Workspace Directory keeps showing the previous project's path until Settings is closed and reopened) is not fixed.

Verified end to end with the two together: with the dialog left open and untouched across a switch, Workspace Directory updated in place. Before this change, the same run left it stale.

## Verification

Full unit suite passes. Lint, types, format, spell clean. Confirmed live in the desktop app against a local engine.
