### PR TITLE
fix(project): resolve computed project variables through one shared resolver

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -256,6 +256,12 @@ class _ProjectVariableResolver:
     none of the known sources and are absent from shell env are left unresolved so
     the underlying ParsedMacro.resolve raises MISSING_REQUIRED_VARIABLES.
 
+    Builtin lookup failures are cached alongside successes, so a builtin that is
+    unavailable in the current context (e.g. `workflow_dir` with no current workflow)
+    is attempted once per resolver instance no matter how many directories or
+    environment values reference it, and its degradation warning logs once rather
+    than once per referencing directory.
+
     Construct via `ProjectManager._build_variable_resolver`. Cycle detection and caches
     are instance-scoped so resolvers are single-use per call site.
     """
@@ -264,6 +270,8 @@ class _ProjectVariableResolver:
     get_builtin: Callable[[str], str]
     secrets_manager: SecretsManager
     builtins_cache: dict[str, str] = field(default_factory=dict)
+    builtins_unavailable: dict[str, RuntimeError | NotImplementedError] = field(default_factory=dict)
+    warned_unavailable_builtins: set[str] = field(default_factory=set)
     env_resolved: dict[str, str] = field(default_factory=dict)
     directories_resolved: dict[str, str] = field(default_factory=dict)
     in_progress: set[str] = field(default_factory=set)
@@ -307,10 +315,22 @@ class _ProjectVariableResolver:
         self.env_resolved[name] = resolved
         return resolved
 
+    def resolve_builtin(self, name: str) -> str:
+        """Resolve a builtin variable, sharing this resolver's success and failure caches."""
+        return self._get_builtin(name)
+
     def _get_builtin(self, name: str) -> str:
-        if name not in self.builtins_cache:
-            self.builtins_cache[name] = self.get_builtin(name)
-        return self.builtins_cache[name]
+        if name in self.builtins_unavailable:
+            raise self.builtins_unavailable[name]
+        if name in self.builtins_cache:
+            return self.builtins_cache[name]
+        try:
+            value = self.get_builtin(name)
+        except (RuntimeError, NotImplementedError) as e:
+            self.builtins_unavailable[name] = e
+            raise
+        self.builtins_cache[name] = value
+        return value
 
     def _resolve_macro_string(self, owner_kind: str, owner_name: str, raw_value: str) -> str:
         token = f"{owner_kind}:{owner_name}"
@@ -337,20 +357,7 @@ class _ProjectVariableResolver:
                         # situation-macro path in on_get_path_for_macro_request. A required
                         # builtin that can't resolve is a genuine error.
                         if not var_info.is_required:
