### PR TITLE
Give exe_types an injected engine and take it off the facade allowlist

### DIFF
--- a/docs/guides/libraries.md
+++ b/docs/guides/libraries.md
@@ -186,6 +186,28 @@ clashing heavy pins can still be edited side by side.
 Declaring no `pip_dependencies_exec` is always safe: the library
 behaves exactly as it did before the split existed.
 
+#### What declaring execution dependencies changes
+
+A library that declares them runs differently, in three ways:
+
+- **Its nodes execute in the library's own process.** The main
+    engine can show, edit, and save them (it has the edit-time
+    dependencies), but running them happens where the heavy
+    packages live. If that process isn't up yet, running the node
+    reports that rather than failing strangely.
+- **Node code asks the engine for state instead of reading it.**
+    Inside `process()`, reaching for a manager directly (config,
+    secrets, files) raises an error telling you the request to use
+    instead. The library's process holds no settings or secrets of
+    its own, so a direct read would be answering from the wrong
+    place. Saving static files still works normally.
+- **Values that can't leave the process must stay inside it.** If a
+    node outputs something marked `serializable=False` (a live
+    model handle, a tensor), you'll get an error explaining the two
+    ways forward: make the value serializable, or keep it inside
+    the library by caching it library-side and outputting a small
+    descriptor that the next node trades back.
+
 ### Process isolation: the Isolated mode
 
 Running a library **Isolated** (in its own dedicated process,

--- a/docs/guides/libraries.md
+++ b/docs/guides/libraries.md
@@ -165,6 +165,27 @@ isolation is the same.
 pip resolution conflicts.** This is the most important guarantee on
 this page.
 
+#### Edit-time vs. execution dependencies
+
+A library can split its dependencies into two sets in its manifest:
+
+- `pip_dependencies` — **edit-time**: what's needed to show the
+    library's nodes in the editor, place them on the canvas, and
+    edit their parameters. Keep this set light.
+- `pip_dependencies_exec` — **execution**: the heavy packages
+    (torch, diffusers, and friends) that are only needed when a
+    node actually *runs*.
+
+Execution dependencies are installed into a separate environment
+(`.venv-exec`, next to the library's `.venv`) and are only loaded
+in the process where nodes execute — never in the main engine
+process. That means a library can depend on multi-gigabyte ML
+stacks while the editor stays light, and two libraries with
+clashing heavy pins can still be edited side by side.
+
+Declaring no `pip_dependencies_exec` is always safe: the library
+behaves exactly as it did before the split existed.
+
 ### Process isolation: the Isolated mode
 
 Running a library **Isolated** (in its own dedicated process,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,7 +177,6 @@ ignore = [
 #
 # Group 2 -- not yet migrated. Each of these should eventually receive an Engine instead.
 # Deleting an entry from this list is the definition of done; do not add new entries.
-"src/griptape_nodes/exe_types/**" = ["TID251"]
 # WorkflowRegistry is still a process-global fake singleton reaching the facade for config.
 # Making it engine-owned is its own change, since it alters what node libraries import.
 "src/griptape_nodes/node_library/workflow_registry.py" = ["TID251"]

--- a/src/griptape_nodes/app/worker_routing.py
+++ b/src/griptape_nodes/app/worker_routing.py
@@ -45,6 +45,7 @@ from griptape_nodes.retained_mode.events.execution_events import (
     CancelExecuteNodeRequest,
     ExecuteNodeRequest,
 )
+from griptape_nodes.retained_mode.events.library_events import ReloadAllLibrariesRequest
 from griptape_nodes.retained_mode.events.parameter_events import MigrateParameterRequest
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 from griptape_nodes.retained_mode.events.project_events import (
@@ -202,6 +203,13 @@ LOCAL_ONLY_REQUEST_TYPES: frozenset[type[RequestPayload]] = frozenset(
         ReloadConfigRequest,
         RefreshSecretsRequest,
         ActivateProjectRequest,
+        # Adopting a project reloads this worker's libraries, and that reload must stay here. The
+        # orchestrator decides WHEN libraries reload -- it is mid-reload already, which is what sent
+        # the activation -- so forwarding would have the worker dictate to it. Worse, the
+        # orchestrator's pre-reload callback is reset_workers, which terminates the very worker that
+        # asked, mid-node. Reached because in_node_execution() is a process-wide refcount, so a
+        # reload dispatched by a broadcast handler forwards whenever any node happens to be running.
+        ReloadAllLibrariesRequest,
         # Two requests carry a live Python object in a field, and both were local under the
         # allowlist this exclusion list replaces -- the flip is what started forwarding them.
         # `_registers_a_python_class` does not catch either: it matches a `type[...]` annotation,

--- a/src/griptape_nodes/app/worker_routing.py
+++ b/src/griptape_nodes/app/worker_routing.py
@@ -4,7 +4,7 @@ On a worker, a handful of request types must be serviced by the orchestrator
 because the authoritative state (flow graph, connections, node registry) lives
 there. This module provides:
 
-- ``FORWARDED_REQUEST_TYPES``: the flat list of request classes whose worker-
+- ``LOCAL_ONLY_REQUEST_TYPES``: the exclusion list of request classes whose worker-
   side handler should forward to the orchestrator.
 - ``RemoteHandler``: an async callable that replaces the original manager
   handler for those request types on the worker. While the worker is actively
@@ -41,53 +41,25 @@ from griptape_nodes.retained_mode.events.base_events import (
     SkipTheLineMixin,
     WorkflowNotAlteredMixin,
 )
-from griptape_nodes.retained_mode.events.config_events import (
-    GetConfigValueRequest,
-    ResetConfigRequest,
-    SetConfigCategoryRequest,
-    SetConfigValueRequest,
-)
-from griptape_nodes.retained_mode.events.connection_events import (
-    CreateConnectionRequest,
-    DeleteConnectionRequest,
-    ListConnectionsForNodeRequest,
-)
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    DeleteFlowRequest,
-    ListFlowsInCurrentContextRequest,
-    ListFlowsInFlowRequest,
-    ListNodesInFlowRequest,
-)
-from griptape_nodes.retained_mode.events.node_events import (
-    CreateNodeRequest,
-    DeleteNodeRequest,
-    GetFlowForNodeRequest,
-    ListParametersOnNodeRequest,
-)
-from griptape_nodes.retained_mode.events.parameter_events import (
-    AddParameterToNodeRequest,
-    AlterParameterDetailsRequest,
-    GetConnectionsForParameterRequest,
-    GetParameterDetailsRequest,
-    GetParameterValueRequest,
-    RemoveParameterFromNodeRequest,
-    SetParameterValueRequest,
+from griptape_nodes.retained_mode.events.execution_events import (
+    CancelExecuteNodeRequest,
+    ExecuteNodeRequest,
 )
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 from griptape_nodes.retained_mode.events.project_events import (
     SetCurrentProjectRequest,
 )
-from griptape_nodes.retained_mode.events.secrets_events import (
-    DeleteSecretValueRequest,
-    GetSecretValueRequest,
-    SetSecretValueRequest,
+from griptape_nodes.retained_mode.events.static_file_events import (
+    CreateStaticFileDownloadUrlFromPathRequest,
+    CreateStaticFileDownloadUrlRequest,
+    CreateStaticFileRequest,
+    CreateStaticFileUploadUrlRequest,
 )
-from griptape_nodes.retained_mode.events.variable_events import (
-    GetVariablesRequest,
-    ListVariablesRequest,
-    ResolveSubstitutionRequest,
-    SetVariablesRequest,
+from griptape_nodes.retained_mode.events.worker_events import (
+    RegisterWorkerRequest,
+    StartWorkerRequest,
+    UnregisterWorkerRequest,
+    WorkerHeartbeatRequest,
 )
 from griptape_nodes.retained_mode.managers.event_manager import ResultContext
 from griptape_nodes.utils.async_utils import call_function
@@ -102,53 +74,6 @@ if TYPE_CHECKING:
 
 
 HandlerCallback = "Callable[[RequestPayload], ResultPayload | Awaitable[ResultPayload]]"
-
-
-FORWARDED_REQUEST_TYPES: frozenset[type[RequestPayload]] = frozenset(
-    {
-        # connection_events
-        CreateConnectionRequest,
-        DeleteConnectionRequest,
-        ListConnectionsForNodeRequest,
-        # node_events
-        CreateNodeRequest,
-        DeleteNodeRequest,
-        ListParametersOnNodeRequest,
-        GetFlowForNodeRequest,
-        # parameter_events
-        AddParameterToNodeRequest,
-        RemoveParameterFromNodeRequest,
-        SetParameterValueRequest,
-        GetParameterDetailsRequest,
-        AlterParameterDetailsRequest,
-        GetParameterValueRequest,
-        GetConnectionsForParameterRequest,
-        # flow_events
-        CreateFlowRequest,
-        DeleteFlowRequest,
-        ListNodesInFlowRequest,
-        ListFlowsInCurrentContextRequest,
-        ListFlowsInFlowRequest,
-        # config_events
-        # Getters forward too: a worker's own ConfigManager is populated from the same shared
-        # files, but it is a non-authoritative copy that can lag the orchestrator's in-memory
-        # state. Reads during node execution should see what the orchestrator sees.
-        GetConfigValueRequest,
-        SetConfigValueRequest,
-        SetConfigCategoryRequest,
-        ResetConfigRequest,
-        # secrets_events
-        GetSecretValueRequest,
-        SetSecretValueRequest,
-        DeleteSecretValueRequest,
-        # variable_events
-        GetVariablesRequest,
-        ListVariablesRequest,
-        # DEPRECATED: forwarded only while the shims live. TODO(https://github.com/griptape-ai/griptape-nodes/issues/5143): remove with the shims.
-        ResolveSubstitutionRequest,
-        SetVariablesRequest,
-    }
-)
 
 
 @dataclass
@@ -242,12 +167,47 @@ class ActivateProjectResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure
     """Worker failed to adopt the orchestrator's current project."""
 
 
+LOCAL_ONLY_REQUEST_TYPES: frozenset[type[RequestPayload]] = frozenset(
+    {
+        # Requests a worker must answer ITSELF while executing a node. Everything else
+        # forwards to the orchestrator, which owns the authoritative state.
+        #
+        # This list is deliberately an exclusion list rather than an allowlist. With an
+        # allowlist, every newly added request type silently resolved against the worker's
+        # own managers -- a non-authoritative copy -- and every migration note that told
+        # authors to "use a request instead" was wrong for any type nobody remembered to
+        # add. Defaulting to forwarding makes that class of mistake impossible.
+        #
+        # execution_events: forwarding a worker's own execution request would send it
+        # straight back to the orchestrator, which would route it here again.
+        ExecuteNodeRequest,
+        CancelExecuteNodeRequest,
+        # static_file_events: the payload is bytes. A worker writes them to the shared
+        # workspace itself and forwards only the resulting registration; shipping a 4K
+        # video across the boundary is the one thing storage must never do.
+        CreateStaticFileRequest,
+        CreateStaticFileUploadUrlRequest,
+        CreateStaticFileDownloadUrlRequest,
+        CreateStaticFileDownloadUrlFromPathRequest,
+        # worker_events + broadcasts: these travel orchestrator -> worker. Sending them back
+        # is the same loop as execution.
+        RegisterWorkerRequest,
+        UnregisterWorkerRequest,
+        WorkerHeartbeatRequest,
+        StartWorkerRequest,
+        ReloadConfigRequest,
+        RefreshSecretsRequest,
+        ActivateProjectRequest,
+    }
+)
+
+
 @dataclass
 class RemoteHandler:
     """Worker-side dispatch shim.
 
     Registered in place of the original manager handler for types in
-    FORWARDED_REQUEST_TYPES. Forwards to the orchestrator while the worker is
+    every registered type except LOCAL_ONLY_REQUEST_TYPES. Forwards to the orchestrator while the worker is
     inside a ``worker_node_execution_scope``; delegates to the original
     handler otherwise (so bootstrap / library-load paths keep running locally).
 
@@ -292,25 +252,24 @@ def schedule_broadcast(broadcast_type: type[RequestPayload]) -> None:
 
 
 def register_remote_handlers(event_manager: EventManager) -> None:
-    """Swap every FORWARDED_REQUEST_TYPE handler for a RemoteHandler.
+    """Route requests made during node execution to the orchestrator.
 
-    Must be called after every manager that claims one of these request types
-    has finished registering (i.e. after ``GriptapeNodes()`` construction is
-    complete) AND after ``configure_worker_forwarding`` has supplied the
-    RequestClient / topic / loop references. See ``_run_worker`` in app.py.
+    Swaps a RemoteHandler in for every registered request type except those in
+    LOCAL_ONLY_REQUEST_TYPES. The handler forwards only while the worker is inside a
+    ``worker_node_execution_scope`` and delegates to the original handler otherwise, so
+    engine boot and library load -- which legitimately need this process's own managers --
+    are unaffected.
 
-    Raises RuntimeError if a forwarded request type has no registered owner;
-    that always indicates a bootstrap-order bug, not a runtime condition.
+    Must be called after every manager has finished registering (i.e. after the engine is
+    constructed) AND after ``configure_worker_forwarding`` has supplied the RequestClient,
+    topic, and loop references. See ``_run_worker`` in app.py.
     """
-    for request_type in FORWARDED_REQUEST_TYPES:
+    for request_type in event_manager.registered_request_types():
+        if request_type in LOCAL_ONLY_REQUEST_TYPES:
+            continue
         original = event_manager.get_manager_for_request_type(request_type)
         if original is None:
-            msg = (
-                f"register_remote_handlers: no manager registered for "
-                f"{request_type.__name__}. Worker bootstrap must finish manager "
-                f"registration before remote handlers are installed."
-            )
-            raise RuntimeError(msg)
+            continue
         remote = RemoteHandler(original=original, event_manager=event_manager)
         event_manager.remove_manager_from_request_type(request_type)
         event_manager.assign_manager_to_request_type(request_type, remote)

--- a/src/griptape_nodes/app/worker_routing.py
+++ b/src/griptape_nodes/app/worker_routing.py
@@ -45,9 +45,13 @@ from griptape_nodes.retained_mode.events.execution_events import (
     CancelExecuteNodeRequest,
     ExecuteNodeRequest,
 )
+from griptape_nodes.retained_mode.events.parameter_events import MigrateParameterRequest
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 from griptape_nodes.retained_mode.events.project_events import (
     SetCurrentProjectRequest,
+)
+from griptape_nodes.retained_mode.events.resource_events import (
+    RegisterResourceTypeRequest,
 )
 from griptape_nodes.retained_mode.events.static_file_events import (
     CreateStaticFileDownloadUrlFromPathRequest,
@@ -198,6 +202,15 @@ LOCAL_ONLY_REQUEST_TYPES: frozenset[type[RequestPayload]] = frozenset(
         ReloadConfigRequest,
         RefreshSecretsRequest,
         ActivateProjectRequest,
+        # Two requests carry a live Python object in a field, and both were local under the
+        # allowlist this exclusion list replaces -- the flip is what started forwarding them.
+        # `_registers_a_python_class` does not catch either: it matches a `type[...]` annotation,
+        # and these carry an INSTANCE (a ResourceType, a Callable). Forwarding puts the object
+        # through `json.dumps(default=str)`, so the orchestrator registers a string and the worker
+        # -- the process that needs it while running a node -- registers nothing, with no error on
+        # either side.
+        RegisterResourceTypeRequest,
+        MigrateParameterRequest,
     }
 )
 

--- a/src/griptape_nodes/app/worker_routing.py
+++ b/src/griptape_nodes/app/worker_routing.py
@@ -42,6 +42,7 @@ from griptape_nodes.retained_mode.events.base_events import (
     WorkflowNotAlteredMixin,
 )
 from griptape_nodes.retained_mode.events.config_events import (
+    GetConfigValueRequest,
     ResetConfigRequest,
     SetConfigCategoryRequest,
     SetConfigValueRequest,
@@ -79,6 +80,7 @@ from griptape_nodes.retained_mode.events.project_events import (
 )
 from griptape_nodes.retained_mode.events.secrets_events import (
     DeleteSecretValueRequest,
+    GetSecretValueRequest,
     SetSecretValueRequest,
 )
 from griptape_nodes.retained_mode.events.variable_events import (
@@ -128,10 +130,15 @@ FORWARDED_REQUEST_TYPES: frozenset[type[RequestPayload]] = frozenset(
         ListFlowsInCurrentContextRequest,
         ListFlowsInFlowRequest,
         # config_events
+        # Getters forward too: a worker's own ConfigManager is populated from the same shared
+        # files, but it is a non-authoritative copy that can lag the orchestrator's in-memory
+        # state. Reads during node execution should see what the orchestrator sees.
+        GetConfigValueRequest,
         SetConfigValueRequest,
         SetConfigCategoryRequest,
         ResetConfigRequest,
         # secrets_events
+        GetSecretValueRequest,
         SetSecretValueRequest,
         DeleteSecretValueRequest,
         # variable_events

--- a/src/griptape_nodes/common/node_executor.py
+++ b/src/griptape_nodes/common/node_executor.py
@@ -360,7 +360,7 @@ class NodeExecutor(EngineScoped):
         lazy fetch inside VariableResolver.get_variables_if_enabled fails with
         KeyError. Pre-seeding here lets the worker skip that path entirely.
         """
-        if not VariableResolver.is_substitution_enabled():
+        if not VariableResolver.is_substitution_enabled(self.engine):
             return {}
         try:
             flow_name = self.engine.node_manager.get_node_parent_flow_by_name(node_name)

--- a/src/griptape_nodes/exe_types/base_iterative_nodes.py
+++ b/src/griptape_nodes/exe_types/base_iterative_nodes.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 from abc import abstractmethod
 from enum import StrEnum
-from typing import Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from griptape_nodes.exe_types.core_types import (
     ControlParameterInput,
@@ -16,66 +18,57 @@ from griptape_nodes.exe_types.core_types import (
 from griptape_nodes.exe_types.flow import ControlFlow
 from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.exe_types.param_components.progress_bar_component import ProgressBarComponent
+from griptape_nodes.retained_mode.events.connection_events import (
+    CreateConnectionRequest,
+    DeleteConnectionRequest,
+    ListConnectionsForNodeRequest,
+    ListConnectionsForNodeResultSuccess,
+)
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
 
 
-def _outgoing_connection_exists(source_node: str, source_param: str) -> bool:
+def _outgoing_connection_exists(engine: Engine, source_node: str, source_param: str) -> bool:
     """Check if a source node/parameter has any outgoing connections.
 
     Args:
+        engine: Engine to ask about the workflow
         source_node: Name of the node that would be sending the connection
         source_param: Name of the parameter on that node
 
     Returns:
         True if the parameter has at least one outgoing connection, False otherwise
 
-    Logic: Look in connections.outgoing_index[source_node][source_param]
+    Asked as a request rather than read from a local connection index: connections are
+    workflow state, and the orchestrator is the only place that holds all of it.
     """
-    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-    connections = GriptapeNodes.FlowManager().get_connections()
-
-    # Check if source_node has any outgoing connections at all
-    source_connections = connections.outgoing_index.get(source_node)
-    if source_connections is None:
+    result = engine.handle_request(ListConnectionsForNodeRequest(node_name=source_node, broadcast_result=False))
+    if not isinstance(result, ListConnectionsForNodeResultSuccess):
         return False
 
-    # Check if source_param has any outgoing connections
-    param_connections = source_connections.get(source_param)
-    if param_connections is None:
-        return False
-
-    # Return True if connections list is populated
-    return bool(param_connections)
+    return any(connection.source_parameter_name == source_param for connection in result.outgoing_connections)
 
 
-def _incoming_connection_exists(target_node: str, target_param: str) -> bool:
+def _incoming_connection_exists(engine: Engine, target_node: str, target_param: str) -> bool:
     """Check if a target node/parameter has any incoming connections.
 
     Args:
+        engine: Engine to ask about the workflow
         target_node: Name of the node that would be receiving the connection
         target_param: Name of the parameter on that node
 
     Returns:
         True if the parameter has at least one incoming connection, False otherwise
 
-    Logic: Look in connections.incoming_index[target_node][target_param]
+    Asked as a request rather than read from a local connection index: connections are
+    workflow state, and the orchestrator is the only place that holds all of it.
     """
-    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-    connections = GriptapeNodes.FlowManager().get_connections()
-
-    # Check if target_node has any incoming connections at all
-    target_connections = connections.incoming_index.get(target_node)
-    if target_connections is None:
+    result = engine.handle_request(ListConnectionsForNodeRequest(node_name=target_node, broadcast_result=False))
+    if not isinstance(result, ListConnectionsForNodeResultSuccess):
         return False
 
-    # Check if target_param has any incoming connections
-    param_connections = target_connections.get(target_param)
-    if param_connections is None:
-        return False
-
-    # Return True if connections list is populated
-    return bool(param_connections)
+    return any(connection.target_parameter_name == target_param for connection in result.incoming_connections)
 
 
 class IterativeNodeParam(StrEnum):
@@ -122,7 +115,7 @@ class BaseIterativeStartNode(BaseNode):
     state tracking, and validation logic used by iterative loop start nodes.
     """
 
-    end_node: "BaseIterativeEndNode | None" = None
+    end_node: BaseIterativeEndNode | None = None
     exec_out: ControlParameterOutput
     _current_iteration_count: int
     _total_iterations: int
@@ -329,8 +322,6 @@ class BaseIterativeStartNode(BaseNode):
 
     def _validate_start_node(self) -> list[Exception] | None:
         """Common validation logic for both workflow and node run validation."""
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         exceptions = []
 
         # Validate end node connection
@@ -344,8 +335,8 @@ class BaseIterativeStartNode(BaseNode):
             exceptions.extend(validation_errors)
 
         try:
-            flow = GriptapeNodes.ObjectManager().get_object_by_name(
-                GriptapeNodes.NodeManager().get_node_parent_flow_by_name(self.name)
+            flow = self.engine.object_manager.get_object_by_name(
+                self.engine.node_manager.get_node_parent_flow_by_name(self.name)
             )
             if isinstance(flow, ControlFlow):
                 self._flow = flow
@@ -481,10 +472,13 @@ class BaseIterativeStartNode(BaseNode):
             self._complete_loop()
             return
 
-        # Continue with current item - unresolve future nodes for fresh evaluation
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-        connections = GriptapeNodes.FlowManager().get_connections()
+        # Continue with current item - unresolve future nodes for fresh evaluation.
+        # NOTE: this walks the LOCAL connection map, which is correct on the orchestrator and
+        # near-empty in a worker, where it would no-op in silence. UnresolveNodeRequest is not
+        # a substitute: it unresolves the node itself and refuses while the node is RESOLVING,
+        # which is exactly this node's state here. An iterative node in a worker-routed library
+        # therefore needs a downstream-only unresolve request that does not exist yet.
+        connections = self.engine.flow_manager.get_connections()
         connections.unresolve_future_nodes(self)
 
         # Always set the index output in base class
@@ -512,7 +506,7 @@ class BaseIterativeStartNode(BaseNode):
         node_type = self._get_base_node_type_name()
 
         # Check if exec_out has outgoing connections
-        if not _outgoing_connection_exists(self.name, self.exec_out.name):
+        if not _outgoing_connection_exists(self.engine, self.name, self.exec_out.name):
             exec_out_display_name = self._get_exec_out_display_name()
             errors.append(
                 Exception(
@@ -535,7 +529,7 @@ class BaseIterativeStartNode(BaseNode):
         # Check if all hidden signal connections exist (only if end_node is connected)
         if self.end_node:
             # Check trigger_next_iteration_signal connection
-            if not _incoming_connection_exists(self.name, self.trigger_next_iteration_signal.name):
+            if not _incoming_connection_exists(self.engine, self.name, self.trigger_next_iteration_signal.name):
                 errors.append(
                     Exception(
                         f"{self.name}: Missing hidden signal connection. "
@@ -545,7 +539,7 @@ class BaseIterativeStartNode(BaseNode):
                 )
 
             # Check break_loop_signal connection
-            if not _incoming_connection_exists(self.name, self.break_loop_signal.name):
+            if not _incoming_connection_exists(self.engine, self.name, self.break_loop_signal.name):
                 errors.append(
                     Exception(
                         f"{self.name}: Missing hidden signal connection. "
@@ -604,7 +598,7 @@ class BaseIterativeEndNode(BaseNode):
     conditional evaluation, and result accumulation logic used by iterative loop end nodes.
     """
 
-    start_node: "BaseIterativeStartNode | None" = None
+    start_node: BaseIterativeStartNode | None = None
 
     def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
         super().__init__(name, metadata)
@@ -887,7 +881,9 @@ class BaseIterativeEndNode(BaseNode):
             )
 
         # Check if all hidden signal connections exist (only if start_node is connected)
-        if self.start_node and not _incoming_connection_exists(self.name, "loop_end_condition_met_signal_input"):
+        if self.start_node and not _incoming_connection_exists(
+            self.engine, self.name, "loop_end_condition_met_signal_input"
+        ):
             errors.append(
                 Exception(
                     f"{self.name}: Missing hidden signal connection. "
@@ -905,7 +901,7 @@ class BaseIterativeEndNode(BaseNode):
         connected_controls = []
 
         for control_name in control_names:
-            if _incoming_connection_exists(self.name, control_name):
+            if _incoming_connection_exists(self.engine, self.name, control_name):
                 connected_controls.append(control_name)  # noqa: PERF401
 
         if not connected_controls:
@@ -988,13 +984,10 @@ class BaseIterativeEndNode(BaseNode):
 
     def _create_hidden_signal_connections(self, start_node: BaseNode) -> None:
         """Automatically create all hidden signal connections between Start and End nodes."""
-        from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         # Create the hidden signal connections and default control flow:
 
         # 1. Start → End: loop_end_condition_met_signal → loop_end_condition_met_signal_input
-        GriptapeNodes.handle_request(
+        self.engine.handle_request(
             CreateConnectionRequest(
                 source_node_name=start_node.name,
                 source_parameter_name=IterativeNodeParam.LOOP_END_CONDITION_MET_SIGNAL.value,
@@ -1004,7 +997,7 @@ class BaseIterativeEndNode(BaseNode):
         )
 
         # 2. End → Start: trigger_next_iteration_signal_output → trigger_next_iteration_signal
-        GriptapeNodes.handle_request(
+        self.engine.handle_request(
             CreateConnectionRequest(
                 source_node_name=self.name,
                 source_parameter_name=IterativeNodeParam.TRIGGER_NEXT_ITERATION_SIGNAL_OUTPUT.value,
@@ -1014,7 +1007,7 @@ class BaseIterativeEndNode(BaseNode):
         )
 
         # 3. End → Start: break_loop_signal_output → break_loop_signal
-        GriptapeNodes.handle_request(
+        self.engine.handle_request(
             CreateConnectionRequest(
                 source_node_name=self.name,
                 source_parameter_name=IterativeNodeParam.BREAK_LOOP_SIGNAL_OUTPUT.value,
@@ -1025,8 +1018,8 @@ class BaseIterativeEndNode(BaseNode):
 
         # 4. Default control flow: Start → End: exec_out → add_item (default "happy path")
         # Only create this connection if the exec_out parameter doesn't already have a connection
-        if not _outgoing_connection_exists(start_node.name, IterativeNodeParam.EXEC_OUT.value):
-            GriptapeNodes.handle_request(
+        if not _outgoing_connection_exists(self.engine, start_node.name, IterativeNodeParam.EXEC_OUT.value):
+            self.engine.handle_request(
                 CreateConnectionRequest(
                     source_node_name=start_node.name,
                     source_parameter_name=IterativeNodeParam.EXEC_OUT.value,
@@ -1037,15 +1030,8 @@ class BaseIterativeEndNode(BaseNode):
 
     def _remove_hidden_signal_connections(self, start_node: BaseNode) -> None:
         """Remove all hidden signal connections when the main tethering connection is removed."""
-        from griptape_nodes.retained_mode.events.connection_events import (
-            DeleteConnectionRequest,
-            ListConnectionsForNodeRequest,
-            ListConnectionsForNodeResultSuccess,
-        )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         # Get current connections for start node to check what still exists
-        list_connections_result = GriptapeNodes.handle_request(ListConnectionsForNodeRequest(node_name=start_node.name))
+        list_connections_result = self.engine.handle_request(ListConnectionsForNodeRequest(node_name=start_node.name))
         if not isinstance(list_connections_result, ListConnectionsForNodeResultSuccess):
             return  # Cannot determine what connections exist, exit gracefully
 
@@ -1080,7 +1066,7 @@ class BaseIterativeEndNode(BaseNode):
             self.name,
             IterativeNodeParam.LOOP_END_CONDITION_MET_SIGNAL_INPUT.value,
         ):
-            GriptapeNodes.handle_request(
+            self.engine.handle_request(
                 DeleteConnectionRequest(
                     source_node_name=start_node.name,
                     source_parameter_name=IterativeNodeParam.LOOP_END_CONDITION_MET_SIGNAL.value,
@@ -1096,7 +1082,7 @@ class BaseIterativeEndNode(BaseNode):
             start_node.name,
             IterativeNodeParam.TRIGGER_NEXT_ITERATION_SIGNAL.value,
         ):
-            GriptapeNodes.handle_request(
+            self.engine.handle_request(
                 DeleteConnectionRequest(
                     source_node_name=self.name,
                     source_parameter_name=IterativeNodeParam.TRIGGER_NEXT_ITERATION_SIGNAL_OUTPUT.value,
@@ -1112,7 +1098,7 @@ class BaseIterativeEndNode(BaseNode):
             start_node.name,
             IterativeNodeParam.BREAK_LOOP_SIGNAL.value,
         ):
-            GriptapeNodes.handle_request(
+            self.engine.handle_request(
                 DeleteConnectionRequest(
                     source_node_name=self.name,
                     source_parameter_name=IterativeNodeParam.BREAK_LOOP_SIGNAL_OUTPUT.value,

--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -414,8 +414,6 @@ class BaseNodeElement:
 
     def _emit_alter_element_event_if_possible(self) -> None:
         """Emit an AlterElementEvent if we have node context and the necessary dependencies."""
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         if self._node_context is None:
             return
 
@@ -449,7 +447,8 @@ class BaseNodeElement:
             wrapped_event=ExecutionEvent(payload=AlterElementEvent(element_details=event_data))
         )
 
-        GriptapeNodes.EventManager().put_event(event)
+        # This is an element, not a node, so the engine comes from the node it belongs to.
+        self._node_context.engine.event_manager.put_event(event)
         self._changes.clear()
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/griptape_nodes/exe_types/node_groups/base_while_node_group.py
+++ b/src/griptape_nodes/exe_types/node_groups/base_while_node_group.py
@@ -132,12 +132,10 @@ class BaseWhileNodeGroup(SubflowNodeGroup):
             iteration: The upcoming iteration number (1-based)
             flow_name: Name of the deserialized flow being executed
         """
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         # Reset all nodes to UNRESOLVED so they re-execute. The DAG builder
         # skips RESOLVED upstream dependencies, so without this reset nodes
         # won't be added to the DAG and won't run on subsequent iterations.
-        GriptapeNodes.FlowManager().unresolve_all_nodes_in_flow(flow_name)
+        self.engine.flow_manager.unresolve_all_nodes_in_flow(flow_name)
 
     def _on_complete(self, *, condition_met: bool, iterations: int) -> None:  # noqa: ARG002
         """Called after all loop iterations are finished, before the node resolves.

--- a/src/griptape_nodes/exe_types/node_groups/subflow_node_group.py
+++ b/src/griptape_nodes/exe_types/node_groups/subflow_node_group.py
@@ -40,7 +40,6 @@ from griptape_nodes.retained_mode.events.parameter_events import (
     AddParameterToNodeResultSuccess,
     RemoveParameterFromNodeRequest,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 
 if TYPE_CHECKING:
@@ -99,7 +98,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             type=ParameterTypeBuiltin.STR,
             allowed_modes={ParameterMode.PROPERTY},
             default_value=LOCAL_EXECUTION,
-            traits={Options(choices=get_library_names_with_publish_handlers())},
+            traits={Options(choices=get_library_names_with_publish_handlers(self.engine))},
         )
         self.add_parameter(self.execution_environment)
         # Track mapping from proxy parameter name to (original_node, original_param_name)
@@ -144,7 +143,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             set_as_new_context=False,
             metadata=subflow_metadata,
         )
-        result = GriptapeNodes.handle_request(request)
+        result = self.engine.handle_request(request)
         if not isinstance(result, CreateFlowResultSuccess):
             # Drop the name we optimistically recorded: no such flow exists, and leaving it set
             # makes every later lookup point at a phantom flow.
@@ -175,7 +174,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
                 return enclosing_subflow_name
 
         # A group can be built with no Flow on the context stack, so this may find nothing.
-        context_manager = GriptapeNodes.ContextManager()
+        context_manager = self.engine.context_manager
         if not context_manager.has_current_flow():
             return None
         return context_manager.get_current_flow().name
@@ -191,7 +190,6 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         4. Stores metadata mapping execution environments to their parameters
         """
         from griptape_nodes.retained_mode.events.workflow_events import PublishWorkflowRequest
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         # Initialize metadata structure for execution environment mappings
         if self.metadata is None:
@@ -200,7 +198,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             self.metadata["execution_environment"] = {}
 
         # Get all libraries that have registered PublishWorkflowRequest handlers
-        library_manager = GriptapeNodes.LibraryManager()
+        library_manager = self.engine.library_manager
         event_handlers = library_manager.get_registered_event_handlers(PublishWorkflowRequest)
 
         # Process each registered library
@@ -327,7 +325,6 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             The newly created proxy parameter
         """
         # Clone the parameter with the new name
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         input_types = None
         output_type = None
@@ -346,7 +343,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             mode_allowed_output=True,
         )
         # Add with a request, because this will handle naming for us.
-        result = GriptapeNodes.handle_request(request)
+        result = self.engine.handle_request(request)
         if not isinstance(result, AddParameterToNodeResultSuccess):
             msg = "Failed to add parameter to node."
             raise TypeError(msg)
@@ -397,7 +394,6 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             # Store the existing connection so it can be recreated if needed.
         else:
             grouped_parameter = conn.source_parameter
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         request = DeleteConnectionRequest(
             conn.source_parameter.name,
@@ -405,7 +401,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             conn.source_node.name,
             conn.target_node.name,
         )
-        result = GriptapeNodes.handle_request(request)
+        result = self.engine.handle_request(request)
         if not isinstance(result, DeleteConnectionResultSuccess):
             return False
         proxy_parameter = self._create_proxy_parameter_for_connection(grouped_parameter, is_incoming=is_incoming)
@@ -416,7 +412,6 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
     def create_connections_for_proxy(
         self, proxy_parameter: Parameter, old_connection: Connection, *, is_incoming: bool
     ) -> None:
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         create_first_connection = CreateConnectionRequest(
             source_parameter_name=old_connection.source_parameter.name,
@@ -438,8 +433,8 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             self._proxy_param_to_connections[proxy_parameter.name] = 2
         else:
             self._proxy_param_to_connections[proxy_parameter.name] += 2
-        GriptapeNodes.handle_request(create_first_connection)
-        GriptapeNodes.handle_request(create_second_connection)
+        self.engine.handle_request(create_first_connection)
+        self.engine.handle_request(create_second_connection)
 
     def unmap_node_connections(self, node: BaseNode, connections: Connections) -> None:  # noqa: C901
         """Remove tracking of an external connection, restore original connection, and clean up proxy parameter.
@@ -448,8 +443,6 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             node: The node to unmap
             connections: The connections object
         """
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         # For the node being removed - We need to figure out all of it's connections TO the node group. These connections need to be remapped.
         # If we delete connections from a proxy parameter, and it has no more connections, then the proxy parameter should be deleted unless it's user defined.
         # It will 1. not be in the proxy map. and 2. it will have a value of > 0
@@ -462,7 +455,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
                 # get old connections first, since this will delete the proxy
                 remap_connections = connections.get_outgoing_connections_from_parameter(self, proxy_parameter)
                 # Delete the internal connection
-                delete_result = GriptapeNodes.FlowManager().on_delete_connection_request(
+                delete_result = self.engine.flow_manager.on_delete_connection_request(
                     DeleteConnectionRequest(
                         source_parameter_name=parameter_name,
                         target_parameter_name=proxy_parameter.name,
@@ -476,7 +469,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
 
                 # Now create the new connection! We need to get the connections from the proxy parameter
                 for connection in remap_connections:
-                    create_result = GriptapeNodes.FlowManager().on_create_connection_request(
+                    create_result = self.engine.flow_manager.on_create_connection_request(
                         CreateConnectionRequest(
                             source_parameter_name=parameter_name,
                             target_parameter_name=connection.target_parameter.name,
@@ -497,7 +490,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
                 # Get the incoming connections to the proxy parameter
                 remap_connections = connections.get_incoming_connections_to_parameter(self, proxy_parameter)
                 # Delete the internal connection
-                delete_result = GriptapeNodes.FlowManager().on_delete_connection_request(
+                delete_result = self.engine.flow_manager.on_delete_connection_request(
                     DeleteConnectionRequest(
                         source_parameter_name=proxy_parameter.name,
                         target_parameter_name=parameter_name,
@@ -511,7 +504,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
 
                 # Now create the new connection! We need to get the connections to the proxy parameter
                 for connection in remap_connections:
-                    create_result = GriptapeNodes.FlowManager().on_create_connection_request(
+                    create_result = self.engine.flow_manager.on_create_connection_request(
                         CreateConnectionRequest(
                             source_parameter_name=connection.source_parameter.name,
                             target_parameter_name=parameter_name,
@@ -530,14 +523,12 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             proxy_parameter: The proxy parameter to potentially clean up
             metadata_key: The metadata key ('left_parameters' or 'right_parameters')
         """
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         if proxy_parameter.name not in self._proxy_param_to_connections:
             return
 
         self._proxy_param_to_connections[proxy_parameter.name] -= 1
         if self._proxy_param_to_connections[proxy_parameter.name] == 0:
-            GriptapeNodes.NodeManager().on_remove_parameter_from_node_request(
+            self.engine.node_manager.on_remove_parameter_from_node_request(
                 request=RemoveParameterFromNodeRequest(node_name=self.name, parameter_name=proxy_parameter.name)
             )
             del self._proxy_param_to_connections[proxy_parameter.name]
@@ -551,8 +542,6 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             node: The node being added to the group
             connections: Connections object from FlowManager
         """
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         outgoing_connections = connections.get_outgoing_connections_to_node(node, to_node=self)
         for parameter_name, outgoing_connection_list in outgoing_connections.items():
             for outgoing_connection in outgoing_connection_list:
@@ -568,7 +557,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
                 )
 
                 # Delete the connection from this node to proxy
-                delete_result = GriptapeNodes.FlowManager().on_delete_connection_request(
+                delete_result = self.engine.flow_manager.on_delete_connection_request(
                     DeleteConnectionRequest(
                         source_parameter_name=parameter_name,
                         target_parameter_name=proxy_parameter.name,
@@ -582,7 +571,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
 
                 # Create direct connections from this node to target nodes
                 for connection in remap_connections:
-                    create_result = GriptapeNodes.FlowManager().on_create_connection_request(
+                    create_result = self.engine.flow_manager.on_create_connection_request(
                         CreateConnectionRequest(
                             source_parameter_name=parameter_name,
                             target_parameter_name=connection.target_parameter.name,
@@ -597,7 +586,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
                 # Only delete outgoing connections from proxy and clean up if no other incoming connections exist
                 if not other_incoming_exists:
                     for connection in remap_connections:
-                        delete_result = GriptapeNodes.FlowManager().on_delete_connection_request(
+                        delete_result = self.engine.flow_manager.on_delete_connection_request(
                             DeleteConnectionRequest(
                                 source_parameter_name=connection.source_parameter.name,
                                 target_parameter_name=connection.target_parameter.name,
@@ -618,8 +607,6 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             node: The node being added to the group
             connections: Connections object from FlowManager
         """
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         incoming_connections = connections.get_incoming_connections_from_node(node, from_node=self)
         for parameter_name, incoming_connection_list in incoming_connections.items():
             for incoming_connection in incoming_connection_list:
@@ -635,7 +622,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
                 )
 
                 # Delete the connection from proxy to this node
-                delete_result = GriptapeNodes.FlowManager().on_delete_connection_request(
+                delete_result = self.engine.flow_manager.on_delete_connection_request(
                     DeleteConnectionRequest(
                         source_parameter_name=proxy_parameter.name,
                         target_parameter_name=parameter_name,
@@ -649,7 +636,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
 
                 # Create direct connections from source nodes to this node
                 for connection in remap_connections:
-                    create_result = GriptapeNodes.FlowManager().on_create_connection_request(
+                    create_result = self.engine.flow_manager.on_create_connection_request(
                         CreateConnectionRequest(
                             source_parameter_name=connection.source_parameter.name,
                             target_parameter_name=parameter_name,
@@ -664,7 +651,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
                 # Only delete incoming connections to proxy and clean up if no other outgoing connections exist
                 if not other_outgoing_exists:
                     for connection in remap_connections:
-                        delete_result = GriptapeNodes.FlowManager().on_delete_connection_request(
+                        delete_result = self.engine.flow_manager.on_delete_connection_request(
                             DeleteConnectionRequest(
                                 source_parameter_name=connection.source_parameter.name,
                                 target_parameter_name=proxy_parameter.name,
@@ -765,7 +752,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
                     self._discard_subflow_created_for_a_failed_add()
                 raise
 
-        connections = GriptapeNodes.FlowManager().get_connections()
+        connections = self.engine.flow_manager.get_connections()
         node_names_in_group = set(self.nodes.keys())
         self.metadata["node_names_in_group"] = list(node_names_in_group)
         self.remap_to_internal(nodes, connections)
@@ -911,7 +898,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         if subflow_name is None:
             return
 
-        subflow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(subflow_name, ControlFlow)
+        subflow = self.engine.object_manager.attempt_get_object_by_name_as_type(subflow_name, ControlFlow)
         if subflow is None:
             self.metadata.pop("subflow_name", None)
             return
@@ -925,7 +912,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             )
             return
 
-        delete_result = GriptapeNodes.handle_request(DeleteFlowRequest(flow_name=subflow_name))
+        delete_result = self.engine.handle_request(DeleteFlowRequest(flow_name=subflow_name))
         if isinstance(delete_result, DeleteFlowResultFailure):
             # Not worth failing the add twice over: it is already failing, and the message the artist
             # gets should be why their nodes did not move, not a leftover flow they cannot see.
@@ -950,7 +937,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             NodeGroupMembershipError: If the engine refused the move, carrying the reason it gave
         """
         move_request = MoveNodeToNewFlowRequest(node_name=node.name, target_flow_name=flow_name)
-        move_result = GriptapeNodes.handle_request(move_request)
+        move_result = self.engine.handle_request(move_request)
         if not isinstance(move_result, MoveNodeToNewFlowResultSuccess):
             # Carry the engine's own reason rather than only logging it: this is the innermost thing
             # that knows why the move was refused, and the caller turns it into what the artist reads.
@@ -988,7 +975,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         # editor but loses its contents on save, so the caller has to hear about it. Both callers
         # turn this into a failure result (see NodeManager.on_add_nodes_to_node_group_request).
         try:
-            GriptapeNodes.FlowManager().reparent_flow(child_subflow_name, parent_subflow_name)
+            self.engine.flow_manager.reparent_flow(child_subflow_name, parent_subflow_name)
         except ValueError as err:
             msg = (
                 f"Attempted to change what group '{node.name}' belongs to. "
@@ -1054,8 +1041,6 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         if not conn_list:
             return
 
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         # All connections share the same external parameter
         # For outgoing: the internal (source) parameter is shared
         # For incoming: the external (source) parameter is shared
@@ -1076,7 +1061,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
                 conn.source_node.name,
                 conn.target_node.name,
             )
-            result = GriptapeNodes.handle_request(request)
+            result = self.engine.handle_request(request)
             if not isinstance(result, DeleteConnectionResultSuccess):
                 logger.warning(
                     "%s failed to delete connection from %s.%s to %s.%s",
@@ -1118,9 +1103,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         Returns:
             The existing proxy parameter if found, None otherwise
         """
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-        connections = GriptapeNodes.FlowManager().get_connections()
+        connections = self.engine.flow_manager.get_connections()
 
         # Determine which proxy parameters to check based on direction
         if is_incoming:
@@ -1154,8 +1137,6 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             old_connection: The original connection being remapped
             is_incoming: True if this is an incoming connection to the group
         """
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         create_first_connection = CreateConnectionRequest(
             source_parameter_name=old_connection.source_parameter.name,
             target_parameter_name=proxy_parameter.name,
@@ -1177,8 +1158,8 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         else:
             self._proxy_param_to_connections[proxy_parameter.name] += 2
 
-        GriptapeNodes.handle_request(create_first_connection)
-        GriptapeNodes.handle_request(create_second_connection)
+        self.engine.handle_request(create_first_connection)
+        self.engine.handle_request(create_second_connection)
 
     def delete_nodes_from_group(self, nodes: list[BaseNode]) -> None:
         """Delete nodes from the group and untrack their connections.
@@ -1231,7 +1212,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             # Rolling back means going the way they came: into this group's subflow.
             self._relocate_nodes(nodes, destination_flow_name=parent_flow_name, rollback_flow_name=subflow_name)
 
-        connections = GriptapeNodes.FlowManager().get_connections()
+        connections = self.engine.flow_manager.get_connections()
         for node in nodes:
             node.parent_group = None
             self.nodes.pop(node.name)
@@ -1261,11 +1242,10 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             StartLocalSubflowRequest,
             StartLocalSubflowResultFailure,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         subflow = self.metadata.get("subflow_name")
         if subflow is not None and isinstance(subflow, str):
-            result = await GriptapeNodes.FlowManager().on_start_local_subflow_request(
+            result = await self.engine.flow_manager.on_start_local_subflow_request(
                 StartLocalSubflowRequest(flow_name=subflow)
             )
 
@@ -1285,9 +1265,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         For each right (output) proxy parameter, finds the internal node connected
         to it and copies the value to this group's parameter_output_values.
         """
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-        connections = GriptapeNodes.FlowManager().get_connections()
+        connections = self.engine.flow_manager.get_connections()
 
         right_params = self.metadata.get(RIGHT_PARAMETERS_KEY, [])
         for proxy_param_name in right_params:
@@ -1330,9 +1308,9 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         self.remove_nodes_from_group(nodes_to_remove)
         subflow_name = self.metadata.get("subflow_name")
         if subflow_name is not None:
-            subflow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(subflow_name, ControlFlow)
+            subflow = self.engine.object_manager.attempt_get_object_by_name_as_type(subflow_name, ControlFlow)
             if subflow is not None:
-                delete_result = GriptapeNodes.handle_request(DeleteFlowRequest(flow_name=subflow_name))
+                delete_result = self.engine.handle_request(DeleteFlowRequest(flow_name=subflow_name))
                 if isinstance(delete_result, DeleteFlowResultFailure):
                     # This will propagate up to DeleteNodeRequest, and prevent the node from deleting.
                     msg = f"Failed to delete subflow {subflow_name} when deleting node {self.name}"
@@ -1351,7 +1329,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         nowhere to put these nodes" rather than an error in itself.
         """
         try:
-            return GriptapeNodes.NodeManager().get_node_parent_flow_by_name(self.name)
+            return self.engine.node_manager.get_node_parent_flow_by_name(self.name)
         except KeyError:
             logger.warning("%s has no parent flow", self.name)
             return None

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -35,6 +35,15 @@ from griptape_nodes.retained_mode.events.base_events import (
     ProgressEvent,
     RequestPayload,
 )
+from griptape_nodes.retained_mode.events.config_events import (
+    GetConfigValueRequest,
+    GetConfigValueResultSuccess,
+    SetConfigValueRequest,
+)
+from griptape_nodes.retained_mode.events.connection_events import (
+    ListConnectionsForNodeRequest,
+    ListConnectionsForNodeResultSuccess,
+)
 from griptape_nodes.retained_mode.events.event_converter import safe_unstructure
 from griptape_nodes.retained_mode.events.parameter_events import (
     AddParameterToNodeRequest,
@@ -48,6 +57,7 @@ from griptape_nodes.utils import async_utils
 if TYPE_CHECKING:
     from griptape_nodes.exe_types.core_types import NodeMessagePayload
     from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
+    from griptape_nodes.retained_mode.engine import Engine
     from griptape_nodes.retained_mode.variable_types import VariableScope
 
 logger = logging.getLogger("griptape_nodes")
@@ -284,13 +294,15 @@ class NodeResolutionState(StrEnum):
     RESOLVED = auto()
 
 
-def get_library_names_with_publish_handlers() -> list[str]:
-    """Get names of all registered libraries that have PublishWorkflowRequest handlers."""
-    from griptape_nodes.retained_mode.events.workflow_events import PublishWorkflowRequest
-    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+def get_library_names_with_publish_handlers(engine: Engine) -> list[str]:
+    """Get names of all registered libraries that have PublishWorkflowRequest handlers.
 
-    library_manager = GriptapeNodes.LibraryManager()
-    event_handlers = library_manager.get_registered_event_handlers(PublishWorkflowRequest)
+    Takes the engine rather than reaching for the facade: a free function has no ``self`` to
+    resolve it from, so its caller (a node, which has one) supplies it.
+    """
+    from griptape_nodes.retained_mode.events.workflow_events import PublishWorkflowRequest
+
+    event_handlers = engine.library_manager.get_registered_event_handlers(PublishWorkflowRequest)
 
     # Always include "local" and "private" as the first options
     library_names = [LOCAL_EXECUTION, PRIVATE_EXECUTION]
@@ -319,6 +331,7 @@ class BaseNode(ABC):
     )
     lock: bool = False  # When lock is true, the node is locked and can't be modified. When lock is false, the node is unlocked and can be modified.
     _cancellation_requested: threading.Event  # Event indicating if cancellation has been requested for this node
+    _engine: Engine | None
 
     @property
     def parameters(self) -> list[Parameter]:
@@ -332,7 +345,27 @@ class BaseNode(ABC):
         name: str,
         metadata: dict[Any, Any] | None = None,
         state: NodeResolutionState = NodeResolutionState.UNRESOLVED,
+        *,
+        engine: Engine | None = None,
     ) -> None:
+        """Initialize the node.
+
+        Args:
+            name: Node name, unique within its flow.
+            metadata: Node metadata (node_type and library, plus optional extras).
+            state: Initial resolution state.
+            engine: The engine this node belongs to. Keyword-only and optional so a library's
+                ``super().__init__(name, metadata=metadata)`` keeps working untouched.
+
+                Nothing in the engine passes it today: ``LibraryRegistry.create_node`` builds
+                nodes as ``node_class(name=name, metadata=metadata)``, and it cannot start
+                passing an engine without breaking every library node and several engine-internal
+                subclasses, all of which fix their signature at two arguments. So in practice a
+                node resolves the ambient engine via ``current_engine()``. The parameter exists
+                for embedders and tests that DO hold a reference, and so the fallback has
+                somewhere to be overridden from -- which is what the unit tests use it for.
+        """
+        self._engine = engine
         self.name = name
         self._state = state
         if metadata is None:
@@ -349,6 +382,29 @@ class BaseNode(ABC):
         self._cancellation_requested = threading.Event()
         self._parent_group = None
         self.set_entry_control_parameter(None)
+
+    @property
+    def engine(self) -> Engine:
+        """The engine this node belongs to.
+
+        Node machinery reaches managers and dispatches requests through here rather than the
+        process-wide ``GriptapeNodes`` facade. The facade remains what it is documented to be:
+        the surface for separately-versioned library code and saved workflow files.
+
+        For a node built without an explicit engine -- which is every node the engine itself
+        creates -- this resolves the ambient one, so the lookup is the same process-wide
+        resolution the facade would have done. What the migration buys is not per-node isolation
+        but the classification it forced: questions about workflow state now travel as requests,
+        which is what makes them answerable from inside a worker.
+        """
+        if self._engine is None:
+            # Deferred import: griptape_nodes.retained_mode.engine pulls in the manager graph,
+            # which pulls in the event payloads, which import this module for
+            # NodeDependencies/NodeResolutionState. Importing it at module scope is a cycle.
+            from griptape_nodes.retained_mode.engine import current_engine
+
+            return current_engine()
+        return self._engine
 
     @property
     def state(self) -> NodeResolutionState:
@@ -393,15 +449,13 @@ class BaseNode(ABC):
     # This is gross and we need to have a universal pass on resolution state changes and emission of events. That's what this ticket does!
     # https://github.com/griptape-ai/griptape-nodes/issues/994
     def make_node_unresolved(self, current_states_to_trigger_change_event: set[NodeResolutionState] | None) -> None:
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         # See if the current state is in the set of states to trigger a change event.
         if current_states_to_trigger_change_event is not None and self.state in current_states_to_trigger_change_event:
             # Trigger the change event.
             # Send an event to the GUI so it knows this node has changed resolution state.
             from griptape_nodes.retained_mode.events.execution_events import NodeUnresolvedEvent
 
-            GriptapeNodes.EventManager().put_event(
+            self.engine.event_manager.put_event(
                 ExecutionGriptapeNodeEvent(
                     wrapped_event=ExecutionEvent(payload=NodeUnresolvedEvent(node_name=self.name))
                 )
@@ -1066,10 +1120,8 @@ class BaseNode(ABC):
             self.metadata["size"] = {"width": width, "height": height}
 
     def kill_parameter_children(self, parameter: Parameter) -> None:
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         for child in parameter.find_elements_by_type(Parameter):
-            GriptapeNodes.handle_request(RemoveParameterFromNodeRequest(parameter_name=child.name, node_name=self.name))
+            self.engine.handle_request(RemoveParameterFromNodeRequest(parameter_name=child.name, node_name=self.name))
 
     def get_parameter_value(self, param_name: str) -> Any:
         param = self.get_parameter_by_name(param_name)
@@ -1188,7 +1240,7 @@ class BaseNode(ABC):
     # if not implemented, it will return no issues.
     def validate_before_workflow_run(self) -> list[Exception] | None:
         """Runs before the entire workflow is run."""
-        if VariableResolver.is_substitution_enabled():
+        if VariableResolver.is_substitution_enabled(self.engine):
             for param in self.parameters:
                 if not param.allow_variable_substitution:
                     continue
@@ -1246,29 +1298,32 @@ class BaseNode(ABC):
         return None
 
     def get_config_value(self, service: str, value: str) -> str:
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         warnings.warn(
-            "get_config_value() is deprecated. Use GriptapeNodes.SecretsManager().get_secret() for secrets/API keys "
-            "or GriptapeNodes.ConfigManager().get_config_value() for other config values.",
+            "get_config_value() is deprecated. Use GetSecretValueRequest for secrets/API keys or "
+            "GetConfigValueRequest for other config values. Both are answered by the main engine "
+            "even when your node runs in an isolated process, where the manager accessors are "
+            "refused.",
             UserWarning,
             stacklevel=2,
         )
 
-        config_value = GriptapeNodes.ConfigManager().get_config_value(f"nodes.{service}.{value}")
+        result = self.engine.handle_request(GetConfigValueRequest(category_and_key=f"nodes.{service}.{value}"))
+        # Typed loosely on purpose: config values are `Any`, and an absent key has always
+        # come back as None here despite the declared return type.
+        config_value: Any = result.value if isinstance(result, GetConfigValueResultSuccess) else None
         return config_value
 
     def set_config_value(self, service: str, value: str, new_value: str) -> None:
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         warnings.warn(
-            "set_config_value() is deprecated. Use GriptapeNodes.SecretsManager().set_secret() for secrets/API keys "
-            "or GriptapeNodes.ConfigManager().set_config_value() for other config values.",
+            "set_config_value() is deprecated. Use SetSecretValueRequest for secrets/API keys or "
+            "SetConfigValueRequest for other config values. Both are answered by the main engine "
+            "even when your node runs in an isolated process, where the manager accessors are "
+            "refused.",
             UserWarning,
             stacklevel=2,
         )
 
-        GriptapeNodes.ConfigManager().set_config_value(f"nodes.{service}.{value}", new_value)
+        self.engine.handle_request(SetConfigValueRequest(category_and_key=f"nodes.{service}.{value}", value=new_value))
 
     def clear_node(self) -> None:
         # set state to unresolved
@@ -1357,8 +1412,6 @@ class BaseNode(ABC):
         return None
 
     def append_value_to_parameter(self, parameter_name: str, value: Any) -> None:
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         # Add the value to the node
         if parameter_name in self.parameter_output_values:
             try:
@@ -1394,13 +1447,12 @@ class BaseNode(ABC):
             return
 
         # Publish the event up!
-        GriptapeNodes.EventManager().put_event(
+        self.engine.event_manager.put_event(
             ProgressEvent(value=value, node_name=self.name, parameter_name=parameter_name)
         )
 
     def publish_update_to_parameter(self, parameter_name: str, value: Any) -> None:
         from griptape_nodes.retained_mode.events.execution_events import ParameterValueUpdateEvent
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         parameter = self.get_parameter_by_name(parameter_name)
         if parameter:
@@ -1416,7 +1468,7 @@ class BaseNode(ABC):
                 value=safe_unstructure(self.get_display_value_for_output(parameter_name, value)),
             )
 
-            GriptapeNodes.EventManager().put_event(
+            self.engine.event_manager.put_event(
                 ExecutionGriptapeNodeEvent(wrapped_event=ExecutionEvent(payload=payload))
             )
         else:
@@ -1531,14 +1583,17 @@ class BaseNode(ABC):
         self.reorder_elements(list(new_order))
 
     def _param_has_incoming_connection(self, param_name: str) -> bool:
-        # GriptapeNodes import is lazy to avoid circular dependency between exe_types and retained_mode
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        """Whether ``param_name`` is fed by a connection.
 
-        connections = GriptapeNodes.FlowManager().get_connections()
-        node_connections = connections.incoming_index.get(self.name)
-        if node_connections is None:
+        Asked as a request rather than read from a local manager: this is a question about
+        the workflow, and the workflow's single source of truth is the orchestrator. A node
+        executing in an isolated process holds only a transient copy of itself, so reading
+        its own process's connection index would answer from almost nothing.
+        """
+        result = self.engine.handle_request(ListConnectionsForNodeRequest(node_name=self.name, broadcast_result=False))
+        if not isinstance(result, ListConnectionsForNodeResultSuccess):
             return False
-        return param_name in node_connections
+        return any(connection.target_parameter_name == param_name for connection in result.incoming_connections)
 
     def _has_connected_whole_list_value(self, parameter_list: ParameterList) -> bool:
         """Whether a ParameterList was handed an entire list through a connection to the list itself.
@@ -1553,11 +1608,15 @@ class BaseNode(ABC):
         param_name = parameter_list.name
         if param_name not in self.parameter_values:
             return False
-        if not self._param_has_incoming_connection(param_name):
-            return False
 
+        # Both cheap local checks run before the connection question, which costs a request
+        # dispatch -- and a cross-process round trip in a worker -- on a path that
+        # get_parameter_value reaches for every read of a populated list.
         value = self.parameter_values[param_name]
         if not isinstance(value, list):
+            return False
+
+        if not self._param_has_incoming_connection(param_name):
             return False
 
         child_count = len(parameter_list.find_elements_by_type(Parameter, find_recursively=False))
@@ -1584,13 +1643,13 @@ class BaseNode(ABC):
 
     def _resolve_variables_in_value(self, value: Any) -> Any:
         """Recursively substitute workflow variables in any str/dict/list value."""
-        variables = VariableResolver.get_variables_if_enabled(self.name)
+        variables = VariableResolver.get_variables_if_enabled(self.engine, self.name)
         if variables is None:
             return value
         return VariableResolver.resolve_value(value, variables, self.name)
 
     def _resolve_variables_in_string(self, text: str) -> str:
-        variables = VariableResolver.get_variables_if_enabled(self.name)
+        variables = VariableResolver.get_variables_if_enabled(self.engine, self.name)
         if variables is None:
             return text
         return VariableResolver.resolve_string(text, variables, self.name)
@@ -1629,7 +1688,7 @@ class BaseNode(ABC):
         # get_variables_without_memoizing, not get_variables_if_enabled: this runs
         # outside aprocess_scope(), where the latter's memo write has no reset token
         # and would leave a stale variable dict on the surrounding context.
-        variables = VariableResolver.get_variables_without_memoizing(self.name)
+        variables = VariableResolver.get_variables_without_memoizing(self.engine, self.name)
         if variables is None:
             return True
         return VariableResolver.would_substitute(raw_value, variables)
@@ -1648,7 +1707,7 @@ class BaseNode(ABC):
         connection never gets substituted, so its output is genuine and its
         stored value must stay writable.
         """
-        if not VariableResolver.is_substitution_enabled():
+        if not VariableResolver.is_substitution_enabled(self.engine):
             return None
         parameter = self.get_parameter_by_name(parameter_name)
         if parameter is None:
@@ -1656,8 +1715,8 @@ class BaseNode(ABC):
         raw_value = self.parameter_values.get(parameter_name, parameter.default_value)
         # One short-circuiting chain rather than a ladder of early returns, so the
         # cheap checks stay ordered ahead of the expensive ones. The connection
-        # lookup is last: it reaches through the GriptapeNodes singleton to the
-        # FlowManager, and the checks before it already rule out the common case.
+        # lookup is last: it costs a request round trip to the FlowManager, and the
+        # checks before it already rule out the common case.
         substitution_would_have_applied = (
             ParameterMode.PROPERTY in parameter.allowed_modes
             and parameter.allow_variable_substitution
@@ -1754,7 +1813,6 @@ class BaseNode(ABC):
         """Emit an AlterElementEvent for parameter add/remove operations."""
         from griptape_nodes.retained_mode.events.base_events import ExecutionEvent, ExecutionGriptapeNodeEvent
         from griptape_nodes.retained_mode.events.parameter_events import AlterElementEvent
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         # Create event data using the parameter's to_event method
         if remove:
@@ -1776,7 +1834,7 @@ class BaseNode(ABC):
                 wrapped_event=ExecutionEvent(payload=AlterElementEvent(element_details=event_data))
             )
 
-        GriptapeNodes.EventManager().put_event(event)
+        self.engine.event_manager.put_event(event)
 
     def _get_element_name(self, element: str | int, element_names: list[str]) -> str:
         """Convert an element identifier (name or index) to its name.
@@ -1978,7 +2036,6 @@ class TrackedParameterOutputValues(dict[str, Any]):
         if parameter is not None:
             from griptape_nodes.retained_mode.events.base_events import ExecutionEvent, ExecutionGriptapeNodeEvent
             from griptape_nodes.retained_mode.events.parameter_events import AlterElementEvent
-            from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
             # Create event data using the parameter's to_event method
             event_data = parameter.to_event(self._node)
@@ -2011,7 +2068,9 @@ class TrackedParameterOutputValues(dict[str, Any]):
                 wrapped_event=ExecutionEvent(payload=AlterElementEvent(element_details=event_data))
             )
 
-            GriptapeNodes.EventManager().put_event(event)
+            # This is a plain dict subclass, not a node, so the engine comes from the node it
+            # belongs to.
+            self._node.engine.event_manager.put_event(event)
 
 
 class ControlNode(BaseNode):
@@ -2109,18 +2168,10 @@ class SuccessFailureNode(BaseNode):
 
     def _has_outgoing_connections(self, parameter: Parameter) -> bool:
         """Check if a specific parameter has outgoing connections."""
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-        connections = GriptapeNodes.FlowManager().get_connections()
-
-        # Check if node has any outgoing connections
-        node_connections = connections.outgoing_index.get(self.name)
-        if node_connections is None:
+        result = self.engine.handle_request(ListConnectionsForNodeRequest(node_name=self.name, broadcast_result=False))
+        if not isinstance(result, ListConnectionsForNodeResultSuccess):
             return False
-
-        # Check if this specific parameter has any outgoing connections
-        param_connections = node_connections.get(parameter.name, [])
-        return len(param_connections) > 0
+        return any(connection.source_parameter_name == parameter.name for connection in result.outgoing_connections)
 
     def _create_status_parameters(
         self,
@@ -2381,8 +2432,6 @@ class ErrorProxyNode(BaseNode):
 
         if existing_param is None:
             # Create new universal parameter with all modes enabled
-            from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
             request = AddParameterToNodeRequest(
                 node_name=self.name,
                 parameter_name=param_name,
@@ -2396,7 +2445,7 @@ class ErrorProxyNode(BaseNode):
                 is_user_defined=False,  # Don't serialize this parameter
                 initial_setup=True,  # Allows setting non-settable parameters and prevents resolution cascades during workflow loading
             )
-            result = GriptapeNodes.handle_request(request)
+            result = self.engine.handle_request(request)
 
             # Check if parameter creation was successful
             from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeResultSuccess

--- a/src/griptape_nodes/exe_types/param_components/api_key_provider_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/api_key_provider_parameter.py
@@ -5,7 +5,10 @@ from typing import Any, NamedTuple
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMessage
 from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.exe_types.param_types.parameter_bool import ParameterBool
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.events.secrets_events import (
+    GetSecretValueRequest,
+    GetSecretValueResultSuccess,
+)
 from griptape_nodes.traits.button import Button
 
 
@@ -152,7 +155,7 @@ class ApiKeyProviderParameter:
         Returns:
             bool: True if the API key exists and is not empty, False otherwise
         """
-        api_key_value = GriptapeNodes.SecretsManager().get_secret(api_key)
+        api_key_value = self._get_secret(api_key, should_error_on_not_found=False)
         if api_key_value is None:
             return False
         if isinstance(api_key_value, str):
@@ -172,7 +175,7 @@ class ApiKeyProviderParameter:
             ValueError: If the API key is not set
         """
         api_key_name = self.api_key_name if use_user_api else self.proxy_api_key_name
-        api_key = GriptapeNodes.SecretsManager().get_secret(api_key_name)
+        api_key = self._get_secret(api_key_name, should_error_on_not_found=True)
         if not api_key:
             msg = f"{self._node.name} is missing {api_key_name}. Ensure it's set in the environment/config."
             raise ValueError(msg)
@@ -198,3 +201,17 @@ class ApiKeyProviderParameter:
             user_api_key = self.get_api_key(use_user_api=True)
 
         return ApiKeyValidationResult(proxy_api_key=proxy_api_key, user_api_key=user_api_key)
+
+    def _get_secret(self, secret_name: str, *, should_error_on_not_found: bool) -> str | None:
+        """Ask the engine for a secret.
+
+        Asked as a request rather than read from a local SecretsManager: when the node runs in
+        a worker, the request reaches the orchestrator, while a manager read would answer from
+        the worker's own copy.
+        """
+        result = self._node.engine.handle_request(
+            GetSecretValueRequest(key=secret_name, should_error_on_not_found=should_error_on_not_found)
+        )
+        if not isinstance(result, GetSecretValueResultSuccess):
+            return None
+        return result.value

--- a/src/griptape_nodes/exe_types/param_components/artifact_url/public_artifact_url_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/artifact_url/public_artifact_url_parameter.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import mimetypes
 import os
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 from urllib.parse import urlparse
 from uuid import uuid4
 
@@ -14,11 +16,13 @@ from griptape.artifacts.video_url_artifact import VideoUrlArtifact
 from griptape_nodes.common.parameter_hydration import hydrate_value
 from griptape_nodes.drivers.cloud_credentials import MISSING_CREDENTIAL_MESSAGE, resolve_cloud_credential
 from griptape_nodes.drivers.storage.griptape_cloud_storage_driver import GriptapeCloudStorageDriver
-from griptape_nodes.exe_types.core_types import Parameter
-from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.retained_mode.events.config_events import GetConfigValueRequest, GetConfigValueResultSuccess
 from griptape_nodes.retained_mode.events.secrets_events import GetSecretValueRequest, GetSecretValueResultSuccess
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+if TYPE_CHECKING:
+    from griptape_nodes.exe_types.core_types import Parameter
+    from griptape_nodes.exe_types.node_types import BaseNode
+    from griptape_nodes.retained_mode.engine import Engine
 
 
 class PublicArtifactUrlParameter:
@@ -53,7 +57,7 @@ class PublicArtifactUrlParameter:
             )
             raise ValueError(msg)
 
-        api_key = resolve_cloud_credential(GriptapeNodes.SecretsManager(), secret_name=self.API_KEY_NAME)
+        api_key = resolve_cloud_credential(node.engine.secrets_manager, secret_name=self.API_KEY_NAME)
         if not api_key:
             msg = (
                 f"Attempted to make '{artifact_url_parameter.name}' publicly accessible. "
@@ -63,16 +67,16 @@ class PublicArtifactUrlParameter:
 
         base = os.getenv("GT_CLOUD_BASE_URL", "https://cloud.griptape.ai")
         self._storage_driver = GriptapeCloudStorageDriver(
-            GriptapeNodes.ConfigManager(),
-            bucket_id=self._get_bucket_id(base, api_key, timeout=self._request_timeout),
+            node.engine.config_manager,
+            bucket_id=self._get_bucket_id(node.engine, base, api_key, timeout=self._request_timeout),
             api_key=api_key,
             base_url=base,
             request_timeout=self._request_timeout,
         )
 
     @classmethod
-    def _get_bucket_id(cls, base_url: str, api_key: str, timeout: float | None = None) -> str:
-        bucket_id: str | None = cls._get_secret_value(cls.BUCKET_ID_NAME, should_error_on_not_found=False)
+    def _get_bucket_id(cls, engine: Engine, base_url: str, api_key: str, timeout: float | None = None) -> str:
+        bucket_id: str | None = cls._get_secret_value(engine, cls.BUCKET_ID_NAME, should_error_on_not_found=False)
 
         # A blank/whitespace-only secret is treated the same as an unset one: it can't
         # point at a real bucket and, left alone, produces confusing downstream 404s from
@@ -116,9 +120,9 @@ class PublicArtifactUrlParameter:
         return default_bucket_id
 
     @classmethod
-    def _get_config_value(cls, key: str, default: Any | None = None) -> Any | None:
+    def _get_config_value(cls, engine: Engine, key: str, default: Any | None = None) -> Any | None:
         request = GetConfigValueRequest(category_and_key=key)
-        result_event = GriptapeNodes.handle_request(request)
+        result_event = engine.handle_request(request)
 
         if isinstance(result_event, GetConfigValueResultSuccess):
             return result_event.value
@@ -127,10 +131,10 @@ class PublicArtifactUrlParameter:
 
     @classmethod
     def _get_secret_value(
-        cls, key: str, default: Any | None = None, *, should_error_on_not_found: bool = False
+        cls, engine: Engine, key: str, default: Any | None = None, *, should_error_on_not_found: bool = False
     ) -> Any | None:
         request = GetSecretValueRequest(key=key, should_error_on_not_found=should_error_on_not_found)
-        result_event = GriptapeNodes.handle_request(request)
+        result_event = engine.handle_request(request)
 
         if isinstance(result_event, GetSecretValueResultSuccess):
             return result_event.value

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
@@ -14,7 +14,6 @@ from griptape_nodes.exe_types.param_components.model_policy import (
 from griptape_nodes.exe_types.param_types.parameter_button import ParameterButton
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.retained_mode.events.model_events import ListModelDownloadsRequest, ListModelDownloadsResultSuccess
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial
 from griptape_nodes.retained_mode.managers.event_manager import reentrant_bus_in_init_would_report
 from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload, OnClickMessageResultPayload
@@ -81,7 +80,7 @@ class HuggingFaceModelParameter(ABC):
         # Repos hidden from the dropdown; read by `filter_choices`.
         self._deprecated_repos: list[str] = deprecated_repos or []
         # Cached at refresh time only — never fetched from inside a callback to
-        # avoid nested GriptapeNodes.handle_request() calls that cause recursion.
+        # avoid nested handle_request() calls that cause recursion.
         self._downloading_model_ids: set[str] = set()
 
         # License-policy state, and the only two pieces of it: `_gate_mode` is the caller's
@@ -394,7 +393,9 @@ class HuggingFaceModelParameter(ABC):
         ambiguous across two libraries, or mid-reload), and treating that as "allow everything"
         would let an admin's deny be bypassed by a lookup error.
         """
-        self._policy = query_model_policy(type(self._node).__name__, fail_closed=self._gate_mode is not False)
+        self._policy = query_model_policy(
+            self._node.engine, type(self._node).__name__, fail_closed=self._gate_mode is not False
+        )
 
     def _apply_denial_badge(self, parameter: Parameter, value: str | None = None) -> None:
         """Set or clear the parameter's badge for the current selection.
@@ -423,7 +424,7 @@ class HuggingFaceModelParameter(ABC):
         if reentrant_bus_in_init_would_report():
             self._downloading_model_ids = set()
             return
-        result = GriptapeNodes.handle_request(ListModelDownloadsRequest())
+        result = self._node.engine.handle_request(ListModelDownloadsRequest())
         if not isinstance(result, ListModelDownloadsResultSuccess):
             self._downloading_model_ids = set()
             return

--- a/src/griptape_nodes/exe_types/param_components/model_access_component.py
+++ b/src/griptape_nodes/exe_types/param_components/model_access_component.py
@@ -113,7 +113,6 @@ from griptape_nodes.retained_mode.events.access_events import (
     QueryModelAccessForNodeRequest,
     QueryModelAccessForNodeResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.button import Button
 from griptape_nodes.traits.options import Options
 
@@ -393,7 +392,7 @@ class ModelAccessComponent:
         # refresh is honored at run time in BOTH directions -- a newly granted permission unblocks
         # the artist without waiting for a refresh, and a newly revoked one still denies. Returning
         # a cached denial early would make grants invisible.
-        result = GriptapeNodes.handle_request(
+        result = self._node.engine.handle_request(
             QueryModelAccessForNodeRequest(
                 node_type=type(self._node).__name__,
                 candidate_model_ids=list(catalog_ids),
@@ -575,7 +574,7 @@ class ModelAccessComponent:
         ``DEFERRED_SNAPSHOT`` comes back instead (see ``query_model_policy``);
         ``query_for_denial`` re-fetches it before its first real verdict.
         """
-        return query_model_policy(type(self._node).__name__)
+        return query_model_policy(self._node.engine, type(self._node).__name__)
 
     def _build_ui_options(self) -> dict[str, Any]:
         """Build the ``ui_options`` dict that decorates the dropdown row-by-row.

--- a/src/griptape_nodes/exe_types/param_components/model_policy.py
+++ b/src/griptape_nodes/exe_types/param_components/model_policy.py
@@ -24,12 +24,12 @@ from griptape_nodes.retained_mode.events.access_events import (
     QueryModelAccessForNodeRequest,
     QueryModelAccessForNodeResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 from griptape_nodes.retained_mode.managers.event_manager import reentrant_bus_in_init_would_report
 
 if TYPE_CHECKING:
     from griptape_nodes.exe_types.core_types import Parameter
+    from griptape_nodes.retained_mode.engine import Engine
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -177,7 +177,7 @@ class ModelPolicySnapshot:
 DEFERRED_SNAPSHOT = ModelPolicySnapshot(deferred=True)
 
 
-def query_model_policy(node_type: str, *, fail_closed: bool = True) -> ModelPolicySnapshot:
+def query_model_policy(engine: Engine, node_type: str, *, fail_closed: bool = True) -> ModelPolicySnapshot:
     """Ask the engine which of ``node_type``'s declared models are permitted.
 
     Returns ``DEFERRED_SNAPSHOT`` without querying when the request would trip
@@ -192,6 +192,7 @@ def query_model_policy(node_type: str, *, fail_closed: bool = True) -> ModelPoli
     only after it runs.
 
     Args:
+        engine: Engine to ask about model access.
         node_type: The node class name the manifest declares ``model_usage`` against.
         fail_closed: What an unanswerable query means. When True, the returned snapshot carries a
             ``failure_detail`` so every subsequent lookup denies -- a broken library registration
@@ -205,7 +206,7 @@ def query_model_policy(node_type: str, *, fail_closed: bool = True) -> ModelPoli
             node_type,
         )
         return DEFERRED_SNAPSHOT
-    result = GriptapeNodes.handle_request(QueryModelAccessForNodeRequest(node_type=node_type))
+    result = engine.handle_request(QueryModelAccessForNodeRequest(node_type=node_type))
     if not isinstance(result, QueryModelAccessForNodeResultSuccess):
         details = getattr(result, "result_details", None) or type(result).__name__
         if not fail_closed:

--- a/src/griptape_nodes/exe_types/param_components/parameter_transition_component.py
+++ b/src/griptape_nodes/exe_types/param_components/parameter_transition_component.py
@@ -15,7 +15,6 @@ from griptape_nodes.retained_mode.events.parameter_events import (
     GetConnectionsForParameterResultSuccess,
     RemoveParameterFromNodeRequest,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -204,7 +203,7 @@ class ParameterTransitionComponent:
     def _capture_connections(self, parameter_name: str) -> GetConnectionsForParameterResultSuccess | None:
         """Fetch the connection lists for a parameter, or None if the query fails."""
         request = GetConnectionsForParameterRequest(parameter_name=parameter_name, node_name=self._node.name)
-        result = GriptapeNodes.handle_request(request)
+        result = self._node.engine.handle_request(request)
         if isinstance(result, GetConnectionsForParameterResultSuccess):
             return result
         logger.warning(
@@ -218,7 +217,7 @@ class ParameterTransitionComponent:
     def _remove_parameter(self, name: str) -> bool:
         """Dispatch RemoveParameterFromNodeRequest. Returns True on success."""
         request = RemoveParameterFromNodeRequest(parameter_name=name, node_name=self._node.name)
-        result = GriptapeNodes.handle_request(request)
+        result = self._node.engine.handle_request(request)
         if result.failed():
             logger.error(
                 "Attempted to remove parameter '%s' from node '%s'. Failed because: %s",
@@ -232,7 +231,7 @@ class ParameterTransitionComponent:
     def _add_parameter(self, desired: TransitionParameter) -> bool:
         """Dispatch the caller-supplied add-request factory. Returns True on success."""
         add_request = desired.add_request_factory()
-        result = GriptapeNodes.handle_request(add_request)
+        result = self._node.engine.handle_request(add_request)
         if result.failed():
             logger.error(
                 "Attempted to add parameter '%s' to node '%s'. Failed because: %s",
@@ -267,7 +266,7 @@ class ParameterTransitionComponent:
             target_node_name=self._node.name,
             target_parameter_name=incoming.target_parameter_name,
         )
-        result = GriptapeNodes.handle_request(request)
+        result = self._node.engine.handle_request(request)
         if result.failed():
             logger.debug(
                 "Dropped incoming connection %s.%s -> %s.%s during replace because: %s",
@@ -285,7 +284,7 @@ class ParameterTransitionComponent:
             target_node_name=outgoing.target_node_name,
             target_parameter_name=outgoing.target_parameter_name,
         )
-        result = GriptapeNodes.handle_request(request)
+        result = self._node.engine.handle_request(request)
         if result.failed():
             logger.debug(
                 "Dropped outgoing connection %s.%s -> %s.%s during replace because: %s",

--- a/src/griptape_nodes/exe_types/param_components/project_file_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/project_file_parameter.py
@@ -8,10 +8,10 @@ from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.files.file import FileDestination, FileDestinationProvider
 from griptape_nodes.files.project_file import ProjectFileDestination
 from griptape_nodes.retained_mode.events.connection_events import (
+    CreateConnectionRequest,
     ListConnectionsForNodeRequest,
     ListConnectionsForNodeResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.retained_mode import RetainedMode
 from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
 from griptape_nodes.traits.file_system_picker import FileSystemPicker
@@ -127,11 +127,11 @@ class ProjectFileParameter:
         Raises:
             ValueError: If an upstream FileDestinationProvider is connected but returns None.
         """
-        result = GriptapeNodes.handle_request(ListConnectionsForNodeRequest(node_name=self._node.name))
+        result = self._node.engine.handle_request(ListConnectionsForNodeRequest(node_name=self._node.name))
         if isinstance(result, ListConnectionsForNodeResultSuccess):
             for conn in result.incoming_connections:
                 if conn.target_parameter_name == self._name:
-                    source_node = GriptapeNodes.ObjectManager().attempt_get_object_by_name(conn.source_node_name)
+                    source_node = self._node.engine.object_manager.attempt_get_object_by_name(conn.source_node_name)
                     if isinstance(source_node, FileDestinationProvider):
                         file_dest = source_node.file_destination
                         if file_dest is None:
@@ -172,7 +172,7 @@ class ProjectFileParameter:
         node_name = self._node.name
 
         has_incoming = False
-        result = GriptapeNodes.handle_request(ListConnectionsForNodeRequest(node_name=node_name))
+        result = self._node.engine.handle_request(ListConnectionsForNodeRequest(node_name=node_name))
         if isinstance(result, ListConnectionsForNodeResultSuccess):
             has_incoming = any(conn.target_parameter_name == self._name for conn in result.incoming_connections)
 
@@ -186,6 +186,9 @@ class ProjectFileParameter:
 
         # TODO: https://github.com/griptape-ai/griptape-nodes/issues/4097
         # Replace with a non-RM utility for creating sibling nodes relative to a given node.
+        # Until then this is the one remaining path from exe_types to the facade: RetainedMode is
+        # a re-export, so the TID251 ban does not see it. It resolves the ambient engine, which is
+        # correct here only because button handlers run where the node lives.
         create_result = RetainedMode.create_node_relative_to(
             reference_node_name=node_name,
             new_node_type="FileOutputSettings",
@@ -205,7 +208,7 @@ class ProjectFileParameter:
 
         configure_node_name = create_result
 
-        configure_node = GriptapeNodes.ObjectManager().attempt_get_object_by_name(configure_node_name)
+        configure_node = self._node.engine.object_manager.attempt_get_object_by_name(configure_node_name)
         if configure_node is not None:
             configure_node.set_parameter_value("situation", self._situation_name)
             configure_node.publish_update_to_parameter("situation", self._situation_name)
@@ -215,9 +218,17 @@ class ProjectFileParameter:
                 configure_node.set_parameter_value("filename", current_filename)
                 configure_node.publish_update_to_parameter("filename", current_filename)
 
-        connection_result = RetainedMode.connect(
-            source=f"{configure_node_name}.file_destination",
-            destination=f"{node_name}.{self._name}",
+        # Dispatched through this node's engine rather than RetainedMode. RetainedMode is a
+        # facade re-export, so going through it resolves the ambient engine -- which the TID251
+        # ban does not catch, and which would answer from a different engine than the request
+        # above it.
+        connection_result = self._node.engine.handle_request(
+            CreateConnectionRequest(
+                source_node_name=configure_node_name,
+                source_parameter_name="file_destination",
+                target_node_name=node_name,
+                target_parameter_name=self._name,
+            )
         )
 
         if not connection_result.succeeded():

--- a/src/griptape_nodes/exe_types/variable_resolver.py
+++ b/src/griptape_nodes/exe_types/variable_resolver.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 import logging
 import re
 from contextvars import ContextVar
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from griptape_nodes.common.macro_parser.core import ParsedMacro
 from griptape_nodes.common.macro_parser.exceptions import MacroResolutionError, MacroSyntaxError
 from griptape_nodes.common.macro_parser.segments import ParsedVariable
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -25,8 +28,9 @@ _aprocess_variable_cache: ContextVar[dict | object | None] = ContextVar(
 class VariableResolver:
     """Resolves inline {VAR} macro references in node parameter values during aprocess().
 
-    All GriptapeNodes singleton access is concentrated in this class's static methods,
-    keeping the lazy-import cycle-break in one place rather than scattered across BaseNode.
+    The methods that need engine state take the engine as their first argument rather than
+    reaching for process-wide state, so a resolver call answers from the same engine as the
+    node that asked.
     """
 
     _HAS_VARIABLE_MACRO: ClassVar[re.Pattern[str]] = re.compile(r"\{[A-Za-z_]")
@@ -121,15 +125,32 @@ class VariableResolver:
         _aprocess_variable_cache.reset(token)  # type: ignore[arg-type]
 
     @staticmethod
-    def is_substitution_enabled() -> bool:
-        """Return True if variable substitution is enabled for the active workflow."""
-        # GriptapeNodes import is lazy to avoid circular dependency between exe_types and retained_mode.
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+    def is_substitution_enabled(engine: Engine) -> bool:
+        """Return True if variable substitution is enabled for the active workflow.
 
-        return GriptapeNodes.WorkflowManager().is_variable_substitution_enabled()
+        KNOWN LIMITATION in a worker: this reads a local manager, and
+        `is_variable_substitution_enabled` answers True whenever there is no current workflow,
+        which is always the case in a worker process.
+
+        The orchestrator encodes "disabled" as an EMPTY variable dict when it pre-seeds one for a
+        dispatch, and substituting with an empty dict is not the same as not substituting:
+        `{VAR}` is preserved either way, but `{VAR?}` collapses to "" instead of staying literal.
+        So an optional macro resolves differently for a worker-executed node than for the same
+        node in-process, on a workflow that turned substitution off. The other affected readers
+        are the ones using this answer to decide whether a stored value is still an unresolved
+        template -- `node_types._variable_template_to_preserve`, and through it the display value
+        and the output write-back -- plus the sibling local read in `get_variables_if_enabled`.
+
+        Routing it through GetVariableSubstitutionEnabledRequest so it forwards was tried and
+        backed out: `parameter_output_values[...] = x` inside a node `__init__` reaches this
+        through TrackedParameterOutputValues, so every node construction became a bus request
+        and tripped `reentrant-bus-in-init`. Fixing it properly means resolving the answer once
+        per execution and carrying it, rather than asking per value.
+        """
+        return engine.workflow_manager.is_variable_substitution_enabled()
 
     @staticmethod
-    def get_variables_if_enabled(node_name: str) -> dict[str, str | int] | None:
+    def get_variables_if_enabled(engine: Engine, node_name: str) -> dict[str, str | int] | None:
         """Return the variable dict if substitution is enabled, else None.
 
         Checks the per-aprocess cache first to avoid repeated singleton lookups.
@@ -147,10 +168,9 @@ class VariableResolver:
         orchestrator-resolved variable dict, so this fallback path is only reached for
         in-process nodes whose request predates the variables field (e.g. unit tests).
         """
-        # GriptapeNodes import is lazy to avoid circular dependency between exe_types and retained_mode.
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-        if not GriptapeNodes.WorkflowManager().is_variable_substitution_enabled():
+        # Same local read as is_substitution_enabled, and the same worker limitation applies;
+        # see the note there.
+        if not engine.workflow_manager.is_variable_substitution_enabled():
             return None
 
         cached = _aprocess_variable_cache.get()
@@ -166,11 +186,11 @@ class VariableResolver:
         from griptape_nodes.retained_mode.variable_types import VariableScope
 
         try:
-            flow_name = GriptapeNodes.NodeManager().get_node_parent_flow_by_name(node_name)
+            flow_name = engine.node_manager.get_node_parent_flow_by_name(node_name)
         except KeyError:
             _aprocess_variable_cache.set(_NO_FLOW)
             return None
-        result = GriptapeNodes.handle_request(
+        result = engine.handle_request(
             ListVariablesRequest(starting_flow=flow_name, lookup_scope=VariableScope.HIERARCHICAL)
         )
         if not isinstance(result, ListVariablesResultSuccess):
@@ -232,7 +252,7 @@ class VariableResolver:
         return False
 
     @staticmethod
-    def get_variables_without_memoizing(node_name: str) -> dict[str, str | int] | None:
+    def get_variables_without_memoizing(engine: Engine, node_name: str) -> dict[str, str | int] | None:
         """Like `get_variables_if_enabled`, but never leaves the memo cache set.
 
         ``get_variables_if_enabled`` memoises its lookup into the ContextVar without
@@ -243,10 +263,10 @@ class VariableResolver:
         outside ``aprocess_scope()``. An already-populated cache is left untouched.
         """
         if _aprocess_variable_cache.get() is not None:
-            return VariableResolver.get_variables_if_enabled(node_name)
+            return VariableResolver.get_variables_if_enabled(engine, node_name)
         token = _aprocess_variable_cache.set(None)
         try:
-            return VariableResolver.get_variables_if_enabled(node_name)
+            return VariableResolver.get_variables_if_enabled(engine, node_name)
         finally:
             _aprocess_variable_cache.reset(token)
 

--- a/src/griptape_nodes/exe_types/workflow_node.py
+++ b/src/griptape_nodes/exe_types/workflow_node.py
@@ -33,13 +33,13 @@ from griptape_nodes.retained_mode.events.workflow_events import (
     ImportWorkflowAsReferencedSubFlowRequest,
     ImportWorkflowAsReferencedSubFlowResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path
 
     from griptape_nodes.node_library.workflow_registry import NodeParametersMapping, ParameterMinimalDict
+    from griptape_nodes.retained_mode.engine import Engine
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -315,7 +315,7 @@ class WorkflowNode(ControlNode):
 
         self._apply_inputs(subflow_name, live_routes)
 
-        result = await GriptapeNodes.ahandle_request(StartLocalSubflowRequest(flow_name=subflow_name))
+        result = await self.engine.ahandle_request(StartLocalSubflowRequest(flow_name=subflow_name))
         if not isinstance(result, StartLocalSubflowResultSuccess):
             msg = (
                 f"Attempted to run the workflow behind node '{self.name}'. "
@@ -352,12 +352,12 @@ class WorkflowNode(ControlNode):
         """
         tracked = self.metadata.get(SUBFLOW_NAME_KEY)
         if tracked is not None:
-            if _get_flow_or_none(tracked) is not None:
+            if _get_flow_or_none(self.engine, tracked) is not None:
                 return tracked
             # Torn down out from under us (for example when the parent flow was deleted).
             self.metadata.pop(SUBFLOW_NAME_KEY, None)
 
-        flow_result = GriptapeNodes.handle_request(GetFlowForNodeRequest(node_name=self.name))
+        flow_result = self.engine.handle_request(GetFlowForNodeRequest(node_name=self.name))
         if not isinstance(flow_result, GetFlowForNodeResultSuccess):
             msg = (
                 f"Attempted to run the workflow behind node '{self.name}'. "
@@ -366,7 +366,7 @@ class WorkflowNode(ControlNode):
             raise RuntimeError(msg)  # noqa: TRY004 - the lookup failed at run time; this is not a type error
 
         registry_key = self._register_workflow()
-        import_result = await GriptapeNodes.ahandle_request(
+        import_result = await self.engine.ahandle_request(
             ImportWorkflowAsReferencedSubFlowRequest(
                 workflow_name=registry_key,
                 flow_name=flow_result.flow_name,
@@ -399,9 +399,9 @@ class WorkflowNode(ControlNode):
         tracked = self.metadata.pop(SUBFLOW_NAME_KEY, None)
         if tracked is None:
             return
-        if _get_flow_or_none(tracked) is None:
+        if _get_flow_or_none(self.engine, tracked) is None:
             return
-        delete_result = GriptapeNodes.handle_request(DeleteFlowRequest(flow_name=tracked))
+        delete_result = self.engine.handle_request(DeleteFlowRequest(flow_name=tracked))
         if delete_result.failed():
             logger.warning(
                 "Node '%s' could not clean up its workflow subflow '%s': %s",
@@ -424,7 +424,7 @@ class WorkflowNode(ControlNode):
             WorkflowNodeRoutingError: A declared parameter is not present on the node it was paired
                 with, meaning the loaded copy does not match the workflow's stored shape.
         """
-        flow = GriptapeNodes.FlowManager().get_flow_by_name(subflow_name)
+        flow = self.engine.flow_manager.get_flow_by_name(subflow_name)
         live_start_nodes = [node.name for node in flow.nodes.values() if isinstance(node, StartNode)]
         live_end_nodes = [node.name for node in flow.nodes.values() if isinstance(node, EndNode)]
 
@@ -472,7 +472,7 @@ class WorkflowNode(ControlNode):
 
     def _apply_inputs(self, subflow_name: str, live_routes: WorkflowNodeLiveRoutes) -> None:
         for surface_name, route in live_routes.inputs.items():
-            set_result = GriptapeNodes.handle_request(
+            set_result = self.engine.handle_request(
                 SetParameterValueRequest(
                     parameter_name=route.parameter_name,
                     node_name=route.workflow_node_name,
@@ -489,7 +489,7 @@ class WorkflowNode(ControlNode):
         logger.debug("Node '%s' applied inputs to workflow subflow '%s'.", self.name, subflow_name)
 
     def _collect_outputs(self, subflow_name: str, live_routes: WorkflowNodeLiveRoutes) -> None:
-        flow = GriptapeNodes.FlowManager().get_flow_by_name(subflow_name)
+        flow = self.engine.flow_manager.get_flow_by_name(subflow_name)
         for surface_name, route in live_routes.outputs.items():
             end_node = flow.nodes[route.workflow_node_name]
             # A node that ran publishes to parameter_output_values; fall back to the stored value
@@ -561,5 +561,5 @@ def _build_surface_parameter(surface_name: str, surface_parameter: WorkflowNodeS
     )
 
 
-def _get_flow_or_none(flow_name: str) -> ControlFlow | None:
-    return GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(flow_name, ControlFlow)
+def _get_flow_or_none(engine: Engine, flow_name: str) -> ControlFlow | None:
+    return engine.object_manager.attempt_get_object_by_name_as_type(flow_name, ControlFlow)

--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -62,9 +62,29 @@ class LibraryNameAndVersion(NamedTuple):
 
 
 class Dependencies(BaseModel):
-    """Pip packages that need to be installed for this library."""
+    """Pip packages that need to be installed for this library.
+
+    Dependencies are declared in two sets, because a library needs far less installed to be
+    *edited* than to be *run*:
+
+    - ``pip_dependencies`` (edit-time): everything needed to import the library's node modules
+      and instantiate its nodes. The orchestrator installs these, so they are what the editor,
+      workflow loading, and parameter/trait behavior depend on. Keep this set light.
+    - ``pip_dependencies_exec`` (execution-time): the heavy packages only ``process`` needs
+      (torch, diffusers, and friends). These are installed into a separate environment and are
+      only on ``sys.path`` where nodes actually execute, so they never enter the orchestrator's
+      import path and cannot collide with another library's pins there.
+
+    A library that declares no execution dependencies behaves exactly as it always has:
+    everything is edit-time, and it runs in the orchestrator.
+
+    ``pip_install_flags`` applies to both installs, since flags in practice configure where
+    packages come from (index URLs, ``--find-links``, backend selection) rather than which set
+    is being installed.
+    """
 
     pip_dependencies: list[str] | None = None
+    pip_dependencies_exec: list[str] | None = None
     pip_install_flags: list[str] | None = None
 
 
@@ -253,7 +273,9 @@ class LibrarySchema(BaseModel):
     library itself.
     """
 
-    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.11.0"
+    # 0.12.0 added Dependencies.pip_dependencies_exec. Older manifests still validate: the
+    # field is optional, and its absence means every dependency is edit-time.
+    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.12.0"
 
     name: str
     library_schema_version: str

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -96,9 +96,10 @@ def _forbid_manager_during_worker_execution(manager_name: str, request_hint: str
     if not engine.event_manager.in_node_execution():
         return
     msg = (
-        f"Attempted to use {manager_name} while running in an isolated library process, where "
-        f"it holds no authoritative state. Use GriptapeNodes.handle_request({request_hint}) "
-        f"instead, which asks the main engine and returns the real value."
+        f"Attempted to use {manager_name} while running in an isolated library process, whose "
+        f"copy of that state is not the source of truth. Use "
+        f"GriptapeNodes.handle_request({request_hint}) instead: requests made while a node is "
+        f"executing are answered by the main engine, so the value is always the real one."
     )
     raise RuntimeError(msg)
 

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -79,6 +79,30 @@ class _EngineRootMeta(type):
         return current_engine()
 
 
+def _forbid_manager_during_worker_execution(manager_name: str, request_hint: str) -> None:
+    """Raise when node code reaches for a manager while executing in a worker process.
+
+    A worker holds no authoritative state: config, secrets, and the filesystem all belong to
+    the orchestrator, and reads that look local would be answered by a process that is not
+    the source of truth. Node code gets there with ``GriptapeNodes.handle_request(...)``,
+    which forwards to the orchestrator, so the value is always the real one.
+
+    Scoped to node execution deliberately: engine boot and library load run in the worker
+    too, and they legitimately need their own managers.
+    """
+    engine = current_engine()
+    if not engine.library_manager.is_worker:
+        return
+    if not engine.event_manager.in_node_execution():
+        return
+    msg = (
+        f"Attempted to use {manager_name} while running in an isolated library process, where "
+        f"it holds no authoritative state. Use GriptapeNodes.handle_request({request_hint}) "
+        f"instead, which asks the main engine and returns the real value."
+    )
+    raise RuntimeError(msg)
+
+
 class GriptapeNodes(metaclass=_EngineRootMeta):
     """Static accessors for the current engine's managers and request handlers."""
 
@@ -157,14 +181,17 @@ class GriptapeNodes(metaclass=_EngineRootMeta):
 
     @classmethod
     def ConfigManager(cls) -> ConfigManager:
+        _forbid_manager_during_worker_execution("ConfigManager", "GetConfigValueRequest(...)")
         return current_engine().config_manager
 
     @classmethod
     def OSManager(cls) -> OSManager:
+        _forbid_manager_during_worker_execution("OSManager", "ReadFileRequest(...) / WriteFileRequest(...)")
         return current_engine().os_manager
 
     @classmethod
     def SecretsManager(cls) -> SecretsManager:
+        _forbid_manager_during_worker_execution("SecretsManager", "GetSecretValueRequest(...)")
         return current_engine().secrets_manager
 
     @classmethod

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -939,6 +939,15 @@ class EventManager(EngineScoped):
         """Return the currently-registered handler callback for a request type, or None."""
         return self._request_type_to_manager.get(request_type)
 
+    def registered_request_types(self) -> list[type[RequestPayload]]:
+        """Every request type that currently has a handler.
+
+        A worker uses this to route requests made during node execution to the orchestrator
+        by default, rather than maintaining a list of types to forward that silently goes
+        stale whenever a new request type is added.
+        """
+        return list(self._request_type_to_manager.keys())
+
     async def forward_to_orchestrator(
         self,
         request: RP,

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -2959,28 +2959,43 @@ class LibraryManager(EngineScoped):
 
         return capabilities
 
-    def _get_library_venv_path(self, library_name: str, library_file_path: str | None = None) -> Path:
-        """Get the path to the virtual environment directory for a library.
+    def _get_library_venv_path(
+        self, library_name: str, library_file_path: str | None = None, *, execution: bool = False
+    ) -> Path:
+        """Get the path to a virtual environment directory for a library.
+
+        A library has up to two environments. The edit-time environment (``.venv``) holds the
+        dependencies needed to import and instantiate nodes, and is the one a developer's
+        ``uv sync`` already produces, so it is deliberately left at the conventional name. The
+        execution environment (``.venv-exec``) holds the heavy dependencies only ``process``
+        needs and is put on ``sys.path`` solely where nodes execute.
 
         Args:
             library_name: Name of the library
             library_file_path: Optional path to the library JSON file
+            execution: Whether to return the execution environment instead of the edit-time one
 
         Returns:
             Path to the virtual environment directory
         """
+        venv_dir_name = ".venv-exec" if execution else ".venv"
         clean_library_name = library_name.replace(" ", "_").strip()
 
         if library_file_path is not None:
             # Create venv relative to the library.json file
             library_dir = Path(library_file_path).parent.absolute()
-            return library_dir / ".venv"
+            return library_dir / venv_dir_name
 
         # Create venv relative to the xdg data home
-        return xdg_data_home() / "griptape_nodes" / "libraries" / clean_library_name / ".venv"
+        return xdg_data_home() / "griptape_nodes" / "libraries" / clean_library_name / venv_dir_name
 
     async def _add_library_paths_to_sys_path(self, library_name: str, library_file_path: str, base_dir: Path) -> None:
         """Add a library's directory and venv site-packages to sys.path.
+
+        The edit-time environment is added everywhere, because importing node modules and
+        instantiating nodes needs it. The execution environment is added only in a worker
+        process: the orchestrator must never have a library's heavy dependencies on its import
+        path, since keeping them out is what stops one library's pins from shadowing another's.
 
         Args:
             library_name: Name of the library (for venv lookup)
@@ -2989,18 +3004,30 @@ class LibraryManager(EngineScoped):
         """
         sys.path.insert(0, str(base_dir))
 
-        venv_path = self._get_library_venv_path(library_name, library_file_path)
-        if await anyio.Path(venv_path).exists():
-            site_packages = str(
-                Path(
-                    sysconfig.get_path(
-                        "purelib",
-                        vars={"base": str(venv_path), "platbase": str(venv_path)},
-                    )
+        await self._add_library_venv_to_sys_path(library_name, library_file_path, execution=False)
+
+        if self._is_worker:
+            await self._add_library_venv_to_sys_path(library_name, library_file_path, execution=True)
+
+    async def _add_library_venv_to_sys_path(
+        self, library_name: str, library_file_path: str, *, execution: bool
+    ) -> None:
+        """Add one of a library's venv site-packages directories to sys.path, if it exists."""
+        venv_path = self._get_library_venv_path(library_name, library_file_path, execution=execution)
+        if not await anyio.Path(venv_path).exists():
+            return
+
+        site_packages = str(
+            Path(
+                sysconfig.get_path(
+                    "purelib",
+                    vars={"base": str(venv_path), "platbase": str(venv_path)},
                 )
             )
-            sys.path.insert(0, site_packages)
-            logger.debug("Added library '%s' venv to sys.path: %s", library_name, site_packages)
+        )
+        sys.path.insert(0, site_packages)
+        venv_kind = "execution" if execution else "edit-time"
+        logger.debug("Added library '%s' %s venv to sys.path: %s", library_name, venv_kind, site_packages)
 
     def _can_write_to_venv_location(self, venv_python_path: Path) -> bool:
         """Check if we can write to the venv location (either create it or modify existing).
@@ -6855,14 +6882,14 @@ class LibraryManager(EngineScoped):
             result_details=details,
         )
 
-    async def install_library_dependencies_request(self, request: InstallLibraryDependenciesRequest) -> ResultPayload:  # noqa: PLR0911
-        """Install a library's dependencies, recovering from a corrupt reused venv.
+    async def install_library_dependencies_request(self, request: InstallLibraryDependenciesRequest) -> ResultPayload:
+        """Install a library's dependencies into its edit-time and execution environments.
 
-        Advanced library hooks (before_library_nodes_loaded) expect the venv to exist, so the
-        venv is always initialized even when there are no dependencies to install. When the
-        venv is reused from a previous session it may be corrupt (e.g. a dist-info directory
-        missing its METADATA file), which makes uv fail while planning the install; in that
-        case the venv is rebuilt once and the install retried against a clean environment.
+        Edit-time dependencies go into ``.venv``, which is always created even when there is
+        nothing to install, because advanced library hooks (before_library_nodes_loaded) expect
+        it to exist. Execution dependencies go into ``.venv-exec``, which is created only when
+        the library declares any, so a library with no execution dependencies produces exactly
+        the layout it always has.
         """
         library_file_path = request.library_file_path
 
@@ -6879,44 +6906,93 @@ class LibraryManager(EngineScoped):
         library_metadata = library_data.metadata
 
         pip_dependencies = []
+        pip_dependencies_exec = []
         pip_install_flags = []
         if library_metadata.dependencies:
             pip_dependencies = library_metadata.dependencies.pip_dependencies or []
+            pip_dependencies_exec = library_metadata.dependencies.pip_dependencies_exec or []
             pip_install_flags = library_metadata.dependencies.pip_install_flags or []
 
-        # Always initialize the venv, even if there are no dependencies to install.
-        # Advanced library hooks (before_library_nodes_loaded) expect the venv to exist.
-        venv_path = self._get_library_venv_path(library_name, library_file_path)
+        edit_failure = await self._install_dependency_set(
+            library_name=library_name,
+            library_file_path=library_file_path,
+            pip_dependencies=pip_dependencies,
+            pip_install_flags=pip_install_flags,
+            execution=False,
+        )
+        if edit_failure is not None:
+            return InstallLibraryDependenciesResultFailure(result_details=edit_failure)
+
+        exec_failure = await self._install_dependency_set(
+            library_name=library_name,
+            library_file_path=library_file_path,
+            pip_dependencies=pip_dependencies_exec,
+            pip_install_flags=pip_install_flags,
+            execution=True,
+        )
+        if exec_failure is not None:
+            return InstallLibraryDependenciesResultFailure(result_details=exec_failure)
+
+        installed_count = len(pip_dependencies) + len(pip_dependencies_exec)
+        if installed_count == 0:
+            details = f"Library '{library_name}' has no dependencies to install"
+        elif pip_dependencies_exec:
+            details = (
+                f"Installed {len(pip_dependencies)} edit-time and {len(pip_dependencies_exec)} "
+                f"execution dependencies for library '{library_name}'"
+            )
+        else:
+            details = f"Installed {len(pip_dependencies)} dependencies for library '{library_name}'"
+        logger.info(details)
+        return InstallLibraryDependenciesResultSuccess(
+            library_name=library_name, dependencies_installed=installed_count, result_details=details
+        )
+
+    async def _install_dependency_set(  # noqa: PLR0911
+        self,
+        *,
+        library_name: str,
+        library_file_path: str,
+        pip_dependencies: list[str],
+        pip_install_flags: list[str],
+        execution: bool,
+    ) -> str | None:
+        """Install one dependency set into its environment, creating the environment first.
+
+        Returns a user-facing failure detail, or None on success.
+
+        The edit-time environment is created even with nothing to install, because advanced
+        library hooks expect it to exist. The execution environment is skipped entirely when
+        the library declares no execution dependencies, so nothing new appears on disk for the
+        libraries that do not use them.
+        """
+        venv_kind = "execution" if execution else "edit-time"
+        if execution and not pip_dependencies:
+            return None
+
+        venv_path = self._get_library_venv_path(library_name, library_file_path, execution=execution)
 
         try:
             venv_init = await self._init_library_venv(venv_path)
         except RuntimeError as e:
-            details = f"Attempted to prepare the environment for library '{library_name}'. Failed due to: {e}"
-            return InstallLibraryDependenciesResultFailure(result_details=details)
+            return f"Attempted to prepare the {venv_kind} environment for library '{library_name}'. Failed due to: {e}"
         library_venv_python_path = venv_init.python_path
 
         if not self._can_write_to_venv_location(library_venv_python_path):
-            details = f"Attempted to set up the environment for library '{library_name}' at {venv_path}. Failed due to: the location is not writable."
+            details = f"Attempted to set up the {venv_kind} environment for library '{library_name}' at {venv_path}. Failed due to: the location is not writable."
             logger.warning(details)
-            return InstallLibraryDependenciesResultFailure(result_details=details)
+            return details
 
-        # Check disk space
         config_manager = self.engine.config_manager
         min_space_gb = config_manager.get_config_value("minimum_disk_space_gb_libraries")
         if not OSManager.check_available_disk_space(Path(venv_path), min_space_gb):
             error_msg = OSManager.format_disk_space_error(Path(venv_path))
-            details = f"Attempted to install the components required by library '{library_name}'. Failed due to insufficient disk space (requires {min_space_gb} GB): {error_msg}"
-            return InstallLibraryDependenciesResultFailure(result_details=details)
+            return f"Attempted to install the components required by library '{library_name}'. Failed due to insufficient disk space (requires {min_space_gb} GB): {error_msg}"
 
         if not pip_dependencies:
-            details = f"Library '{library_name}' has no dependencies to install"
-            logger.info(details)
-            return InstallLibraryDependenciesResultSuccess(
-                library_name=library_name, dependencies_installed=0, result_details=details
-            )
+            return None
 
-        # Install dependencies
-        logger.info("Installing %d dependencies for library '%s'", len(pip_dependencies), library_name)
+        logger.info("Installing %d %s dependencies for library '%s'", len(pip_dependencies), venv_kind, library_name)
         is_debug = config_manager.get_config_value("log_level").upper() == "DEBUG"
 
         try:
@@ -6940,19 +7016,11 @@ class LibraryManager(EngineScoped):
                 )
         except subprocess.CalledProcessError as e:
             reason = e.stderr or f"the installer exited with code {e.returncode}"
-            details = (
-                f"Attempted to install the components required by library '{library_name}'. Failed due to: {reason}"
-            )
-            return InstallLibraryDependenciesResultFailure(result_details=details)
+            return f"Attempted to install the components required by library '{library_name}'. Failed due to: {reason}"
         except RuntimeError as e:
-            details = f"Attempted to rebuild the environment for library '{library_name}'. Failed due to: {e}"
-            return InstallLibraryDependenciesResultFailure(result_details=details)
+            return f"Attempted to rebuild the {venv_kind} environment for library '{library_name}'. Failed due to: {e}"
 
-        details = f"Installed {len(pip_dependencies)} dependencies for library '{library_name}'"
-        logger.info(details)
-        return InstallLibraryDependenciesResultSuccess(
-            library_name=library_name, dependencies_installed=len(pip_dependencies), result_details=details
-        )
+        return None
 
     async def _install_deps_with_recovery(
         self,

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -510,6 +510,13 @@ class LibraryManager(EngineScoped):
         # parsed (discovery or lifecycle progression). Absence of the relevant
         # declarations falls through to False.
         requires_worker: bool = False
+        # True when this library's nodes EXECUTE in a dedicated worker process, for either
+        # reason: legacy worker-mode declarations (requires_worker above, which also skips
+        # orchestrator-side loading in favor of stubs) or execution dependencies
+        # (pip_dependencies_exec -- the library loads REAL nodes on the orchestrator and
+        # only its process() runs in the worker, where .venv-exec is on sys.path).
+        # Consumed by execution routing; never by load-time skips.
+        executes_in_worker: bool = False
         # Set when the library enters WORKER_PENDING state. The orchestrator waits on this
         # event before returning RegisterLibraryFromFileResultSuccess so callers see the real
         # fitness once the worker has loaded and reported back.
@@ -750,7 +757,10 @@ class LibraryManager(EngineScoped):
         # Register stub node classes from the worker-reported schemas so the orchestrator
         # can display nodes in the sidebar and recreate them during workflow loading.
         # Skip on the worker itself -- it already has the real node classes registered.
-        if notification.node_schemas and not self._is_worker:
+        # Exec-deps libraries registered REAL node classes locally at load; overwriting
+        # them with schema stubs would throw away converters/validators/traits/hooks.
+        # Only legacy worker-mode libraries (requires_worker) use stub registration.
+        if notification.node_schemas and not self._is_worker and library_info.requires_worker:
             self._register_nodes_from_worker_schemas(notification.library_name, notification.node_schemas)
         # Unblock any code awaiting this library's worker_ready event.
         if library_info.worker_ready is not None:
@@ -776,7 +786,7 @@ class LibraryManager(EngineScoped):
         """
         if library_name:
             library_info = self.get_library_info_by_library_name(library_name)
-            if library_info and library_info.requires_worker:
+            if library_info and library_info.executes_in_worker:
                 wm = self._worker_manager
                 if wm:
                     worker = wm.get_worker_for_key(library_name)
@@ -802,10 +812,15 @@ class LibraryManager(EngineScoped):
         that worker creation is always tied to an active session.
         """
         for library_info in self._library_file_path_to_info.values():
-            if library_info.requires_worker and library_info.library_name and not self._is_worker:
-                library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.WORKER_PENDING
-                # Create (or reset) the worker_ready event for this spawn.
-                library_info.worker_ready = asyncio.Event()
+            if library_info.executes_in_worker and library_info.library_name and not self._is_worker:
+                # Legacy worker-mode libraries load AS the worker confirms (stubs meanwhile),
+                # so their lifecycle gates on the spawn. Exec-deps libraries loaded real
+                # nodes locally already: the worker gates execution availability only, and
+                # registration must not block on it.
+                if library_info.requires_worker:
+                    library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.WORKER_PENDING
+                    # Create (or reset) the worker_ready event for this spawn.
+                    library_info.worker_ready = asyncio.Event()
                 await self.engine.ahandle_request(StartWorkerRequest(library_name=library_info.library_name))
 
     def on_worker_evicted(self, worker_engine_id: str, library_name: str | None) -> None:
@@ -2183,11 +2198,15 @@ class LibraryManager(EngineScoped):
                 )
 
                 # Update or create LibraryInfo
+                executes_in_worker = self._resolve_executes_in_worker(
+                    requires_worker=requires_worker, metadata=metadata_result.library_schema.metadata
+                )
                 if lib_info:
                     lib_info.library_name = library_name
                     lib_info.library_version = metadata_result.library_schema.metadata.library_version
                     lib_info.lifecycle_state = LibraryManager.LibraryLifecycleState.METADATA_LOADED
                     lib_info.requires_worker = requires_worker
+                    lib_info.executes_in_worker = executes_in_worker
                 else:
                     # Create new LibraryInfo since it doesn't exist yet
                     lib_info = LibraryManager.LibraryInfo(
@@ -2199,6 +2218,7 @@ class LibraryManager(EngineScoped):
                         fitness=LibraryManager.LibraryFitness.NOT_EVALUATED,
                         problems=[],
                         requires_worker=requires_worker,
+                        executes_in_worker=executes_in_worker,
                     )
                     self._library_file_path_to_info[file_path] = lib_info
             else:
@@ -2316,6 +2336,10 @@ class LibraryManager(EngineScoped):
                     library_info.requires_worker = self._resolve_requires_worker(
                         library_info.registered_path,
                         metadata_result.library_schema.metadata.declarations,
+                    )
+                    library_info.executes_in_worker = self._resolve_executes_in_worker(
+                        requires_worker=library_info.requires_worker,
+                        metadata=metadata_result.library_schema.metadata,
                     )
                     library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.METADATA_LOADED
 
@@ -5115,6 +5139,14 @@ class LibraryManager(EngineScoped):
         registered node type to extract its parameter layout, so the orchestrator
         can create stub classes without importing the library's Python modules.
         """
+        # Only a legacy worker-mode library is stubbed on the orchestrator: an
+        # execution-dependency library is loaded there for real (its node modules are
+        # base-clean by contract), and stub registration is gated on `requires_worker`.
+        # The two stub-loss detectors below are gated on the same fact, or they warn that
+        # converters, traits and hooks "will not execute on the orchestrator stub" for a
+        # library that has no stub -- sending an author to fix code that is already correct.
+        library_info = self.get_library_info_by_library_name(library_name)
+        will_be_stubbed = library_info is None or library_info.requires_worker
         try:
             library = LibraryRegistry.get_library(library_name)
         except KeyError:
@@ -5158,8 +5190,9 @@ class LibraryManager(EngineScoped):
                 # Run the parameter-behavior-drop and inert-hook detectors
                 # inside the scope so warnings attach to the same LOAD_PROBE
                 # scope that owns the probe attempt.
-                self._report_parameter_behavior_losses(probe)
-                self._report_inert_worker_hooks(probe)
+                if will_be_stubbed:
+                    self._report_parameter_behavior_losses(probe)
+                    self._report_inert_worker_hooks(probe)
 
             # Drop the class only when a rule flagged drops_class_from_schema
             # fired. Severity is a logging concern; drops_class_from_schema is
@@ -5437,6 +5470,18 @@ class LibraryManager(EngineScoped):
 
         return manifest_default
 
+    @staticmethod
+    def _resolve_executes_in_worker(*, requires_worker: bool, metadata: LibraryMetadata) -> bool:
+        """Whether this library's nodes execute in a dedicated worker process.
+
+        True for legacy worker-mode libraries (requires_worker) and for libraries that
+        declare execution dependencies: their heavy packages live in .venv-exec, which is
+        only on sys.path in a worker, so process() can only run there.
+        """
+        dependencies = metadata.dependencies
+        has_exec_dependencies = bool(dependencies and dependencies.pip_dependencies_exec)
+        return requires_worker or has_exec_dependencies
+
     def _remove_missing_libraries_from_config(self, config_category: str) -> None:
         # Now remove all libraries that were missing from the user's config.
         config_mgr = self.engine.config_manager
@@ -5691,6 +5736,7 @@ class LibraryManager(EngineScoped):
         library_name = None
         library_version = None
         requires_worker = False
+        executes_in_worker = False
         lifecycle_state = LibraryManager.LibraryLifecycleState.DISCOVERED
 
         if isinstance(metadata_result, LoadLibraryMetadataFromFileResultSuccess):
@@ -5699,6 +5745,9 @@ class LibraryManager(EngineScoped):
             requires_worker = self._resolve_requires_worker(
                 registered_path,
                 metadata_result.library_schema.metadata.declarations,
+            )
+            executes_in_worker = self._resolve_executes_in_worker(
+                requires_worker=requires_worker, metadata=metadata_result.library_schema.metadata
             )
             lifecycle_state = LibraryManager.LibraryLifecycleState.METADATA_LOADED
 
@@ -5715,6 +5764,7 @@ class LibraryManager(EngineScoped):
             library_version=library_version,
             registered_path=registered_path,
             requires_worker=requires_worker,
+            executes_in_worker=executes_in_worker,
         )
 
     async def discover_libraries_request(

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -804,6 +804,37 @@ class LibraryManager(EngineScoped):
                 raise RuntimeError(msg)
         return None
 
+    async def wait_for_worker_library_load(self, library_name: str) -> None:
+        """Block until this library's worker has reported the library fully loaded, if one is expected.
+
+        A worker registers with the orchestrator at process start, BEFORE it has loaded its
+        library -- so a node executed in that window would reach a worker that cannot create
+        it yet. The worker's LibraryLoadedNotification is what "loaded" means, exactly as it
+        did for legacy worker-mode libraries; this waits for it, bounded by the same startup
+        grace the boot-time wait uses. Returns immediately for a library with no spawned
+        worker. An eviction during the wait also releases it: the reason is recorded, and
+        get_worker_for_library reports it to the caller.
+
+        Raises:
+            RuntimeError: If the worker did not report the library loaded within the grace
+                period.
+        """
+        library_info = self.get_library_info_by_library_name(library_name)
+        if library_info is None or library_info.worker_ready is None or library_info.worker_ready.is_set():
+            return
+        config_mgr = self.engine.config_manager
+        wait_seconds = config_mgr.get_config_value(WORKER_HEARTBEAT_STARTUP_GRACE_KEY, default=600.0, cast_type=float)
+        logger.info("Waiting for library '%s' to finish loading in its worker before running the node", library_name)
+        try:
+            with anyio.fail_after(wait_seconds):
+                await library_info.worker_ready.wait()
+        except TimeoutError:
+            msg = (
+                f"Attempted to run a node from library '{library_name}'. Failed because its worker "
+                f"process did not finish loading the library within {wait_seconds:.0f} seconds."
+            )
+            raise RuntimeError(msg) from None
+
     async def _start_workers(self) -> None:
         """Issue StartWorkerRequest for every library that requires a dedicated worker.
 
@@ -819,8 +850,13 @@ class LibraryManager(EngineScoped):
                 # registration must not block on it.
                 if library_info.requires_worker:
                     library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.WORKER_PENDING
-                    # Create (or reset) the worker_ready event for this spawn.
-                    library_info.worker_ready = asyncio.Event()
+                # Create (or reset) the worker_ready event for this spawn -- for EVERY spawned
+                # worker, not only legacy ones. A worker registers with the orchestrator at
+                # process start, BEFORE it has loaded its library, so registration alone cannot
+                # gate execution: a node routed in that window fails in the worker with
+                # "Library not found". This event is set by the worker's LibraryLoadedNotification,
+                # and the execute path waits on it (wait_for_worker_library_load).
+                library_info.worker_ready = asyncio.Event()
                 await self.engine.ahandle_request(StartWorkerRequest(library_name=library_info.library_name))
 
     def on_worker_evicted(self, worker_engine_id: str, library_name: str | None) -> None:
@@ -835,12 +871,15 @@ class LibraryManager(EngineScoped):
         library_info = self.get_library_info_by_library_name(library_name)
         if library_info is None:
             return
+        # Unblock any code awaiting this library's worker_ready event, whatever the
+        # lifecycle: an exec-deps library stays LOADED through an eviction, and a waiter
+        # on the execute path would otherwise hold on for the full grace period for a
+        # worker that is already gone.
+        if library_info.worker_ready is not None:
+            library_info.worker_ready.set()
         if library_info.lifecycle_state == LibraryManager.LibraryLifecycleState.WORKER_PENDING:
             library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.FAILURE
             library_info.fitness = LibraryManager.LibraryFitness.UNUSABLE
-            # Unblock any code awaiting this library's worker_ready event.
-            if library_info.worker_ready is not None:
-                library_info.worker_ready.set()
             logger.warning(
                 "Worker '%s' evicted before confirming load of library '%s'; library marked as FAILURE.",
                 worker_engine_id,
@@ -4463,10 +4502,16 @@ class LibraryManager(EngineScoped):
         the orchestrator ceiling stays aligned with the worker self-timeout; first-time
         installs of large libraries can easily exceed the default heartbeat timeout.
         """
+        # Only legacy WORKER_PENDING libraries gate BOOT: their nodes arrive as stubs from
+        # the worker, so nothing exists until it reports. An exec-deps library has real node
+        # classes locally and its worker gates execution only -- blocking startup on its
+        # worker's heavy imports would put torch back on the boot path.
         pending_events = [
             info.worker_ready
             for info in self._library_file_path_to_info.values()
-            if info.worker_ready is not None and not info.worker_ready.is_set()
+            if info.worker_ready is not None
+            and not info.worker_ready.is_set()
+            and info.lifecycle_state == LibraryManager.LibraryLifecycleState.WORKER_PENDING
         ]
         if not pending_events:
             return

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -3146,6 +3146,12 @@ class NodeManager(EngineScoped):
         # scope, not ours. Decide forwarding first; only open a local scope when
         # this process is actually going to execute the node.
         if not is_worker:
+            # The worker registers before it has loaded its library; routing in that window
+            # fails in the worker with "Library not found". Wait for the worker's
+            # LibraryLoadedNotification first -- immediate for any library without a
+            # spawned worker.
+            if library_name:
+                await library_manager.wait_for_worker_library_load(library_name)
             worker = library_manager.get_worker_for_library(library_name) if library_name else None
             wm = self.engine.worker_manager
             if wm is not None and worker is not None:

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -3359,7 +3359,7 @@ class NodeManager(EngineScoped):
         # installed (register_remote_handlers is worker-only), so opening the
         # scope there would just bump a refcount that nothing reads. Skip it
         # to keep the depth counter accurate to its name.
-        is_worker = self.engine.library_manager._is_worker
+        is_worker = self.engine.library_manager.is_worker
         scope_cm = self.engine.event_manager.worker_node_execution_scope() if is_worker else contextlib.nullcontext()
         with scope_cm:
             # Rehydrate serialized artifacts that crossed the orchestrator->worker JSON boundary.
@@ -3411,10 +3411,38 @@ class NodeManager(EngineScoped):
                     result_details=f"Attempted to execute node '{node_name}'. Failed with error: {e}",
                     exception=e,
                 )
+        if self.engine.library_manager.is_worker:
+            unshippable = self._unshippable_output_names(node)
+            if unshippable:
+                library_name = node.metadata.get("library", "its library")
+                details = (
+                    f"Node '{node_name}' produced {', '.join(unshippable)}, which cannot leave "
+                    f"'{library_name}'s isolated process. Either make the value serializable, or keep "
+                    f"it inside the library: cache it library-side and output a small serializable "
+                    f"descriptor that the consuming node trades back."
+                )
+                return ExecuteNodeResultFailure(result_details=details)
+
         return ExecuteNodeResultSuccess(
             parameter_output_values=dict(node.parameter_output_values),
             result_details=f"Node '{node_name}' executed successfully.",
         )
+
+    @staticmethod
+    def _unshippable_output_names(node: BaseNode) -> list[str]:
+        """Output parameter names holding values that cannot cross the process boundary.
+
+        ``serializable=False`` is the author declaring the value unreasonable to move (a live
+        tensor, an open pipeline). In a worker those outputs would be dropped or mangled on
+        the wire, so producing one is a failure with an actionable message rather than a
+        silent hole in the graph.
+        """
+        names = []
+        for parameter_name in node.parameter_output_values:
+            parameter = node.get_parameter_by_name(parameter_name)
+            if parameter is not None and not parameter.serializable:
+                names.append(f"'{parameter_name}'")
+        return names
 
     def on_validate_node_dependencies_request(self, request: ValidateNodeDependenciesRequest) -> ResultPayload:
         node_name = request.node_name

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -1,6 +1,7 @@
 import base64
 import binascii
 import logging
+import os
 import threading
 from pathlib import Path
 from typing import NamedTuple
@@ -52,7 +53,13 @@ from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
 from griptape_nodes.servers import bind_free_socket
-from griptape_nodes.servers.static import STATIC_SERVER_HOST, STATIC_SERVER_PORT, STATIC_SERVER_URL, start_static_server
+from griptape_nodes.servers.static import (
+    ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV,
+    STATIC_SERVER_HOST,
+    STATIC_SERVER_PORT,
+    STATIC_SERVER_URL,
+    start_static_server,
+)
 from griptape_nodes.utils.url_utils import uri_to_path
 
 logger = logging.getLogger("griptape_nodes")
@@ -472,6 +479,13 @@ class StaticFilesManager(EngineScoped):
             # Initialization can complete more than once per process: a workflow executor
             # broadcasts it for its own run. Where the workspace is served is already settled.
             logger.debug("Static server already settled at %s", self._static_server_base_url)
+        elif os.getenv(ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV):
+            # A worker: the orchestrator that spawned this process already serves the shared
+            # workspace, and its server outlives this one. Adopting it keeps asset URLs valid
+            # after this worker is evicted, where a URL on our own ephemeral port would not be.
+            adopted = os.environ[ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV].rstrip("/")
+            self._static_server_base_url = adopted
+            logger.debug("Adopted the orchestrator's static server at %s", adopted)
         else:
             # No host-provided server, so serve the workspace here.
             #

--- a/src/griptape_nodes/retained_mode/managers/worker_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/worker_manager.py
@@ -21,6 +21,7 @@ from griptape_nodes.retained_mode.managers.settings import (
     WORKER_HEARTBEAT_STARTUP_GRACE_KEY,
     WORKER_HEARTBEAT_TIMEOUT_KEY,
 )
+from griptape_nodes.servers.static import ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV
 from griptape_nodes.utils.version_utils import engine_version
 
 if TYPE_CHECKING:
@@ -340,6 +341,16 @@ class WorkerManager(EngineScoped):
         # desktop app); unbuffered output keeps worker log lines from stalling in Python's
         # block buffer and from being lost on a crash.
         worker_environ["PYTHONUNBUFFERED"] = "1"
+
+        # Hand the worker the URL of the static server the orchestrator is ALREADY serving
+        # this workspace on. Without it the worker starts its own server, wins an arbitrary
+        # OS-assigned port, and hands back asset URLs on that port -- which die when the
+        # worker is evicted and are already dead by the time a saved workflow is reopened.
+        # Both processes share the workspace on disk, so the orchestrator's long-lived
+        # server is the right place to serve anything a worker writes.
+        static_base_url = self._orchestrator_static_server_base_url()
+        if static_base_url is not None:
+            worker_environ[ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV] = static_base_url
         # Hand the orchestrator's own stdout/stderr to the worker explicitly so worker log
         # lines land in the same stream as orchestrator logs. Implicit inheritance is
         # POSIX-only: on Windows, redirected std handles (e.g. the desktop app's pipes) are
@@ -424,6 +435,19 @@ class WorkerManager(EngineScoped):
         # RequestClient.cancel_requests_by_tag, so a dead worker still surfaces
         # to the caller without a per-request ceiling.
         return await future
+
+    def _orchestrator_static_server_base_url(self) -> str | None:
+        """The base URL this engine serves the workspace on, when it has resolved one.
+
+        Returns None before app initialization settles it (nothing to hand a worker yet) or
+        when this engine serves nothing itself, in which case the worker falls back to its
+        own server exactly as before.
+        """
+        try:
+            return self.engine.static_files_manager.static_server_base_url
+        except RuntimeError:
+            # Raised when accessed before on_app_initialization_complete resolved it.
+            return None
 
     async def evict_worker(self, worker_engine_id: str) -> None:
         """Remove a worker from the registry and unsubscribe from its response topic."""

--- a/src/griptape_nodes/retained_mode/publishing/project_packager.py
+++ b/src/griptape_nodes/retained_mode/publishing/project_packager.py
@@ -92,6 +92,10 @@ WORKSPACE_DIRECTORY_KEY = "workspace_directory"
 _MIRROR_IGNORE_PATTERNS = [
     ".env",
     ".venv",
+    # Matched by fnmatch, so ".venv" does not cover it. An execution venv is a full torch
+    # install with host-specific binaries and absolute paths in pyvenv.cfg -- gigabytes that
+    # are wrong on any other machine.
+    ".venv-exec",
     ".git",
     "__pycache__",
     ".griptape-nodes-previews",

--- a/src/griptape_nodes/retained_mode/publishing/workflow_packager.py
+++ b/src/griptape_nodes/retained_mode/publishing/workflow_packager.py
@@ -177,7 +177,7 @@ class WorkflowPackager:
         default exclusions.
         """
         if ignore_patterns is None:
-            ignore_patterns = [".venv", "__pycache__", ".git"]
+            ignore_patterns = [".venv", ".venv-exec", "__pycache__", ".git"]
         result = GriptapeNodes.handle_request(
             CopyTreeRequest(
                 source_path=str(source_path),

--- a/src/griptape_nodes/servers/static.py
+++ b/src/griptape_nodes/servers/static.py
@@ -27,6 +27,10 @@ STATIC_SERVER_ENABLED = os.getenv("STATIC_SERVER_ENABLED", "true").lower() == "t
 STATIC_SERVER_HOST = os.getenv("STATIC_SERVER_HOST", "localhost")
 # Port of the static server (where uvicorn binds). Falls back to an OS-assigned free port if unavailable.
 STATIC_SERVER_PORT = int(os.getenv("STATIC_SERVER_PORT", "8124"))
+# Set by the orchestrator on a worker subprocess's environment: the URL of the static server
+# the orchestrator already serves this workspace on. A worker adopts it instead of starting a
+# server of its own, so asset URLs a worker produces outlive that worker.
+ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV = "GTN_ORCHESTRATOR_STATIC_SERVER_BASE_URL"
 # URL path for the static server
 STATIC_SERVER_URL = os.getenv("STATIC_SERVER_URL", "/workspace")
 # Log level for the static server

--- a/tests/e2e/fixtures/behavior_preservation_library/behavior_preservation_node.py
+++ b/tests/e2e/fixtures/behavior_preservation_library/behavior_preservation_node.py
@@ -1,0 +1,102 @@
+"""Node carrying everything a schema stub drops, for a library routed to a worker.
+
+The point of this fixture is the combination: the library declares execution dependencies, so
+its execution goes to a worker -- and yet the ORCHESTRATOR holds this real class, so the
+parameter behaviors that only exist in Python survive. A stub rebuilt from
+``WorkerParameterSchema`` carries scalar fields and ``ui_options`` only, so all three of these
+would be gone:
+
+- a ``Button`` trait, whose click handler lives on the trait rather than on the node. This is
+  the worst of the family, because ``ui_options`` DO serialize, so the button renders and
+  looks clickable while being guaranteed to fail (griptape-nodes-engine#5420).
+- a converter, which rewrites an incoming value.
+- a validator, which refuses one.
+- a value hook and a connection hook override, which a stub class does not carry at all.
+
+Module scope stays clean of the execution dependency on purpose: that is the contract that
+lets the orchestrator import this at all.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import NodeMessageResult, Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import DataNode
+from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
+
+CLICK_ACKNOWLEDGEMENT = "the node's own handler ran on the orchestrator"
+
+
+def _shout(value: Any) -> Any:
+    if isinstance(value, str):
+        return value.upper()
+    return value
+
+
+def _reject_forbidden(parameter: Parameter, value: Any) -> None:  # noqa: ARG001
+    if value == "FORBIDDEN":
+        msg = "forbidden value"
+        raise ValueError(msg)
+
+
+class BehaviorPreservationNode(DataNode):
+    BUTTON_PARAMETER = "model_manager"
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        button = Button(full_width=True)
+        button.on_click_callback = self._on_button_clicked
+        self.add_parameter(
+            Parameter(
+                name=self.BUTTON_PARAMETER,
+                type="str",
+                default_value="",
+                tooltip="Opens the model manager",
+                allowed_modes={ParameterMode.PROPERTY},
+                traits={button},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="mode",
+                type="str",
+                default_value="plain",
+                tooltip="Converted to upper case; refuses FORBIDDEN",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                converters=[_shout],
+                validators=[_reject_forbidden],
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="observed_mode",
+                type="str",
+                default_value="",
+                tooltip="",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def _on_button_clicked(self, _button: Button, _details: ButtonDetailsMessagePayload) -> NodeMessageResult:
+        return NodeMessageResult(success=True, details=CLICK_ACKNOWLEDGEMENT)
+
+    def after_value_set(self, parameter: Parameter, value: Any) -> None:
+        """Overridden so the value-hook detector has something to find."""
+        super().after_value_set(parameter, value)
+
+    def after_incoming_connection(
+        self,
+        source_node: Any,
+        source_parameter: Parameter,
+        target_parameter: Parameter,
+    ) -> None:
+        """Overridden so the connection-hook detector has something to find."""
+        super().after_incoming_connection(source_node, source_parameter, target_parameter)
+
+    def process(self) -> None:
+        # Deferred on purpose: this library declares it as execution-only, so it is absent
+        # from the orchestrator by design.
+        import fakeexec  # type: ignore[reportMissingImports]  # noqa: F401
+
+        self.parameter_output_values["observed_mode"] = self.get_parameter_value("mode")

--- a/tests/e2e/fixtures/behavior_preservation_library/griptape_nodes_library.json
+++ b/tests/e2e/fixtures/behavior_preservation_library/griptape_nodes_library.json
@@ -1,0 +1,38 @@
+{
+  "name": "Behavior Preservation Library",
+  "library_schema_version": "0.12.0",
+  "metadata": {
+    "author": "Test Fixture",
+    "description": "Library whose nodes carry traits, converters and validators",
+    "library_version": "0.1.0",
+    "engine_version": "0.0.0",
+    "tags": [
+      "test"
+    ],
+    "dependencies": {
+      "pip_dependencies": [],
+      "pip_dependencies_exec": []
+    }
+  },
+  "categories": [
+    {
+      "test": {
+        "title": "test",
+        "description": "Test nodes",
+        "color": "border-gray-500",
+        "icon": "Folder"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "class_name": "BehaviorPreservationNode",
+      "file_path": "behavior_preservation_node.py",
+      "metadata": {
+        "category": "test",
+        "description": "Node carrying a Button trait, a converter and a validator",
+        "display_name": "Behavior Preservation Node"
+      }
+    }
+  ]
+}

--- a/tests/e2e/fixtures/exec_dep_library/exec_dep_node.py
+++ b/tests/e2e/fixtures/exec_dep_library/exec_dep_node.py
@@ -1,0 +1,51 @@
+"""Node that splits its dependencies the way the execution-environment design requires.
+
+The two imports in this file are the whole point:
+
+- ``fakeedit`` is imported at module scope, so it is an EDIT-TIME dependency. It has to resolve
+  anywhere a node is merely defined or instantiated, which includes the orchestrator.
+- ``fakeexec`` is imported inside ``process``, so it is an EXECUTION dependency. It only has to
+  resolve where nodes actually execute.
+
+Real heavy libraries have this shape with torch and diffusers standing in for ``fakeexec``.
+"""
+
+from __future__ import annotations
+
+import fakeedit  # type: ignore[reportMissingImports]  # Edit-time dep: only importable from the library's edit venv.
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import DataNode
+
+
+class ExecDepNode(DataNode):
+    def __init__(self, name: str, metadata: dict | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        # Reading the edit-time dep here proves it is available at instantiation, not just import.
+        self.add_parameter(
+            Parameter(
+                name="edit_dep_version",
+                tooltip="Version of the edit-time dependency seen at instantiation",
+                type="str",
+                default_value=fakeedit.__version__,
+                allowed_modes={ParameterMode.PROPERTY, ParameterMode.OUTPUT},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="exec_dep_version",
+                tooltip="Version of the execution dependency seen while running",
+                type="str",
+                default_value="",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        # Deliberate deferred import, not a circular-import workaround: this dependency is
+        # declared as execution-only, so it is absent from the orchestrator by design and
+        # importing it at module scope would make this node impossible to instantiate there.
+        import fakeexec  # type: ignore[reportMissingImports]
+
+        self.parameter_output_values["edit_dep_version"] = fakeedit.__version__
+        self.parameter_output_values["exec_dep_version"] = fakeexec.__version__

--- a/tests/e2e/fixtures/exec_dep_library/griptape_nodes_library.json
+++ b/tests/e2e/fixtures/exec_dep_library/griptape_nodes_library.json
@@ -1,0 +1,36 @@
+{
+  "name": "Exec Dep Library",
+  "library_schema_version": "0.12.0",
+  "metadata": {
+    "author": "Test Fixture",
+    "description": "Library that declares edit-time and execution dependencies separately",
+    "library_version": "0.1.0",
+    "engine_version": "0.0.0",
+    "tags": ["test"],
+    "dependencies": {
+      "pip_dependencies": [],
+      "pip_dependencies_exec": []
+    }
+  },
+  "categories": [
+    {
+      "test": {
+        "title": "test",
+        "description": "Test nodes",
+        "color": "border-gray-500",
+        "icon": "Folder"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "class_name": "ExecDepNode",
+      "file_path": "exec_dep_node.py",
+      "metadata": {
+        "category": "test",
+        "description": "Node whose module needs an edit-time dep and whose process needs an execution dep",
+        "display_name": "Exec Dep Node"
+      }
+    }
+  ]
+}

--- a/tests/e2e/fixtures/worker_behavior_library/griptape_nodes_library.json
+++ b/tests/e2e/fixtures/worker_behavior_library/griptape_nodes_library.json
@@ -1,0 +1,92 @@
+{
+  "name": "Worker Behavior Library",
+  "library_schema_version": "0.12.0",
+  "metadata": {
+    "author": "Test Fixture",
+    "description": "Behaviors a heavy library depends on when executing in a worker",
+    "library_version": "0.1.0",
+    "engine_version": "0.0.0",
+    "tags": [
+      "test"
+    ],
+    "dependencies": {
+      "pip_dependencies": [],
+      "pip_dependencies_exec": []
+    }
+  },
+  "categories": [
+    {
+      "test": {
+        "title": "test",
+        "description": "Test nodes",
+        "color": "border-gray-500",
+        "icon": "Folder"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "class_name": "SaveMediaNode",
+      "file_path": "worker_behavior_nodes.py",
+      "metadata": {
+        "category": "test",
+        "description": "Writes bytes and returns a URL",
+        "display_name": "SaveMediaNode"
+      }
+    },
+    {
+      "class_name": "ReadConfigNode",
+      "file_path": "worker_behavior_nodes.py",
+      "metadata": {
+        "category": "test",
+        "description": "Reads engine config via a request",
+        "display_name": "ReadConfigNode"
+      }
+    },
+    {
+      "class_name": "StreamingNode",
+      "file_path": "worker_behavior_nodes.py",
+      "metadata": {
+        "category": "test",
+        "description": "Streams progress and yields work",
+        "display_name": "StreamingNode"
+      }
+    },
+    {
+      "class_name": "ChainStartNode",
+      "file_path": "worker_behavior_nodes.py",
+      "metadata": {
+        "category": "test",
+        "description": "First hop of a three-node chain",
+        "display_name": "ChainStartNode"
+      }
+    },
+    {
+      "class_name": "ChainMiddleNode",
+      "file_path": "worker_behavior_nodes.py",
+      "metadata": {
+        "category": "test",
+        "description": "Second hop of a three-node chain",
+        "display_name": "ChainMiddleNode"
+      }
+    },
+    {
+      "class_name": "ChainEndNode",
+      "file_path": "worker_behavior_nodes.py",
+      "metadata": {
+        "category": "test",
+        "description": "Third hop of a three-node chain",
+        "display_name": "ChainEndNode"
+      }
+    },
+    {
+      "class_name": "EditorBehaviorNode",
+      "file_path": "worker_behavior_nodes.py",
+      "metadata": {
+        "category": "test",
+        "description": "Converters, validators, dynamic parameters",
+        "display_name": "EditorBehaviorNode"
+      }
+    }
+  ]
+}

--- a/tests/e2e/fixtures/worker_behavior_library/worker_behavior_nodes.py
+++ b/tests/e2e/fixtures/worker_behavior_library/worker_behavior_nodes.py
@@ -1,0 +1,257 @@
+"""Nodes exercising the behaviors a heavy library depends on when it runs in a worker.
+
+Each node here stands in for something a real library (diffusers, advanced media) does that
+the minimal fixtures did not cover:
+
+- ``SaveMediaNode``: writes bytes and returns a URL. Proves a worker's asset URLs are served
+  by the orchestrator's long-lived server rather than the worker's ephemeral one.
+- ``ReadConfigNode``: reads config and a secret through requests. Proves the sanctioned
+  state-access path works from inside a worker.
+- ``StreamingNode``: streams progress and uses the ``AsyncResult`` yield pattern, which 24
+  standard-library files rely on.
+- ``ChainStartNode`` / ``ChainMiddleNode`` / ``ChainEndNode``: a three-hop chain of
+  serializable values, so every hop round-trips through the orchestrator.
+- ``EditorBehaviorNode``: converters, validators, and parameters added and removed from
+  ``after_value_set`` -- all of which now run orchestrator-side on the real class instead of
+  being lost to a schema stub.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
+from griptape_nodes.retained_mode.events.config_events import GetConfigValueRequest, GetConfigValueResultSuccess
+from griptape_nodes.retained_mode.events.parameter_events import (
+    AddParameterToNodeRequest,
+    RemoveParameterFromNodeRequest,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+MEDIA_BYTES = b"\x89PNG\r\n\x1a\n" + b"fixture-media-payload"
+
+
+class SaveMediaNode(DataNode):
+    """Writes bytes through the storage driver and outputs the resulting URL."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="url",
+                type="str",
+                default_value="",
+                tooltip="URL of the saved media",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        # Storage is the one capability a worker keeps locally: the bytes must not cross the
+        # process boundary. The URL, however, has to point at a server that outlives us.
+        url = GriptapeNodes.StaticFilesManager().save_static_file(MEDIA_BYTES, f"{self.name}.png")
+        self.parameter_output_values["url"] = url
+
+
+class ReadConfigNode(DataNode):
+    """Reads engine state the sanctioned way: a request, not a manager reference."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="config_key",
+                type="str",
+                default_value="workspace_directory",
+                tooltip="Config key to read",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="config_value",
+                type="str",
+                default_value="",
+                tooltip="Value the engine reported",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        key = self.get_parameter_value("config_key")
+        result = GriptapeNodes.handle_request(GetConfigValueRequest(category_and_key=key))
+        value = result.value if isinstance(result, GetConfigValueResultSuccess) else ""
+        self.parameter_output_values["config_value"] = str(value)
+
+
+class StreamingNode(DataNode):
+    """Streams progress mid-execution and yields work the framework runs off-thread."""
+
+    CHUNKS = ("alpha", "beta", "gamma")
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="stream",
+                type="str",
+                default_value="",
+                tooltip="Accumulated streamed output",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> AsyncResult:
+        def work() -> str:
+            return "".join(self.CHUNKS)
+
+        for chunk in self.CHUNKS:
+            self.append_value_to_parameter("stream", chunk)
+        # The yield-a-callable pattern: the framework runs this off the event loop and sends
+        # the result back into the generator.
+        total = yield work
+        self.parameter_output_values["stream"] = total
+
+
+class ChainStartNode(DataNode):
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="out",
+                type="str",
+                default_value="",
+                tooltip="",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        self.parameter_output_values["out"] = "start"
+
+
+class ChainMiddleNode(DataNode):
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="in_value",
+                type="str",
+                default_value="",
+                tooltip="",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="out",
+                type="str",
+                default_value="",
+                tooltip="",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        self.parameter_output_values["out"] = f"{self.get_parameter_value('in_value')}->middle"
+
+
+class ChainEndNode(DataNode):
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="in_value",
+                type="str",
+                default_value="",
+                tooltip="",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="final",
+                type="str",
+                default_value="",
+                tooltip="",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        self.parameter_output_values["final"] = f"{self.get_parameter_value('in_value')}->end"
+
+
+def _shout(value: Any) -> Any:
+    """Converter: proves converters run where the node object is real."""
+    if isinstance(value, str):
+        return value.upper()
+    return value
+
+
+def _reject_forbidden(parameter: Parameter, value: Any) -> None:  # noqa: ARG001 (validator signature)
+    """Validator: proves validators run where the node object is real."""
+    if value == "FORBIDDEN":
+        msg = "value 'forbidden' is not allowed"
+        raise ValueError(msg)
+
+
+class EditorBehaviorNode(DataNode):
+    """Carries converters, validators, and dynamic parameters driven by value changes.
+
+    A schema stub would drop all of this: the converter and validator would not travel, and
+    the dynamic parameter would never appear. With a real class on the orchestrator they all
+    work at edit time, which is what the dependency split buys.
+    """
+
+    DYNAMIC_PARAMETER = "dynamic_extra"
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="mode",
+                type="str",
+                default_value="plain",
+                tooltip="Set to 'expand' to grow a dynamic parameter",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                converters=[_shout],
+                validators=[_reject_forbidden],
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="observed_mode",
+                type="str",
+                default_value="",
+                tooltip="",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def after_value_set(self, parameter: Parameter, value: Any) -> None:
+        if parameter.name != "mode":
+            return
+        wants_extra = value == "EXPAND"
+        has_extra = self.get_parameter_by_name(self.DYNAMIC_PARAMETER) is not None
+        if wants_extra and not has_extra:
+            GriptapeNodes.handle_request(
+                AddParameterToNodeRequest(
+                    node_name=self.name,
+                    parameter_name=self.DYNAMIC_PARAMETER,
+                    type="str",
+                    default_value="grown",
+                    tooltip="Added because mode is expand",
+                    mode_allowed_input=True,
+                    mode_allowed_property=True,
+                    mode_allowed_output=False,
+                )
+            )
+        elif not wants_extra and has_extra:
+            GriptapeNodes.handle_request(
+                RemoveParameterFromNodeRequest(node_name=self.name, parameter_name=self.DYNAMIC_PARAMETER)
+            )
+
+    def process(self) -> None:
+        self.parameter_output_values["observed_mode"] = self.get_parameter_value("mode")

--- a/tests/e2e/offline_wheels.py
+++ b/tests/e2e/offline_wheels.py
@@ -1,0 +1,48 @@
+"""Hand-built wheels for dependency-environment tests.
+
+Building the wheel by hand keeps these tests fully offline: no network, no build backend, and
+no dependency on any package that happens to be installed. Because the packages built here
+exist nowhere else, a successful import of one is proof that the environment it was installed
+into was created AND wired onto ``sys.path``.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import zipfile
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def build_wheel(wheel_dir: Path, name: str, version: str = "1.0.0") -> Path:
+    """Write a minimal importable wheel for ``name`` into ``wheel_dir``.
+
+    The built package exposes ``__version__`` so tests can assert *which* environment
+    satisfied an import.
+    """
+    wheel_dir.mkdir(parents=True, exist_ok=True)
+    wheel_path = wheel_dir / f"{name}-{version}-py3-none-any.whl"
+    dist_info = f"{name}-{version}.dist-info"
+    files = {
+        f"{name}/__init__.py": f'__version__ = "{version}"\n',
+        f"{dist_info}/METADATA": f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n",
+        f"{dist_info}/WHEEL": "Wheel-Version: 1.0\nGenerator: test-fixture\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+    }
+    record_rows = []
+    with zipfile.ZipFile(wheel_path, "w") as zf:
+        for file_name, content in files.items():
+            data = content.encode()
+            zf.writestr(file_name, data)
+            digest = base64.urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=").decode()
+            record_rows.append(f"{file_name},sha256={digest},{len(data)}")
+        record_rows.append(f"{dist_info}/RECORD,,")
+        zf.writestr(f"{dist_info}/RECORD", "\n".join(record_rows) + "\n")
+    return wheel_path
+
+
+def offline_install_flags(wheel_dir: Path) -> list[str]:
+    """Pip flags that install only from ``wheel_dir``, never the network."""
+    return ["--no-index", "--find-links", str(wheel_dir)]

--- a/tests/e2e/test_exec_dep_worker_routing.py
+++ b/tests/e2e/test_exec_dep_worker_routing.py
@@ -1,0 +1,461 @@
+"""End-to-end tests for the exec-dep worker MVP.
+
+A library that declares execution dependencies (``pip_dependencies_exec``) gets a different
+deal than either mode that exists today:
+
+- It loads REAL node classes on the orchestrator (not schema stubs), because its node
+  modules import with edit-time deps only.
+- Its nodes EXECUTE in its dedicated worker process, where ``.venv-exec`` is on
+  ``sys.path``.
+- While executing there, node code cannot reach orchestrator-owned managers directly; it
+  asks the orchestrator with a request instead.
+- A value it produces that cannot leave that process fails loudly with instructions.
+
+These tests pin those four behaviors, plus the crucial negative: a library that declares no
+execution dependencies is untouched by any of it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+from pathlib import Path
+
+import pytest
+
+from griptape_nodes.node_library.library_registry import LibraryRegistry, LibrarySchema
+from griptape_nodes.retained_mode.engine import current_engine
+from griptape_nodes.retained_mode.events.app_events import LibraryLoadedNotification
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.events.node_events import (
+    SendNodeMessageRequest,
+    SendNodeMessageResultSuccess,
+)
+
+# The facade import survives for the dummy-manager guard tests, whose subject it is.
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes  # noqa: TID251
+from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
+from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
+from griptape_nodes.utils.version_utils import engine_version
+from tests.e2e.fixtures.behavior_preservation_library.behavior_preservation_node import CLICK_ACKNOWLEDGEMENT
+from tests.e2e.offline_wheels import build_wheel, offline_install_flags
+
+EXEC_FIXTURE = Path(__file__).parent / "fixtures" / "exec_dep_library"
+NONSERIALIZABLE_FIXTURE = Path(__file__).parent / "fixtures" / "nonserializable_library"
+BEHAVIOR_FIXTURE = Path(__file__).parent / "fixtures" / "behavior_preservation_library"
+
+
+def _register(  # noqa: PLR0913 (a test-library builder; each knob is one manifest field)
+    tmp_path: Path,
+    *,
+    fixture_dir: Path,
+    node_file: str,
+    name: str,
+    exec_dependencies: list[str] | None = None,
+    edit_dependencies: list[str] | None = None,
+) -> str:
+    """Register a fixture library, optionally declaring execution dependencies."""
+    library_dir = tmp_path / name.replace(" ", "_")
+    library_dir.mkdir(parents=True, exist_ok=True)
+    schema = json.loads((fixture_dir / "griptape_nodes_library.json").read_text())
+    schema["name"] = name
+    schema["library_schema_version"] = LibrarySchema.LATEST_SCHEMA_VERSION
+    schema["metadata"]["engine_version"] = engine_version
+    dependencies: dict[str, list[str]] = {"pip_dependencies": list(edit_dependencies or [])}
+    if exec_dependencies:
+        wheel_dir = tmp_path / "wheels"
+        for dep in [*(edit_dependencies or []), *exec_dependencies]:
+            build_wheel(wheel_dir, dep, "1.0.0")
+        dependencies["pip_dependencies_exec"] = exec_dependencies
+        dependencies["pip_install_flags"] = offline_install_flags(wheel_dir)
+    elif edit_dependencies:
+        wheel_dir = tmp_path / "wheels"
+        for dep in edit_dependencies:
+            build_wheel(wheel_dir, dep, "1.0.0")
+        dependencies["pip_install_flags"] = offline_install_flags(wheel_dir)
+    schema["metadata"]["dependencies"] = dependencies
+    library_json = library_dir / "griptape_nodes_library.json"
+    library_json.write_text(json.dumps(schema, indent=2))
+    shutil.copy(fixture_dir / node_file, library_dir / node_file)
+    result = current_engine().handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    assert isinstance(result, RegisterLibraryFromFileResultSuccess), getattr(result, "result_details", result)
+    return str(library_json)
+
+
+def _library_info(library_json: str) -> LibraryManager.LibraryInfo:
+    return current_engine().library_manager._library_file_path_to_info[library_json]
+
+
+class TestRoutingFact:
+    def test_exec_dependencies_mean_execution_in_a_worker(self, tmp_path: Path) -> None:
+        """Declaring exec deps routes execution to a worker WITHOUT the legacy stub path."""
+        library_json = _register(
+            tmp_path,
+            fixture_dir=EXEC_FIXTURE,
+            node_file="exec_dep_node.py",
+            name="Routing Heavy",
+            edit_dependencies=["fakeedit"],
+            exec_dependencies=["fakeexec"],
+        )
+
+        info = _library_info(library_json)
+        assert info.executes_in_worker is True
+        # Crucially NOT the legacy worker mode: no stub path, no WORKER_PENDING gating.
+        assert info.requires_worker is False
+        assert info.lifecycle_state is LibraryManager.LibraryLifecycleState.LOADED
+
+    def test_no_exec_dependencies_means_no_worker(self, tmp_path: Path) -> None:
+        library_json = _register(
+            tmp_path,
+            fixture_dir=NONSERIALIZABLE_FIXTURE,
+            node_file="nonserializable_nodes.py",
+            name="Routing Light",
+        )
+
+        info = _library_info(library_json)
+        assert info.executes_in_worker is False
+        assert info.requires_worker is False
+
+    def test_worker_is_required_once_declared(self, tmp_path: Path) -> None:
+        """With no worker registered, routing raises instead of silently running locally.
+
+        Falling back to in-process execution would run the node in the one process that
+        deliberately lacks its execution dependencies.
+        """
+        _register(
+            tmp_path,
+            fixture_dir=EXEC_FIXTURE,
+            node_file="exec_dep_node.py",
+            name="Routing Guard",
+            edit_dependencies=["fakeedit"],
+            exec_dependencies=["fakeexec"],
+        )
+
+        with pytest.raises(RuntimeError, match="requires a dedicated worker"):
+            current_engine().library_manager.get_worker_for_library("Routing Guard")
+
+
+class TestRealNodesOnOrchestrator:
+    def test_orchestrator_holds_real_node_classes_not_stubs(self, tmp_path: Path) -> None:
+        """The point of the dep split: real classes in the editor, heavy deps elsewhere.
+
+        The node instantiates here with its edit-time dependency importable and its
+        execution dependency absent from this process.
+        """
+        _register(
+            tmp_path,
+            fixture_dir=EXEC_FIXTURE,
+            node_file="exec_dep_node.py",
+            name="Real Nodes",
+            edit_dependencies=["fakeedit"],
+            exec_dependencies=["fakeexec"],
+        )
+
+        node = LibraryRegistry.create_node(node_type="ExecDepNode", name="real", specific_library_name="Real Nodes")
+
+        # A stub would carry parameter shape only; this is the real class, so its
+        # __init__ ran and read its edit-time dependency.
+        assert node.get_parameter_value("edit_dep_version") == "1.0.0"
+        assert type(node).__name__ == "ExecDepNode"
+        assert type(node).__module__ != "griptape_nodes.retained_mode.managers.library_manager"
+
+
+class TestParameterBehaviorsSurviveOnRealClasses:
+    """What a schema stub drops, and what these libraries keep by not being stubbed.
+
+    A stub is rebuilt from ``WorkerParameterSchema``, which carries scalar fields and
+    ``ui_options`` only. Traits, converters and validators live in Python and cannot travel,
+    so a worker-mode library loses all of them on the orchestrator -- see
+    griptape-nodes-engine#5420 for the trait case, which is the worst of the family because
+    ``ui_options`` DO serialize: the button renders, looks clickable, and cannot work.
+
+    An execution-dependency library sets ``executes_in_worker`` WITHOUT setting
+    ``requires_worker``, and stub registration is gated on the latter, so these libraries keep
+    the real class. ``test_the_orchestrator_refuses_worker_schemas_that_would_clobber_real_classes``
+    is the one that drives that gate; the rest cover what survives on the class itself.
+    """
+
+    def _register_behavior_library(self, tmp_path: Path) -> str:
+        return _register(
+            tmp_path,
+            fixture_dir=BEHAVIOR_FIXTURE,
+            node_file="behavior_preservation_node.py",
+            name="Behavior Library",
+            exec_dependencies=["fakeexec"],
+        )
+
+    def test_a_button_trait_survives_and_its_click_resolves(self, tmp_path: Path) -> None:
+        """The #5420 case: the trait is present, so the click reaches the node's handler."""
+        self._register_behavior_library(tmp_path)
+        node = LibraryRegistry.create_node(
+            node_type="BehaviorPreservationNode", name="behaviors", specific_library_name="Behavior Library"
+        )
+        current_engine().object_manager.add_object_by_name("behaviors", node)
+
+        parameter = node.get_parameter_by_name("model_manager")
+        assert parameter is not None
+        assert list(parameter.find_elements_by_type(Button)), "the Button trait did not survive"
+
+        result = current_engine().handle_request(
+            SendNodeMessageRequest(
+                node_name="behaviors",
+                optional_element_name="model_manager",
+                message_type="on_click",
+                message=ButtonDetailsMessagePayload(label="Open", variant="default", size="md", state="ready"),
+            )
+        )
+
+        assert isinstance(result, SendNodeMessageResultSuccess), getattr(result, "result_details", result)
+        # The trait's bound callback is what produced this, so the string proves the node's own
+        # handler ran rather than something merely accepting the message.
+        assert CLICK_ACKNOWLEDGEMENT in str(result.result_details)
+
+    @pytest.mark.asyncio
+    async def test_the_orchestrator_refuses_worker_schemas_that_would_clobber_real_classes(
+        self, tmp_path: Path
+    ) -> None:
+        """Drive the gate itself: a worker's schemas must not replace real classes.
+
+        The tests above load a library in-process, which is true of any library and never
+        reaches the gate. The clobber happens later and elsewhere: the worker sends a
+        LibraryLoadedNotification carrying serialized schemas, and the ORCHESTRATOR decides
+        whether to build stub classes from them. `Library.register_new_node_type` overwrites
+        unconditionally, so a gate keyed on the wrong flag silently swaps this library's real
+        classes -- traits and all -- for stubs after load.
+        """
+        self._register_behavior_library(tmp_path)
+        library_manager = current_engine().library_manager
+        library_info = library_manager.get_library_info_by_library_name("Behavior Library")
+        assert library_info is not None
+        assert library_info.executes_in_worker is True, "the library must be worker-routed for this to mean anything"
+        assert library_info.requires_worker is False, "...but not via the legacy stub path"
+
+        # Exactly what a worker broadcasts after loading the library.
+        schemas = await library_manager._serialize_library_node_schemas("Behavior Library")
+        await library_manager._on_library_loaded_notification(
+            LibraryLoadedNotification(
+                library_name="Behavior Library",
+                fitness=LibraryManager.LibraryFitness.GOOD,
+                node_schemas=schemas,
+            )
+        )
+
+        node = LibraryRegistry.create_node(
+            node_type="BehaviorPreservationNode", name="post_notification", specific_library_name="Behavior Library"
+        )
+        parameter = node.get_parameter_by_name("model_manager")
+        assert parameter is not None
+        assert list(parameter.find_elements_by_type(Button)), (
+            "the worker's schemas replaced the real class with a stub, dropping the Button trait"
+        )
+
+    def test_converters_and_validators_survive(self, tmp_path: Path) -> None:
+        """The quieter half of the same family: both only exist as Python callables."""
+        self._register_behavior_library(tmp_path)
+        node = LibraryRegistry.create_node(
+            node_type="BehaviorPreservationNode", name="callables", specific_library_name="Behavior Library"
+        )
+
+        node.set_parameter_value("mode", "expand")
+        assert node.get_parameter_value("mode") == "EXPAND", "the converter did not run"
+
+        with pytest.raises(ValueError, match="forbidden"):
+            node.set_parameter_value("mode", "FORBIDDEN")
+
+    @pytest.mark.asyncio
+    async def test_the_stub_loss_warnings_stay_quiet_for_a_library_that_is_not_stubbed(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The detectors describe what a stub loses, so they must not fire when there is none.
+
+        Both fire from the worker-side schema probe, which runs for every library a worker
+        loads -- including execution-dependency libraries, whose schemas the orchestrator
+        then ignores. Ungated, this node's converter, validator and trait each produced a
+        warning saying they "will not execute on the orchestrator stub", for a library whose
+        orchestrator copy is the real class. That sends an author to fix correct code.
+        """
+        self._register_behavior_library(tmp_path)
+        library_manager = current_engine().library_manager
+
+        with caplog.at_level(logging.WARNING):
+            await library_manager._serialize_library_node_schemas("Behavior Library")
+
+        assert "will not execute on the orchestrator stub" not in caplog.text
+        assert "parameter-behaviors-dropped-in-schema" not in caplog.text
+        # The other two gated rules carry their own wording; assert each, or half the gate
+        # can be reverted with nothing failing.
+        assert "connection hooks run on the orchestrator against a stub" not in caplog.text
+        assert "these fire only during" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_the_stub_loss_warnings_still_fire_for_a_legacy_worker_mode_library(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The other direction: a library that IS stubbed still gets told what it loses."""
+        self._register_behavior_library(tmp_path)
+        library_manager = current_engine().library_manager
+        library_info = library_manager.get_library_info_by_library_name("Behavior Library")
+        assert library_info is not None
+        library_info.requires_worker = True
+
+        with caplog.at_level(logging.WARNING):
+            await library_manager._serialize_library_node_schemas("Behavior Library")
+
+        assert "will not execute on the orchestrator stub" in caplog.text
+        assert "connection hooks run on the orchestrator against a stub" in caplog.text
+        assert "these fire only during" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_the_stub_path_these_libraries_avoid_would_drop_the_button(self, tmp_path: Path) -> None:
+        """Negative control: the same parameters through stub synthesis lose the trait.
+
+        Without this, the test above passes for any ordinary library and proves nothing about
+        the routing decision. Driving the real serializer and stub builder shows the loss is in
+        stub synthesis, and reproduces the reported failure message exactly.
+        """
+        self._register_behavior_library(tmp_path)
+        library_manager = current_engine().library_manager
+
+        schemas = await library_manager._serialize_library_node_schemas("Behavior Library")
+        node_schema = next(s for s in schemas if s.class_name == "BehaviorPreservationNode")
+        stub_class = library_manager._make_worker_stub_class("BehaviorPreservationNode", node_schema.parameters)
+        stub = stub_class(name="stubbed")
+        current_engine().object_manager.add_object_by_name("stubbed", stub)
+
+        stub_parameter = stub.get_parameter_by_name("model_manager")
+        assert stub_parameter is not None, "the parameter itself should survive -- only its trait is lost"
+        assert not list(stub_parameter.find_elements_by_type(Button))
+
+        result = current_engine().handle_request(
+            SendNodeMessageRequest(
+                node_name="stubbed",
+                optional_element_name="model_manager",
+                message_type="on_click",
+                message=ButtonDetailsMessagePayload(label="Open", variant="default", size="md", state="ready"),
+            )
+        )
+
+        assert not isinstance(result, SendNodeMessageResultSuccess)
+        assert "no handler was available" in str(result.result_details)
+
+
+class TestUnshippableOutputGuardrail:
+    @pytest.mark.asyncio
+    async def test_worker_producing_an_unshippable_value_fails_with_instructions(self, tmp_path: Path) -> None:
+        """A serializable=False output cannot cross the boundary, so say so usefully."""
+        from griptape_nodes.retained_mode.events.execution_events import (
+            ExecuteNodeRequest,
+            ExecuteNodeResultFailure,
+        )
+
+        _register(
+            tmp_path,
+            fixture_dir=NONSERIALIZABLE_FIXTURE,
+            node_file="nonserializable_nodes.py",
+            name="Guardrail Library",
+        )
+        library_manager = current_engine().library_manager
+        library_manager._is_worker = True
+        node = LibraryRegistry.create_node(
+            node_type="ProducerNode", name="Producer", specific_library_name="Guardrail Library"
+        )
+        current_engine().object_manager.add_object_by_name("Producer", node)
+
+        result = await current_engine().ahandle_request(
+            ExecuteNodeRequest(
+                node_name="Producer",
+                node_metadata={"node_type": "ProducerNode", "library": "Guardrail Library"},
+            )
+        )
+
+        assert isinstance(result, ExecuteNodeResultFailure)
+        details = str(result.result_details)
+        assert "'session'" in details
+        assert "cannot leave" in details
+        # The message must teach the way forward, not just refuse.
+        assert "descriptor" in details
+
+    @pytest.mark.asyncio
+    async def test_serializable_outputs_are_unaffected(self, tmp_path: Path) -> None:
+        from griptape_nodes.retained_mode.events.execution_events import (
+            ExecuteNodeRequest,
+            ExecuteNodeResultSuccess,
+        )
+
+        _register(
+            tmp_path,
+            fixture_dir=EXEC_FIXTURE,
+            node_file="exec_dep_node.py",
+            name="Guardrail Serializable",
+            edit_dependencies=["fakeedit"],
+        )
+        current_engine().library_manager._is_worker = True
+        node = LibraryRegistry.create_node(
+            node_type="ExecDepNode", name="Fine", specific_library_name="Guardrail Serializable"
+        )
+        current_engine().object_manager.add_object_by_name("Fine", node)
+
+        result = await current_engine().ahandle_request(
+            ExecuteNodeRequest(
+                node_name="Fine",
+                node_metadata={"node_type": "ExecDepNode", "library": "Guardrail Serializable"},
+            )
+        )
+
+        # fakeexec is not importable here, so process() raises -- but on the exec dep, NOT
+        # on the guardrail. What matters is the guardrail did not fire for its string outputs.
+        if isinstance(result, ExecuteNodeResultSuccess):
+            assert result.parameter_output_values["edit_dep_version"] == "1.0.0"
+        else:
+            assert "cannot leave" not in str(result.result_details)
+
+
+class TestManagerAccessDuringWorkerExecution:
+    def test_config_manager_is_refused_inside_worker_execution(self) -> None:
+        """In a worker, node code must ask the orchestrator rather than read local state."""
+        library_manager = current_engine().library_manager
+        library_manager._is_worker = True
+        event_manager = current_engine().event_manager
+
+        with event_manager.worker_node_execution_scope(), pytest.raises(RuntimeError) as excinfo:
+            GriptapeNodes.ConfigManager()
+
+        message = str(excinfo.value)
+        assert "ConfigManager" in message
+        assert "GetConfigValueRequest" in message
+
+    def test_secrets_and_os_managers_are_refused_too(self) -> None:
+        current_engine().library_manager._is_worker = True
+        event_manager = current_engine().event_manager
+
+        with event_manager.worker_node_execution_scope():
+            with pytest.raises(RuntimeError, match="GetSecretValueRequest"):
+                GriptapeNodes.SecretsManager()
+            with pytest.raises(RuntimeError, match="ReadFileRequest"):
+                GriptapeNodes.OSManager()
+
+    def test_managers_work_outside_node_execution_in_a_worker(self) -> None:
+        """Engine boot and library load happen in the worker too, and need real managers."""
+        current_engine().library_manager._is_worker = True
+
+        assert GriptapeNodes.ConfigManager() is not None
+        assert GriptapeNodes.SecretsManager() is not None
+
+    def test_managers_work_during_execution_on_the_orchestrator(self) -> None:
+        """The refusal is about being in a worker, not about executing."""
+        event_manager = current_engine().event_manager
+
+        with event_manager.worker_node_execution_scope():
+            assert GriptapeNodes.ConfigManager() is not None
+
+    def test_static_files_manager_stays_available(self) -> None:
+        """Storage is the one local capability: media bytes cannot cross the boundary."""
+        current_engine().library_manager._is_worker = True
+        event_manager = current_engine().event_manager
+
+        with event_manager.worker_node_execution_scope():
+            assert GriptapeNodes.StaticFilesManager() is not None

--- a/tests/e2e/test_library_execution_dependency_split.py
+++ b/tests/e2e/test_library_execution_dependency_split.py
@@ -1,0 +1,250 @@
+"""End-to-end tests for the edit-time / execution dependency split.
+
+A library declares its dependencies in two sets. Edit-time dependencies are what the engine
+needs to import node modules and instantiate nodes; execution dependencies are the heavy
+packages only ``process`` needs. The split exists so the orchestrator can hold real node
+classes for every library without ever putting those heavy packages on its import path, which
+is what stops one library's pins from shadowing another's.
+
+The contract these tests pin:
+
+- **On the orchestrator**: edit-time dependencies are importable and nodes instantiate, while
+  execution dependencies are installed on disk but deliberately absent from ``sys.path``.
+- **In a worker**: both environments are on ``sys.path``, so ``process`` runs.
+- **For a library that declares no execution dependencies**: nothing changes, and no second
+  environment appears on disk.
+
+Both dependencies are hand-built wheels installed from a local ``--find-links`` directory with
+``--no-index``, so the tests are fully offline. Because ``fakeedit`` and ``fakeexec`` exist
+nowhere except those wheels, a successful import IS proof the matching environment was created
+and wired onto ``sys.path`` -- and an ImportError is proof it was not.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import sysconfig
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.node_library.library_registry import LibraryRegistry, LibrarySchema
+from griptape_nodes.retained_mode.engine import current_engine
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
+from griptape_nodes.utils.version_utils import engine_version
+from tests.e2e.offline_wheels import build_wheel, offline_install_flags
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "exec_dep_library"
+FIXTURE_FILES = ("exec_dep_node.py",)
+EDIT_DEP = "fakeedit"
+EXEC_DEP = "fakeexec"
+EDIT_DEP_VERSION = "1.0.0"
+EXEC_DEP_VERSION = "2.0.0"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_import_state() -> Iterator[None]:
+    """Keep sys.path and sys.modules from leaking between tests.
+
+    Every registration inserts paths and imports modules. Without this, a dependency imported
+    by one test would satisfy the next test's import from the module cache, which would hide
+    exactly the wiring these tests exist to check.
+    """
+    original_path = list(sys.path)
+    original_is_worker = current_engine().library_manager._is_worker
+    for dep in (EDIT_DEP, EXEC_DEP):
+        sys.modules.pop(dep, None)
+    yield
+    sys.path[:] = original_path
+    current_engine().library_manager._is_worker = original_is_worker
+    for dep in (EDIT_DEP, EXEC_DEP):
+        sys.modules.pop(dep, None)
+
+
+def _materialize_library(
+    target_dir: Path,
+    *,
+    wheel_dir: Path,
+    name: str,
+    exec_dependencies: list[str],
+) -> Path:
+    """Write a registrable copy of the fixture library, declaring the given dependency split."""
+    schema = json.loads((FIXTURE_DIR / "griptape_nodes_library.json").read_text())
+    schema["name"] = name
+    schema["library_schema_version"] = LibrarySchema.LATEST_SCHEMA_VERSION
+    schema["metadata"]["engine_version"] = engine_version
+    schema["metadata"]["dependencies"] = {
+        "pip_dependencies": [EDIT_DEP],
+        "pip_dependencies_exec": exec_dependencies,
+        "pip_install_flags": offline_install_flags(wheel_dir),
+    }
+    target_dir.mkdir(parents=True, exist_ok=True)
+    library_json = target_dir / "griptape_nodes_library.json"
+    library_json.write_text(json.dumps(schema, indent=2))
+    for file_name in FIXTURE_FILES:
+        (target_dir / file_name).write_text((FIXTURE_DIR / file_name).read_text())
+    return library_json
+
+
+def _build_both_wheels(wheel_dir: Path) -> None:
+    build_wheel(wheel_dir, EDIT_DEP, EDIT_DEP_VERSION)
+    build_wheel(wheel_dir, EXEC_DEP, EXEC_DEP_VERSION)
+
+
+def _register(library_json: Path) -> RegisterLibraryFromFileResultSuccess:
+    result = current_engine().handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    assert isinstance(result, RegisterLibraryFromFileResultSuccess), getattr(result, "result_details", result)
+    return result
+
+
+def _library_info(library_json: Path) -> LibraryManager.LibraryInfo:
+    return current_engine().library_manager._library_file_path_to_info[str(library_json)]
+
+
+def _site_packages(venv_path: Path) -> str:
+    return str(Path(sysconfig.get_path("purelib", vars={"base": str(venv_path), "platbase": str(venv_path)})))
+
+
+def _import_fresh(module_name: str) -> object:
+    """Import a module without letting a previous test's cache answer for it."""
+    sys.modules.pop(module_name, None)
+    importlib.invalidate_caches()
+    return importlib.import_module(module_name)
+
+
+class TestOrchestratorHoldsEditTimeDepsOnly:
+    def test_execution_dependencies_are_installed_but_absent_from_sys_path(self, tmp_path: Path) -> None:
+        """The orchestrator installs both sets but only imports against the edit-time one.
+
+        This is the isolation the whole design rests on: the heavy packages exist on disk, ready
+        for a worker, and cannot be reached from the process that runs the editor.
+        """
+        wheel_dir = tmp_path / "wheels"
+        _build_both_wheels(wheel_dir)
+        library_dir = tmp_path / "library"
+        library_json = _materialize_library(
+            library_dir, wheel_dir=wheel_dir, name="Exec Dep Orchestrator", exec_dependencies=[EXEC_DEP]
+        )
+
+        _register(library_json)
+
+        info = _library_info(library_json)
+        assert info.lifecycle_state is LibraryManager.LibraryLifecycleState.LOADED
+        assert info.fitness is LibraryManager.LibraryFitness.GOOD
+
+        # Both environments were built on disk.
+        edit_venv = library_dir / ".venv"
+        exec_venv = library_dir / ".venv-exec"
+        assert edit_venv.exists()
+        assert exec_venv.exists()
+
+        # Only the edit-time one is importable from here.
+        assert _site_packages(edit_venv) in sys.path
+        assert _site_packages(exec_venv) not in sys.path
+        assert _import_fresh(EDIT_DEP).__version__ == EDIT_DEP_VERSION  # type: ignore[attr-defined]
+        with pytest.raises(ImportError):
+            _import_fresh(EXEC_DEP)
+
+    def test_node_instantiates_on_the_orchestrator_without_execution_dependencies(self, tmp_path: Path) -> None:
+        """A real node class, instantiated for real, with the heavy dependency unreachable.
+
+        This is what lets the orchestrator drop stub nodes: it holds the actual class, and the
+        actual class only needs edit-time dependencies to exist.
+        """
+        wheel_dir = tmp_path / "wheels"
+        _build_both_wheels(wheel_dir)
+        library_dir = tmp_path / "library"
+        library_json = _materialize_library(
+            library_dir, wheel_dir=wheel_dir, name="Exec Dep Instantiate", exec_dependencies=[EXEC_DEP]
+        )
+        _register(library_json)
+
+        node = LibraryRegistry.create_node(
+            node_type="ExecDepNode", name="exec_dep_node", specific_library_name="Exec Dep Instantiate"
+        )
+
+        assert node.get_parameter_value("edit_dep_version") == EDIT_DEP_VERSION
+        with pytest.raises(ImportError):
+            _import_fresh(EXEC_DEP)
+
+
+class TestWorkerHoldsBothEnvironments:
+    def test_worker_puts_both_environments_on_sys_path(self, tmp_path: Path) -> None:
+        wheel_dir = tmp_path / "wheels"
+        _build_both_wheels(wheel_dir)
+        library_dir = tmp_path / "library"
+        library_json = _materialize_library(
+            library_dir, wheel_dir=wheel_dir, name="Exec Dep Worker", exec_dependencies=[EXEC_DEP]
+        )
+        current_engine().library_manager._is_worker = True
+
+        _register(library_json)
+
+        assert _site_packages(library_dir / ".venv") in sys.path
+        assert _site_packages(library_dir / ".venv-exec") in sys.path
+        assert _import_fresh(EDIT_DEP).__version__ == EDIT_DEP_VERSION  # type: ignore[attr-defined]
+        assert _import_fresh(EXEC_DEP).__version__ == EXEC_DEP_VERSION  # type: ignore[attr-defined]
+
+    def test_process_runs_in_a_worker(self, tmp_path: Path) -> None:
+        """The payoff: the same node whose process is unrunnable on the orchestrator runs here."""
+        wheel_dir = tmp_path / "wheels"
+        _build_both_wheels(wheel_dir)
+        library_dir = tmp_path / "library"
+        library_json = _materialize_library(
+            library_dir, wheel_dir=wheel_dir, name="Exec Dep Worker Process", exec_dependencies=[EXEC_DEP]
+        )
+        current_engine().library_manager._is_worker = True
+        _register(library_json)
+        node = LibraryRegistry.create_node(
+            node_type="ExecDepNode", name="exec_dep_node", specific_library_name="Exec Dep Worker Process"
+        )
+
+        node.process()
+
+        assert node.parameter_output_values["edit_dep_version"] == EDIT_DEP_VERSION
+        assert node.parameter_output_values["exec_dep_version"] == EXEC_DEP_VERSION
+
+
+class TestLibrariesWithoutExecutionDependencies:
+    def test_no_execution_environment_is_created(self, tmp_path: Path) -> None:
+        """A library that declares no execution dependencies gets exactly today's layout.
+
+        Backward compatibility is the point: the split is opt-in, and opting out leaves no new
+        artifacts on disk.
+        """
+        wheel_dir = tmp_path / "wheels"
+        _build_both_wheels(wheel_dir)
+        library_dir = tmp_path / "library"
+        library_json = _materialize_library(
+            library_dir, wheel_dir=wheel_dir, name="Exec Dep None Declared", exec_dependencies=[]
+        )
+
+        _register(library_json)
+
+        info = _library_info(library_json)
+        assert info.lifecycle_state is LibraryManager.LibraryLifecycleState.LOADED
+        assert (library_dir / ".venv").exists()
+        assert not (library_dir / ".venv-exec").exists()
+        assert _import_fresh(EDIT_DEP).__version__ == EDIT_DEP_VERSION  # type: ignore[attr-defined]
+
+    def test_manifest_without_the_field_still_validates(self) -> None:
+        """An older manifest that never heard of execution dependencies loads unchanged."""
+        schema = json.loads((FIXTURE_DIR / "griptape_nodes_library.json").read_text())
+        schema["library_schema_version"] = "0.11.0"
+        schema["metadata"]["dependencies"] = {"pip_dependencies": ["something"]}
+
+        parsed = LibrarySchema.model_validate(schema)
+
+        assert parsed.metadata.dependencies is not None
+        assert parsed.metadata.dependencies.pip_dependencies == ["something"]
+        assert parsed.metadata.dependencies.pip_dependencies_exec is None

--- a/tests/e2e/test_worker_behavior_suite.py
+++ b/tests/e2e/test_worker_behavior_suite.py
@@ -1,0 +1,249 @@
+"""End-to-end tests for the behaviors a heavy library needs when it executes in a worker.
+
+The minimal fixtures proved routing and isolation. These prove the things a real library
+(diffusers, advanced media) actually does all day, each of which has its own way of breaking
+across a process boundary:
+
+- saving media and handing back a URL that outlives the worker that wrote it
+- reading engine state through requests rather than local managers
+- streaming progress and using the yield-a-callable pattern
+- chaining serializable values across several nodes, each hop crossing the boundary
+- converters, validators, and dynamic parameters, which run on the orchestrator's real class
+
+Run against the ``worker_behavior_library`` fixture, in both roles: the orchestrator (where
+nodes are instantiated and edited) and a worker (where ``process`` runs).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.node_library.library_registry import LibraryRegistry, LibrarySchema
+from griptape_nodes.retained_mode.engine import current_engine
+from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
+from griptape_nodes.retained_mode.events.execution_events import (
+    ExecuteNodeRequest,
+    ExecuteNodeResultSuccess,
+)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
+from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
+from griptape_nodes.servers.static import ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV
+from griptape_nodes.utils.version_utils import engine_version
+
+if TYPE_CHECKING:
+    from griptape_nodes.exe_types.node_types import BaseNode
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "worker_behavior_library"
+LIBRARY = "Worker Behavior Library"
+
+
+@pytest.fixture(autouse=True)
+def _register_library(tmp_path: Path) -> None:
+    library_dir = tmp_path / "worker_behavior_library"
+    library_dir.mkdir()
+    schema = json.loads((FIXTURE_DIR / "griptape_nodes_library.json").read_text())
+    schema["library_schema_version"] = LibrarySchema.LATEST_SCHEMA_VERSION
+    schema["metadata"]["engine_version"] = engine_version
+    (library_dir / "griptape_nodes_library.json").write_text(json.dumps(schema, indent=2))
+    shutil.copy(FIXTURE_DIR / "worker_behavior_nodes.py", library_dir / "worker_behavior_nodes.py")
+    result = current_engine().handle_request(
+        RegisterLibraryFromFileRequest(file_path=str(library_dir / "griptape_nodes_library.json"))
+    )
+    assert isinstance(result, RegisterLibraryFromFileResultSuccess), getattr(result, "result_details", result)
+
+
+def _make(node_type: str, name: str) -> BaseNode:
+    """Create a node directly, for tests that only execute it."""
+    node = LibraryRegistry.create_node(node_type=node_type, name=name, specific_library_name=LIBRARY)
+    current_engine().object_manager.add_object_by_name(name, node)
+    return node
+
+
+def _make_in_flow(node_type: str, name: str) -> BaseNode:
+    """Create a node inside a real flow.
+
+    Editing a parameter unresolves downstream nodes, which needs a parent flow, so anything
+    exercising value hooks has to go through the normal creation path.
+    """
+    current_engine().context_manager.push_workflow(workflow_name=f"wf_{name}")
+    flow_result = current_engine().handle_request(
+        CreateFlowRequest(parent_flow_name=None, flow_name=f"flow_{name}", set_as_new_context=False)
+    )
+    assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
+    create_result = current_engine().handle_request(
+        CreateNodeRequest(
+            node_type=node_type,
+            specific_library_name=LIBRARY,
+            node_name=name,
+            override_parent_flow_name=flow_result.flow_name,
+        )
+    )
+    assert isinstance(create_result, CreateNodeResultSuccess), getattr(create_result, "result_details", create_result)
+    return current_engine().node_manager.get_node_by_name(create_result.node_name)
+
+
+async def _execute(node_type: str, name: str, **parameter_values: object) -> ExecuteNodeResultSuccess:
+    result = await current_engine().ahandle_request(
+        ExecuteNodeRequest(
+            node_name=name,
+            parameter_values=dict(parameter_values),
+            node_metadata={"node_type": node_type, "library": LIBRARY},
+        )
+    )
+    assert isinstance(result, ExecuteNodeResultSuccess), getattr(result, "result_details", result)
+    return result
+
+
+class TestMediaFromAWorker:
+    @pytest.mark.asyncio
+    async def test_worker_asset_url_uses_the_orchestrators_server(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A URL a worker produces must be served by something that outlives the worker.
+
+        Without this the worker advertises its own OS-assigned port, so the URL dies with the
+        worker and a saved workflow reopens with a dead link.
+        """
+        orchestrator_url = "http://localhost:8124"
+        monkeypatch.setenv(ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV, orchestrator_url)
+        # Re-resolve the static server with the worker's environment in place. The payload
+        # carries no host URL, which is exactly the worker case: without the env var this
+        # would start a server here and advertise its own ephemeral port.
+        static_files_manager = current_engine().static_files_manager
+        static_files_manager._static_server_base_url = None
+        static_files_manager.on_app_initialization_complete(AppInitializationComplete(is_worker=True))
+
+        assert static_files_manager.static_server_base_url == orchestrator_url
+
+    def test_without_the_env_var_a_process_serves_the_workspace_itself(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The orchestrator's own path is unchanged: no env var, so it serves and advertises."""
+        monkeypatch.delenv(ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV, raising=False)
+        static_files_manager = current_engine().static_files_manager
+        static_files_manager._static_server_base_url = None
+        static_files_manager.on_app_initialization_complete(AppInitializationComplete())
+
+        assert static_files_manager.static_server_base_url.startswith("http://")
+
+    @pytest.mark.asyncio
+    async def test_media_bytes_are_written_and_a_url_returned(self) -> None:
+        """Bytes stay local (they cannot cross the boundary); the URL is what travels."""
+        _make("SaveMediaNode", "Media")
+
+        result = await _execute("SaveMediaNode", "Media")
+
+        url = result.parameter_output_values["url"]
+        assert isinstance(url, str)
+        assert url  # a real URL, not an empty default
+        assert "Media.png" in url
+
+
+class TestStateAccessFromAWorker:
+    @pytest.mark.asyncio
+    async def test_config_read_through_a_request_succeeds_in_a_worker(self) -> None:
+        """The sanctioned path works from inside a worker, where the manager path is refused."""
+        current_engine().library_manager._is_worker = True
+        _make("ReadConfigNode", "Reader")
+
+        result = await _execute("ReadConfigNode", "Reader", config_key="workspace_directory")
+
+        # A real value came back, which means the request resolved rather than being blocked.
+        assert result.parameter_output_values["config_value"]
+
+    def test_config_getter_forwards_from_a_worker(self) -> None:
+        """The getter must be in the forwarded set, or a worker reads its own stale copy.
+
+        The guardrail tells authors to use this request instead of the manager; that advice is
+        only true if the request actually reaches the orchestrator.
+        """
+        from griptape_nodes.app.worker_routing import FORWARDED_REQUEST_TYPES
+        from griptape_nodes.retained_mode.events.config_events import GetConfigValueRequest
+        from griptape_nodes.retained_mode.events.secrets_events import GetSecretValueRequest
+
+        assert GetConfigValueRequest in FORWARDED_REQUEST_TYPES
+        assert GetSecretValueRequest in FORWARDED_REQUEST_TYPES
+
+
+class TestStreamingAndAsyncResult:
+    @pytest.mark.asyncio
+    async def test_streaming_node_yields_work_and_accumulates_output(self) -> None:
+        """The AsyncResult yield pattern (24 standard-library files use it) works here."""
+        _make("StreamingNode", "Streamer")
+
+        result = await _execute("StreamingNode", "Streamer")
+
+        assert result.parameter_output_values["stream"] == "alphabetagamma"
+
+    @pytest.mark.asyncio
+    async def test_streaming_works_in_a_worker_too(self) -> None:
+        current_engine().library_manager._is_worker = True
+        _make("StreamingNode", "WorkerStreamer")
+
+        result = await _execute("StreamingNode", "WorkerStreamer")
+
+        assert result.parameter_output_values["stream"] == "alphabetagamma"
+
+
+class TestMultiHopChain:
+    @pytest.mark.asyncio
+    async def test_three_hops_of_serializable_values(self) -> None:
+        """Each hop's value round-trips through the orchestrator, as per-node dispatch requires."""
+        current_engine().library_manager._is_worker = True
+        for node_type, name in (
+            ("ChainStartNode", "Start"),
+            ("ChainMiddleNode", "Middle"),
+            ("ChainEndNode", "End"),
+        ):
+            _make(node_type, name)
+
+        start = await _execute("ChainStartNode", "Start")
+        middle = await _execute("ChainMiddleNode", "Middle", in_value=start.parameter_output_values["out"])
+        end = await _execute("ChainEndNode", "End", in_value=middle.parameter_output_values["out"])
+
+        assert end.parameter_output_values["final"] == "start->middle->end"
+
+
+class TestEditorTimeBehaviorOnRealNodes:
+    """These are exactly what a schema stub would have dropped."""
+
+    def test_converter_runs_on_the_orchestrator(self) -> None:
+        node = _make_in_flow("EditorBehaviorNode", "Editor")
+
+        current_engine().handle_request(
+            SetParameterValueRequest(node_name="Editor", parameter_name="mode", value="expand")
+        )
+
+        # The converter uppercased the value; a stub would have stored it verbatim.
+        assert node.get_parameter_value("mode") == "EXPAND"
+
+    def test_validator_runs_on_the_orchestrator(self) -> None:
+        _make_in_flow("EditorBehaviorNode", "Validated")
+
+        result = current_engine().handle_request(
+            SetParameterValueRequest(node_name="Validated", parameter_name="mode", value="forbidden")
+        )
+
+        # The validator rejected it; a stub carries no validators at all.
+        assert result.failed()
+
+    def test_dynamic_parameter_grows_and_shrinks_from_a_value_hook(self) -> None:
+        """after_value_set mutating the parameter set, which diffusers relies on heavily."""
+        node = _make_in_flow("EditorBehaviorNode", "Dynamic")
+        assert node.get_parameter_by_name("dynamic_extra") is None
+
+        current_engine().handle_request(
+            SetParameterValueRequest(node_name="Dynamic", parameter_name="mode", value="expand")
+        )
+        assert node.get_parameter_by_name("dynamic_extra") is not None
+
+        current_engine().handle_request(
+            SetParameterValueRequest(node_name="Dynamic", parameter_name="mode", value="plain")
+        )
+        assert node.get_parameter_by_name("dynamic_extra") is None

--- a/tests/e2e/test_worker_behavior_suite.py
+++ b/tests/e2e/test_worker_behavior_suite.py
@@ -163,12 +163,16 @@ class TestStateAccessFromAWorker:
         The guardrail tells authors to use this request instead of the manager; that advice is
         only true if the request actually reaches the orchestrator.
         """
-        from griptape_nodes.app.worker_routing import FORWARDED_REQUEST_TYPES
+        from griptape_nodes.app.worker_routing import LOCAL_ONLY_REQUEST_TYPES
         from griptape_nodes.retained_mode.events.config_events import GetConfigValueRequest
+        from griptape_nodes.retained_mode.events.os_events import ReadFileRequest, WriteFileRequest
         from griptape_nodes.retained_mode.events.secrets_events import GetSecretValueRequest
 
-        assert GetConfigValueRequest in FORWARDED_REQUEST_TYPES
-        assert GetSecretValueRequest in FORWARDED_REQUEST_TYPES
+        # Forwarding is the default now, so the assertion is that these are NOT excluded.
+        # Every request the guardrails name has to reach the orchestrator, or the advice
+        # they give authors is false.
+        for request_type in (GetConfigValueRequest, GetSecretValueRequest, ReadFileRequest, WriteFileRequest):
+            assert request_type not in LOCAL_ONLY_REQUEST_TYPES, request_type.__name__
 
 
 class TestStreamingAndAsyncResult:

--- a/tests/e2e/test_worker_forwarding_reentrancy.py
+++ b/tests/e2e/test_worker_forwarding_reentrancy.py
@@ -1,0 +1,256 @@
+"""End-to-end tests for worker->orchestrator request forwarding under reentrancy.
+
+When a node executes off the orchestrator, every request it makes mid-execution forwards to
+the orchestrator, which must service those requests while it is itself awaiting the execution
+that produced them. These tests pin that machinery -- ``EventManager.forward_to_orchestrator``,
+``RequestClient`` response matching, and the cross-loop dispatch topology -- without a real
+websocket, using a fake broker that loops forwarded requests into a real engine's dispatch.
+
+The topology reproduced here is the real one, because it is exactly the topology that has
+bitten before (see ``configure_worker_forwarding``'s docstring): the ``RequestClient`` and its
+futures live on a daemon thread's event loop, while the code that forwards runs on the main
+loop, so every forward crosses loops twice. Awaiting the client's primitives from the wrong
+loop historically stalled for seconds per request; the latency assertions here exist to fail
+if that regression returns.
+
+The contract these tests pin:
+
+- **Service while awaiting**: a forwarded request is dispatched and answered while the main
+  loop coroutine that sent it is still awaiting the reply.
+- **Contention**: many concurrent forwards, including from foreign threads (the diffusers
+  thread-pool shape), all complete, and none stalls for seconds.
+- **Bounded failure**: when the orchestrator never replies, the forward raises TimeoutError
+  within the configured bound instead of hanging.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import time
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+import pytest_asyncio
+
+from griptape_nodes.api_client.request_client import RequestClient
+from griptape_nodes.retained_mode.engine import current_engine
+from griptape_nodes.retained_mode.events.app_events import GetEngineVersionRequest
+from griptape_nodes.retained_mode.events.base_events import (
+    EventResultFailure,
+    EventResultSuccess,
+)
+from griptape_nodes.retained_mode.events.event_converter import converter
+from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
+from griptape_nodes.retained_mode.managers.event_manager import ResultContext
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Callable
+
+    from griptape_nodes.retained_mode.events.base_events import RequestPayload
+
+ORCHESTRATOR_REQUEST_TOPIC = "sessions/test/request"
+WORKER_RESPONSE_TOPIC = "engines/test-worker/response"
+
+# Generous enough for CI noise, far below the seconds-long stalls this guards against.
+SINGLE_FORWARD_BUDGET_S = 2.0
+CONTENTION_TOTAL_BUDGET_S = 10.0
+CONTENTION_COUNT = 50
+
+
+class FakeBrokerClient:
+    """Stands in for the websocket Client: loops forwarded requests into a real engine.
+
+    ``publish`` to the orchestrator request topic dispatches the deserialized request into
+    the orchestrator engine on ``orchestrator_loop`` as its own task (mirroring the app's
+    task-per-request ingress), then delivers the result back through the registered message
+    filters on the broker loop, which is where ``RequestClient._try_match`` and its futures
+    live. Set ``drop_requests`` to simulate an orchestrator that never answers.
+    """
+
+    def __init__(self, orchestrator_loop: asyncio.AbstractEventLoop) -> None:
+        self.orchestrator_loop = orchestrator_loop
+        self.drop_requests = False
+        self._filters: list[Callable[[dict[str, Any]], Any]] = []
+        self.subscribed_topics: list[str] = []
+
+    def add_message_filter(self, filter_fn: Callable[[dict[str, Any]], Any]) -> None:
+        self._filters.append(filter_fn)
+
+    def remove_message_filter(self, filter_fn: Callable[[dict[str, Any]], Any]) -> None:
+        self._filters.remove(filter_fn)
+
+    async def subscribe(self, topic: str) -> None:
+        self.subscribed_topics.append(topic)
+
+    async def publish(self, event_type: str, payload: dict[str, Any], topic: str) -> None:
+        assert event_type == "EventRequest"
+        assert topic == ORCHESTRATOR_REQUEST_TOPIC
+        if self.drop_requests:
+            return
+
+        broker_loop = asyncio.get_running_loop()
+        request_type = PayloadRegistry.get_type(payload["request_type"])
+        assert request_type is not None
+        request = cast("RequestPayload", converter.structure(payload["request"], request_type))
+        request_id = payload.get("request_id")
+
+        async def dispatch_and_reply() -> None:
+            # Task-per-request, exactly like the app's ingress: nothing serializes behind
+            # whatever the orchestrator is currently awaiting.
+            result = await current_engine().ahandle_request(request)
+            event_cls = EventResultSuccess if result.succeeded() else EventResultFailure
+            reply = event_cls(request=request, request_id=request_id, result=result)
+            reply_payload = json.loads(reply.json())
+            broker_loop.call_soon_threadsafe(
+                lambda: broker_loop.create_task(self._deliver(reply_payload)),
+            )
+
+        self.orchestrator_loop.call_soon_threadsafe(
+            lambda: self.orchestrator_loop.create_task(dispatch_and_reply()),
+        )
+
+    async def _deliver(self, payload: dict[str, Any]) -> None:
+        message = {"payload": payload}
+        for filter_fn in list(self._filters):
+            claimed = await filter_fn(message)
+            if claimed:
+                return
+
+
+class BrokerThread:
+    """A daemon thread running its own event loop, like the app's websocket thread."""
+
+    def __init__(self) -> None:
+        self.loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self.loop.run_forever, daemon=True)
+        self._thread.start()
+
+    def run(self, coro: Any) -> Any:
+        return asyncio.run_coroutine_threadsafe(coro, self.loop).result(timeout=30)
+
+    def shutdown(self) -> None:
+        self.loop.call_soon_threadsafe(self.loop.stop)
+        self._thread.join(timeout=5)
+        self.loop.close()
+
+
+@pytest_asyncio.fixture
+async def forwarding() -> AsyncIterator[FakeBrokerClient]:
+    """Configure worker-style forwarding on a real engine, against the fake broker."""
+    orchestrator_loop = asyncio.get_running_loop()
+    broker = BrokerThread()
+    fake_client = FakeBrokerClient(orchestrator_loop)
+    request_client = RequestClient(fake_client)  # type: ignore[arg-type]
+    broker.run(request_client.__aenter__())
+
+    event_manager = current_engine().event_manager
+    event_manager.configure_worker_forwarding(
+        request_client=request_client,
+        orchestrator_request_topic=ORCHESTRATOR_REQUEST_TOPIC,
+        worker_response_topic=WORKER_RESPONSE_TOPIC,
+        websocket_event_loop=broker.loop,
+        timeout_ms=1_000,
+    )
+    yield fake_client
+    broker.run(request_client.__aexit__(None, None, None))
+    broker.shutdown()
+
+
+class TestServiceWhileAwaiting:
+    @pytest.mark.asyncio
+    async def test_forward_is_serviced_while_sender_awaits(self, forwarding: FakeBrokerClient) -> None:  # noqa: ARG002 (fixture wires forwarding)
+        """The main loop services the forwarded request while the forwarding coroutine awaits it.
+
+        This is the reentrancy shape the whole design depends on: the awaiting side and the
+        servicing side share the orchestrator loop.
+        """
+        event_manager = current_engine().event_manager
+        started = time.monotonic()
+
+        result = await event_manager.forward_to_orchestrator(GetEngineVersionRequest(), ResultContext())
+
+        elapsed = time.monotonic() - started
+        assert isinstance(result, EventResultSuccess)
+        assert result.result.succeeded()
+        assert elapsed < SINGLE_FORWARD_BUDGET_S, f"single forward took {elapsed:.2f}s; cross-loop stall regression"
+
+    @pytest.mark.asyncio
+    async def test_forward_inside_node_execution_scope(self, forwarding: FakeBrokerClient) -> None:  # noqa: ARG002 (fixture wires forwarding)
+        """Forwarding works from inside the scope that marks node execution."""
+        event_manager = current_engine().event_manager
+        with event_manager.worker_node_execution_scope():
+            assert event_manager.in_node_execution()
+            result = await event_manager.forward_to_orchestrator(GetEngineVersionRequest(), ResultContext())
+        assert isinstance(result, EventResultSuccess)
+
+
+class TestContention:
+    @pytest.mark.asyncio
+    async def test_many_concurrent_forwards_from_the_main_loop(self, forwarding: FakeBrokerClient) -> None:  # noqa: ARG002 (fixture wires forwarding)
+        event_manager = current_engine().event_manager
+        started = time.monotonic()
+
+        results = await asyncio.gather(
+            *(
+                event_manager.forward_to_orchestrator(GetEngineVersionRequest(), ResultContext())
+                for _ in range(CONTENTION_COUNT)
+            )
+        )
+
+        elapsed = time.monotonic() - started
+        assert all(isinstance(r, EventResultSuccess) for r in results)
+        assert elapsed < CONTENTION_TOTAL_BUDGET_S, f"{CONTENTION_COUNT} forwards took {elapsed:.2f}s"
+
+    @pytest.mark.asyncio
+    async def test_forwards_from_foreign_threads(self, forwarding: FakeBrokerClient) -> None:  # noqa: ARG002 (fixture wires forwarding)
+        """Requests emitted from library-internal threads (the diffusers thread-pool shape).
+
+        A foreign thread cannot await on the orchestrator loop, so it does what node code
+        effectively does: schedule the coroutine onto the loop and block on the result.
+        """
+        event_manager = current_engine().event_manager
+        orchestrator_loop = asyncio.get_running_loop()
+        errors: list[BaseException] = []
+
+        def forward_from_thread() -> None:
+            future = asyncio.run_coroutine_threadsafe(
+                event_manager.forward_to_orchestrator(GetEngineVersionRequest(), ResultContext()),
+                orchestrator_loop,
+            )
+            try:
+                result = future.result(timeout=SINGLE_FORWARD_BUDGET_S * 5)
+                assert isinstance(result, EventResultSuccess)
+            except BaseException as e:
+                errors.append(e)
+
+        with event_manager.worker_node_execution_scope():
+            threads = [threading.Thread(target=forward_from_thread) for _ in range(8)]
+            for t in threads:
+                t.start()
+            # The orchestrator loop must stay free to service while threads block on replies.
+            await asyncio.sleep(0)
+            deadline = time.monotonic() + CONTENTION_TOTAL_BUDGET_S
+            while any(t.is_alive() for t in threads):
+                if time.monotonic() > deadline:
+                    pytest.fail("foreign-thread forwards did not complete within budget")
+                await asyncio.sleep(0.05)
+
+        assert not errors, f"foreign-thread forwards failed: {errors!r}"
+
+
+class TestBoundedFailure:
+    @pytest.mark.asyncio
+    async def test_unanswered_forward_times_out_instead_of_hanging(self, forwarding: FakeBrokerClient) -> None:
+        """An orchestrator that never replies produces a TimeoutError within the bound."""
+        forwarding.drop_requests = True
+        event_manager = current_engine().event_manager
+        started = time.monotonic()
+
+        with pytest.raises(TimeoutError):
+            await event_manager.forward_to_orchestrator(GetEngineVersionRequest(), ResultContext())
+
+        elapsed = time.monotonic() - started
+        # Configured timeout is 1s; anything wildly past it means the bound is not real.
+        assert elapsed < SINGLE_FORWARD_BUDGET_S * 2, f"timeout took {elapsed:.2f}s to fire"

--- a/tests/unit/app/test_worker_routing.py
+++ b/tests/unit/app/test_worker_routing.py
@@ -23,6 +23,8 @@ import pytest
 
 from griptape_nodes.app.worker_routing import (
     LOCAL_ONLY_REQUEST_TYPES,
+    ActivateProjectRequest,
+    ReloadAllLibrariesRequest,
     RemoteHandler,
     register_remote_handlers,
 )
@@ -178,6 +180,17 @@ class TestInstallRemoteHandlersSwap:
             assert event_manager.get_manager_for_request_type(request_type) is original, (
                 f"{request_type.__name__} must not be forwarded"
             )
+
+    def test_a_project_activation_and_the_reload_it_causes_are_both_local(self) -> None:
+        """The orchestrator decides when libraries reload; a worker must not ask it to.
+
+        Adopting a project reloads the worker's libraries, and that dispatch goes through the bus.
+        Forwarded, it reaches the orchestrator's pre-reload callback -- reset_workers -- which
+        terminates the worker that asked, mid-node. The pair has to stay local together: making the
+        activation local while its consequence forwards is the same defect with an extra hop.
+        """
+        assert ActivateProjectRequest in LOCAL_ONLY_REQUEST_TYPES
+        assert ReloadAllLibrariesRequest in LOCAL_ONLY_REQUEST_TYPES
 
     def test_unregistered_types_are_skipped_without_error(self) -> None:
         """Nothing to swap is not a bootstrap failure: only registered types are touched.

--- a/tests/unit/app/test_worker_routing.py
+++ b/tests/unit/app/test_worker_routing.py
@@ -9,7 +9,7 @@ These tests pin down the two invariants that replaced the old
    library-load behaviour (e.g. nodes calling ``self.add_parameter(...)``
    during LOAD_PROBE).
 2. ``register_remote_handlers`` swaps the dispatch table entry for every
-   entry in ``FORWARDED_REQUEST_TYPES``, preserving the "one handler per
+   registered type outside ``LOCAL_ONLY_REQUEST_TYPES``, preserving the "one handler per
    request type" invariant enforced by ``assign_manager_to_request_type``.
    Missing an original handler raises with a bootstrap-order diagnostic.
 """
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 from griptape_nodes.app.worker_routing import (
-    FORWARDED_REQUEST_TYPES,
+    LOCAL_ONLY_REQUEST_TYPES,
     RemoteHandler,
     register_remote_handlers,
 )
@@ -32,7 +32,10 @@ from griptape_nodes.retained_mode.events.base_events import (
     ResultPayloadSuccess,
 )
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import (
+    AddParameterToNodeRequest,
+    SetParameterValueRequest,
+)
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 
 if TYPE_CHECKING:
@@ -129,14 +132,13 @@ class _StubResult(ResultPayloadSuccess):
 
 
 class TestInstallRemoteHandlersSwap:
-    """register_remote_handlers must displace each FORWARDED type's handler."""
+    """register_remote_handlers forwards everything except the local-only exclusions."""
 
-    def test_swap_replaces_each_forwarded_handler(self) -> None:
+    def test_swap_replaces_every_registered_handler(self) -> None:
         event_manager = EventManager()
 
-        # Give every forwarded type a uniquely-identifiable async original.
         originals: dict[type[RequestPayload], Any] = {}
-        for request_type in FORWARDED_REQUEST_TYPES:
+        for request_type in (CreateNodeRequest, AddParameterToNodeRequest, SetParameterValueRequest):
 
             async def original(_request: RequestPayload) -> _StubResult:
                 return _StubResult(result_details="ok")
@@ -154,22 +156,46 @@ class TestInstallRemoteHandlersSwap:
             assert swapped.original is original
             assert swapped.event_manager is event_manager
 
-    def test_missing_original_raises_bootstrap_error(self) -> None:
-        event_manager = EventManager()
+    def test_local_only_types_are_left_alone(self) -> None:
+        """Excluded types must keep their own handler.
 
-        # Register everything except CreateNodeRequest so register_remote_handlers
-        # trips on the first missing original it encounters.
-        for request_type in FORWARDED_REQUEST_TYPES:
-            if request_type is CreateNodeRequest:
-                continue
+        ExecuteNodeRequest is the sharpest case: forwarding a worker's own execution request
+        would send it back to the orchestrator, which would route it straight here again.
+        """
+        event_manager = EventManager()
+        locals_registered: dict[type[RequestPayload], Any] = {}
+        for request_type in LOCAL_ONLY_REQUEST_TYPES:
 
             async def original(_request: RequestPayload) -> _StubResult:
-                return _StubResult(result_details="ok")
+                return _StubResult(result_details="local")
 
+            locals_registered[request_type] = original
             event_manager.assign_manager_to_request_type(request_type, original)
 
-        with pytest.raises(RuntimeError, match="CreateNodeRequest"):
-            register_remote_handlers(event_manager)
+        register_remote_handlers(event_manager)
+
+        for request_type, original in locals_registered.items():
+            assert event_manager.get_manager_for_request_type(request_type) is original, (
+                f"{request_type.__name__} must not be forwarded"
+            )
+
+    def test_unregistered_types_are_skipped_without_error(self) -> None:
+        """Nothing to swap is not a bootstrap failure: only registered types are touched.
+
+        The allowlist version raised when a listed type had no owner, because the list could
+        name types nobody had registered. Iterating what IS registered removes that failure
+        mode entirely.
+        """
+        event_manager = EventManager()
+
+        async def original(_request: RequestPayload) -> _StubResult:
+            return _StubResult(result_details="ok")
+
+        event_manager.assign_manager_to_request_type(CreateNodeRequest, original)
+
+        register_remote_handlers(event_manager)
+
+        assert isinstance(event_manager.get_manager_for_request_type(CreateNodeRequest), RemoteHandler)
 
     def test_post_install_out_of_scope_still_runs_original(self) -> None:
         """Bootstrap-path regression guard: LOAD_PROBE-style calls must stay local.
@@ -187,17 +213,7 @@ class TestInstallRemoteHandlersSwap:
             local_calls.append(request)
             return _StubResult(result_details="local")
 
-        # Register the single type we assert on; register_remote_handlers needs
-        # every forwarded type registered, so fill in trivial stubs for the rest.
         event_manager.assign_manager_to_request_type(AddParameterToNodeRequest, local_add_parameter)
-        for request_type in FORWARDED_REQUEST_TYPES:
-            if request_type is AddParameterToNodeRequest:
-                continue
-
-            async def stub(_request: RequestPayload) -> _StubResult:
-                return _StubResult(result_details="ok")
-
-            event_manager.assign_manager_to_request_type(request_type, stub)
 
         register_remote_handlers(event_manager)
 

--- a/tests/unit/app/test_worker_routing_strict_mode.py
+++ b/tests/unit/app/test_worker_routing_strict_mode.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from griptape_nodes.app.worker_routing import (
-    FORWARDED_REQUEST_TYPES,
+    LOCAL_ONLY_REQUEST_TYPES,
     RemoteHandler,
     register_remote_handlers,
 )
@@ -40,6 +40,16 @@ from griptape_nodes.retained_mode.managers.event_manager import EventManager
 
 if TYPE_CHECKING:
     from griptape_nodes.retained_mode.managers.event_manager import ResultContext
+
+
+def _forwarded_sample() -> tuple[type, ...]:
+    """A few representative types that forward (i.e. are not local-only)."""
+    from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
+    from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+
+    sample = (CreateNodeRequest, AddParameterToNodeRequest)
+    assert not set(sample) & LOCAL_ONLY_REQUEST_TYPES
+    return sample
 
 
 @dataclass(kw_only=True)
@@ -224,8 +234,8 @@ class TestWorkerReachIntoOrchestrator:
         ``register_remote_handlers`` swaps a real FORWARDED type's handler
         for a ``RemoteHandler`` shim, and dispatching that real type
         directly through the shim records the violation. Locks in the
-        ``FORWARDED_REQUEST_TYPES`` <-> ``RemoteHandler`` integration: if
-        a future change drops a type from ``FORWARDED_REQUEST_TYPES``,
+        ``LOCAL_ONLY_REQUEST_TYPES`` <-> ``RemoteHandler`` integration: if
+        a future change adds a type to ``LOCAL_ONLY_REQUEST_TYPES``,
         this test stays green only because
         ``ListConnectionsForNodeRequest`` is still a member.
         """
@@ -253,10 +263,9 @@ class TestWorkerReachIntoOrchestrator:
 
         event_manager.forward_to_orchestrator = fake_forward  # type: ignore[method-assign]
 
-        # register_remote_handlers requires every FORWARDED type to have an
-        # original handler registered first. Stub them all with a trivial
-        # local handler; the swap installs RemoteHandler in their place.
-        for request_type in FORWARDED_REQUEST_TYPES:
+        # register_remote_handlers swaps whatever is registered, so the type this test
+        # asserts on has to be registered first. Stub it plus a couple of representatives.
+        for request_type in (ListConnectionsForNodeRequest, *_forwarded_sample()):
 
             async def stub(_request: RequestPayload) -> ResultPayloadSuccess:
                 return ListConnectionsForNodeResultSuccess(

--- a/tests/unit/common/test_node_executor_propagation.py
+++ b/tests/unit/common/test_node_executor_propagation.py
@@ -18,6 +18,10 @@ import pytest
 from griptape_nodes.common.node_executor import NodeExecutor
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import TrackedParameterOutputValues
+from griptape_nodes.retained_mode.events.connection_events import (
+    ListConnectionsForNodeRequest,
+    ListConnectionsForNodeResultSuccess,
+)
 from griptape_nodes.retained_mode.events.execution_events import ExecuteNodeResultSuccess
 from griptape_nodes.retained_mode.events.flow_events import (
     OriginalNodeParameter,
@@ -30,9 +34,9 @@ from tests.unit.exe_types.mocks import MockNode
 
 _EXPECTED_FRESH_OUTPUT_EMITS = 2
 
-# GriptapeNodes is lazy-imported inside the event emitters; patch it at the
-# source module so those imports pick up the mock at call time.
-_GN_PATCH = "griptape_nodes.retained_mode.griptape_nodes.GriptapeNodes"
+# A node built without an engine resolves the ambient one; patch that resolution at the
+# source module so the property picks up the stand-in at call time.
+_CURRENT_ENGINE_PATCH = "griptape_nodes.retained_mode.engine.current_engine"
 
 
 def _make_executor() -> NodeExecutor:
@@ -158,7 +162,7 @@ def _make_end_mapping(
 
 
 def _gn_mock_with_variable(name: str = "SHOT") -> Any:
-    """A GN patch where `name` is a real, defined flow variable.
+    """A stand-in engine where `name` is a real, defined flow variable.
 
     `should_preserve_stored_template` confirms substitution would actually rewrite
     the stored text before declining a write, so these tests have to define a
@@ -167,20 +171,22 @@ def _gn_mock_with_variable(name: str = "SHOT") -> Any:
     return a non-ListVariablesResultSuccess and fall back to trusting the regex
     heuristic -- but then they would no longer be testing the intended path.
     """
-    mock_gn = MagicMock()
-    mock_gn.WorkflowManager.return_value.is_variable_substitution_enabled.return_value = True
-    mock_gn.NodeManager.return_value.get_node_parent_flow_by_name.return_value = "test_flow"
-    mock_gn.FlowManager.return_value.get_connections.return_value = MagicMock(incoming_index={})
-    mock_gn.handle_request.side_effect = lambda req: (
+    engine = MagicMock()
+    engine.workflow_manager.is_variable_substitution_enabled.return_value = True
+    engine.node_manager.get_node_parent_flow_by_name.return_value = "test_flow"
+    engine.handle_request.side_effect = lambda req: (
         ListVariablesResultSuccess(
             variables=[FlowVariable(name=name, owning_flow_name="test_flow", type="str", value="hyperreal")],
             layers=[VariableLayerKind.FLOW],
             result_details="ok",
         )
         if isinstance(req, ListVariablesRequest)
+        else ListConnectionsForNodeResultSuccess(incoming_connections=[], outgoing_connections=[], result_details="ok")
+        if isinstance(req, ListConnectionsForNodeRequest)
         else MagicMock()
     )
-    return patch(_GN_PATCH, mock_gn)
+    # The nodes under test are built without an engine, so they resolve the ambient one.
+    return patch(_CURRENT_ENGINE_PATCH, return_value=engine)
 
 
 class TestGroupCopyBackPreservesTemplate:

--- a/tests/unit/exe_types/param_components/artifact_url/test_public_artifact_url_parameter.py
+++ b/tests/unit/exe_types/param_components/artifact_url/test_public_artifact_url_parameter.py
@@ -9,7 +9,7 @@ paths. See griptape-ai/griptape-nodes-engine#4688.
 import re
 from pathlib import Path
 from typing import Any, NamedTuple
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 from griptape.artifacts import ErrorArtifact
@@ -159,7 +159,7 @@ class TestGetBucketId:
     def test_valid_bucket_id_passes_through(self, mocker: Any) -> None:
         exists_mock, default_mock = self._patch(mocker, bucket_id_value="bucket-123", bucket_exists=True)
 
-        assert PublicArtifactUrlParameter._get_bucket_id("https://base", "key") == "bucket-123"
+        assert PublicArtifactUrlParameter._get_bucket_id(MagicMock(), "https://base", "key") == "bucket-123"
         # A configured ID is validated directly; the org default is never consulted.
         exists_mock.assert_called_once()
         default_mock.assert_not_called()
@@ -169,23 +169,23 @@ class TestGetBucketId:
         # `bucket_exists` (a direct GET) must be the source of truth, not the list.
         self._patch(mocker, bucket_id_value="page-2-bucket", bucket_exists=True)
 
-        assert PublicArtifactUrlParameter._get_bucket_id("https://base", "key") == "page-2-bucket"
+        assert PublicArtifactUrlParameter._get_bucket_id(MagicMock(), "https://base", "key") == "page-2-bucket"
 
     def test_unset_secret_falls_back_to_org_default_bucket(self, mocker: Any) -> None:
         self._patch(mocker, bucket_id_value=None, default_bucket_id="org-default")
 
-        assert PublicArtifactUrlParameter._get_bucket_id("https://base", "key") == "org-default"
+        assert PublicArtifactUrlParameter._get_bucket_id(MagicMock(), "https://base", "key") == "org-default"
 
     def test_blank_secret_falls_back_to_org_default_bucket(self, mocker: Any) -> None:
         self._patch(mocker, bucket_id_value="   ", default_bucket_id="org-default")
 
-        assert PublicArtifactUrlParameter._get_bucket_id("https://base", "key") == "org-default"
+        assert PublicArtifactUrlParameter._get_bucket_id(MagicMock(), "https://base", "key") == "org-default"
 
     def test_invalid_bucket_id_raises_clear_error(self, mocker: Any) -> None:
         self._patch(mocker, bucket_id_value="does-not-exist", bucket_exists=False)
 
         with pytest.raises(RuntimeError, match="invalid bucket ID") as excinfo:
-            PublicArtifactUrlParameter._get_bucket_id("https://base", "key")
+            PublicArtifactUrlParameter._get_bucket_id(MagicMock(), "https://base", "key")
 
         message = str(excinfo.value)
         assert PublicArtifactUrlParameter.BUCKET_ID_NAME in message
@@ -195,13 +195,13 @@ class TestGetBucketId:
         self._patch(mocker, bucket_id_value="", default_bucket_id=None)
 
         with pytest.raises(RuntimeError, match=PublicArtifactUrlParameter.BUCKET_ID_NAME):
-            PublicArtifactUrlParameter._get_bucket_id("https://base", "key")
+            PublicArtifactUrlParameter._get_bucket_id(MagicMock(), "https://base", "key")
 
     def test_unset_secret_with_no_default_bucket_raises_original_message(self, mocker: Any) -> None:
         self._patch(mocker, bucket_id_value=None, default_bucket_id=None)
 
         with pytest.raises(RuntimeError, match="No Griptape Cloud storage buckets found"):
-            PublicArtifactUrlParameter._get_bucket_id("https://base", "key")
+            PublicArtifactUrlParameter._get_bucket_id(MagicMock(), "https://base", "key")
 
 
 class TestUploadPathLifecycle:

--- a/tests/unit/exe_types/param_components/huggingface/test_huggingface_gating_against_real_catalog.py
+++ b/tests/unit/exe_types/param_components/huggingface/test_huggingface_gating_against_real_catalog.py
@@ -42,6 +42,8 @@ from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from griptape_nodes.retained_mode.engine import Engine
+
 _LIBRARY_NAME = "hf-gating-real-catalog-test-library"
 _MODULE = "griptape_nodes.exe_types.param_components.huggingface"
 
@@ -193,7 +195,7 @@ def _deny_denied_provider(checkpoint: AuthorizationCheckpoint) -> CheckpointDeni
 
 
 @pytest.fixture
-def denying_policy(engine) -> Iterator[None]:  # noqa: ANN001
+def denying_policy(engine: Engine) -> Iterator[None]:
     """Install the real deny hook for the duration of a test."""
     engine.event_manager.add_authorization_hook(_deny_denied_provider)
     try:

--- a/tests/unit/exe_types/param_components/huggingface/test_huggingface_repo_parameter_gating.py
+++ b/tests/unit/exe_types/param_components/huggingface/test_huggingface_repo_parameter_gating.py
@@ -65,7 +65,7 @@ def _stub_engine() -> Iterator[None]:
     with (
         patch(f"{module}.huggingface_repo_parameter.list_repo_revisions_in_cache", return_value=[]),
         patch(f"{module}.huggingface_repo_parameter.list_all_repo_revisions_in_cache", return_value=[]),
-        patch(f"{module}.huggingface_model_parameter.GriptapeNodes.handle_request", side_effect=handle_request),
+        patch("griptape_nodes.retained_mode.engine.Engine.handle_request", side_effect=handle_request),
     ):
         yield
 
@@ -124,9 +124,8 @@ class TestFailClosed:
 
     def test_policy_resolution_failure_denies_everything(self) -> None:
         """A library that cannot be resolved must not silently open the gate."""
-        module = "griptape_nodes.exe_types.param_components.huggingface"
         with patch(
-            f"{module}.huggingface_model_parameter.GriptapeNodes.handle_request",
+            "griptape_nodes.retained_mode.engine.Engine.handle_request",
             return_value=QueryModelAccessForNodeResultFailure(result_details="node type not found"),
         ):
             param = _param(gated=True)
@@ -152,9 +151,8 @@ class TestTheEmptyCachePlaceholderIsNotBadgedAsUnlicensed:
     """
 
     def _unresolvable_param(self, *, add_parameters: bool = False) -> HuggingFaceRepoParameter:
-        module = "griptape_nodes.exe_types.param_components.huggingface"
         with patch(
-            f"{module}.huggingface_model_parameter.GriptapeNodes.handle_request",
+            "griptape_nodes.retained_mode.engine.Engine.handle_request",
             return_value=QueryModelAccessForNodeResultFailure(result_details="node type not found"),
         ):
             # `repo_ids=[]` + `list_all_models=True` is the "offer whatever is cached" config, and
@@ -195,8 +193,7 @@ class TestUngatedIsUnchanged:
         assert param.query_for_denial(UNDECLARED_REPO) is None
 
     def test_ungated_does_not_query_policy(self) -> None:
-        module = "griptape_nodes.exe_types.param_components.huggingface"
-        with patch(f"{module}.huggingface_model_parameter.GriptapeNodes.handle_request") as handle:
+        with patch("griptape_nodes.retained_mode.engine.Engine.handle_request") as handle:
             _param(gated=False)
         access_calls = [
             call for call in handle.call_args_list if isinstance(call.args[0], QueryModelAccessForNodeRequest)
@@ -235,9 +232,8 @@ class TestAutoDetect:
 
     def test_stays_ungated_when_the_node_declares_nothing(self) -> None:
         """An empty verdict list means no catalog to gate against, so offer everything."""
-        module = "griptape_nodes.exe_types.param_components.huggingface"
         with patch(
-            f"{module}.huggingface_model_parameter.GriptapeNodes.handle_request",
+            "griptape_nodes.retained_mode.engine.Engine.handle_request",
             return_value=QueryModelAccessForNodeResultSuccess(verdicts=[], result_details="ok"),
         ):
             param = _param(gated=None)
@@ -252,9 +248,8 @@ class TestAutoDetect:
         not be resolved at all (unregistered, ambiguous across two libraries, or mid-reload), and
         treating that as "allow everything" let an admin's deny be bypassed by a lookup error.
         """
-        module = "griptape_nodes.exe_types.param_components.huggingface"
         with patch(
-            f"{module}.huggingface_model_parameter.GriptapeNodes.handle_request",
+            "griptape_nodes.retained_mode.engine.Engine.handle_request",
             return_value=QueryModelAccessForNodeResultFailure(result_details="node type not found"),
         ):
             param = _param(gated=None)
@@ -263,9 +258,8 @@ class TestAutoDetect:
 
     def test_stays_ungated_for_a_library_that_declares_nothing(self) -> None:
         """The real pre-adoption path: a Success carrying no verdicts leaves gating off."""
-        module = "griptape_nodes.exe_types.param_components.huggingface"
         with patch(
-            f"{module}.huggingface_model_parameter.GriptapeNodes.handle_request",
+            "griptape_nodes.retained_mode.engine.Engine.handle_request",
             return_value=QueryModelAccessForNodeResultSuccess(verdicts=[], result_details="ok"),
         ):
             param = _param(gated=None)
@@ -274,9 +268,8 @@ class TestAutoDetect:
 
     def test_explicit_true_still_fails_closed_on_resolution_failure(self) -> None:
         """Opting in explicitly keeps the loud behavior auto-detect deliberately softens."""
-        module = "griptape_nodes.exe_types.param_components.huggingface"
         with patch(
-            f"{module}.huggingface_model_parameter.GriptapeNodes.handle_request",
+            "griptape_nodes.retained_mode.engine.Engine.handle_request",
             return_value=QueryModelAccessForNodeResultFailure(result_details="node type not found"),
         ):
             param = _param(gated=True)
@@ -328,8 +321,7 @@ class TestConstructionDefersBusRequests:
         return param
 
     def test_construction_issues_no_bus_requests(self) -> None:
-        module = "griptape_nodes.exe_types.param_components.huggingface"
-        with patch(f"{module}.huggingface_model_parameter.GriptapeNodes.handle_request") as handle:
+        with patch("griptape_nodes.retained_mode.engine.Engine.handle_request") as handle:
             self._construct_deferred(gated=True)
         handle.assert_not_called()
 
@@ -412,7 +404,6 @@ class TestConstructionWithoutAScopeStillQueries:
                 return QueryModelAccessForNodeResultSuccess(verdicts=_verdicts(), result_details="ok")
             return object()  # not a ResultSuccess -> "nothing downloading", as in _stub_engine
 
-        module = "griptape_nodes.exe_types.param_components.huggingface"
-        with patch(f"{module}.huggingface_model_parameter.GriptapeNodes.handle_request", side_effect=handle_request):
+        with patch("griptape_nodes.retained_mode.engine.Engine.handle_request", side_effect=handle_request):
             self._construct_in_init()
         assert ListModelDownloadsRequest in seen

--- a/tests/unit/exe_types/param_components/huggingface/test_huggingface_subclass_gating.py
+++ b/tests/unit/exe_types/param_components/huggingface/test_huggingface_subclass_gating.py
@@ -57,7 +57,7 @@ def _stub(verdicts: list[ModelAccessVerdict]):  # noqa: ANN202
         msg = f"unexpected request: {type(request).__name__}"
         raise AssertionError(msg)
 
-    return patch(f"{_MODULE}.huggingface_model_parameter.GriptapeNodes.handle_request", side_effect=handle_request)
+    return patch("griptape_nodes.retained_mode.engine.Engine.handle_request", side_effect=handle_request)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/exe_types/param_components/test_model_access_component.py
+++ b/tests/unit/exe_types/param_components/test_model_access_component.py
@@ -21,6 +21,7 @@ Focused on:
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
@@ -28,6 +29,10 @@ import pytest
 from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.exe_types.param_components.model_access_component import ModelAccessComponent
+from griptape_nodes.retained_mode.engine import current_engine
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
 from griptape_nodes.retained_mode.events.access_events import QueryModelAccessForNodeResultFailure
 from griptape_nodes.traits.button import Button
 from griptape_nodes.traits.options import Options
@@ -185,7 +190,7 @@ class TestPickPermittedDefault:
         )
         assert helper.pick_permitted_default() == "alpha"
 
-    def test_falls_back_to_first_allowed_when_default_denied(self, engine) -> None:  # noqa: ANN001
+    def test_falls_back_to_first_allowed_when_default_denied(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
@@ -204,7 +209,7 @@ class TestPickPermittedDefault:
         finally:
             engine.event_manager.remove_authorization_hook(deny_alpha)
 
-    def test_returns_none_when_every_choice_is_denied(self, engine) -> None:  # noqa: ANN001
+    def test_returns_none_when_every_choice_is_denied(self, engine: Engine) -> None:
         """Every declared choice denied -> None. Caller decides what to do next.
 
         The helper does not silently return a denied model as the default -- that
@@ -237,7 +242,7 @@ class TestInstall:
         assert len(param.find_elements_by_type(Options)) == 1
         assert len(param.find_elements_by_type(Button)) == 1
 
-    def test_install_populates_ui_options_with_dropdown_data(self, engine) -> None:  # noqa: ANN001
+    def test_install_populates_ui_options_with_dropdown_data(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
@@ -280,7 +285,7 @@ class TestInstall:
         # update_ui_options merges; display_name set by the node must survive.
         assert post_param.ui_options.get("display_name") == pre_display_name
 
-    def test_install_applies_initial_badge_when_stored_value_denied(self, engine) -> None:  # noqa: ANN001
+    def test_install_applies_initial_badge_when_stored_value_denied(self, engine: Engine) -> None:
         """A node born with a denied stored value shows the badge immediately.
 
         Setup: every choice is denied so ``pick_permitted_default()`` returns
@@ -308,7 +313,7 @@ class TestInstall:
         finally:
             engine.event_manager.remove_authorization_hook(deny_everything)
 
-    def test_constructor_relocates_stored_value_off_denied_default(self, engine) -> None:  # noqa: ANN001
+    def test_constructor_relocates_stored_value_off_denied_default(self, engine: Engine) -> None:
         """Constructor moves the stored value off a denied default to a permitted alternative.
 
         The parameter's declarative default_value is preserved (unchanged); only
@@ -532,7 +537,7 @@ class TestEngineFailureIsFailClosedAtRuntime:
 
 
 class TestOnValueChanged:
-    def test_sets_badge_when_switching_to_denied_value(self, engine) -> None:  # noqa: ANN001
+    def test_sets_badge_when_switching_to_denied_value(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
@@ -556,7 +561,7 @@ class TestOnValueChanged:
         finally:
             engine.event_manager.remove_authorization_hook(deny_alpha)
 
-    def test_clears_badge_when_switching_to_allowed_value(self, engine) -> None:  # noqa: ANN001
+    def test_clears_badge_when_switching_to_allowed_value(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
@@ -596,7 +601,7 @@ class TestOnValueChanged:
 
 
 class TestRefreshAndQueryForDenial:
-    def test_query_for_denial_returns_denial_for_denied_model(self, engine) -> None:  # noqa: ANN001
+    def test_query_for_denial_returns_denial_for_denied_model(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
@@ -616,7 +621,7 @@ class TestRefreshAndQueryForDenial:
         finally:
             engine.event_manager.remove_authorization_hook(deny_alpha)
 
-    def test_query_for_denial_honors_a_grant_made_since_the_last_refresh(self, engine) -> None:  # noqa: ANN001
+    def test_query_for_denial_honors_a_grant_made_since_the_last_refresh(self, engine: Engine) -> None:
         """The run-path re-query must work in BOTH directions, not just allow -> deny.
 
         The snapshot is captured at construction/refresh time. If a cached denial short-circuited
@@ -641,7 +646,7 @@ class TestRefreshAndQueryForDenial:
 
         assert helper.query_for_denial("alpha") is None
 
-    def test_an_unanswerable_live_requery_falls_back_to_the_cached_denial(self, engine) -> None:  # noqa: ANN001
+    def test_an_unanswerable_live_requery_falls_back_to_the_cached_denial(self, engine: Engine) -> None:  # noqa: ARG002 - boots the ambient engine
         """A transient lookup failure must not forget a denial we already hold.
 
         The run path re-asks policy live so grants are honored. If that query cannot be answered
@@ -655,20 +660,19 @@ class TestRefreshAndQueryForDenial:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Alpha not enabled."),))
             return None
 
-        engine.event_manager.add_authorization_hook(deny_alpha)
+        current_engine().event_manager.add_authorization_hook(deny_alpha)
         try:
             _, helper = _install_probe_node_with_helper(model_choices=["alpha", "beta"], default_model="beta")
             assert helper.query_for_denial("alpha") is not None
 
             # The live re-query now comes back unanswerable.
-            with patch.object(
-                engine,
-                "handle_request",
+            with patch(
+                "griptape_nodes.retained_mode.engine.Engine.handle_request",
                 return_value=QueryModelAccessForNodeResultFailure(result_details="library unregistered"),
             ):
                 assert helper.query_for_denial("alpha") is not None
         finally:
-            engine.event_manager.remove_authorization_hook(deny_alpha)
+            current_engine().event_manager.remove_authorization_hook(deny_alpha)
 
     def test_query_for_denial_ignores_non_string_values(self) -> None:
         _, helper = _install_probe_node_with_helper(model_choices=["alpha", "beta"], default_model="alpha")
@@ -688,7 +692,7 @@ class TestRefreshAndQueryForDenial:
 
         assert helper.query_for_denial("never-heard-of-this-model") is None
 
-    def test_refresh_picks_up_hook_change(self, engine) -> None:  # noqa: ANN001
+    def test_refresh_picks_up_hook_change(self, engine: Engine) -> None:
         """refresh() re-fetches the denial map so a policy change becomes visible."""
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
@@ -722,7 +726,7 @@ class TestRefreshAndQueryForDenial:
 
 
 class TestRaiseIfDenied:
-    def test_raises_runtimeerror_with_denial_reason(self, engine) -> None:  # noqa: ANN001
+    def test_raises_runtimeerror_with_denial_reason(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
@@ -753,7 +757,7 @@ class TestRaiseIfDenied:
 
 
 class TestRefreshButton:
-    def test_refresh_button_click_rebuilds_state(self, engine) -> None:  # noqa: ANN001
+    def test_refresh_button_click_rebuilds_state(self, engine: Engine) -> None:
         """The inline Button trait's on_click hook invokes refresh()."""
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
@@ -788,7 +792,7 @@ class TestRefreshButton:
 
 
 class TestSuccessFailureUsagePattern:
-    def test_query_for_denial_supports_early_return_without_raising(self, engine) -> None:  # noqa: ANN001
+    def test_query_for_denial_supports_early_return_without_raising(self, engine: Engine) -> None:
         """A SuccessFailure-style caller can inspect the denial and route without an exception.
 
         Verifies that the helper never raises on its own -- the caller decides
@@ -835,7 +839,7 @@ class TestModelChoicesProperty:
 
 
 class TestReinstallOptions:
-    def test_reinstall_puts_options_and_decoration_back(self, engine) -> None:  # noqa: ANN001
+    def test_reinstall_puts_options_and_decoration_back(self, engine: Engine) -> None:
         """After remove_trait(Options), reinstall_options() re-adds it with decoration + badge."""
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
@@ -1064,7 +1068,7 @@ class TestSelectionReadingApi:
         node.set_parameter_value(param.name, "beta")
         assert helper.selected_value == "beta"
 
-    def test_selection_denial_gates_the_current_selection(self, engine) -> None:  # noqa: ANN001
+    def test_selection_denial_gates_the_current_selection(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
@@ -1086,7 +1090,7 @@ class TestSelectionReadingApi:
         finally:
             engine.event_manager.remove_authorization_hook(deny_alpha)
 
-    def test_raise_if_selection_denied_raises_for_the_current_selection(self, engine) -> None:  # noqa: ANN001
+    def test_raise_if_selection_denied_raises_for_the_current_selection(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
@@ -1107,7 +1111,7 @@ class TestSelectionReadingApi:
         finally:
             engine.event_manager.remove_authorization_hook(deny_alpha)
 
-    def test_on_value_set_ignores_other_parameters(self, engine) -> None:  # noqa: ANN001
+    def test_on_value_set_ignores_other_parameters(self, engine: Engine) -> None:
         """The component filters for its own parameter so nodes can forward unconditionally."""
         from griptape_nodes.exe_types.core_types import Parameter
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
@@ -1145,7 +1149,7 @@ class TestConstructionDeferral:
     ``TestConstructionWithoutAScopeStillQueries``.
     """
 
-    def test_construction_defers_the_query_and_keeps_the_default(self, engine) -> None:  # noqa: ANN001
+    def test_construction_defers_the_query_and_keeps_the_default(self, engine: Engine) -> None:
         from unittest.mock import MagicMock
 
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
@@ -1158,7 +1162,7 @@ class TestConstructionDeferral:
         try:
             with (
                 patch(
-                    "griptape_nodes.exe_types.param_components.model_policy.GriptapeNodes.handle_request",
+                    "griptape_nodes.retained_mode.engine.Engine.handle_request",
                     handle,
                 ),
                 constructing_under_probe(),
@@ -1176,7 +1180,7 @@ class TestConstructionDeferral:
         finally:
             engine.event_manager.remove_authorization_hook(deny_all)
 
-    def test_query_for_denial_heals_a_deferred_snapshot(self, engine) -> None:  # noqa: ANN001
+    def test_query_for_denial_heals_a_deferred_snapshot(self, engine: Engine) -> None:
         """The enforcement-gap regression: run-time gating must not stay bypassed until a refresh.
 
         This component has no validate_before_node_run equivalent, so if query_for_denial
@@ -1203,7 +1207,7 @@ class TestConstructionDeferral:
         finally:
             engine.event_manager.remove_authorization_hook(deny_alpha)
 
-    def test_refresh_heals_decoration(self, engine) -> None:  # noqa: ANN001
+    def test_refresh_heals_decoration(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
@@ -1236,7 +1240,7 @@ class TestConstructionWithoutAScopeStillQueries:
     artist clicks refresh.
     """
 
-    def test_denial_decoration_and_default_relocation_happen_at_construction(self, engine) -> None:  # noqa: ANN001
+    def test_denial_decoration_and_default_relocation_happen_at_construction(self, engine: Engine) -> None:
         from griptape_nodes.node_library.library_registry import LibraryRegistry
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 

--- a/tests/unit/exe_types/param_components/test_model_policy.py
+++ b/tests/unit/exe_types/param_components/test_model_policy.py
@@ -7,6 +7,7 @@ in particular the one axis on which the two are ALLOWED to differ: `refuse_unrec
 """
 
 import logging
+from collections.abc import Callable
 from dataclasses import FrozenInstanceError
 from unittest.mock import MagicMock, patch
 
@@ -26,7 +27,20 @@ from griptape_nodes.retained_mode.events.access_events import (
 from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 from tests.unit.exe_types.param_components.probe_scope import constructing_under_probe
 
-_HANDLE = "griptape_nodes.exe_types.param_components.model_policy.GriptapeNodes.handle_request"
+
+def _engine(result: object | None = None, *, side_effect: Callable[[object], object] | None = None) -> MagicMock:
+    """A stand-in engine whose ``handle_request`` answers with a canned result.
+
+    ``query_model_policy`` takes the engine to ask, so these tests hand it one rather than
+    patching a process-wide accessor.
+    """
+    engine = MagicMock()
+    if side_effect is not None:
+        engine.handle_request.side_effect = side_effect
+    else:
+        engine.handle_request.return_value = result
+    return engine
+
 
 DENIED = "owner/denied"
 ALLOWED = "owner/allowed"
@@ -45,16 +59,16 @@ class TestQueryModelPolicy:
             ModelAccessVerdict(model_id="md_denied", provider_model_id=DENIED, denial=_DENIAL),
             ModelAccessVerdict(model_id="md_allowed", provider_model_id=ALLOWED, denial=None),
         ]
-        with patch(_HANDLE, return_value=_success(verdicts)):
-            snapshot = query_model_policy("SomeNode")
+        snapshot = query_model_policy(_engine(_success(verdicts)), "SomeNode")
         assert snapshot.denial_by_provider_id == {DENIED: _DENIAL}
         assert snapshot.catalog_ids_by_provider_id == {DENIED: ("md_denied",), ALLOWED: ("md_allowed",)}
         assert snapshot.failure_detail is None
         assert snapshot.has_unmatchable_entries is False
 
     def test_fail_closed_records_a_failure_detail(self) -> None:
-        with patch(_HANDLE, return_value=QueryModelAccessForNodeResultFailure(result_details="not found")):
-            snapshot = query_model_policy("SomeNode")
+        snapshot = query_model_policy(
+            _engine(QueryModelAccessForNodeResultFailure(result_details="not found")), "SomeNode"
+        )
         assert snapshot.failure_detail is not None
         assert snapshot.denial_for(ALLOWED) is not None
 
@@ -66,11 +80,10 @@ class TestQueryModelPolicy:
         them, and a registration problem worded as a licensing one sends them looking in the wrong
         place entirely.
         """
-        with (
-            caplog.at_level(logging.WARNING, logger="griptape_nodes"),
-            patch(_HANDLE, return_value=QueryModelAccessForNodeResultFailure(result_details="not registered")),
-        ):
-            snapshot = query_model_policy("SomeNode")
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+            snapshot = query_model_policy(
+                _engine(QueryModelAccessForNodeResultFailure(result_details="not registered")), "SomeNode"
+            )
 
         detail = snapshot.failure_detail
         assert detail is not None
@@ -84,16 +97,16 @@ class TestQueryModelPolicy:
 
     def test_fail_open_records_nothing(self) -> None:
         """Auto-detect uses this: an unresolvable node means "has not adopted declarations"."""
-        with patch(_HANDLE, return_value=QueryModelAccessForNodeResultFailure(result_details="not found")):
-            snapshot = query_model_policy("SomeNode", fail_closed=False)
+        snapshot = query_model_policy(
+            _engine(QueryModelAccessForNodeResultFailure(result_details="not found")), "SomeNode", fail_closed=False
+        )
         assert snapshot.failure_detail is None
         assert snapshot.declares_models is False
 
     def test_a_model_without_a_provider_handle_is_declared_but_unmatchable(self) -> None:
         """`provider_model_id` is optional, and absence is NOT "unresolved"."""
         verdicts = [ModelAccessVerdict(model_id="md_no_handle", provider_model_id=None, denial=None)]
-        with patch(_HANDLE, return_value=_success(verdicts)):
-            snapshot = query_model_policy("SomeNode")
+        snapshot = query_model_policy(_engine(_success(verdicts)), "SomeNode")
         assert snapshot.has_unmatchable_entries is True
         assert snapshot.catalog_ids_by_provider_id == {}
         # Still counts as declaring models -- otherwise enforcement would silently switch off.
@@ -175,8 +188,7 @@ class TestAnUnattributableDenialIsNotDropped:
     """
 
     def test_the_whole_parameter_is_refused(self) -> None:
-        with patch(_HANDLE, return_value=_success([ModelAccessVerdict("md_flux_dev", None, _DENIAL)])):
-            snapshot = query_model_policy("SomeNode")
+        snapshot = query_model_policy(_engine(_success([ModelAccessVerdict("md_flux_dev", None, _DENIAL)])), "SomeNode")
         assert snapshot.unmatchable_denials == ("md_flux_dev",)
         denial = snapshot.denial_for(ALLOWED, refuse_unrecognized=True)
         assert denial is not None
@@ -187,16 +199,14 @@ class TestAnUnattributableDenialIsNotDropped:
 
     def test_a_permitted_handleless_entry_does_not_refuse_anything(self) -> None:
         """Only a DENIED unmatchable entry escalates; a permitted one is merely unmatchable."""
-        with patch(_HANDLE, return_value=_success([ModelAccessVerdict("md_no_handle", None, None)])):
-            snapshot = query_model_policy("SomeNode")
+        snapshot = query_model_policy(_engine(_success([ModelAccessVerdict("md_no_handle", None, None)])), "SomeNode")
         assert snapshot.unmatchable_denials == ()
         assert snapshot.has_unmatchable_entries is True
         assert snapshot.denial_for(ALLOWED, refuse_unrecognized=True) is None
 
     def test_it_applies_even_with_refuse_unrecognized_off(self) -> None:
         """A static dropdown must not run a model policy explicitly forbade either."""
-        with patch(_HANDLE, return_value=_success([ModelAccessVerdict("md_flux_dev", None, _DENIAL)])):
-            snapshot = query_model_policy("SomeNode")
+        snapshot = query_model_policy(_engine(_success([ModelAccessVerdict("md_flux_dev", None, _DENIAL)])), "SomeNode")
         assert snapshot.denial_for(ALLOWED) is not None
 
 
@@ -214,8 +224,7 @@ class TestASharedProviderModelIdIsNotLastWriteWins:
             ModelAccessVerdict(model_id="md_flux_byok", provider_model_id=shared, denial=_DENIAL),
             ModelAccessVerdict(model_id="md_flux_gtc", provider_model_id=shared, denial=None),
         ]
-        with patch(_HANDLE, return_value=_success(verdicts)):
-            snapshot = query_model_policy("SomeNode")
+        snapshot = query_model_policy(_engine(_success(verdicts)), "SomeNode")
         assert snapshot.denial_for(shared) is _DENIAL
 
     def test_every_catalog_id_behind_a_handle_is_retained(self) -> None:
@@ -225,8 +234,7 @@ class TestASharedProviderModelIdIsNotLastWriteWins:
             ModelAccessVerdict(model_id="md_flux_byok", provider_model_id=shared, denial=None),
             ModelAccessVerdict(model_id="md_flux_gtc", provider_model_id=shared, denial=None),
         ]
-        with patch(_HANDLE, return_value=_success(verdicts)):
-            snapshot = query_model_policy("SomeNode")
+        snapshot = query_model_policy(_engine(_success(verdicts)), "SomeNode")
         assert snapshot.catalog_ids_for(shared) == ("md_flux_byok", "md_flux_gtc")
 
     def test_an_unknown_handle_has_no_catalog_ids(self) -> None:
@@ -260,11 +268,7 @@ class TestBothComponentsAgreeOnAnUnattributableDenial:
         node = MockNode()
         parameter = Parameter(name="model", type="str", default_value="alpha", tooltip="m")
         node.add_parameter(parameter)
-        module = "griptape_nodes.exe_types.param_components"
-        with (
-            patch(f"{module}.model_policy.GriptapeNodes.handle_request", side_effect=handle),
-            patch(f"{module}.model_access_component.GriptapeNodes.handle_request", side_effect=handle),
-        ):
+        with patch("griptape_nodes.retained_mode.engine.Engine.handle_request", side_effect=handle):
             component = ModelAccessComponent(
                 node=node, parameter=parameter, model_choices=["alpha"], default_model="alpha"
             )
@@ -290,10 +294,10 @@ class TestConstructionDeferral:
     """
 
     def test_no_bus_request_while_constructing_under_a_probe_scope(self) -> None:
-        handle = MagicMock()
-        with patch(_HANDLE, handle), constructing_under_probe():
-            snapshot = query_model_policy("SomeNode")
-        handle.assert_not_called()
+        engine = _engine()
+        with constructing_under_probe():
+            snapshot = query_model_policy(engine, "SomeNode")
+        engine.handle_request.assert_not_called()
         assert snapshot.deferred is True
 
     def test_construction_outside_a_strict_mode_scope_queries_normally(self) -> None:
@@ -304,8 +308,8 @@ class TestConstructionDeferral:
         rows and the badge until the node ran.
         """
         verdicts = [ModelAccessVerdict(model_id="md_denied", provider_model_id=DENIED, denial=_DENIAL)]
-        with patch(_HANDLE, return_value=_success(verdicts)), LibraryRegistry.constructing_node():
-            snapshot = query_model_policy("SomeNode")
+        with LibraryRegistry.constructing_node():
+            snapshot = query_model_policy(_engine(_success(verdicts)), "SomeNode")
         assert snapshot.deferred is False
         assert snapshot.denial_for(DENIED) is _DENIAL
 
@@ -326,10 +330,10 @@ class TestConstructionDeferral:
 
     def test_the_query_goes_through_once_construction_ends(self) -> None:
         verdicts = [ModelAccessVerdict(model_id="md_denied", provider_model_id=DENIED, denial=_DENIAL)]
-        with patch(_HANDLE, return_value=_success(verdicts)):
-            with constructing_under_probe():
-                assert query_model_policy("SomeNode").deferred is True
-            snapshot = query_model_policy("SomeNode")
+        engine = _engine(_success(verdicts))
+        with constructing_under_probe():
+            assert query_model_policy(engine, "SomeNode").deferred is True
+        snapshot = query_model_policy(engine, "SomeNode")
         assert snapshot.deferred is False
         assert snapshot.denial_for(DENIED) is _DENIAL
 

--- a/tests/unit/exe_types/param_components/test_parameter_transition_component.py
+++ b/tests/unit/exe_types/param_components/test_parameter_transition_component.py
@@ -44,9 +44,7 @@ from tests.unit.exe_types.mocks import MockNode
 
 # Patch target — GriptapeNodes is imported INTO the component module, so the
 # binding to patch is the module-local reference, not the global singleton.
-_HANDLE_REQUEST_TARGET = (
-    "griptape_nodes.exe_types.param_components.parameter_transition_component.GriptapeNodes.handle_request"
-)
+_HANDLE_REQUEST_TARGET = "griptape_nodes.retained_mode.engine.Engine.handle_request"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/exe_types/test_variable_substitution.py
+++ b/tests/unit/exe_types/test_variable_substitution.py
@@ -1,6 +1,7 @@
 """Tests for inline workflow variable substitution in get_parameter_value()."""
 
-from contextlib import AbstractContextManager
+from collections.abc import Iterator
+from contextlib import AbstractContextManager, contextmanager
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -8,6 +9,11 @@ from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import TrackedParameterOutputValues, aprocess_scope
 from griptape_nodes.exe_types.variable_resolver import _aprocess_variable_cache
 from griptape_nodes.retained_mode.events.base_events import ProgressEvent
+from griptape_nodes.retained_mode.events.connection_events import (
+    IncomingConnection,
+    ListConnectionsForNodeRequest,
+    ListConnectionsForNodeResultSuccess,
+)
 from griptape_nodes.retained_mode.events.execution_events import ParameterValueUpdateEvent
 from griptape_nodes.retained_mode.events.parameter_events import AlterElementEvent
 from griptape_nodes.retained_mode.events.variable_events import (
@@ -18,11 +24,11 @@ from griptape_nodes.retained_mode.variable_types import FlowVariable, VariableLa
 
 from .mocks import MockNode
 
-# GriptapeNodes is lazy-imported inside _param_has_incoming_connection and
-# _resolve_variables_in_string to break the exe_types <-> retained_mode cycle.
-# Patch it at the source module so the lazy `from ... import GriptapeNodes`
-# picks up the mock at call time.
-_GN_PATCH = "griptape_nodes.retained_mode.griptape_nodes.GriptapeNodes"
+# Node machinery reaches its collaborators through ``self.engine``, and a node built without
+# one falls back to the ambient engine. Patching that fallback is what puts a stand-in engine
+# under a MockNode; it is resolved lazily inside the property, so patching the source module
+# catches it at call time.
+_CURRENT_ENGINE_PATCH = "griptape_nodes.retained_mode.engine.current_engine"
 
 
 def _make_str_param(name: str, default: str = "", modes: set | None = None) -> Parameter:
@@ -51,13 +57,65 @@ def _make_property_output_param(name: str, default: Any) -> Parameter:
     )
 
 
+def _connections_result(connected_params: set[str]) -> ListConnectionsForNodeResultSuccess:
+    """The connections a real ListConnectionsForNodeRequest would report for "mock_node"."""
+    return ListConnectionsForNodeResultSuccess(
+        incoming_connections=[
+            IncomingConnection(
+                source_node_name="upstream",
+                source_parameter_name="out",
+                target_parameter_name=param_name,
+            )
+            for param_name in sorted(connected_params)
+        ],
+        outgoing_connections=[],
+        result_details="ok",
+    )
+
+
+def _engine_mock(
+    variables: dict,
+    connected_params: set[str],
+    captured: list | None = None,
+    *,
+    substitution_enabled: bool = True,
+) -> Any:
+    """A stand-in engine answering everything the substitution path asks of one.
+
+    Every gate is configured here rather than left to MagicMock's defaults, because a
+    MagicMock answers truthily by accident: that is how these tests used to pass while
+    ``_param_has_incoming_connection`` did ``param_name in <MagicMock>``, which is False
+    only because ``MagicMock.__contains__`` defaults to False. Any refactor of a lookup
+    left implicit would flip every assertion for the wrong reason.
+    """
+    engine = MagicMock()
+    engine.handle_request.side_effect = lambda req: (
+        _list_variables_result(variables)
+        if isinstance(req, ListVariablesRequest)
+        else _connections_result(connected_params)
+        if isinstance(req, ListConnectionsForNodeRequest)
+        else MagicMock()
+    )
+    engine.workflow_manager.is_variable_substitution_enabled.return_value = substitution_enabled
+    engine.node_manager.get_node_parent_flow_by_name.return_value = "test_flow"
+    if captured is not None:
+        engine.event_manager.put_event.side_effect = captured.append
+    return engine
+
+
+@contextmanager
+def _patch_engine(engine: Any) -> Iterator[None]:
+    with patch(_CURRENT_ENGINE_PATCH, return_value=engine):
+        yield
+
+
 def _mock_gn(
     variables: dict,
     *,
     connected_params: set[str] | None = None,
     substitution_enabled: bool = True,
 ) -> AbstractContextManager:
-    """Patch GriptapeNodes managers for substitution tests.
+    """Put a stand-in engine under the nodes these tests build.
 
     connected_params: parameter names on "mock_node" that have incoming connections.
     substitution_enabled: value returned by is_variable_substitution_enabled().
@@ -65,19 +123,7 @@ def _mock_gn(
     if connected_params is None:
         connected_params = set()
 
-    mock_gn = MagicMock()
-    mock_gn.NodeManager.return_value.get_node_parent_flow_by_name.return_value = "test_flow"
-    mock_gn.handle_request.side_effect = lambda req: (
-        _list_variables_result(variables) if isinstance(req, ListVariablesRequest) else MagicMock()
-    )
-
-    incoming_index = {"mock_node": dict.fromkeys(connected_params, True)} if connected_params else {}
-    mock_connections = MagicMock()
-    mock_connections.incoming_index = incoming_index
-    mock_gn.FlowManager.return_value.get_connections.return_value = mock_connections
-    mock_gn.WorkflowManager.return_value.is_variable_substitution_enabled.return_value = substitution_enabled
-
-    return patch(_GN_PATCH, mock_gn)
+    return _patch_engine(_engine_mock(variables, connected_params, substitution_enabled=substitution_enabled))
 
 
 def _list_variables_result(variables: dict) -> ListVariablesResultSuccess:
@@ -111,24 +157,8 @@ def _payloads_of_type(captured: list, payload_type: type) -> list:
 
 
 def _capturing_gn_mock(captured: list, variables: dict, *, connected_params: set[str] | None = None) -> Any:
-    """A GN patch that captures events and makes every suppression gate explicit.
-
-    Every gate in ``_variable_template_to_preserve`` is configured here rather than
-    left to MagicMock's defaults. Leaving them implicit is how these tests used to
-    pass: ``_param_has_incoming_connection`` did ``param_name in <MagicMock>``, which
-    is False only because ``MagicMock.__contains__`` defaults to False, so any
-    refactor of that lookup would flip every assertion for the wrong reason.
-    """
-    mock_gn = MagicMock()
-    mock_gn.NodeManager.return_value.get_node_parent_flow_by_name.return_value = "test_flow"
-    mock_gn.handle_request.side_effect = lambda req: (
-        _list_variables_result(variables) if isinstance(req, ListVariablesRequest) else MagicMock()
-    )
-    incoming_index = {"mock_node": dict.fromkeys(connected_params, True)} if connected_params else {}
-    mock_gn.FlowManager.return_value.get_connections.return_value = MagicMock(incoming_index=incoming_index)
-    mock_gn.WorkflowManager.return_value.is_variable_substitution_enabled.return_value = True
-    mock_gn.EventManager.return_value.put_event.side_effect = captured.append
-    return patch(_GN_PATCH, mock_gn)
+    """Like ``_mock_gn``, and also collects every event the engine is handed."""
+    return _patch_engine(_engine_mock(variables, connected_params or set(), captured))
 
 
 def _run_tracked_set(
@@ -351,13 +381,10 @@ class TestVariableSubstitutionFallbacks:
         node.add_parameter(_make_str_param("text", "{SHOT}"))
         node.parameter_values["text"] = "{SHOT}"
 
-        mock_gn = MagicMock()
-        mock_gn.NodeManager.return_value.get_node_parent_flow_by_name.side_effect = KeyError("mock_node")
-        mock_connections = MagicMock()
-        mock_connections.incoming_index = {}
-        mock_gn.FlowManager.return_value.get_connections.return_value = mock_connections
+        engine = _engine_mock({}, set())
+        engine.node_manager.get_node_parent_flow_by_name.side_effect = KeyError("mock_node")
 
-        with patch(_GN_PATCH, mock_gn), aprocess_scope():
+        with _patch_engine(engine), aprocess_scope():
             value = node.get_parameter_value("text")
 
         assert value == "{SHOT}"

--- a/tests/unit/exe_types/test_workflow_node.py
+++ b/tests/unit/exe_types/test_workflow_node.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import pytest
 
@@ -20,10 +20,8 @@ from griptape_nodes.exe_types.workflow_node import (
     pair_shape_nodes,
 )
 from griptape_nodes.node_library.workflow_registry import WorkflowMetadata, WorkflowRegistry, WorkflowShape
+from griptape_nodes.retained_mode.engine import current_engine
 from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
-
-if TYPE_CHECKING:
-    from griptape_nodes.retained_mode.engine import Engine
 
 CONTROL_TYPE = "parametercontroltype"
 
@@ -55,20 +53,20 @@ def _metadata(shape: WorkflowShape | None) -> WorkflowMetadata:
     )
 
 
-def _build_live_subflow(engine: Engine) -> str:
+def _build_live_subflow() -> str:
     """Create a flow standing in for an imported workflow, and return its name.
 
     Mirrors what an import produces for the shape used by `TestResolveLiveRoutes`: a parameterless
     Start Flow node, a Start Flow node exposing `text`, and an End Flow node exposing `result`, all
     renamed because their original names were already taken on the canvas.
     """
-    engine.context_manager.push_workflow(workflow_name="workflow_node_live_routes")
-    flow_result = engine.handle_request(
+    current_engine().context_manager.push_workflow(workflow_name="workflow_node_live_routes")
+    flow_result = current_engine().handle_request(
         CreateFlowRequest(parent_flow_name=None, flow_name="Subflow", set_as_new_context=False)
     )
     assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
 
-    flow = engine.flow_manager.get_flow_by_name(flow_result.flow_name)
+    flow = current_engine().flow_manager.get_flow_by_name(flow_result.flow_name)
     flow.add_node(StartNode(name="Start Flow_1"))
 
     start_with_text = StartNode(name="Start Flow_2")
@@ -251,7 +249,7 @@ class TestPairShapeNodes:
 class TestResolveLiveRoutes:
     """Routes are re-pointed at the imported copy of the workflow before every run."""
 
-    def test_parameterless_start_node_is_counted_and_skipped(self, engine: Engine) -> None:
+    def test_parameterless_start_node_is_counted_and_skipped(self) -> None:
         """A Start Flow node carrying only control flow contributes no route but still holds a slot.
 
         Pairing is positional, so the parameterless node has to be counted on the declared side or
@@ -270,7 +268,7 @@ class TestResolveLiveRoutes:
             workflow_metadata=_metadata(shape),
         )
         node = node_class(name="Shout It")
-        subflow_name = _build_live_subflow(engine)
+        subflow_name = _build_live_subflow()
 
         live_routes = node._resolve_live_routes(subflow_name)
 

--- a/tests/unit/node_library/test_library_declarations.py
+++ b/tests/unit/node_library/test_library_declarations.py
@@ -402,8 +402,9 @@ class TestRequiresWorkerProcess:
 
 
 class TestSchemaVersion:
-    def test_latest_schema_version_is_0_11_0(self) -> None:
-        assert LibrarySchema.LATEST_SCHEMA_VERSION == "0.11.0"
+    def test_latest_schema_version_is_0_12_0(self) -> None:
+        # 0.12.0 added Dependencies.pip_dependencies_exec.
+        assert LibrarySchema.LATEST_SCHEMA_VERSION == "0.12.0"
 
 
 # ---------- Model catalog ----------

--- a/tests/unit/retained_mode/managers/test_execute_node.py
+++ b/tests/unit/retained_mode/managers/test_execute_node.py
@@ -36,6 +36,9 @@ def _make_mock_library_manager(*, is_worker: bool) -> MagicMock:
     lib_mgr.is_worker = is_worker
     lib_mgr._is_worker = is_worker
     lib_mgr.get_worker_for_library.return_value = None
+    # The execute path awaits this before consulting get_worker_for_library; a plain
+    # MagicMock attribute is not awaitable.
+    lib_mgr.wait_for_worker_library_load = AsyncMock()
     return lib_mgr
 
 
@@ -371,6 +374,7 @@ class TestExecuteNodeWorkerRoute:
         lib_mgr = MagicMock()
         lib_mgr.is_worker = False
         lib_mgr._is_worker = False
+        lib_mgr.wait_for_worker_library_load = AsyncMock()
         lib_mgr.get_worker_for_library.return_value = ("eng-id", "topic")
 
         node_manager = _make_node_manager(object_manager=mock_obj_mgr, library_manager=lib_mgr, worker_manager=wm)
@@ -402,6 +406,7 @@ class TestExecuteNodeWorkerRoute:
         lib_mgr = MagicMock()
         lib_mgr.is_worker = False
         lib_mgr._is_worker = False
+        lib_mgr.wait_for_worker_library_load = AsyncMock()
         lib_mgr.get_worker_for_library.return_value = ("eng-id", "topic")
 
         node_manager = _make_node_manager(object_manager=mock_obj_mgr, library_manager=lib_mgr, worker_manager=wm)

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -792,6 +792,7 @@ class TestLibraryManagerInstallLibraryDependencies:
         schema.metadata.library_version = "1.0.0"
         schema.metadata.dependencies.pip_dependencies = []
         schema.metadata.dependencies.pip_install_flags = []
+        schema.metadata.dependencies.pip_dependencies_exec = None
 
         with (
             patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
@@ -859,6 +860,7 @@ class TestLibraryManagerInstallLibraryDependencies:
         schema.metadata.library_version = "1.0.0"
         schema.metadata.dependencies.pip_dependencies = []
         schema.metadata.dependencies.pip_install_flags = []
+        schema.metadata.dependencies.pip_dependencies_exec = None
 
         with (
             patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
@@ -881,6 +883,7 @@ class TestLibraryManagerInstallLibraryDependencies:
         schema.metadata.library_version = "1.0.0"
         schema.metadata.dependencies.pip_dependencies = []
         schema.metadata.dependencies.pip_install_flags = []
+        schema.metadata.dependencies.pip_dependencies_exec = None
 
         with (
             patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
@@ -908,6 +911,7 @@ class TestLibraryManagerInstallLibraryDependencies:
         schema.metadata.library_version = "1.0.0"
         schema.metadata.dependencies.pip_dependencies = []
         schema.metadata.dependencies.pip_install_flags = []
+        schema.metadata.dependencies.pip_dependencies_exec = None
 
         with (
             patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
@@ -944,6 +948,7 @@ class TestLibraryManagerInstallLibraryDependencies:
         schema.metadata.library_version = "1.0.0"
         schema.metadata.dependencies.pip_dependencies = ["a==1"]
         schema.metadata.dependencies.pip_install_flags = []
+        schema.metadata.dependencies.pip_dependencies_exec = None
 
         with (
             patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
@@ -984,6 +989,7 @@ class TestLibraryManagerInstallLibraryDependencies:
         schema.metadata.library_version = "1.0.0"
         schema.metadata.dependencies.pip_dependencies = ["a==1"]
         schema.metadata.dependencies.pip_install_flags = []
+        schema.metadata.dependencies.pip_dependencies_exec = None
         expected_attempts = 2
 
         with (
@@ -1031,6 +1037,7 @@ class TestLibraryManagerInstallLibraryDependencies:
         schema.metadata.library_version = "1.0.0"
         schema.metadata.dependencies.pip_dependencies = ["a==1"]
         schema.metadata.dependencies.pip_install_flags = []
+        schema.metadata.dependencies.pip_dependencies_exec = None
 
         with (
             patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
@@ -1071,6 +1078,7 @@ class TestLibraryManagerInstallLibraryDependencies:
         schema.metadata.library_version = "1.0.0"
         schema.metadata.dependencies.pip_dependencies = ["a==1"]
         schema.metadata.dependencies.pip_install_flags = []
+        schema.metadata.dependencies.pip_dependencies_exec = None
         expected_attempts = 2
 
         with (

--- a/tests/unit/retained_mode/managers/test_library_manager_deps.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_deps.py
@@ -69,7 +69,8 @@ class TestLibraryDependencyDeclaration:
         assert not hasattr(deps, "library_dependencies")
 
     def test_schema_version_bumped(self) -> None:
-        assert LibrarySchema.LATEST_SCHEMA_VERSION == "0.11.0"
+        # 0.12.0 added Dependencies.pip_dependencies_exec.
+        assert LibrarySchema.LATEST_SCHEMA_VERSION == "0.12.0"
 
 
 class TestLibraryDependencyProblem:

--- a/tests/unit/retained_mode/managers/test_library_manager_strict_mode.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_strict_mode.py
@@ -18,13 +18,12 @@ from griptape_nodes.common.strict_mode import STRICT_MODE
 from griptape_nodes.exe_types.core_types import Parameter, Trait
 from griptape_nodes.exe_types.param_components.huggingface.huggingface_repo_parameter import HuggingFaceRepoParameter
 from griptape_nodes.node_library.library_registry import LibraryRegistry
+from griptape_nodes.retained_mode.engine import current_engine
 from tests.unit.exe_types.mocks import MockNode
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
     from contextlib import AbstractContextManager
-
-    from griptape_nodes.retained_mode.engine import Engine
 
 
 @pytest.fixture
@@ -92,10 +91,8 @@ class _ViolatingProbe:
 
 class TestSerializeSchemasStrictMode:
     @pytest.mark.asyncio
-    async def test_clean_class_is_included(
-        self, engine: Engine, patched_registry: Callable[[dict[str, type]], Any]
-    ) -> None:
-        manager = engine.library_manager
+    async def test_clean_class_is_included(self, patched_registry: Callable[[dict[str, type]], Any]) -> None:
+        manager = current_engine().library_manager
         with patched_registry({"Clean": _CleanProbe}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
@@ -103,10 +100,10 @@ class TestSerializeSchemasStrictMode:
 
     @pytest.mark.asyncio
     async def test_violating_class_is_skipped(
-        self, engine: Engine, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.DEBUG, logger="griptape_nodes.strict_mode")
-        manager = engine.library_manager
+        manager = current_engine().library_manager
         with patched_registry({"Violator": _ViolatingProbe, "Clean": _CleanProbe}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
@@ -136,7 +133,7 @@ class _ProbeWithHuggingFaceRepoParam(MockNode):
 class TestHuggingFaceRepoParameterSurvivesTheProbe:
     @pytest.mark.asyncio
     async def test_hf_param_node_is_included_and_issues_no_bus_requests(
-        self, engine: Engine, patched_registry: Callable[[dict[str, type]], Any]
+        self, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         module = "griptape_nodes.exe_types.param_components.huggingface"
 
@@ -144,10 +141,10 @@ class TestHuggingFaceRepoParameterSurvivesTheProbe:
             msg = f"bus request issued during probe construction: {type(request).__name__}"
             raise AssertionError(msg)
 
-        manager = engine.library_manager
+        manager = current_engine().library_manager
         with (
             patch(f"{module}.huggingface_repo_parameter.list_repo_revisions_in_cache", return_value=[]),
-            patch(f"{module}.huggingface_model_parameter.GriptapeNodes.handle_request", side_effect=_refuse_bus),
+            patch("griptape_nodes.retained_mode.engine.Engine.handle_request", side_effect=_refuse_bus),
             patched_registry({"HFNode": _ProbeWithHuggingFaceRepoParam}),
         ):
             schemas = await manager._serialize_library_node_schemas("libA")
@@ -208,10 +205,10 @@ class TestParameterBehaviorsDropped:
 
     @pytest.mark.asyncio
     async def test_clean_parameters_produce_no_violation(
-        self, engine: Engine, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
-        manager = engine.library_manager
+        manager = current_engine().library_manager
         with patched_registry({"Clean": _ProbeWithCleanParams}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
@@ -220,10 +217,10 @@ class TestParameterBehaviorsDropped:
 
     @pytest.mark.asyncio
     async def test_parameter_with_converter_reports_warning_but_keeps_schema(
-        self, engine: Engine, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
-        manager = engine.library_manager
+        manager = current_engine().library_manager
         with patched_registry({"WithBehavior": _ProbeWithConverterParam}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
@@ -237,10 +234,10 @@ class TestParameterBehaviorsDropped:
 
     @pytest.mark.asyncio
     async def test_parameter_with_validator_reports_warning_but_keeps_schema(
-        self, engine: Engine, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
-        manager = engine.library_manager
+        manager = current_engine().library_manager
         with patched_registry({"WithValidator": _ProbeWithValidatorParam}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
@@ -251,10 +248,10 @@ class TestParameterBehaviorsDropped:
 
     @pytest.mark.asyncio
     async def test_parameter_with_trait_reports_warning_but_keeps_schema(
-        self, engine: Engine, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
-        manager = engine.library_manager
+        manager = current_engine().library_manager
         with patched_registry({"WithTrait": _ProbeWithTraitParam}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
@@ -314,10 +311,10 @@ class TestInertWorkerHooks:
 
     @pytest.mark.asyncio
     async def test_connection_hook_override_reports_warning_but_keeps_schema(
-        self, engine: Engine, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
-        manager = engine.library_manager
+        manager = current_engine().library_manager
         with patched_registry({"WithConnHook": _ProbeWithConnectionHook}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
@@ -331,10 +328,10 @@ class TestInertWorkerHooks:
 
     @pytest.mark.asyncio
     async def test_value_hook_override_reports_warning_but_keeps_schema(
-        self, engine: Engine, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
-        manager = engine.library_manager
+        manager = current_engine().library_manager
         with patched_registry({"WithValueHook": _ProbeWithValueHook}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
@@ -347,13 +344,13 @@ class TestInertWorkerHooks:
 
     @pytest.mark.asyncio
     async def test_engine_owned_hook_override_is_not_reported(
-        self, engine: Engine, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         # A hook implemented by an engine-owned base/component (module under
         # griptape_nodes.) is not the author's code; flagging it would nag on
         # something the library author cannot remediate.
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
-        manager = engine.library_manager
+        manager = current_engine().library_manager
         with patched_registry({"EngineHook": _ProbeInheritingEngineHook}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
@@ -362,10 +359,10 @@ class TestInertWorkerHooks:
 
     @pytest.mark.asyncio
     async def test_hookless_class_produces_no_hook_violation(
-        self, engine: Engine, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
-        manager = engine.library_manager
+        manager = current_engine().library_manager
         with patched_registry({"Clean": _CleanProbe}):
             schemas = await manager._serialize_library_node_schemas("libA")
 

--- a/tests/unit/retained_mode/managers/test_library_worker_config.py
+++ b/tests/unit/retained_mode/managers/test_library_worker_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any, cast
 from unittest.mock import MagicMock
 
@@ -218,3 +219,95 @@ class TestResolveExecutesInWorker:
             requires_worker=True, metadata=self._metadata(exec_deps=None)
         )
         assert result is True
+
+
+class TestExecuteWaitsForTheWorkerLibraryLoad:
+    """Routing must gate on the worker's LibraryLoadedNotification, not on registration.
+
+    A worker registers at process start, BEFORE it has loaded its library -- with eager
+    execution-module imports, seconds before. A node routed in that window failed in the
+    worker with "Library 'X' not found". The old worker system never had this window:
+    stub nodes did not exist until the worker confirmed the load, so nothing could execute.
+    """
+
+    def _spawned_info(self, *, loaded: bool) -> LibraryManager.LibraryInfo:
+        info = LibraryManager.LibraryInfo(
+            lifecycle_state=LibraryManager.LibraryLifecycleState.LOADED,
+            fitness=LibraryManager.LibraryFitness.GOOD,
+            library_path="/some/path.json",
+            is_sandbox=False,
+            library_name="Lib",
+            executes_in_worker=True,
+        )
+        info.worker_ready = asyncio.Event()
+        if loaded:
+            info.worker_ready.set()
+        return info
+
+    @pytest.mark.asyncio
+    async def test_the_wait_releases_when_the_notification_arrives(self) -> None:
+        mgr = _make_library_manager()
+        info = self._spawned_info(loaded=False)
+        mgr._library_file_path_to_info["/some/path.json"] = info
+        order: list[str] = []
+
+        async def executes() -> None:
+            await mgr.wait_for_worker_library_load("Lib")
+            order.append("routed")
+
+        async def worker_finishes_loading() -> None:
+            order.append("loaded")
+            await mgr._on_library_loaded_notification(LibraryLoadedNotification(library_name="Lib", fitness="GOOD"))
+
+        await asyncio.gather(executes(), worker_finishes_loading())
+
+        assert order == ["loaded", "routed"], "execution routed before the worker reported the library loaded"
+
+    @pytest.mark.asyncio
+    async def test_an_already_loaded_library_does_not_wait(self) -> None:
+        mgr = _make_library_manager()
+        mgr._library_file_path_to_info["/some/path.json"] = self._spawned_info(loaded=True)
+
+        await mgr.wait_for_worker_library_load("Lib")
+
+    @pytest.mark.asyncio
+    async def test_a_library_with_no_spawned_worker_does_not_wait(self) -> None:
+        mgr = _make_library_manager()
+        info = self._spawned_info(loaded=False)
+        info.worker_ready = None
+        mgr._library_file_path_to_info["/some/path.json"] = info
+
+        await mgr.wait_for_worker_library_load("Lib")
+
+    @pytest.mark.asyncio
+    async def test_the_timeout_names_the_library_and_the_ceiling(self) -> None:
+        mgr = _make_library_manager()
+        mgr._library_file_path_to_info["/some/path.json"] = self._spawned_info(loaded=False)
+        mgr._engine = MagicMock()  # type: ignore[assignment]
+        mgr._engine.config_manager.get_config_value.return_value = 0.01
+
+        with pytest.raises(RuntimeError, match="Lib"):
+            await mgr.wait_for_worker_library_load("Lib")
+
+    @pytest.mark.asyncio
+    async def test_an_eviction_during_the_wait_releases_it(self) -> None:
+        """The waiter must not hold on for the full grace for a worker that is already gone."""
+        mgr = _make_library_manager()
+        info = self._spawned_info(loaded=False)
+        mgr._library_file_path_to_info["/some/path.json"] = info
+        order: list[str] = []
+
+        async def executes() -> None:
+            await mgr.wait_for_worker_library_load("Lib")
+            order.append("released")
+
+        async def worker_dies() -> None:
+            order.append("evicted")
+            mgr.on_worker_evicted("worker-1", "Lib")
+
+        await asyncio.gather(executes(), worker_dies())
+
+        assert order == ["evicted", "released"]
+        assert info.lifecycle_state is LibraryManager.LibraryLifecycleState.LOADED, (
+            "an exec-deps library must stay editable through an eviction"
+        )

--- a/tests/unit/retained_mode/managers/test_library_worker_config.py
+++ b/tests/unit/retained_mode/managers/test_library_worker_config.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from griptape_nodes.node_library.library_registry import LibraryMetadata
+from griptape_nodes.node_library.library_registry import Dependencies, LibraryMetadata
 from griptape_nodes.retained_mode.events.app_events import LibraryLoadedNotification
 from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
 
@@ -69,6 +69,7 @@ class TestGetWorkerForLibrary:
             is_sandbox=False,
             library_name="my_lib",
             requires_worker=True,
+            executes_in_worker=True,
         )
 
         cast("MagicMock", mgr._worker_manager).get_worker_for_key.return_value = (
@@ -106,6 +107,7 @@ class TestGetWorkerForLibrary:
             is_sandbox=False,
             library_name="my_lib",
             requires_worker=True,
+            executes_in_worker=True,
         )
 
         cast("MagicMock", mgr._worker_manager).get_worker_for_key.return_value = None
@@ -174,3 +176,45 @@ class TestRegisterPreReloadCallback:
         mgr.register_pre_reload_callback(second)
 
         assert mgr._pre_reload_callbacks == [*baseline, first, second]
+
+
+class TestResolveExecutesInWorker:
+    """Execution placement is a fact about dependencies, derived not declared."""
+
+    def _metadata(self, *, exec_deps: list[str] | None) -> LibraryMetadata:
+        dependencies = None
+        if exec_deps is not None:
+            dependencies = Dependencies(pip_dependencies=["pillow"], pip_dependencies_exec=exec_deps)
+        return LibraryMetadata(
+            author="t",
+            description="d",
+            library_version="1.0.0",
+            engine_version="0.0.0",
+            tags=[],
+            dependencies=dependencies,
+        )
+
+    def test_exec_dependencies_require_a_worker(self) -> None:
+        result = LibraryManager._resolve_executes_in_worker(
+            requires_worker=False, metadata=self._metadata(exec_deps=["torch"])
+        )
+        assert result is True
+
+    def test_no_dependencies_section_means_no_worker(self) -> None:
+        result = LibraryManager._resolve_executes_in_worker(
+            requires_worker=False, metadata=self._metadata(exec_deps=None)
+        )
+        assert result is False
+
+    def test_empty_exec_dependencies_mean_no_worker(self) -> None:
+        result = LibraryManager._resolve_executes_in_worker(
+            requires_worker=False, metadata=self._metadata(exec_deps=[])
+        )
+        assert result is False
+
+    def test_legacy_worker_mode_still_executes_in_a_worker(self) -> None:
+        """The two reasons are independent: declaring worker mode is sufficient alone."""
+        result = LibraryManager._resolve_executes_in_worker(
+            requires_worker=True, metadata=self._metadata(exec_deps=None)
+        )
+        assert result is True

--- a/tests/unit/retained_mode/managers/test_node_manager_strict_mode.py
+++ b/tests/unit/retained_mode/managers/test_node_manager_strict_mode.py
@@ -69,6 +69,9 @@ class TestExecuteNodeStrictMode:
         m.is_worker = is_worker
         m._is_worker = is_worker
         m.get_worker_for_library.return_value = None
+        # Awaited on the orchestrator route before a node is routed, so it has to be a coroutine
+        # rather than a plain MagicMock attribute.
+        m.wait_for_worker_library_load = AsyncMock(return_value=None)
         return m
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Part of griptape-ai/internal#214 — prerequisite for widening the manager guard. (Stack position map at the bottom.)

Node machinery reached its collaborators through the process-wide `GriptapeNodes` facade, which the architecture reserves for callers that cannot be handed a reference: saved workflow files, separately-versioned libraries, and process entry points. `exe_types` is none of those, and pyproject's TID251 allowlist named it as work to be done. **That entry is now deleted** — this PR is also a chunk of the same migration main has been landing independently (#5385–#5389, #5406, #5388), so it reads as convergence, not coincidence.

## What changed

- `BaseNode` takes an optional keyword-only `engine` and falls back to the ambient one, so a library's `super().__init__(name, metadata=metadata)` is unaffected. Nothing passes it today — `LibraryRegistry.create_node` cannot without breaking every node subclass's two-arg signature — so what the migration buys is the classification it forced, not per-node isolation.
- Calls were classified per-site, not blanket-substituted:
  - questions about workflow state became **requests** (`ListConnectionsForNode`, `GetConfigValue`, `GetSecretValue`) — the orchestrator is the only process that holds all of it, and a request is what reaches it from a worker
  - DAG machinery and event dispatch became **`self.engine.*`**, the sanctioned engine-internal path
- Internal connection queries pass `broadcast_result=False`: they run on the hottest read path in the engine, and the default queued a full connection-list event to the GUI per call.
- Objects that are not nodes reach the engine through the node they hold (`TrackedParameterOutputValues`, `BaseElement`). Module-level helpers and classmethods take an engine parameter (`query_model_policy`, three `VariableResolver` staticmethods, two `PublicArtifactUrlParameter` classmethods, which also adopt the `ConfigManager`-injected storage-driver construction from #5406).
- `ControlFlow`'s delegation shim landed separately on main (#5388) and is used as-is. Tests that patched the facade now patch or inject the engine, using the `engine` fixture from #5385.

## Why it sits in this stack

The worker feature is the forcing function: the facade guard (next PR) can only go broad once every engine-internal path is off the facade, because the guard cannot tell library code from engine code — both arrive as the same classmethod.

> **Merge note.** This stack lands as a unit. Intermediate tips are not intended as shippable states: #5409 forwards OS file requests until #5426 makes them local, and #5390 through #5468 splice `.venv-exec` onto a worker's `sys.path` until #5472 retires that mechanism — a running interpreter cannot be handed a library's own dependency versions that way, because `sys.modules` never reconsiders a module already imported. The orchestrator installing the execution set is therefore the intended end state, not a step: it has to be the builder, since the worker receives that directory as `PYTHONPATH` and so cannot create it.

## Stack

| # | PR | Branch |
|---|----|--------|
| 1 | #5390 | `feat/venue-exec-deps` |
| 2 | #5391 | `feat/venue-reentrancy` |
| 3 | #5402 | `feat/venue-worker-mvp` |
| 4 | #5409 | `feat/venue-worker-behavior-suite` |
| 5 | #5425 ← this | `feat/exe-types-engine-injection` |
| 6 | #5426 | `feat/worker-wire-hardening` |
| 7 | #5427 | `feat/library-exec-lifecycle` |
| 8 | #5428 | `fix/failed-nodes-leave-resolving` |
| 9 | #5430 | `feat/parameter-structure-contract` |