-                            # Logged because the degraded result is a PLAUSIBLE path, not an
-                            # obviously broken one: dropping `{workflow_dir}` from
-                            # `{workflow_dir?:/}outputs` silently relocates writes and reads
-                            # from the workflow's folder to the workspace root. Without this
-                            # line the only symptom is media that resolves to a file which was
-                            # never written there.
-                            logger.warning(
-                                "Optional builtin '%s' could not be resolved while resolving %s '%s'; "
-                                "dropping it from the path (%s)",
-                                ref,
-                                owner_kind,
-                                owner_name,
-                                e,
-                            )
+                            self._warn_unavailable_builtin_once(ref, owner_kind, owner_name, e)
                             continue
                         msg = (
                             f"Cannot resolve {owner_kind} '{owner_name}': "
@@ -392,6 +399,35 @@ class _ProjectVariableResolver:
         finally:
             self.in_progress.discard(token)
         return resolved
+
+    def _warn_unavailable_builtin_once(
+        self,
+        ref: str,
+        owner_kind: str,
+        owner_name: str,
+        error: RuntimeError | NotImplementedError,
+    ) -> None:
+        """Log the optional-builtin degradation warning for the first failure of `ref` only.
+
+        Logged because the degraded result is a PLAUSIBLE path, not an obviously broken one:
+        dropping `{workflow_dir}` from `{workflow_dir?:/}outputs` silently relocates writes and
+        reads from the workflow's folder to the workspace root. Without this line the only
+        symptom is media that resolves to a file which was never written there.
+
+        Every directory and environment value referencing the same unavailable builtin reaches
+        this call, so the warning is emitted once per builtin per resolver instance and the
+        references after the first degrade silently.
+        """
+        if ref in self.warned_unavailable_builtins:
+            return
+        self.warned_unavailable_builtins.add(ref)
+        logger.warning(
+            "Optional builtin '%s' could not be resolved while resolving %s '%s'; dropping it from the path (%s)",
+            ref,
+            owner_kind,
+            owner_name,
+            error,
+        )
 
 
 @dataclass
@@ -459,6 +495,20 @@ class _BuiltinResolutionResult(NamedTuple):
     """
 
     conflicts: set[str]
+    unavailable: dict[str, Exception]
+
+
+class _ProjectVariableResolution(NamedTuple):
+    """Outcome of resolving a batch of computed project variables through one resolver.
+
+    `resolved` holds a READ_ONLY snapshot per name that produced a value. `unavailable`
+    maps each remaining name to the exception explaining why its context isn't ready
+    (e.g. "No current workflow"). Callers enumerating the whole computed namespace skip
+    the unavailable names; the split lets them report which name failed and why without
+    resolving twice.
+    """
+
+    resolved: dict[str, FlowVariable]
     unavailable: dict[str, Exception]
 
 
@@ -4527,32 +4577,69 @@ class ProjectManager(EngineScoped):
         Stored (user-defined) project variables are NOT resolved here; those live in
         VariablesManager's project bags. This method covers only the computed namespace.
 
+        Use `resolve_project_variables` to resolve several names at once; it shares one
+        resolver across the whole call instead of building one per name.
+
         Raises ValueError when the project isn't loaded or the name isn't a computed name;
         RuntimeError / NotImplementedError when the value's context isn't ready (e.g.
         {workflow_dir} before the workflow is saved).
         """
+        project_info = self._loaded_project_info(project_id)
+        resolver = self._build_variable_resolver(project_info.template, project_info)
+        return self._computed_variable_snapshot(name, project_info, resolver)
+
+    def resolve_project_variables(self, names: Iterable[str], *, project_id: str | None) -> _ProjectVariableResolution:
+        """Resolve many computed project variables through a single shared resolver.
+
+        One resolver serves every name, so a builtin or directory that several names
+        reference is resolved once for the whole call rather than once per name. That
+        matters for the default template, where seven directories anchor to
+        `{workflow_dir?:/}`: a per-name resolver re-resolved the builtin seven times and
+        emitted seven identical degradation warnings.
+
+        Names whose context isn't ready are reported in `unavailable` instead of raising,
+        so a caller enumerating the whole namespace can skip them. A name that isn't a
+        computed name at all still raises ValueError, since that is a caller bug rather
+        than a not-ready value.
+        """
+        project_info = self._loaded_project_info(project_id)
+        resolver = self._build_variable_resolver(project_info.template, project_info)
+
+        resolved: dict[str, FlowVariable] = {}
+        unavailable: dict[str, Exception] = {}
+        for name in names:
+            try:
+                resolved[name] = self._computed_variable_snapshot(name, project_info, resolver)
+            except (RuntimeError, NotImplementedError, MacroResolutionError) as e:
+                unavailable[name] = e
+        return _ProjectVariableResolution(resolved=resolved, unavailable=unavailable)
+
+    def _loaded_project_info(self, project_id: str | None) -> ProjectInfo:
+        """Return the loaded template info for `project_id`, or raise if it isn't loaded."""
         effective = self.resolve_project_id(project_id)
         if effective is None:
             msg = f"Project '{project_id}' is not loaded"
             raise ValueError(msg)
-        project_info = self._successfully_loaded_project_templates[effective]
+        return self._successfully_loaded_project_templates[effective]
 
+    def _computed_variable_snapshot(
+        self, name: str, project_info: ProjectInfo, resolver: _ProjectVariableResolver
+    ) -> FlowVariable:
+        """Resolve one computed name to a READ_ONLY snapshot through `resolver`.
+
+        Builtins go through the resolver rather than `_get_builtin_variable_value` directly so
+        they share its caches with any directory macro that references them.
+        """
         if name in BUILTIN_VARIABLES:
-            value = self._get_builtin_variable_value(name, project_info)
-            return FlowVariable(
-                name=name, owning_flow_name=None, type="str", value=value, permission=VariablePermission.READ_ONLY
-            )
-        if name in project_info.template.directories:
-            resolver = self._build_variable_resolver(project_info.template, project_info)
-            return FlowVariable(
-                name=name,
-                owning_flow_name=None,
-                type="str",
-                value=resolver.resolve_directory(name),
-                permission=VariablePermission.READ_ONLY,
-            )
-        msg = f"Unknown computed project variable '{name}'"
-        raise ValueError(msg)
+            value = resolver.resolve_builtin(name)
+        elif name in project_info.template.directories:
+            value = resolver.resolve_directory(name)
+        else:
+            msg = f"Unknown computed project variable '{name}'"
+            raise ValueError(msg)
+        return FlowVariable(
+            name=name, owning_flow_name=None, type="str", value=value, permission=VariablePermission.READ_ONLY
+        )
 
     # Helper methods (private)
 

--- a/src/griptape_nodes/retained_mode/managers/variable_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/variable_manager.py
@@ -404,12 +404,34 @@ class VariablesManager(EngineScoped):
         Silent-skip for bulk enumeration: computed values whose context isn't ready (e.g.
         workflow_dir before the workflow is saved) are omitted rather than raising. Each entry
         carries VariableLayerKind.PROJECT so callers can distinguish it from a same-named global.
+
+        Every computed name resolves through one shared resolver, so a builtin that many
+        template directories reference is resolved once for the whole enumeration.
         """
+        effective = self._effective_project_id(project_id)
+        if effective is None:
+            return []
+
+        project_manager = self.engine.project_manager
+        computed_names = project_manager.project_computed_names(project_id=effective)
+        if not computed_names:
+            resolved_computed: dict[str, FlowVariable] = {}
+        else:
+            resolution = project_manager.resolve_project_variables(computed_names, project_id=effective)
+            for name, error in resolution.unavailable.items():
+                logger.debug("Computed project variable %r unavailable: %s", name, error)
+            resolved_computed = resolution.resolved
+
         collected: list[ResolvedVariable] = []
         for name in self._list_project_variable_names(project_id=project_id):
             if name in seen:
                 continue
-            variable = self._get_project_variable(name, project_id=project_id)
+            # A computed name that failed to resolve gets no stored-layer fallback: the name is
+            # defined, just unavailable right now.
+            if name in computed_names:
+                variable = resolved_computed.get(name)
+            else:
+                variable = self._get_project_variable(name, project_id=project_id)
             if variable is None:
                 continue
             collected.append(ResolvedVariable(variable=variable, layer=VariableLayerKind.PROJECT))

--- a/tests/unit/retained_mode/managers/test_project_manager.py
+++ b/tests/unit/retained_mode/managers/test_project_manager.py
@@ -875,6 +875,65 @@ class TestProjectManagerBuiltinVariables:
             f"Expected a warning about the dropped optional builtin, got: {warning_messages}"
         )
 
+    def test_get_builtin_caches_unavailable_builtin_across_directories(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """One resolver instance warns once per unavailable builtin, not once per referencing directory.
+
+        Regression guard for a warning storm observed against a live engine: a single 3-node flow
+        run on an unsaved workflow emitted one identical WARNING per default project directory that
+        anchors to `{workflow_dir?:/}` (backups, inputs, outputs, temp, workflow_run_failures, and
+        the two dotted metadata/preview directories) -- 21 lines from 3 resolution passes over 7
+        directories. Callers that resolve every directory through one shared resolver (e.g.
+        `_absolute_path_to_macro_path`, `on_get_path_for_macro_request`) hit the same unavailable
+        builtin once per directory. `_get_builtin` caches the failure alongside successes, so the
+        underlying builtin callable runs once per resolver instance regardless of how many
+        directories reference it, and `_resolve_macro_string` warns only on that first failure.
+        """
+        from griptape_nodes.retained_mode.managers.project_manager import (
+            DEFAULT_PROJECT_TEMPLATE as DEFAULT_TEMPLATE_FROM_MODULE,
+        )
+        from griptape_nodes.retained_mode.managers.project_manager import _ProjectVariableResolver
+
+        directories_anchored_to_workflow_dir = [
+            name
+            for name, directory in DEFAULT_TEMPLATE_FROM_MODULE.directories.items()
+            if isinstance(directory.path_macro, str) and "workflow_dir" in directory.path_macro
+        ]
+        # Sanity: this is the exact multi-directory fan-out that produced the storm, not one directory.
+        min_expected_directories_anchored_to_workflow_dir = 5
+        assert len(directories_anchored_to_workflow_dir) >= min_expected_directories_anchored_to_workflow_dir
+
+        call_count = 0
+
+        def unavailable_get_builtin(name: str) -> str:  # noqa: ARG001
+            nonlocal call_count
+            call_count += 1
+            msg = "No current workflow"
+            raise RuntimeError(msg)
+
+        resolver = _ProjectVariableResolver(
+            template=DEFAULT_TEMPLATE_FROM_MODULE,
+            get_builtin=unavailable_get_builtin,
+            secrets_manager=Mock(),
+        )
+
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+            resolved = {name: resolver.resolve_directory(name) for name in directories_anchored_to_workflow_dir}
+
+        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warning_records) == 1, f"Expected exactly one warning, got: {[r.message for r in warning_records]}"
+        assert "workflow_dir" in warning_records[0].message
+        assert "dropping it from the path" in warning_records[0].message
+        # The unavailable builtin still degrades every directory to its workspace-relative
+        # suffix rather than erroring -- it just loses its workflow-relative anchor.
+        for name in directories_anchored_to_workflow_dir:
+            path_macro = cast("str", DEFAULT_TEMPLATE_FROM_MODULE.directories[name].path_macro)
+            assert resolved[name] == path_macro.removeprefix("{workflow_dir?:/}")
+        # The actual mechanism: the builtin callable itself ran once, not once per directory.
+        assert call_count == 1
+
     @patch("griptape_nodes.retained_mode.managers.project_manager.WorkflowRegistry")
     def test_builtin_workflow_dir_survives_stale_registry_key(
         self,

--- a/tests/unit/retained_mode/managers/test_variable_manager.py
+++ b/tests/unit/retained_mode/managers/test_variable_manager.py
@@ -56,6 +56,7 @@ from griptape_nodes.retained_mode.variable_types import (
 )
 
 _GET_PROJECT_VAR_PATCH = "griptape_nodes.retained_mode.managers.variable_manager.VariablesManager._get_project_variable"
+_COMPUTED_NAMES_PATCH = "griptape_nodes.retained_mode.managers.project_manager.ProjectManager.project_computed_names"
 _LIST_PROJECT_VAR_NAMES_PATCH = (
     "griptape_nodes.retained_mode.managers.variable_manager.VariablesManager._list_project_variable_names"
 )
@@ -80,6 +81,10 @@ def _macro(name: str, value: Any) -> FlowVariable:
 def project_macros(macros: dict[str, Any]) -> Iterator[None]:
     """Patch VariablesManager's project-layer seams to return the given macros.
 
+    Every macro is served through `_get_project_variable`, so the computed namespace is
+    emptied for the duration: the bulk computed-resolution path would otherwise resolve
+    real builtins and directories from the live project template and shadow these values.
+
     Usage: `with project_macros({"workspace_dir": "/x"}): ...`.
     """
 
@@ -91,9 +96,13 @@ def project_macros(macros: dict[str, Any]) -> Iterator[None]:
             return None
         return _macro(name, macros[name])
 
+    def no_computed_names(_self: object, *, project_id: str | None = None) -> frozenset[str]:  # noqa: ARG001
+        return frozenset()
+
     with (
         patch(_LIST_PROJECT_VAR_NAMES_PATCH, autospec=True, side_effect=list_names),
         patch(_GET_PROJECT_VAR_PATCH, autospec=True, side_effect=get_var),
+        patch(_COMPUTED_NAMES_PATCH, autospec=True, side_effect=no_computed_names),
     ):
         yield
 


### PR DESCRIPTION
Enumerating the computed project namespace built a fresh resolver per variable name, so the seven default directories anchored to `{workflow_dir?:/}` each re-resolved the same builtin and logged the same degradation warning, flooding a normal unsaved-workflow run. `VariablesManager` now resolves the whole computed namespace through one shared resolver, which also caches builtin lookup failures alongside successes.

## Before

A two-node flow run on an unsaved workflow, 14 warnings (7 directories x 2 resolution passes):

```
INFO     Resolving n2
WARNING  Optional builtin 'workflow_dir' could not be resolved while resolving directory 'backups'; dropping it from the path (Workflow 'warn_probe' is not registered on this engine (it may be registered under a different workspace))
WARNING  Optional builtin 'workflow_dir' could not be resolved while resolving directory 'griptape-nodes-metadata'; dropping it from the path (...)
WARNING  Optional builtin 'workflow_dir' could not be resolved while resolving directory 'griptape-nodes-previews'; dropping it from the path (...)
WARNING  Optional builtin 'workflow_dir' could not be resolved while resolving directory 'inputs'; dropping it from the path (...)
WARNING  Optional builtin 'workflow_dir' could not be resolved while resolving directory 'outputs'; dropping it from the path (...)
WARNING  Optional builtin 'workflow_dir' could not be resolved while resolving directory 'temp'; dropping it from the path (...)
WARNING  Optional builtin 'workflow_dir' could not be resolved while resolving directory 'workflow_run_failures'; dropping it from the path (...)
... the same seven again for the second pass ...
INFO     Flow is complete.
```

A three-node run produced 21.

## After

Same probe, 2 warnings, one per resolution pass:

```
INFO     Resolving n2
WARNING  Optional builtin 'workflow_dir' could not be resolved while resolving directory 'griptape-nodes-previews'; dropping it from the path (Workflow 'warn_probe' is not registered on this engine (it may be registered under a different workspace))
WARNING  Optional builtin 'workflow_dir' could not be resolved while resolving directory 'griptape-nodes-previews'; dropping it from the path (...)
INFO     Flow is complete.
```

Both captured from a real engine run against this branch versus `main`. Re-running after saving the workflow stays clean, as before.

## Notes

The warning keeps its WARNING level. It reports that a path silently relocated from the workflow's folder to the workspace root, which is worth one line per resolver pass; it was never worth one line per directory that happened to reference the same builtin.

`resolve_project_variables` is additive and reports not-ready names in `unavailable` so bulk enumeration keeps its silent-skip contract, while an unknown name still raises. `resolve_project_variable` stays for single-name callers and now delegates to the same helper.

Builtins route through the resolver instead of `_get_builtin_variable_value` directly, so a builtin and the directory macros referencing it share one cache.

`project_macros` in the variable-manager tests empties the computed namespace for its duration, keeping every macro on the `_get_project_variable` seam it already patched.
