### PR TITLE
Harden the worker wire: only what survives serialization may forward

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,10 +180,6 @@ ignore = [
 # WorkflowRegistry is still a process-global fake singleton reaching the facade for config.
 # Making it engine-owned is its own change, since it alters what node libraries import.
 "src/griptape_nodes/node_library/workflow_registry.py" = ["TID251"]
-# artifact_normalization.py is called from Parameter converter closures in
-# exe_types/param_types/parameter_{image,audio,video,three_d}.py, which have no Engine of
-# their own yet, so it cannot come off this list until exe_types does.
-"src/griptape_nodes/utils/artifact_normalization.py" = ["TID251"]
 
 [tool.ruff.lint.flake8-type-checking]
 runtime-evaluated-base-classes = ["pydantic.BaseModel"]

--- a/src/griptape_nodes/app/worker_routing.py
+++ b/src/griptape_nodes/app/worker_routing.py
@@ -51,7 +51,10 @@ from griptape_nodes.retained_mode.events.library_events import ReloadAllLibrarie
 from griptape_nodes.retained_mode.events.parameter_events import MigrateParameterRequest
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 from griptape_nodes.retained_mode.events.project_events import (
+    AttemptMapAbsolutePathToProjectRequest,
     GetCurrentProjectRequest,
+    GetPathForMacroRequest,
+    GetSituationRequest,
     SetCurrentProjectRequest,
 )
 from griptape_nodes.retained_mode.events.resource_events import (
@@ -338,6 +341,20 @@ LOCAL_ONLY_REQUEST_TYPES: frozenset[type[RequestPayload]] = frozenset(
         # the first attribute access fails. In a worker that meant every sidecar write logged
         # "'dict' object has no attribute 'project_base_dir'" and silently wrote nothing.
         GetCurrentProjectRequest,
+        # The same argument, for the reads that resolve a path against that project. All three are
+        # pure template reads carrying serializable payloads, and all three sit on the per-file
+        # write path, so forwarding them costs a round trip per saved file.
+        # GetPathForMacroResultFailure also declares `missing_variables: set[str] | None`, the same
+        # shape cattrs cannot round-trip that broke the os_events forwards.
+        #
+        # AttemptMapAbsolutePathToProjectRequest is the write-side counterpart and hid longest:
+        # every file written through a ProjectFileDestination asks whether its absolute path maps
+        # back into the project so the caller can store a portable macro reference instead. It sits
+        # AFTER the write rather than before it, which is the only reason it read as a different
+        # case; its handler is a pure read of the same project template.
+        GetSituationRequest,
+        GetPathForMacroRequest,
+        AttemptMapAbsolutePathToProjectRequest,
         # Two requests carry a live Python object in a field, and both were local under the
         # allowlist this exclusion list replaces -- the flip is what started forwarding them.
         # `_registers_a_python_class` does not catch either: it matches a `type[...]` annotation,

--- a/src/griptape_nodes/app/worker_routing.py
+++ b/src/griptape_nodes/app/worker_routing.py
@@ -226,26 +226,18 @@ def _carries_a_macro_path(payload: type) -> bool:
     and fails if a carrier appears elsewhere -- rather than this widening to the registry, where
     a false positive would silently answer a request in the wrong process.
     """
-    # Handles both annotation forms: a real class where the module evaluates annotations eagerly,
-    # and the text where `from __future__ import annotations` postponed it.
     return any("MacroPath" in _annotation_text(field.type) for field in dc_fields(payload))
 
 
-# Requests a worker must answer itself, derived rather than listed. Two independent reasons, and
-# both are derived from the CAUSE so that a request added later is covered without anyone
-# remembering this file:
+# Requests a worker must answer itself, derived from the CAUSE rather than listed, so a request
+# added later is covered without anyone remembering this file. Two independent reasons: filesystem
+# work, where the shared-on-disk workspace makes the worker's own answer the authoritative one and
+# forwarding a write corrupts it (`content` is `str | bytes` and the wire form resolves back to
+# `str`); and carrying a MacroPath, which cannot serialize at all.
 #
-#   1. Filesystem work. The workspace is shared on disk, so the worker's own answer is already the
-#      right one -- and forwarding a write corrupted it (`content` is `str | bytes`, and the wire
-#      form resolves back to `str`).
-#   2. Anything carrying a MacroPath in either module swept below. `os_events` was not the only
-#      one: the artifact preview requests carry one too, and are reached from a handler that a
-#      worker runs locally, so the first version of this derivation still let them forward and
-#      fail. A registry-wide test guards the case of a third module growing a carrier.
-#
-# OpenAssociatedFileRequest is the one filesystem request that is deliberately NOT local: it hands
-# a path to the OS to open in the user's default application, and that side effect belongs where
-# the user is, not in a headless subprocess. It carries no MacroPath, so nothing else claims it.
+# OpenAssociatedFileRequest is the one filesystem request deliberately NOT local: it hands a path to
+# the OS to open in the user's default application, and that side effect belongs where the user is,
+# not in a headless subprocess. It carries no MacroPath, so nothing else claims it.
 _FORWARDING_FILESYSTEM_REQUESTS: frozenset[type[RequestPayload]] = frozenset({os_events.OpenAssociatedFileRequest})
 
 
@@ -372,8 +364,8 @@ LOCAL_ONLY_REQUEST_TYPES: frozenset[type[RequestPayload]] = frozenset(
 class RemoteHandler:
     """Worker-side dispatch shim.
 
-    Registered in place of the original manager handler for types in
-    every registered type except LOCAL_ONLY_REQUEST_TYPES. Forwards to the orchestrator while the worker is
+    Registered in place of the original manager handler for every registered type except
+    LOCAL_ONLY_REQUEST_TYPES. Forwards to the orchestrator while the worker is
     inside a ``worker_node_execution_scope``; delegates to the original
     handler otherwise (so bootstrap / library-load paths keep running locally).
 

--- a/src/griptape_nodes/app/worker_routing.py
+++ b/src/griptape_nodes/app/worker_routing.py
@@ -4,8 +4,8 @@ On a worker, a handful of request types must be serviced by the orchestrator
 because the authoritative state (flow graph, connections, node registry) lives
 there. This module provides:
 
-- ``LOCAL_ONLY_REQUEST_TYPES``: the exclusion list of request classes whose worker-
-  side handler should forward to the orchestrator.
+- ``LOCAL_ONLY_REQUEST_TYPES``: the request classes a worker answers ITSELF. Every other
+  registered type gets a ``RemoteHandler`` that forwards to the orchestrator.
 - ``RemoteHandler``: an async callable that replaces the original manager
   handler for those request types on the worker. While the worker is actively
   executing a node it forwards; outside that scope it delegates back to the
@@ -29,10 +29,12 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from dataclasses import fields as dc_fields
 from typing import TYPE_CHECKING, Any, cast
 
 from griptape_nodes.common.strict_mode import STRICT_MODE
 from griptape_nodes.common.strict_mode_checks import RULES
+from griptape_nodes.retained_mode.events import artifact_events, os_events
 from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultPayload,
@@ -49,6 +51,7 @@ from griptape_nodes.retained_mode.events.library_events import ReloadAllLibrarie
 from griptape_nodes.retained_mode.events.parameter_events import MigrateParameterRequest
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 from griptape_nodes.retained_mode.events.project_events import (
+    GetCurrentProjectRequest,
     SetCurrentProjectRequest,
 )
 from griptape_nodes.retained_mode.events.resource_events import (
@@ -172,6 +175,101 @@ class ActivateProjectResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure
     """Worker failed to adopt the orchestrator's current project."""
 
 
+def _registers_a_python_class(payload: type) -> bool:
+    """Whether a field is declared as a bare ``type``.
+
+    Two reasons such a request must stay local, and either alone is sufficient. cattrs has no
+    structure hook for ``type``, so the orchestrator's ingress raises and the worker blocks until
+    the forward times out. And the point of the request is to put a *class* into a process-local
+    registry: forwarding it would register something in the wrong process while the worker -- the
+    one that needs the provider while running a node -- registers nothing.
+    """
+    return any(
+        _annotation_text(field.type).strip().startswith(("type[", "type "))
+        or _annotation_text(field.type).strip() == "type"
+        for field in dc_fields(payload)
+    )
+
+
+def _annotation_text(annotation: object) -> str:
+    """The annotation as text, whichever form the module stored it in.
+
+    `str(annotation)` rather than `__name__`, because composite shapes have no useful name:
+    `MacroPath | None` is a UnionType whose `__name__` does not exist, and `list[MacroPath]`
+    is named just `list` -- both would silently defeat a matcher that only reads names, and
+    a missed MacroPath means a forwarded request that dies on the wire instead of answering
+    locally.
+    """
+    if isinstance(annotation, str):
+        return annotation
+    if isinstance(annotation, type):
+        # str() of a plain class is "<class 'x.Y'>", which matches nothing a matcher looks
+        # for -- and `provider_class: type` (a bare builtin) is exactly the shape the
+        # type-registration predicate exists to catch.
+        return annotation.__name__
+    return str(annotation)
+
+
+def _carries_a_macro_path(payload: type) -> bool:
+    """Whether any field of ``payload`` is declared as a ``MacroPath``.
+
+    A MacroPath wraps a ParsedMacro, which will not serialize, so a request carrying one cannot be
+    forwarded at all: the send raises and the worker blocks until the forward times out. Matched on
+    the declared annotation text rather than a resolved type, because these modules annotate under
+    `from __future__ import annotations` and several cannot be resolved at runtime.
+
+    Applied to the two modules swept below, which are the only ones defining a MacroPath carrier
+    today. The invariant is wider than that scope, so a test sweeps the whole payload registry
+    and fails if a carrier appears elsewhere -- rather than this widening to the registry, where
+    a false positive would silently answer a request in the wrong process.
+    """
+    # Handles both annotation forms: a real class where the module evaluates annotations eagerly,
+    # and the text where `from __future__ import annotations` postponed it.
+    return any("MacroPath" in _annotation_text(field.type) for field in dc_fields(payload))
+
+
+# Requests a worker must answer itself, derived rather than listed. Two independent reasons, and
+# both are derived from the CAUSE so that a request added later is covered without anyone
+# remembering this file:
+#
+#   1. Filesystem work. The workspace is shared on disk, so the worker's own answer is already the
+#      right one -- and forwarding a write corrupted it (`content` is `str | bytes`, and the wire
+#      form resolves back to `str`).
+#   2. Anything carrying a MacroPath in either module swept below. `os_events` was not the only
+#      one: the artifact preview requests carry one too, and are reached from a handler that a
+#      worker runs locally, so the first version of this derivation still let them forward and
+#      fail. A registry-wide test guards the case of a third module growing a carrier.
+#
+# OpenAssociatedFileRequest is the one filesystem request that is deliberately NOT local: it hands
+# a path to the OS to open in the user's default application, and that side effect belongs where
+# the user is, not in a headless subprocess. It carries no MacroPath, so nothing else claims it.
+_FORWARDING_FILESYSTEM_REQUESTS: frozenset[type[RequestPayload]] = frozenset({os_events.OpenAssociatedFileRequest})
+
+
+def _local_only_by_derivation() -> frozenset[type[RequestPayload]]:
+    derived: set[type[RequestPayload]] = set()
+    for module in (os_events, artifact_events):
+        for payload in vars(module).values():
+            # `__module__` rather than mere namespace membership: these modules import request
+            # types from each other, and a re-exported CreateNodeRequest becoming local-only would
+            # silently let a worker mutate its own non-authoritative graph.
+            if (
+                not isinstance(payload, type)
+                or not issubclass(payload, RequestPayload)
+                or payload is RequestPayload
+                or payload.__module__ != module.__name__
+            ):
+                continue
+            if payload in _FORWARDING_FILESYSTEM_REQUESTS:
+                continue
+            if module is os_events or _carries_a_macro_path(payload) or _registers_a_python_class(payload):
+                derived.add(payload)
+    return frozenset(derived)
+
+
+_LOCAL_ONLY_FILESYSTEM_REQUESTS: frozenset[type[RequestPayload]] = _local_only_by_derivation()
+
+
 LOCAL_ONLY_REQUEST_TYPES: frozenset[type[RequestPayload]] = frozenset(
     {
         # Requests a worker must answer ITSELF while executing a node. Everything else
@@ -210,6 +308,36 @@ LOCAL_ONLY_REQUEST_TYPES: frozenset[type[RequestPayload]] = frozenset(
         # asked, mid-node. Reached because in_node_execution() is a process-wide refcount, so a
         # reload dispatched by a broadcast handler forwards whenever any node happens to be running.
         ReloadAllLibrariesRequest,
+        # os_events: a worker does its own filesystem work. The workspace is shared on disk, so
+        # the local answer is already the right one -- the same argument as the project reads
+        # below -- and forwarding was actively destructive. `content` is `str | bytes`, and the
+        # wire form base64s bytes into a JSON string that cattrs resolves back to `str`, so a
+        # worker's write landed corrupted with no error anywhere. Requests carrying a `MacroPath`
+        # (`File("{outputs}/out.png")`, `Directory(...).with_versioning()`) cannot be serialized
+        # at all, so the worker blocked until the forward timed out. And four of the failure
+        # results declare `SequenceScanFailureReason | FileIOFailureReason`, a union cattrs cannot
+        # disambiguate, so even the error could not come back.
+        #
+        # Stated as a rule over the whole module rather than a list of the ones found broken,
+        # because the list kept being incomplete: `_LOCAL_ONLY_FILESYSTEM_REQUESTS` is derived
+        # from os_events itself, so a filesystem request added later is covered by construction.
+        # `tests/unit/app/test_worker_routing_filesystem.py` fails if a new one appears without a
+        # routing decision.
+        *_LOCAL_ONLY_FILESYSTEM_REQUESTS,
+        # project_events: a worker already adopts the orchestrator's project (at spawn, and
+        # again on a switch), and a project's base directory is shared on-disk state -- the
+        # same class as the workspace path. So the worker's own answer is correct by
+        # construction, and forwarding buys nothing while costing a round trip on a path as
+        # hot as writing sidecar metadata for every saved file.
+        #
+        # It also cost correctness. Forwarded results are rebuilt with cattrs, and
+        # GetCurrentProjectResultSuccess annotates `project_info: ProjectInfo` under
+        # TYPE_CHECKING to break an import cycle. cattrs cannot resolve that name from this
+        # module's namespace, so the converter's documented NameError fallback passes the raw
+        # dict into the constructor: isinstance() passes while `.project_info` is a dict, and
+        # the first attribute access fails. In a worker that meant every sidecar write logged
+        # "'dict' object has no attribute 'project_base_dir'" and silently wrote nothing.
+        GetCurrentProjectRequest,
         # Two requests carry a live Python object in a field, and both were local under the
         # allowlist this exclusion list replaces -- the flip is what started forwarding them.
         # `_registers_a_python_class` does not catch either: it matches a `type[...]` annotation,

--- a/src/griptape_nodes/files/drivers/local_file_driver.py
+++ b/src/griptape_nodes/files/drivers/local_file_driver.py
@@ -13,7 +13,7 @@ from griptape_nodes.files.path_utils import (
     resolve_path_safely,
     sanitize_path_string,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.engine import current_engine
 
 
 class LocalFileDriver(BaseFileDriver):
@@ -91,7 +91,7 @@ class LocalFileDriver(BaseFileDriver):
         # Anchor a relative path on the workspace directory. Mirrors File.resolve()
         # logic so reported path matches opened path.
         if not path.is_absolute():
-            workspace_path = GriptapeNodes.ConfigManager().workspace_path
+            workspace_path = current_engine().config_manager.workspace_path
             # Normalise joined path without evaluating symlinks en route.
             path = resolve_path_safely(workspace_path / path)
 

--- a/src/griptape_nodes/files/drivers/static_server_file_driver.py
+++ b/src/griptape_nodes/files/drivers/static_server_file_driver.py
@@ -12,7 +12,7 @@ import anyio
 
 from griptape_nodes.files.base_file_driver import BaseFileDriver
 from griptape_nodes.files.path_utils import parse_static_server_url
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.engine import current_engine
 
 
 class StaticServerFileDriver(BaseFileDriver):
@@ -57,7 +57,7 @@ class StaticServerFileDriver(BaseFileDriver):
         Raises:
             ValueError: If URL format is invalid
         """
-        workspace_path = GriptapeNodes.ConfigManager().workspace_path
+        workspace_path = current_engine().config_manager.workspace_path
         local_path = parse_static_server_url(location, workspace_path)
 
         if local_path is None:

--- a/src/griptape_nodes/files/file.py
+++ b/src/griptape_nodes/files/file.py
@@ -18,6 +18,7 @@ from griptape_nodes.files.path_utils import (
     resolve_file_path,
     resolve_path_safely,
 )
+from griptape_nodes.retained_mode.engine import current_engine
 from griptape_nodes.retained_mode.events.os_events import (
     ExistingFilePolicy,
     FileIOFailureReason,
@@ -221,7 +222,7 @@ def _resolve_plain_path(path_str: str) -> str:
     if local_path is not None:
         path_str = local_path
 
-    workspace_path = GriptapeNodes.ConfigManager().workspace_path
+    workspace_path = current_engine().config_manager.workspace_path
 
     if is_url(path_str):
         static_server_path = parse_static_server_url(path_str, workspace_path)

--- a/src/griptape_nodes/retained_mode/events/event_converter.py
+++ b/src/griptape_nodes/retained_mode/events/event_converter.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import logging
 import traceback
 import types
+from collections.abc import Mapping, MutableMapping
 from dataclasses import fields as dc_fields
 from dataclasses import is_dataclass
 from datetime import datetime
+from functools import cache
 from pathlib import Path
-from typing import Any, Union, get_args, get_origin
+from typing import Any, Union, get_args, get_origin, get_type_hints
 
 from cattrs.gen import make_dict_structure_fn, make_dict_unstructure_fn, override
 from cattrs.preconf.json import make_converter
@@ -169,12 +171,96 @@ def _fallback_unstructure(obj: Any) -> dict[str, Any]:
     return result
 
 
+# Classes already reported as arriving with an unstructured field, so the warning below fires
+# once per class rather than once per payload.
+_REPORTED_DEGRADED_CLASSES: set[type] = set()
+
+# Annotation fragments meaning "a dict here IS the declared type", so a dict-valued field is not
+# evidence of anything going wrong. Includes project aliases OF a mapping: `Requirements` is
+# `dict[str, RequirementValue]`, and reads as neither "dict" nor "Mapping", so without it every
+# forwarded resource-lock request reported its own `requirements` as corrupted. Matched as text
+# because the classes reaching this path are precisely the ones whose annotations cannot be
+# resolved -- get_type_hints is tried first for the ones that can.
+_DICT_SHAPED_ANNOTATIONS = ("dict", "Dict", "Mapping", "Any", "object", "Requirements")
+
+
+@cache
+def _dict_shaped_fields(cls: type) -> frozenset[str]:
+    """Fields where a dict IS the declared type, so a dict value proves nothing is wrong.
+
+    Resolved properly where possible rather than matched as text, because an alias hides the shape:
+    ``Requirements = dict[str, RequirementValue]`` reads as neither "dict" nor "Mapping", so a text
+    rule reported a GPU-lock request's `requirements` as corrupted every time one was forwarded --
+    the exact false-alarm class this reporting was gated to avoid. Falls back to annotation text for
+    fields that cannot be resolved, which is the situation this whole code path exists for.
+    """
+    shaped: set[str] = set()
+    try:
+        hints = get_type_hints(cls)
+    except Exception:
+        hints = {}
+    for field in dc_fields(cls):
+        resolved = hints.get(field.name)
+        if resolved is not None:
+            origin = get_origin(resolved) or resolved
+            if origin in (dict, Mapping, MutableMapping) or resolved in (Any, object):
+                shaped.add(field.name)
+            continue
+        annotation = field.type if isinstance(field.type, str) else getattr(field.type, "__name__", "")
+        if any(fragment in annotation for fragment in _DICT_SHAPED_ANNOTATIONS):
+            shaped.add(field.name)
+    return frozenset(shaped)
+
+
+def _looks_unstructured(value: Any) -> bool:
+    """Whether a value came through as raw JSON rather than the type its field declares.
+
+    Lists count: a field declared ``list[SomeDataclass]`` degrades into a list of dicts exactly
+    the way a single field degrades into one dict, and reporting only the scalar case would miss
+    every collection-valued payload.
+    """
+    if isinstance(value, dict):
+        return True
+    return isinstance(value, list) and any(isinstance(item, dict) for item in value)
+
+
+def _report_unstructured_fields(cls: type, values: dict[str, Any]) -> None:
+    """Warn when the fallback left a field holding a raw dict.
+
+    Checked against the actual value rather than the annotation, because the annotation is
+    unresolvable by definition in this path -- that is why the fallback is running. A dict where
+    the declared type is something else is the corruption signature: the object passes isinstance()
+    while the field is not the type it claims, and the mismatch surfaces later as
+    "'dict' object has no attribute ...", arbitrarily far from here.
+
+    Deliberately silent for classes that reach the fallback over an alias of a builtin
+    (``ProjectID = str``), which is most of them. There the raw JSON value is already the right
+    type and nothing degrades; warning would bury the cases that matter in false alarms.
+    """
+    if cls in _REPORTED_DEGRADED_CLASSES:
+        return
+    dict_shaped = _dict_shaped_fields(cls)
+    degraded = [name for name, value in values.items() if _looks_unstructured(value) and name not in dict_shaped]
+    if not degraded:
+        return
+    _REPORTED_DEGRADED_CLASSES.add(cls)
+    logger.warning(
+        "'%s' was rebuilt from a serialized payload with %s left as raw dict(s), because its "
+        "annotations could not be resolved (usually a TYPE_CHECKING-only import). Attribute "
+        "access on those fields will fail. Give the annotation a runtime-importable name, or "
+        "register an explicit structure hook for this class.",
+        cls.__name__,
+        ", ".join(f"'{name}'" for name in degraded),
+    )
+
+
 def _make_fallback_structure_fn(cls: type) -> Any:
     """Fallback structure for dataclasses where get_type_hints() fails."""
 
     def structure_fn(data: dict[str, Any], _cls: type = cls) -> Any:
         init_fields = {f.name for f in dc_fields(_cls) if f.init}
         filtered = {k: v for k, v in data.items() if k in init_fields}
+        _report_unstructured_fields(_cls, filtered)
         return _cls(**filtered)
 
     return structure_fn
@@ -196,7 +282,11 @@ def _make_dataclass_structure_fn(cls: type) -> Any:
             if not f.init:
                 overrides[f.name] = override(omit=True)
         return make_dict_structure_fn(cls, converter, **overrides)
-    except NameError:
+    except NameError as err:
+        # Reported when a payload actually arrives with an unstructured field, not here: most
+        # classes reaching this branch do so over an alias of a builtin and degrade in no way.
+        # See _report_unstructured_fields.
+        logger.debug("Falling back to field-iteration structuring for '%s': %s", cls.__name__, err)
         return _make_fallback_structure_fn(cls)
 
 

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -249,9 +249,8 @@ class GriptapeNodes(metaclass=_EngineRootMeta):
 
     @classmethod
     def StaticFilesManager(cls) -> StaticFilesManager:
-        # Deliberately unguarded: a worker shares the workspace on disk and serves static
-        # files through the orchestrator's server URL, so its StaticFilesManager is real and
-        # its answers are correct. This is a decided exception, not an oversight.
+        # Unguarded: a worker shares the workspace on disk and serves static files through the
+        # orchestrator's server URL, so its StaticFilesManager answers correctly.
         return current_engine().static_files_manager
 
     @classmethod

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -89,6 +89,18 @@ def _forbid_manager_during_worker_execution(manager_name: str, request_hint: str
 
     Scoped to node execution deliberately: engine boot and library load run in the worker
     too, and they legitimately need their own managers.
+
+    Adding a manager here is only safe once EVERY engine-internal path to it is off the facade.
+    The guard cannot tell library code from engine code -- both arrive as the same classmethod --
+    so a manager still reached internally through the facade raises on the engine's own plumbing
+    rather than on the node author it is meant to teach. That is not hypothetical: the storage
+    driver read the workspace path this way, which made a worker unable to write a single file.
+
+    Every manager accessor carries this guard except StaticFilesManager, which is a decided
+    exception: a worker shares the workspace on disk, so its static-file answers are real.
+    Everything else either answers from worker state that can diverge from the orchestrator's
+    (silently wrong, which is worse than an error) or is orchestrator bookkeeping a node has
+    no business touching mid-execution.
     """
     engine = current_engine()
     if not engine.library_manager.is_worker:
@@ -142,42 +154,67 @@ class GriptapeNodes(metaclass=_EngineRootMeta):
 
     @classmethod
     def EventManager(cls) -> EventManager:
+        _forbid_manager_during_worker_execution(
+            "EventManager",
+            "your node's own APIs (append_value_to_parameter, publish_update_to_parameter), whose events forward on their own",
+        )
         return current_engine().event_manager
 
     @classmethod
     def LibraryManager(cls) -> LibraryManager:
+        _forbid_manager_during_worker_execution(
+            "LibraryManager", "ListRegisteredLibrariesRequest(...) / GetNodeMetadataFromLibraryRequest(...)"
+        )
         return current_engine().library_manager
 
     @classmethod
     def ModelManager(cls) -> ModelManager:
+        _forbid_manager_during_worker_execution("ModelManager", "ListModelDownloadsRequest(...)")
         return current_engine().model_manager
 
     @classmethod
     def AccessManager(cls) -> AccessManager:
+        _forbid_manager_during_worker_execution("AccessManager", "QueryModelAccessForNodeRequest(...)")
         return current_engine().access_manager
 
     @classmethod
     def ObjectManager(cls) -> ObjectManager:
+        _forbid_manager_during_worker_execution(
+            "ObjectManager", "a request against the orchestrator's graph (e.g., RenameObjectRequest(...))"
+        )
         return current_engine().object_manager
 
     @classmethod
     def FlowManager(cls) -> FlowManager:
+        _forbid_manager_during_worker_execution(
+            "FlowManager", "flow requests (e.g., ListNodesInFlowRequest(...), ListConnectionsForNodeRequest(...))"
+        )
         return current_engine().flow_manager
 
     @classmethod
     def NodeManager(cls) -> NodeManager:
+        _forbid_manager_during_worker_execution(
+            "NodeManager", "node requests (e.g., GetNodeResolutionStateRequest(...), AddParameterToNodeRequest(...))"
+        )
         return current_engine().node_manager
 
     @classmethod
     def ContextManager(cls) -> ContextManager:
+        _forbid_manager_during_worker_execution(
+            "ContextManager", "GetCurrentProjectRequest(...) for the project; flow context belongs to the orchestrator"
+        )
         return current_engine().context_manager
 
     @classmethod
     def WorkflowManager(cls) -> WorkflowManager:
+        _forbid_manager_during_worker_execution(
+            "WorkflowManager", "workflow requests (e.g., ListWorkflowsRequest(...))"
+        )
         return current_engine().workflow_manager
 
     @classmethod
     def ArbitraryCodeExecManager(cls) -> ArbitraryCodeExecManager:
+        _forbid_manager_during_worker_execution("ArbitraryCodeExecManager", "RunArbitraryPythonStringRequest(...)")
         return current_engine().arbitrary_code_exec_manager
 
     @classmethod
@@ -187,7 +224,15 @@ class GriptapeNodes(metaclass=_EngineRootMeta):
 
     @classmethod
     def OSManager(cls) -> OSManager:
-        _forbid_manager_during_worker_execution("OSManager", "ReadFileRequest(...) / WriteFileRequest(...)")
+        # Files are the exception to the reason this guard exists: a worker shares the workspace
+        # on disk, so its own answer is right, and ReadFileRequest / WriteFileRequest are
+        # answered locally rather than forwarded. Going through the request still matters --
+        # paths get canonicalized and the OS boundary's policies apply -- so the guard stays,
+        # but it must not claim the orchestrator is what makes the value correct.
+        _forbid_manager_during_worker_execution(
+            "OSManager",
+            "ReadFileRequest(...) / WriteFileRequest(...), which canonicalize the path and apply the write policy",
+        )
         return current_engine().os_manager
 
     @classmethod
@@ -197,60 +242,95 @@ class GriptapeNodes(metaclass=_EngineRootMeta):
 
     @classmethod
     def OperationDepthManager(cls) -> OperationDepthManager:
+        _forbid_manager_during_worker_execution(
+            "OperationDepthManager", "nothing: operation depth is orchestrator bookkeeping with no node-facing request"
+        )
         return current_engine().operation_depth_manager
 
     @classmethod
     def StaticFilesManager(cls) -> StaticFilesManager:
+        # Deliberately unguarded: a worker shares the workspace on disk and serves static
+        # files through the orchestrator's server URL, so its StaticFilesManager is real and
+        # its answers are correct. This is a decided exception, not an oversight.
         return current_engine().static_files_manager
 
     @classmethod
     def AgentManager(cls) -> AgentManager:
+        _forbid_manager_during_worker_execution("AgentManager", "agent requests (e.g., RunAgentRequest(...))")
         return current_engine().agent_manager
 
     @classmethod
     def VersionCompatibilityManager(cls) -> VersionCompatibilityManager:
+        _forbid_manager_during_worker_execution("VersionCompatibilityManager", "GetEngineVersionRequest(...)")
         return current_engine().version_compatibility_manager
 
     @classmethod
     def SessionManager(cls) -> SessionManager:
+        _forbid_manager_during_worker_execution(
+            "SessionManager", "session state belongs to the orchestrator; there is no node-facing request"
+        )
         return current_engine().session_manager
 
     @classmethod
     def MCPManager(cls) -> MCPManager:
+        _forbid_manager_during_worker_execution("MCPManager", "MCP requests (e.g., ListMCPServersRequest(...))")
         return current_engine().mcp_manager
 
     @classmethod
     def EngineIdentityManager(cls) -> EngineIdentityManager:
+        _forbid_manager_during_worker_execution("EngineIdentityManager", "GetEngineNameRequest(...)")
         return current_engine().engine_identity_manager
 
     @classmethod
     def ResourceManager(cls) -> ResourceManager:
+        _forbid_manager_during_worker_execution(
+            "ResourceManager", "resource requests (e.g., ListResourcesRequest(...))"
+        )
         return current_engine().resource_manager
 
     @classmethod
     def SyncManager(cls) -> SyncManager:
+        _forbid_manager_during_worker_execution(
+            "SyncManager", "sync state belongs to the orchestrator; there is no node-facing request"
+        )
         return current_engine().sync_manager
 
     @classmethod
     def VariablesManager(cls) -> VariablesManager:
+        _forbid_manager_during_worker_execution(
+            "VariablesManager",
+            "variable requests (e.g., GetVariableRequest(...)); {VAR} macros resolve before process() runs",
+        )
         return current_engine().variables_manager
 
     @classmethod
     def UserManager(cls) -> UserManager:
+        _forbid_manager_during_worker_execution("UserManager", "user requests (e.g., GetUserRequest(...))")
         return current_engine().user_manager
 
     @classmethod
     def ProjectManager(cls) -> ProjectManager:
+        _forbid_manager_during_worker_execution(
+            "ProjectManager",
+            "project requests (e.g., GetCurrentProjectRequest(...)), which answer locally and correctly",
+        )
         return current_engine().project_manager
 
     @classmethod
     def ArtifactManager(cls) -> ArtifactManager:
+        _forbid_manager_during_worker_execution(
+            "ArtifactManager", "artifact requests (e.g., ExtractArtifactMetadataRequest(...)), which answer locally"
+        )
         return current_engine().artifact_manager
 
     @classmethod
     def ManifestManager(cls) -> ManifestManager:
+        _forbid_manager_during_worker_execution("ManifestManager", "manifest requests, answered by the orchestrator")
         return current_engine().manifest_manager
 
     @classmethod
     def WorkerManager(cls) -> WorkerManager:
+        _forbid_manager_during_worker_execution(
+            "WorkerManager", "nothing: worker lifecycle belongs to the orchestrator"
+        )
         return current_engine().worker_manager

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -469,16 +469,12 @@ class StaticFilesManager(EngineScoped):
         if not isinstance(self.storage_driver, LocalStorageDriver):
             return
 
-        # Checked ahead of the payload deliberately. A parent that set this is telling us it
-        # serves the shared workspace on a port that outlives this process, which is a strictly
-        # stronger signal than "some process serves it" -- and the host announces its own URL on
-        # the payload either way, so testing the payload first made this branch unreachable and
-        # the app repo the only thing standing between a worker and an ephemeral-port URL.
-        # Gated on being a worker: only a spawning orchestrator sets this variable on purpose,
-        # so in any other process it is a leaked shell export, and adopting it would silently
-        # point every asset URL at an address nothing here controls. The payload's own flag is
-        # the only race-free source: the engine-level worker flag is set by LibraryManager's
-        # listener for this same event, and listeners run concurrently in no defined order.
+        # The env var outranks the payload: a parent that set it serves the shared workspace on a
+        # port outliving this process, a stronger signal than "some process serves it". Gated on
+        # being a worker, because anywhere else the variable is a leaked shell export and adopting
+        # it would point every asset URL at an address nothing here controls. Read from the payload
+        # rather than the engine-level worker flag, which LibraryManager sets from a concurrent
+        # listener for this same event.
         if payload.is_worker and os.getenv(ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV):
             adopted = os.environ[ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV].rstrip("/")
             self._static_server_base_url = adopted

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -469,7 +469,21 @@ class StaticFilesManager(EngineScoped):
         if not isinstance(self.storage_driver, LocalStorageDriver):
             return
 
-        if payload.static_server_base_url is not None:
+        # Checked ahead of the payload deliberately. A parent that set this is telling us it
+        # serves the shared workspace on a port that outlives this process, which is a strictly
+        # stronger signal than "some process serves it" -- and the host announces its own URL on
+        # the payload either way, so testing the payload first made this branch unreachable and
+        # the app repo the only thing standing between a worker and an ephemeral-port URL.
+        # Gated on being a worker: only a spawning orchestrator sets this variable on purpose,
+        # so in any other process it is a leaked shell export, and adopting it would silently
+        # point every asset URL at an address nothing here controls. The payload's own flag is
+        # the only race-free source: the engine-level worker flag is set by LibraryManager's
+        # listener for this same event, and listeners run concurrently in no defined order.
+        if payload.is_worker and os.getenv(ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV):
+            adopted = os.environ[ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV].rstrip("/")
+            self._static_server_base_url = adopted
+            logger.debug("Adopted the orchestrator's static server at %s", adopted)
+        elif payload.static_server_base_url is not None:
             # The host process serves this workspace and told us where. Pointing at its server
             # keeps asset URLs valid for as long as the host runs, rather than only as long as
             # this engine does.
@@ -479,13 +493,6 @@ class StaticFilesManager(EngineScoped):
             # Initialization can complete more than once per process: a workflow executor
             # broadcasts it for its own run. Where the workspace is served is already settled.
             logger.debug("Static server already settled at %s", self._static_server_base_url)
-        elif os.getenv(ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV):
-            # A worker: the orchestrator that spawned this process already serves the shared
-            # workspace, and its server outlives this one. Adopting it keeps asset URLs valid
-            # after this worker is evicted, where a URL on our own ephemeral port would not be.
-            adopted = os.environ[ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV].rstrip("/")
-            self._static_server_base_url = adopted
-            logger.debug("Adopted the orchestrator's static server at %s", adopted)
         else:
             # No host-provided server, so serve the workspace here.
             #

--- a/src/griptape_nodes/retained_mode/managers/worker_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/worker_manager.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from griptape_nodes.bootstrap.utils.subprocess_websocket_base import WebSocketMessage
+from griptape_nodes.drivers.storage.local_storage_driver import LocalStorageDriver
 from griptape_nodes.retained_mode.engine import EngineScoped
 from griptape_nodes.retained_mode.events import worker_events
 from griptape_nodes.retained_mode.events.app_events import ConfigChanged, CurrentProjectChanged, SecretChanged
@@ -446,7 +447,21 @@ class WorkerManager(EngineScoped):
         try:
             return self.engine.static_files_manager.static_server_base_url
         except RuntimeError:
-            # Raised when accessed before on_app_initialization_complete resolved it.
+            # Raised when accessed before on_app_initialization_complete resolved it. The two
+            # listeners involved run as concurrent tasks, so this is a race the static one normally
+            # wins -- but losing it hands the worker no URL, and it falls back to serving on its own
+            # ephemeral port, which is the dead-links bug this exists to prevent. Loud, because it
+            # is invisible otherwise.
+            #
+            # Only for local storage. On a cloud backend nothing resolves this property at all, and
+            # a worker's URLs come from the same bucket as the orchestrator's, so they outlive it
+            # regardless -- warning there would fire on every single spawn and be false.
+            if isinstance(self.engine.static_files_manager.storage_driver, LocalStorageDriver):
+                logger.warning(
+                    "The static server URL was not resolved yet when a worker was spawned, so the "
+                    "worker will serve assets on its own port. URLs it produces will stop working "
+                    "when it exits."
+                )
             return None
 
     async def evict_worker(self, worker_engine_id: str) -> None:
@@ -645,11 +660,12 @@ class WorkerManager(EngineScoped):
         ]
         await self.spawn_worker(args, library_name)
 
-    @staticmethod
-    def _log_spawn_error(task: asyncio.Task, library_name: str) -> None:
+    def _log_spawn_error(self, task: asyncio.Task, library_name: str) -> None:
+        """Log a spawn that never produced a worker."""
         exc = task.exception()
-        if exc is not None:
-            logger.error("Failed to spawn worker for library '%s': %s", library_name, exc)
+        if exc is None:
+            return
+        logger.error("Failed to spawn worker for library '%s': %s", library_name, exc)
 
     def get_topics_to_subscribe(self, *, is_worker: bool) -> list[str]:
         """Build the list of topics to subscribe to at connection start.

--- a/src/griptape_nodes/servers/static.py
+++ b/src/griptape_nodes/servers/static.py
@@ -21,9 +21,8 @@ from rich.logging import RichHandler
 
 # Reaches managers through the ambient engine rather than the GriptapeNodes facade. This module
 # runs on uvicorn's thread, and the facade's worker guard keys off a PROCESS-WIDE
-# in-node-execution refcount rather than a contextvar -- so serving a workspace asset while any
-# node was executing raised, and a worker running its own static server would 500 on every
-# fetch. servers/** is TID251-allowlisted, so nothing would have flagged it.
+# in-node-execution refcount rather than a contextvar, so serving a workspace asset would raise
+# whenever any node happened to be executing.
 from griptape_nodes.retained_mode.engine import current_engine
 
 # Whether to enable the static server

--- a/src/griptape_nodes/servers/static.py
+++ b/src/griptape_nodes/servers/static.py
@@ -19,7 +19,12 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from rich.logging import RichHandler
 
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+# Reaches managers through the ambient engine rather than the GriptapeNodes facade. This module
+# runs on uvicorn's thread, and the facade's worker guard keys off a PROCESS-WIDE
+# in-node-execution refcount rather than a contextvar -- so serving a workspace asset while any
+# node was executing raised, and a worker running its own static server would 500 on every
+# fetch. servers/** is TID251-allowlisted, so nothing would have flagged it.
+from griptape_nodes.retained_mode.engine import current_engine
 
 # Whether to enable the static server
 STATIC_SERVER_ENABLED = os.getenv("STATIC_SERVER_ENABLED", "true").lower() == "true"
@@ -45,7 +50,7 @@ async def _create_static_file_upload_url(request: Request) -> dict:
 
     Similar to a presigned URL, but for uploading files to the static server.
     """
-    base_url = GriptapeNodes.StaticFilesManager().static_server_base_url
+    base_url = current_engine().static_files_manager.static_server_base_url
 
     body = await request.json()
     file_path = body["file_path"].lstrip("/")
@@ -60,7 +65,7 @@ async def _create_static_file(request: Request, file_path: str) -> dict:
         msg = "Static server is not enabled. Please set STATIC_SERVER_ENABLED to True."
         raise ValueError(msg)
 
-    workspace_directory = GriptapeNodes.ConfigManager().workspace_path
+    workspace_directory = current_engine().config_manager.workspace_path
     full_file_path = workspace_directory / file_path
 
     # Create parent directories if they don't exist
@@ -78,7 +83,7 @@ async def _create_static_file(request: Request, file_path: str) -> dict:
         logger.error(msg)
         raise HTTPException(status_code=500, detail=msg) from e
 
-    base_url = GriptapeNodes.StaticFilesManager().static_server_base_url
+    base_url = current_engine().static_files_manager.static_server_base_url
     static_url = urljoin(f"{base_url}{STATIC_SERVER_URL}/", file_path)
     return {"url": static_url}
 
@@ -89,7 +94,7 @@ async def _list_static_files(file_path_prefix: str = "") -> dict:
         msg = "Static server is not enabled. Please set STATIC_SERVER_ENABLED to True."
         raise HTTPException(status_code=500, detail=msg)
 
-    workspace_directory = GriptapeNodes.ConfigManager().workspace_path
+    workspace_directory = current_engine().config_manager.workspace_path
 
     # Handle the prefix path
     if file_path_prefix:
@@ -119,7 +124,7 @@ async def _delete_static_file(file_path: str) -> dict:
         msg = "Static server is not enabled. Please set STATIC_SERVER_ENABLED to True."
         raise HTTPException(status_code=500, detail=msg)
 
-    workspace_directory = GriptapeNodes.ConfigManager().workspace_path
+    workspace_directory = current_engine().config_manager.workspace_path
     file_full_path = workspace_directory / file_path
 
     anyio_file_path = anyio.Path(file_full_path)
@@ -163,7 +168,7 @@ async def _serve_library_widget(library_name: str, file_path: str) -> FileRespon
     Raises:
         HTTPException: If library not found, file not found, or path traversal detected
     """
-    library_manager = GriptapeNodes.LibraryManager()
+    library_manager = current_engine().library_manager
 
     # Find the library's directory by looking up its info
     library_info = library_manager.get_library_info_by_library_name(library_name)
@@ -278,7 +283,7 @@ class WorkspaceStaticFiles(StaticFiles):
         return super().lookup_path(path)
 
     def _current_directory(self) -> Path:
-        workspace_directory = GriptapeNodes.ConfigManager().workspace_path
+        workspace_directory = current_engine().config_manager.workspace_path
         if self._subdirectory is None:
             return workspace_directory
         return workspace_directory / self._subdirectory
@@ -321,7 +326,7 @@ def start_static_server(sock: socket.socket) -> None:
         "http://localhost:5173",
         "http://localhost:5174",
         "gtn-editor://editor",
-        GriptapeNodes.StaticFilesManager().static_server_base_url,
+        current_engine().static_files_manager.static_server_base_url,
     ]
 
     # Add CORS middleware
@@ -336,8 +341,8 @@ def start_static_server(sock: socket.socket) -> None:
 
     # Mount static files. The served directories resolve the workspace live on each request
     # (see WorkspaceStaticFiles) so they follow runtime workspace changes such as project switches.
-    workspace_directory = GriptapeNodes.ConfigManager().workspace_path
-    static_files_directory = GriptapeNodes.ConfigManager().get_config_value("static_files_directory")
+    workspace_directory = current_engine().config_manager.workspace_path
+    static_files_directory = current_engine().config_manager.get_config_value("static_files_directory")
 
     app.mount(
         STATIC_SERVER_URL,

--- a/src/griptape_nodes/utils/artifact_normalization.py
+++ b/src/griptape_nodes/utils/artifact_normalization.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from griptape_nodes.files.path_utils import parse_static_server_url
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.engine import current_engine
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +54,7 @@ def _resolve_file_path(file_path: str) -> Path | None:  # noqa: PLR0911
 
     # Get workspace path (can raise exceptions from ConfigManager)
     try:
-        workspace_path = GriptapeNodes.ConfigManager().workspace_path
+        workspace_path = current_engine().config_manager.workspace_path
     except (AttributeError, RuntimeError, KeyError) as e:
         logger.debug("Failed to get workspace path: %s", e)
         return None
@@ -117,7 +117,7 @@ def _upload_file_to_static_storage(file_path: Path, artifact_type: type[Any]) ->
     try:
         file_data = file_path.read_bytes()
         file_name = file_path.name
-        static_files_manager = GriptapeNodes.StaticFilesManager()
+        static_files_manager = current_engine().static_files_manager
         url = static_files_manager.save_static_file(file_data, file_name)
         return artifact_type(url)
     except Exception as e:

--- a/src/griptape_nodes/utils/async_utils.py
+++ b/src/griptape_nodes/utils/async_utils.py
@@ -18,6 +18,13 @@ logger = logging.getLogger(__name__)
 async def call_function(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
     """Call a function, handling both sync and async cases.
 
+    Awaits on what the call RETURNS rather than asking whether ``func`` is a coroutine
+    function. The two differ for a callable object: ``inspect.iscoroutinefunction`` inspects
+    the object, not its ``__call__``, so an instance with an ``async def __call__`` looks
+    synchronous and its coroutine comes back unawaited -- as a value, silently, to be handed
+    on as though it were the result. Every caller here dispatches to registered callbacks,
+    and a callback is as likely to be an instance as a function.
+
     Args:
         func: The function to call (sync or async)
         *args: Positional arguments to pass to the function
@@ -26,9 +33,10 @@ async def call_function(func: Callable[..., Any], *args: Any, **kwargs: Any) -> 
     Returns:
         The result of the function call
     """
-    if inspect.iscoroutinefunction(func):
-        return await func(*args, **kwargs)
-    return func(*args, **kwargs)
+    result = func(*args, **kwargs)
+    if inspect.isawaitable(result):
+        return await result
+    return result
 
 
 async def to_thread(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:

--- a/tests/e2e/fixtures/worker_behavior_library/griptape_nodes_library.json
+++ b/tests/e2e/fixtures/worker_behavior_library/griptape_nodes_library.json
@@ -87,6 +87,33 @@
         "description": "Converters, validators, dynamic parameters",
         "display_name": "EditorBehaviorNode"
       }
+    },
+    {
+      "class_name": "ReadSecretNode",
+      "file_path": "worker_behavior_nodes.py",
+      "metadata": {
+        "category": "test",
+        "description": "Reads a secret via a request",
+        "display_name": "ReadSecretNode"
+      }
+    },
+    {
+      "class_name": "UnshippableOutputNode",
+      "file_path": "worker_behavior_nodes.py",
+      "metadata": {
+        "category": "test",
+        "description": "Outputs a value that cannot be serialized",
+        "display_name": "UnshippableOutputNode"
+      }
+    },
+    {
+      "class_name": "WriteBytesNode",
+      "file_path": "worker_behavior_nodes.py",
+      "metadata": {
+        "category": "test",
+        "description": "Writes binary through File and verifies it survived",
+        "display_name": "WriteBytesNode"
+      }
     }
   ]
 }

--- a/tests/e2e/fixtures/worker_behavior_library/worker_behavior_nodes.py
+++ b/tests/e2e/fixtures/worker_behavior_library/worker_behavior_nodes.py
@@ -5,8 +5,14 @@ the minimal fixtures did not cover:
 
 - ``SaveMediaNode``: writes bytes and returns a URL. Proves a worker's asset URLs are served
   by the orchestrator's long-lived server rather than the worker's ephemeral one.
-- ``ReadConfigNode``: reads config and a secret through requests. Proves the sanctioned
-  state-access path works from inside a worker.
+- ``ReadConfigNode`` / ``ReadSecretNode``: read config and a secret through requests. Prove
+  the sanctioned state-access path works from inside a worker, where the manager path is
+  refused and a local read would answer from the wrong process.
+- ``UnshippableOutputNode``: outputs a value its author declared unserializable, which a
+  worker must refuse to ship rather than drop on the wire.
+- ``WriteBytesNode``: writes binary through ``File``, the ordinary way a node emits a file.
+  Reads it back and reports whether the bytes survived, so a routing change that sends file
+  I/O across the process boundary fails a test instead of silently writing mojibake.
 - ``StreamingNode``: streams progress and uses the ``AsyncResult`` yield pattern, which 24
   standard-library files rely on.
 - ``ChainStartNode`` / ``ChainMiddleNode`` / ``ChainEndNode``: a three-hop chain of
@@ -22,11 +28,13 @@ from typing import Any
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
+from griptape_nodes.files.file import File
 from griptape_nodes.retained_mode.events.config_events import GetConfigValueRequest, GetConfigValueResultSuccess
 from griptape_nodes.retained_mode.events.parameter_events import (
     AddParameterToNodeRequest,
     RemoveParameterFromNodeRequest,
 )
+from griptape_nodes.retained_mode.events.secrets_events import GetSecretValueRequest, GetSecretValueResultSuccess
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 MEDIA_BYTES = b"\x89PNG\r\n\x1a\n" + b"fixture-media-payload"
@@ -255,3 +263,111 @@ class EditorBehaviorNode(DataNode):
 
     def process(self) -> None:
         self.parameter_output_values["observed_mode"] = self.get_parameter_value("mode")
+
+
+class ReadSecretNode(DataNode):
+    """Reads a secret the sanctioned way: a request, not a manager reference.
+
+    Secrets are the case that matters most in practice -- almost every real node needs an API
+    key -- and the one where reading the worker's own copy is most likely to differ from the
+    orchestrator's, because a worker's environment is frozen when it spawns.
+    """
+
+    # The NAME of a secret, not a secret.
+    SECRET_NAME = "GTN_WORKER_FIXTURE_SECRET"  # noqa: S105
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="secret_value",
+                type="str",
+                default_value="",
+                tooltip="Value the engine reported for the fixture secret",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        result = GriptapeNodes.handle_request(
+            GetSecretValueRequest(key=self.SECRET_NAME, should_error_on_not_found=False)
+        )
+        value = result.value if isinstance(result, GetSecretValueResultSuccess) else None
+        self.parameter_output_values["secret_value"] = value or ""
+
+
+class UnshippableOutputNode(DataNode):
+    """Produces a value that cannot cross a process boundary.
+
+    ``serializable=False`` is the author saying "this is unreasonable to move" -- a live
+    tensor, an open pipeline handle. Executing in a worker, that output has nowhere to go, and
+    the engine must say so instead of silently dropping it and leaving a hole in the graph.
+    """
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="live_handle",
+                type="Any",
+                default_value=None,
+                tooltip="Stands in for a tensor or an open pipeline",
+                allowed_modes={ParameterMode.OUTPUT},
+                serializable=False,
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="summary",
+                type="str",
+                default_value="",
+                tooltip="A serializable descriptor, which is what a library should output instead",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        # An object with no meaningful serialized form, which is the whole point.
+        self.parameter_output_values["live_handle"] = object()
+        self.parameter_output_values["summary"] = "handle-1"
+
+
+class WriteBytesNode(DataNode):
+    """Writes binary through ``File`` and reports whether it survived the round trip.
+
+    ``File.write_bytes`` goes through ``WriteFileRequest``, so this is the path a node takes to
+    emit a file. It exists because that request was briefly forwarded from workers, and the wire
+    form turned bytes into a base64 string that came back as ``str`` -- every write landing
+    corrupted, with no error anywhere. Asserting on the bytes read back is the only thing that
+    catches it.
+    """
+
+    PAYLOAD = b"\x89PNG\r\n\x1a\n\x00\xff\xfe binary-payload"
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="bytes_survived",
+                type="bool",
+                default_value=False,
+                tooltip="True when the bytes read back match the bytes written",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="byte_count",
+                type="int",
+                default_value=0,
+                tooltip="Length of what was read back",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        target = File(f"{self.name}-payload.bin")
+        target.write_bytes(self.PAYLOAD)
+        read_back = target.read_bytes()
+        self.parameter_output_values["bytes_survived"] = read_back == self.PAYLOAD
+        self.parameter_output_values["byte_count"] = len(read_back)

--- a/tests/e2e/test_exec_dep_worker_routing.py
+++ b/tests/e2e/test_exec_dep_worker_routing.py
@@ -20,7 +20,9 @@ from __future__ import annotations
 import json
 import logging
 import shutil
+import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -43,6 +45,9 @@ from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
 from griptape_nodes.utils.version_utils import engine_version
 from tests.e2e.fixtures.behavior_preservation_library.behavior_preservation_node import CLICK_ACKNOWLEDGEMENT
 from tests.e2e.offline_wheels import build_wheel, offline_install_flags
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 EXEC_FIXTURE = Path(__file__).parent / "fixtures" / "exec_dep_library"
 NONSERIALIZABLE_FIXTURE = Path(__file__).parent / "fixtures" / "nonserializable_library"
@@ -88,6 +93,29 @@ def _register(  # noqa: PLR0913 (a test-library builder; each knob is one manife
 
 def _library_info(library_json: str) -> LibraryManager.LibraryInfo:
     return current_engine().library_manager._library_file_path_to_info[library_json]
+
+
+EDIT_DEP = "fakeedit"
+EXEC_DEP = "fakeexec"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_import_state() -> Iterator[None]:
+    """Keep sys.path and sys.modules from leaking between tests.
+
+    Every registration inserts paths and imports modules. Without this, a dependency imported
+    by one test would satisfy the next test's import from the module cache, which would hide
+    exactly the wiring these tests exist to check.
+    """
+    original_path = list(sys.path)
+    original_is_worker = current_engine().library_manager._is_worker
+    for dep in (EDIT_DEP, EXEC_DEP):
+        sys.modules.pop(dep, None)
+    yield
+    sys.path[:] = original_path
+    current_engine().library_manager._is_worker = original_is_worker
+    for dep in (EDIT_DEP, EXEC_DEP):
+        sys.modules.pop(dep, None)
 
 
 class TestRoutingFact:
@@ -386,14 +414,20 @@ class TestUnshippableOutputGuardrail:
             ExecuteNodeResultSuccess,
         )
 
+        # Set BEFORE registering: the execution venv is spliced onto sys.path during load, and only
+        # for a worker, so flipping the flag afterwards leaves the heavy import unavailable.
+        current_engine().library_manager._is_worker = True
         _register(
             tmp_path,
             fixture_dir=EXEC_FIXTURE,
             node_file="exec_dep_node.py",
             name="Guardrail Serializable",
             edit_dependencies=["fakeedit"],
+            # Installed so process() actually completes. Without it the node raised on the missing
+            # import every time, so the branch this test is named for never ran and the assertion
+            # below could not distinguish success from any unrelated failure.
+            exec_dependencies=["fakeexec"],
         )
-        current_engine().library_manager._is_worker = True
         node = LibraryRegistry.create_node(
             node_type="ExecDepNode", name="Fine", specific_library_name="Guardrail Serializable"
         )
@@ -406,12 +440,14 @@ class TestUnshippableOutputGuardrail:
             )
         )
 
-        # fakeexec is not importable here, so process() raises -- but on the exec dep, NOT
-        # on the guardrail. What matters is the guardrail did not fire for its string outputs.
-        if isinstance(result, ExecuteNodeResultSuccess):
-            assert result.parameter_output_values["edit_dep_version"] == "1.0.0"
-        else:
-            assert "cannot leave" not in str(result.result_details)
+        # A node whose outputs are all serializable must ship them, so the unshippable-output
+        # guardrail must NOT fire. Asserted on success rather than either-branch: the previous
+        # version passed whether or not the node ran.
+        assert isinstance(result, ExecuteNodeResultSuccess), getattr(result, "result_details", result)
+        # This suite builds both wheels at 1.0.0; the version itself is not the point, having
+        # BOTH outputs is -- one proves the edit environment, the other the execution one.
+        assert result.parameter_output_values["edit_dep_version"] == "1.0.0"
+        assert result.parameter_output_values["exec_dep_version"] == "1.0.0"
 
 
 class TestManagerAccessDuringWorkerExecution:
@@ -437,6 +473,31 @@ class TestManagerAccessDuringWorkerExecution:
                 GriptapeNodes.SecretsManager()
             with pytest.raises(RuntimeError, match="ReadFileRequest"):
                 GriptapeNodes.OSManager()
+
+    def test_the_guard_covers_every_manager_but_static_files(self) -> None:
+        """The guard is broad by design: silently-wrong local answers are worse than errors.
+
+        Sweeps every manager accessor on the facade rather than naming a few, so adding an
+        accessor without deciding its worker story fails here instead of shipping unguarded.
+        """
+        current_engine().library_manager._is_worker = True
+        event_manager = current_engine().event_manager
+
+        minimum_believable_sweep = 20
+        accessors = [
+            name
+            for name, member in vars(GriptapeNodes).items()
+            if isinstance(member, classmethod) and name[0].isupper() and name.endswith("Manager")
+        ]
+        assert len(accessors) > minimum_believable_sweep, "sweep found too few accessors to be believed"
+
+        with event_manager.worker_node_execution_scope():
+            for name in accessors:
+                if name == "StaticFilesManager":
+                    assert getattr(GriptapeNodes, name)() is not None
+                    continue
+                with pytest.raises(RuntimeError, match=name):
+                    getattr(GriptapeNodes, name)()
 
     def test_managers_work_outside_node_execution_in_a_worker(self) -> None:
         """Engine boot and library load happen in the worker too, and need real managers."""

--- a/tests/e2e/test_worker_behavior_suite.py
+++ b/tests/e2e/test_worker_behavior_suite.py
@@ -20,6 +20,7 @@ import json
 import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
 
@@ -105,18 +106,40 @@ async def _execute(node_type: str, name: str, **parameter_values: object) -> Exe
 
 
 class TestMediaFromAWorker:
-    @pytest.mark.asyncio
-    async def test_worker_asset_url_uses_the_orchestrators_server(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """A URL a worker produces must be served by something that outlives the worker.
+    """Where a worker's asset URLs point, which decides whether they survive the worker.
 
-        Without this the worker advertises its own OS-assigned port, so the URL dies with the
-        worker and a saved workflow reopens with a dead link.
-        """
+    Both branches below reach the same place, and BOTH are needed. An earlier version of this
+    class tested only the env-var branch, with a payload carrying no URL -- a state the real
+    host never produces, because it starts a static server for every role and announces it.
+    So the assertion passed while a live worker still advertised its own ephemeral port. A
+    precondition no caller can produce proves nothing about the caller.
+    """
+
+    @pytest.mark.asyncio
+    async def test_worker_adopts_the_url_the_host_announces(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The live path: the host resolves the orchestrator's server and rides it on the payload."""
+        monkeypatch.delenv(ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV, raising=False)
         orchestrator_url = "http://localhost:8124"
+        static_files_manager = current_engine().static_files_manager
+        static_files_manager._static_server_base_url = None
+        static_files_manager.on_app_initialization_complete(
+            AppInitializationComplete(is_worker=True, static_server_base_url=orchestrator_url)
+        )
+
+        assert static_files_manager.static_server_base_url == orchestrator_url
+
+    @pytest.mark.asyncio
+    async def test_worker_falls_back_to_the_spawn_environment(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The fallback: a host that spawns a worker without announcing a server.
+
+        WorkerManager puts the orchestrator's URL on the spawn environment, so a worker whose
+        host stays silent still has somewhere durable to point.
+        """
+        # Deliberately NOT the static server's default port: an earlier version of this test
+        # used 8124, and a broken adoption gate passed it anyway because the self-serve branch
+        # bound the default port and produced the same URL by coincidence.
+        orchestrator_url = "http://localhost:18125"
         monkeypatch.setenv(ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV, orchestrator_url)
-        # Re-resolve the static server with the worker's environment in place. The payload
-        # carries no host URL, which is exactly the worker case: without the env var this
-        # would start a server here and advertise its own ephemeral port.
         static_files_manager = current_engine().static_files_manager
         static_files_manager._static_server_base_url = None
         static_files_manager.on_app_initialization_complete(AppInitializationComplete(is_worker=True))
@@ -124,13 +147,65 @@ class TestMediaFromAWorker:
         assert static_files_manager.static_server_base_url == orchestrator_url
 
     def test_without_the_env_var_a_process_serves_the_workspace_itself(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """The orchestrator's own path is unchanged: no env var, so it serves and advertises."""
+        """The orchestrator's own path is unchanged: no env var, so it serves and advertises.
+
+        Patched rather than actually started. Letting it bind left a uvicorn thread running for the
+        rest of the session, and the next test's engine reset made that thread raise -- reported
+        against whichever unrelated test happened to be running. What matters here is the branch
+        taken, not that a socket got bound.
+        """
         monkeypatch.delenv(ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV, raising=False)
         static_files_manager = current_engine().static_files_manager
         static_files_manager._static_server_base_url = None
-        static_files_manager.on_app_initialization_complete(AppInitializationComplete())
+        with (
+            patch("griptape_nodes.retained_mode.managers.static_files_manager.start_static_server"),
+            patch("griptape_nodes.retained_mode.managers.static_files_manager.bind_free_socket") as mock_bind,
+        ):
+            mock_bind.return_value.getsockname.return_value = ("localhost", 18124)
+            static_files_manager.on_app_initialization_complete(AppInitializationComplete())
 
         assert static_files_manager.static_server_base_url.startswith("http://")
+
+    @pytest.mark.asyncio
+    async def test_the_spawn_environment_outranks_the_hosts_own_announcement(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Both sources present, different values: the parent's durable server must win.
+
+        This is the ordering, and it is load-bearing. The host announces a URL for every role, so
+        checking the payload first made the environment branch unreachable -- leaving one repo's
+        code as the only thing preventing a worker from advertising its own ephemeral port. With
+        only one source set at a time, flipping the branches back passes.
+        """
+        orchestrator_url = "http://localhost:8124"
+        worker_own_url = "http://localhost:59999"
+        monkeypatch.setenv(ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV, orchestrator_url)
+        static_files_manager = current_engine().static_files_manager
+        static_files_manager._static_server_base_url = None
+        static_files_manager.on_app_initialization_complete(
+            AppInitializationComplete(is_worker=True, static_server_base_url=worker_own_url)
+        )
+
+        assert static_files_manager.static_server_base_url == orchestrator_url
+
+    @pytest.mark.asyncio
+    async def test_a_leaked_environment_variable_does_not_redirect_an_orchestrator(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The env var only means something in a worker the orchestrator spawned.
+
+        An orchestrator started from a shell where the variable leaked (an export left over
+        from debugging, a stale wrapper script) must not silently point every asset URL it
+        mints at an address nothing in this process controls.
+        """
+        monkeypatch.setenv(ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV, "http://localhost:4444")
+        static_files_manager = current_engine().static_files_manager
+        static_files_manager._static_server_base_url = None
+        static_files_manager.on_app_initialization_complete(
+            AppInitializationComplete(static_server_base_url="http://localhost:8124")
+        )
+
+        assert static_files_manager.static_server_base_url == "http://localhost:8124"
 
     @pytest.mark.asyncio
     async def test_media_bytes_are_written_and_a_url_returned(self) -> None:
@@ -144,11 +219,33 @@ class TestMediaFromAWorker:
         assert url  # a real URL, not an empty default
         assert "Media.png" in url
 
+    @pytest.mark.asyncio
+    async def test_media_bytes_are_written_from_inside_a_worker(self) -> None:
+        """The same save, in the role that actually performs it.
+
+        Saving is the one capability a worker keeps local, and the storage driver reaches the
+        workspace path to do it. The manager guard that stops NODE code reading divergent state
+        must not fire on that: a worker shares the workspace on disk, so the read is correct, and
+        refusing it left every worker unable to write a single file.
+        """
+        current_engine().library_manager._is_worker = True
+        _make("SaveMediaNode", "WorkerMedia")
+
+        result = await _execute("SaveMediaNode", "WorkerMedia")
+
+        assert "WorkerMedia.png" in result.parameter_output_values["url"]
+
 
 class TestStateAccessFromAWorker:
     @pytest.mark.asyncio
     async def test_config_read_through_a_request_succeeds_in_a_worker(self) -> None:
-        """The sanctioned path works from inside a worker, where the manager path is refused."""
+        """The request path resolves for a node marked as running in a worker.
+
+        Scoped honestly: this process has no forwarding configured, so the request is answered
+        locally. What it pins is that the facade guard does not block the request path. That
+        forwarding itself works over the wire is covered by test_worker_forwarding_reentrancy.py
+        and by the real two-process verification.
+        """
         current_engine().library_manager._is_worker = True
         _make("ReadConfigNode", "Reader")
 
@@ -158,21 +255,44 @@ class TestStateAccessFromAWorker:
         assert result.parameter_output_values["config_value"]
 
     def test_config_getter_forwards_from_a_worker(self) -> None:
-        """The getter must be in the forwarded set, or a worker reads its own stale copy.
+        """Config and secrets must forward; file I/O must NOT.
 
-        The guardrail tells authors to use this request instead of the manager; that advice is
-        only true if the request actually reaches the orchestrator.
+        Config and secrets can differ between the two processes -- a worker's environment is
+        frozen when it spawns -- so the guardrail's advice to use a request is only true if the
+        request reaches the orchestrator.
+
+        Files are the opposite, and the reason is concrete rather than philosophical. The
+        workspace is shared on disk, so the local answer is already right; and forwarding
+        actively corrupted it, because `content` is `str | bytes` and the wire form base64s
+        bytes into a JSON string that cattrs resolves back to `str`. A path carrying macro
+        variables could not be structured at all.
         """
         from griptape_nodes.app.worker_routing import LOCAL_ONLY_REQUEST_TYPES
         from griptape_nodes.retained_mode.events.config_events import GetConfigValueRequest
         from griptape_nodes.retained_mode.events.os_events import ReadFileRequest, WriteFileRequest
         from griptape_nodes.retained_mode.events.secrets_events import GetSecretValueRequest
 
-        # Forwarding is the default now, so the assertion is that these are NOT excluded.
-        # Every request the guardrails name has to reach the orchestrator, or the advice
-        # they give authors is false.
-        for request_type in (GetConfigValueRequest, GetSecretValueRequest, ReadFileRequest, WriteFileRequest):
+        for request_type in (GetConfigValueRequest, GetSecretValueRequest):
             assert request_type not in LOCAL_ONLY_REQUEST_TYPES, request_type.__name__
+        for request_type in (ReadFileRequest, WriteFileRequest):
+            assert request_type in LOCAL_ONLY_REQUEST_TYPES, request_type.__name__
+
+    def test_forwarding_a_file_write_would_corrupt_the_bytes(self) -> None:
+        """Pin the mechanism, so nobody moves file I/O back into the forwarded set.
+
+        This is the round trip `forward_to_orchestrator` performs on a result: unstructure to
+        JSON, structure back. `content` is `str | bytes`, and the union resolves to `str`, so the
+        bytes come back as mojibake rather than raising -- which is why the corruption was silent.
+        """
+        from griptape_nodes.retained_mode.events.event_converter import converter
+        from griptape_nodes.retained_mode.events.os_events import WriteFileRequest
+
+        original = b"\x89PNG\r\n\x1a\n\x00\xff\xfe"
+        wire = json.loads(json.dumps(converter.unstructure(WriteFileRequest(file_path="x.png", content=original))))
+        round_tripped = converter.structure(wire, WriteFileRequest).content
+
+        assert round_tripped != original, "if this now round-trips, file I/O could safely forward"
+        assert isinstance(round_tripped, str)
 
 
 class TestStreamingAndAsyncResult:
@@ -251,3 +371,128 @@ class TestEditorTimeBehaviorOnRealNodes:
             SetParameterValueRequest(node_name="Dynamic", parameter_name="mode", value="plain")
         )
         assert node.get_parameter_by_name("dynamic_extra") is None
+
+
+class TestUnshippableOutputsAreRefused:
+    """A value the author declared unserializable must not silently vanish across the boundary.
+
+    Dropping it would leave the consuming node reading None with no error anywhere, which is
+    the failure mode this guardrail exists to convert into a message an author can act on.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_worker_refuses_to_ship_an_unserializable_output(self) -> None:
+        current_engine().library_manager._is_worker = True
+        _make("UnshippableOutputNode", "Unshippable")
+
+        result = await current_engine().ahandle_request(
+            ExecuteNodeRequest(
+                node_name="Unshippable",
+                parameter_values={},
+                node_metadata={"node_type": "UnshippableOutputNode", "library": LIBRARY},
+            )
+        )
+
+        assert result.failed()
+        details = str(result.result_details)
+        # The message has to name the parameter and tell the author what to do instead.
+        assert "live_handle" in details
+        assert "serializable" in details
+
+    @pytest.mark.asyncio
+    async def test_the_same_node_is_fine_on_the_orchestrator(self) -> None:
+        """Nothing crosses a boundary in-process, so the value is legal there.
+
+        This is what keeps the guardrail from being a blanket ban on unserializable outputs:
+        they are only a problem when they have to travel.
+        """
+        current_engine().library_manager._is_worker = False
+        _make("UnshippableOutputNode", "LocalHandle")
+
+        result = await _execute("UnshippableOutputNode", "LocalHandle")
+
+        assert result.parameter_output_values["summary"] == "handle-1"
+
+
+class TestSecretsFromAWorker:
+    @pytest.mark.asyncio
+    async def test_secret_read_through_a_request_reaches_the_engine(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Almost every real node needs an API key, and this is the path it must take.
+
+        A worker's environment is frozen when it spawns, so a manager read can answer from a
+        stale copy; the request is what reaches the process that owns the secret.
+        """
+        monkeypatch.setenv("GTN_WORKER_FIXTURE_SECRET", "fixture-secret-value")
+        current_engine().library_manager._is_worker = True
+        _make("ReadSecretNode", "SecretReader")
+
+        result = await _execute("ReadSecretNode", "SecretReader")
+
+        assert result.parameter_output_values["secret_value"] == "fixture-secret-value"  # noqa: S105
+
+    def test_the_secret_getter_is_forwarded_from_a_worker(self) -> None:
+        """The request has to be forwarded, or the read answers locally and the advice is false."""
+        from griptape_nodes.app.worker_routing import LOCAL_ONLY_REQUEST_TYPES
+        from griptape_nodes.retained_mode.events.secrets_events import GetSecretValueRequest
+
+        assert GetSecretValueRequest not in LOCAL_ONLY_REQUEST_TYPES
+
+
+class TestProjectReadsStayLocalInAWorker:
+    """A worker answers project questions itself rather than forwarding them.
+
+    Two reasons, and the second is why this is pinned. A worker already adopts the
+    orchestrator's project and a project's base directory is shared on-disk state, so the
+    local answer is correct and a round trip buys nothing on a path as hot as writing sidecar
+    metadata for every saved file.
+
+    The round trip also corrupted the answer. Forwarded results are rebuilt with cattrs, and
+    GetCurrentProjectResultSuccess annotates `project_info: ProjectInfo` under TYPE_CHECKING to
+    break an import cycle; cattrs cannot resolve that name, so the converter's NameError
+    fallback hands the raw dict to the constructor. isinstance() then passes while
+    `.project_info` is a dict, and every sidecar write in a worker failed with
+    "'dict' object has no attribute 'project_base_dir'" and silently wrote nothing.
+
+    This asserts the routing decision, which is what an in-process test can reach. That the
+    sidecar file actually lands is checked by the real two-process verification, since the
+    corruption only happens when a result crosses the wire.
+    """
+
+    def test_get_current_project_is_not_forwarded(self) -> None:
+        from griptape_nodes.app.worker_routing import LOCAL_ONLY_REQUEST_TYPES
+        from griptape_nodes.retained_mode.events.project_events import GetCurrentProjectRequest
+
+        assert GetCurrentProjectRequest in LOCAL_ONLY_REQUEST_TYPES
+
+
+class TestBinaryFileWritesFromAWorker:
+    """A node's file output must survive being written from a worker.
+
+    Scoped honestly: this suite flips `_is_worker` but never installs the RemoteHandlers, so
+    WriteFileRequest is answered locally whatever the routing says -- these do not guard the
+    routing decision. What they cover is that a node writing binary through `File` works at all,
+    in both roles, which the suite had no node for. The routing itself is guarded by the
+    membership and converter tests above and by tests/unit/app/test_worker_routing_filesystem.py.
+    """
+
+    @pytest.mark.asyncio
+    async def test_binary_survives_a_write_from_a_worker(self) -> None:
+        current_engine().library_manager._is_worker = True
+        _make("WriteBytesNode", "WorkerBytes")
+
+        result = await _execute("WriteBytesNode", "WorkerBytes")
+
+        # `bytes_survived` is the oracle: the node compares what it read against what it wrote,
+        # in the one process where both values exist. The count guards against that comparison
+        # passing over two empty reads.
+        assert result.parameter_output_values["bytes_survived"] is True
+        assert result.parameter_output_values["byte_count"] > 0
+
+    @pytest.mark.asyncio
+    async def test_binary_survives_a_write_on_the_orchestrator(self) -> None:
+        current_engine().library_manager._is_worker = False
+        _make("WriteBytesNode", "OrchestratorBytes")
+
+        result = await _execute("WriteBytesNode", "OrchestratorBytes")
+
+        assert result.parameter_output_values["bytes_survived"] is True

--- a/tests/unit/app/test_worker_routing.py
+++ b/tests/unit/app/test_worker_routing.py
@@ -38,6 +38,11 @@ from griptape_nodes.retained_mode.events.parameter_events import (
     AddParameterToNodeRequest,
     SetParameterValueRequest,
 )
+from griptape_nodes.retained_mode.events.project_events import (
+    AttemptMapAbsolutePathToProjectRequest,
+    GetPathForMacroRequest,
+    GetSituationRequest,
+)
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 
 if TYPE_CHECKING:
@@ -191,6 +196,18 @@ class TestInstallRemoteHandlersSwap:
         """
         assert ActivateProjectRequest in LOCAL_ONLY_REQUEST_TYPES
         assert ReloadAllLibrariesRequest in LOCAL_ONLY_REQUEST_TYPES
+
+    def test_per_file_project_reads_stay_local(self) -> None:
+        """Three project-template reads on the per-saved-file path must not forward.
+
+        Each is a pure read of a project the worker has already adopted, and each sits on the path
+        taken for every file written, so forwarding them charged a round trip per file. The
+        write-side one is easy to miss because it runs after the write rather than before it.
+        """
+        for request_type in (GetSituationRequest, GetPathForMacroRequest, AttemptMapAbsolutePathToProjectRequest):
+            assert request_type in LOCAL_ONLY_REQUEST_TYPES, (
+                f"{request_type.__name__} must be answered by the worker, not forwarded"
+            )
 
     def test_unregistered_types_are_skipped_without_error(self) -> None:
         """Nothing to swap is not a bootstrap failure: only registered types are touched.

--- a/tests/unit/app/test_worker_routing_filesystem.py
+++ b/tests/unit/app/test_worker_routing_filesystem.py
@@ -1,0 +1,212 @@
+"""Filesystem requests must not cross the worker boundary.
+
+Forwarding-by-default made "every request a node can issue survives a cattrs round trip" a
+requirement, and the filesystem family does not meet it. Three separate ways:
+
+- `content` is `str | bytes`. The wire form base64s bytes into a JSON string and cattrs resolves
+  the union back to `str`, so a worker's write landed on disk as mojibake with no error raised
+  anywhere. Silent data corruption.
+- A path carrying macro variables is a `MacroPath` wrapping a `ParsedMacro`, which will not
+  serialize at all. The worker blocked until the forward timed out.
+- Four failure results declare `SequenceScanFailureReason | FileIOFailureReason`, which cattrs
+  cannot disambiguate, so even the error could not travel.
+
+None of that is a reason to make the wire smarter: the workspace is shared on disk, so a worker's
+own answer was already the correct one. These tests pin the routing decision and the mechanism
+behind it, so neither can be undone by accident.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.app.worker_routing import (
+    _FORWARDING_FILESYSTEM_REQUESTS,
+    LOCAL_ONLY_REQUEST_TYPES,
+)
+from griptape_nodes.common.macro_parser import ParsedMacro
+from griptape_nodes.retained_mode.events import os_events
+from griptape_nodes.retained_mode.events.base_events import RequestPayload
+from griptape_nodes.retained_mode.events.event_converter import converter
+from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
+from griptape_nodes.retained_mode.events.project_events import MacroPath
+
+# Sanity floor for the derived list; os_events has 18 request types today.
+_MINIMUM_EXPECTED_REQUESTS = 10
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+
+def _requests_defined_in(module: ModuleType) -> list[type[RequestPayload]]:
+    """Request types this module DEFINES.
+
+    Filtered on `__module__` rather than namespace membership: these modules import request types
+    from each other, and an imported one becoming local-only by accident would let a worker answer
+    it against its own non-authoritative state.
+    """
+    return [
+        payload
+        for payload in vars(module).values()
+        if isinstance(payload, type)
+        and issubclass(payload, RequestPayload)
+        and payload is not RequestPayload
+        and payload.__module__ == module.__name__
+    ]
+
+
+def _filesystem_requests() -> list[type[RequestPayload]]:
+    return _requests_defined_in(os_events)
+
+
+def _macro_path_requests() -> list[type[RequestPayload]]:
+    """Every registered request carrying a MacroPath, wherever it is defined.
+
+    Derived from the whole payload registry on purpose. The first version of this rule was scoped
+    to os_events, which missed the artifact preview requests entirely -- and a test built from the
+    same scope agreed with the bug instead of failing.
+    """
+    carriers = []
+    for payload in PayloadRegistry.get_registry().values():
+        if not (isinstance(payload, type) and issubclass(payload, RequestPayload)):
+            continue
+        if not dataclasses.is_dataclass(payload):
+            continue
+        annotations = [f.type if isinstance(f.type, str) else str(f.type) for f in dataclasses.fields(payload)]
+        if any("MacroPath" in annotation for annotation in annotations):
+            carriers.append(payload)
+    return carriers
+
+
+class TestEveryFilesystemRequestHasARoutingDecision:
+    def test_the_module_is_not_empty(self) -> None:
+        """Guards the guard: a rename that empties this list would make the rest vacuous."""
+        assert len(_filesystem_requests()) > _MINIMUM_EXPECTED_REQUESTS
+
+    @pytest.mark.parametrize("request_type", _filesystem_requests(), ids=lambda cls: cls.__name__)
+    def test_it_is_either_local_only_or_deliberately_forwarded(self, request_type: type[RequestPayload]) -> None:
+        """A filesystem request added later must be routed on purpose, not by default.
+
+        Defaulting to local is the safe direction here, so this fails only if someone adds a
+        request AND puts it in the forwarding set without it being a user-facing side effect.
+        """
+        if request_type in _FORWARDING_FILESYSTEM_REQUESTS:
+            assert request_type not in LOCAL_ONLY_REQUEST_TYPES
+        else:
+            assert request_type in LOCAL_ONLY_REQUEST_TYPES
+
+    def test_opening_a_file_in_the_users_app_is_the_only_forwarded_one(self) -> None:
+        """It is a side effect, not a filesystem read: it belongs where the user is.
+
+        A headless worker subprocess launching a desktop application would be either invisible or
+        wrong, so this one goes to the process sitting next to the person.
+        """
+        assert {os_events.OpenAssociatedFileRequest} == _FORWARDING_FILESYSTEM_REQUESTS
+
+
+class TestNothingCarryingAMacroPathIsForwarded:
+    """A MacroPath cannot be serialized, so forwarding one hangs the worker until it times out.
+
+    Checked across the whole payload registry rather than one module: MacroPath is defined in
+    project_events and used by both os_events and artifact_events, and the artifact preview
+    requests are reachable from a handler a worker runs locally -- so a module-scoped rule let them
+    through while looking complete.
+    """
+
+    def test_the_sweep_finds_the_ones_we_know_about(self) -> None:
+        """Guards the guard: if the sweep silently found nothing, everything below is vacuous."""
+        names = {payload.__name__ for payload in _macro_path_requests()}
+        assert {"GetPreviewForArtifactRequest", "GetNextVersionIndexRequest"} <= names
+
+    @pytest.mark.parametrize("request_type", _macro_path_requests(), ids=lambda cls: cls.__name__)
+    def test_it_is_local_only(self, request_type: type[RequestPayload]) -> None:
+        assert request_type in LOCAL_ONLY_REQUEST_TYPES
+
+
+class TestTypeRegisteringRequestsAnswerLocally:
+    """The two provider-registration payloads carry a bare `type` field.
+
+    cattrs has no structure hook for `type`, and the point of the request is a
+    process-local registry -- so these must answer locally. They fell out of the
+    derivation once already: the bare builtin `type` annotation is an evaluated class,
+    and a matcher reading `str(annotation)` sees "<class 'type'>" and misses it.
+    """
+
+    def test_register_artifact_provider_is_local(self) -> None:
+        from griptape_nodes.retained_mode.events.artifact_events import RegisterArtifactProviderRequest
+
+        assert RegisterArtifactProviderRequest in LOCAL_ONLY_REQUEST_TYPES
+
+    def test_register_preview_generator_is_local(self) -> None:
+        from griptape_nodes.retained_mode.events.artifact_events import RegisterPreviewGeneratorRequest
+
+        assert RegisterPreviewGeneratorRequest in LOCAL_ONLY_REQUEST_TYPES
+
+
+class TestTheWireCannotCarryThese:
+    """Pin the mechanisms, so the exclusion is not "fixed" by routing these instead."""
+
+    def test_bytes_come_back_as_a_corrupted_string(self) -> None:
+        original = b"\x89PNG\r\n\x1a\n\x00\xff\xfe"
+        wire = json.loads(
+            json.dumps(converter.unstructure(os_events.WriteFileRequest(file_path="x.png", content=original)))
+        )
+
+        round_tripped = converter.structure(wire, os_events.WriteFileRequest).content
+
+        assert round_tripped != original, "if bytes now survive, revisit whether writes may forward"
+        assert isinstance(round_tripped, str)
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            os_events.GetNextVersionIndexRequest(
+                macro_path=MacroPath(parsed_macro=ParsedMacro("{outputs}/o.png"), variables={})
+            ),
+            os_events.ResolveMacroPathRequest(
+                macro_path=MacroPath(parsed_macro=ParsedMacro("{outputs}/o.png"), variables={})
+            ),
+            os_events.GetNextUnusedFilenameRequest(
+                file_path=MacroPath(parsed_macro=ParsedMacro("{outputs}/o.png"), variables={})
+            ),
+        ],
+        ids=lambda p: type(p).__name__,
+    )
+    def test_a_macro_path_will_not_serialize(self, payload: RequestPayload) -> None:
+        """`Directory("{outputs}/renders").with_versioning()` is the ordinary caller of these."""
+        with pytest.raises(Exception):  # noqa: B017, PT011 - any failure to serialize is the point
+            json.dumps(converter.unstructure(payload))
+
+    def test_the_sequence_failure_union_cannot_be_structured(self) -> None:
+        """So a worker could not even receive the error, let alone the result."""
+        failure = os_events.ScanSequencesResultFailure(
+            failure_reason=os_events.SequenceScanFailureReason.INVALID_TEMPLATE,
+            result_details="no",
+        )
+        wire = json.loads(json.dumps(converter.unstructure(failure)))
+
+        with pytest.raises(Exception):  # noqa: B017, PT011 - any failure to serialize is the point
+            converter.structure(wire, os_events.ScanSequencesResultFailure)
+
+    def test_the_ambiguous_union_is_still_declared_where_we_think(self) -> None:
+        """If these are ever given a structure hook, the test above stops meaning anything."""
+        annotated = [
+            cls.__name__
+            for cls in vars(os_events).values()
+            if isinstance(cls, type)
+            and dataclasses.is_dataclass(cls)
+            and any(
+                isinstance(f.type, str) and "SequenceScanFailureReason | FileIOFailureReason" in f.type
+                for f in dataclasses.fields(cls)
+            )
+        ]
+        assert sorted(annotated) == [
+            "DeduceSequencesFromFileListResultFailure",
+            "ListDirectoryResultFailure",
+            "ListDirectorySequencesResultFailure",
+            "ScanSequencesResultFailure",
+        ]

--- a/tests/unit/files/drivers/test_local_file_driver.py
+++ b/tests/unit/files/drivers/test_local_file_driver.py
@@ -334,16 +334,15 @@ class TestLocalFileDriverRelativePaths:
 
     @pytest.fixture
     def mock_config_manager_accessor(self, mock_config_manager: Mock) -> Iterator[Mock]:
-        """Patch the facade accessor the driver uses to reach the ConfigManager.
+        """Patch the engine lookup the driver uses to reach the ConfigManager.
 
-        Patched by dotted string rather than an imported `GriptapeNodes` reference: the
-        driver (src/griptape_nodes/files/drivers/local_file_driver.py) still calls the
-        facade's `ConfigManager()` classmethod, and `patch()` handles saving and restoring
-        the classmethod descriptor correctly on teardown.
+        The tests assert on this mock to pin WHETHER the driver consulted the workspace at
+        all, which is the difference between anchoring a bare relative path and trusting the
+        process's cwd.
         """
         with patch(
-            "griptape_nodes.retained_mode.griptape_nodes.GriptapeNodes.ConfigManager",
-            return_value=mock_config_manager,
+            "griptape_nodes.files.drivers.local_file_driver.current_engine",
+            return_value=Mock(config_manager=mock_config_manager),
         ) as accessor:
             yield accessor
 

--- a/tests/unit/files/drivers/test_static_server_file_driver.py
+++ b/tests/unit/files/drivers/test_static_server_file_driver.py
@@ -86,8 +86,8 @@ class TestStaticServerFileDriver:
     ) -> None:
         """Test reading an existing file from localhost URL."""
         with patch(
-            "griptape_nodes.files.drivers.static_server_file_driver.GriptapeNodes.ConfigManager",
-            return_value=mock_config_manager,
+            "griptape_nodes.files.drivers.static_server_file_driver.current_engine",
+            return_value=MagicMock(config_manager=mock_config_manager),
         ):
             content = await driver.read(
                 "http://localhost:8124/workspace/static_files/test.png",
@@ -103,8 +103,8 @@ class TestStaticServerFileDriver:
     ) -> None:
         """Test that query parameters (cachebuster) are stripped before resolving."""
         with patch(
-            "griptape_nodes.files.drivers.static_server_file_driver.GriptapeNodes.ConfigManager",
-            return_value=mock_config_manager,
+            "griptape_nodes.files.drivers.static_server_file_driver.current_engine",
+            return_value=MagicMock(config_manager=mock_config_manager),
         ):
             content = await driver.read(
                 "http://localhost:8124/workspace/static_files/test.png?t=1234567890",
@@ -121,8 +121,8 @@ class TestStaticServerFileDriver:
         """Test reading a non-existent file raises FileNotFoundError."""
         with (
             patch(
-                "griptape_nodes.files.drivers.static_server_file_driver.GriptapeNodes.ConfigManager",
-                return_value=mock_config_manager,
+                "griptape_nodes.files.drivers.static_server_file_driver.current_engine",
+                return_value=MagicMock(config_manager=mock_config_manager),
             ),
             pytest.raises(FileNotFoundError, match="file not found"),
         ):
@@ -140,8 +140,8 @@ class TestStaticServerFileDriver:
         """Test reading a directory raises IsADirectoryError."""
         with (
             patch(
-                "griptape_nodes.files.drivers.static_server_file_driver.GriptapeNodes.ConfigManager",
-                return_value=mock_config_manager,
+                "griptape_nodes.files.drivers.static_server_file_driver.current_engine",
+                return_value=MagicMock(config_manager=mock_config_manager),
             ),
             pytest.raises(IsADirectoryError, match="directory"),
         ):
@@ -169,8 +169,8 @@ class TestStaticServerFileDriver:
     ) -> None:
         """Test exists returns True for existing file."""
         with patch(
-            "griptape_nodes.files.drivers.static_server_file_driver.GriptapeNodes.ConfigManager",
-            return_value=mock_config_manager,
+            "griptape_nodes.files.drivers.static_server_file_driver.current_engine",
+            return_value=MagicMock(config_manager=mock_config_manager),
         ):
             result = await driver.exists("http://localhost:8124/workspace/static_files/test.png")
         assert result is True
@@ -183,8 +183,8 @@ class TestStaticServerFileDriver:
     ) -> None:
         """Test exists returns False for non-existent file."""
         with patch(
-            "griptape_nodes.files.drivers.static_server_file_driver.GriptapeNodes.ConfigManager",
-            return_value=mock_config_manager,
+            "griptape_nodes.files.drivers.static_server_file_driver.current_engine",
+            return_value=MagicMock(config_manager=mock_config_manager),
         ):
             result = await driver.exists("http://localhost:8124/workspace/static_files/nonexistent.png")
         assert result is False
@@ -204,8 +204,8 @@ class TestStaticServerFileDriver:
     ) -> None:
         """Test get_size returns the correct file size."""
         with patch(
-            "griptape_nodes.files.drivers.static_server_file_driver.GriptapeNodes.ConfigManager",
-            return_value=mock_config_manager,
+            "griptape_nodes.files.drivers.static_server_file_driver.current_engine",
+            return_value=MagicMock(config_manager=mock_config_manager),
         ):
             size = driver.get_size("http://localhost:8124/workspace/static_files/test.png")
         assert size == len(b"fake image data")
@@ -218,8 +218,8 @@ class TestStaticServerFileDriver:
         """Test get_size raises FileNotFoundError for non-existent file."""
         with (
             patch(
-                "griptape_nodes.files.drivers.static_server_file_driver.GriptapeNodes.ConfigManager",
-                return_value=mock_config_manager,
+                "griptape_nodes.files.drivers.static_server_file_driver.current_engine",
+                return_value=MagicMock(config_manager=mock_config_manager),
             ),
             pytest.raises(FileNotFoundError, match="file not found"),
         ):
@@ -233,8 +233,8 @@ class TestStaticServerFileDriver:
         """Test get_size raises IsADirectoryError for directories."""
         with (
             patch(
-                "griptape_nodes.files.drivers.static_server_file_driver.GriptapeNodes.ConfigManager",
-                return_value=mock_config_manager,
+                "griptape_nodes.files.drivers.static_server_file_driver.current_engine",
+                return_value=MagicMock(config_manager=mock_config_manager),
             ),
             pytest.raises(IsADirectoryError, match="directory"),
         ):

--- a/tests/unit/files/test_file.py
+++ b/tests/unit/files/test_file.py
@@ -1,11 +1,8 @@
 """Unit tests for File and FileDestination."""
 
-from __future__ import annotations
-
 import base64
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
@@ -35,13 +32,12 @@ from griptape_nodes.retained_mode.events.project_events import (
     PathResolutionFailureReason,
 )
 
-if TYPE_CHECKING:
-    from griptape_nodes.retained_mode.engine import Engine
-
 HANDLE_REQUEST_PATH = "griptape_nodes.files.file.GriptapeNodes.handle_request"
 AHANDLE_REQUEST_PATH = "griptape_nodes.files.file.GriptapeNodes.ahandle_request"
-CONFIG_MANAGER_PATH = "griptape_nodes.files.file.GriptapeNodes.ConfigManager"
-STATIC_SERVER_CONFIG_MANAGER_PATH = "griptape_nodes.files.drivers.static_server_file_driver.GriptapeNodes.ConfigManager"
+# These modules read the workspace off the engine they resolve, so the tests patch that
+# resolution and hand back a stand-in whose config_manager is the mock.
+CURRENT_ENGINE_PATH = "griptape_nodes.files.file.current_engine"
+STATIC_SERVER_CURRENT_ENGINE_PATH = "griptape_nodes.files.drivers.static_server_file_driver.current_engine"
 
 
 class TestFileConstructor:
@@ -872,8 +868,8 @@ class TestFileDestinationWrite:
     def test_resolve_anchors_relative_path_to_workspace(self, tmp_path: Path) -> None:
         dest = FileDestination("output.png")
 
-        with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
-            mock_config_manager.return_value.workspace_path = tmp_path
+        with patch(CURRENT_ENGINE_PATH) as mock_config_manager:
+            mock_config_manager.return_value.config_manager.workspace_path = tmp_path
             resolved = dest.resolve()
 
         assert Path(resolved) == tmp_path / "output.png"
@@ -1121,16 +1117,16 @@ class TestFileResolve:
 
     def test_resolve_absolute_path_passes_through(self, tmp_path: Path) -> None:
         abs_path = tmp_path / "absolute" / "image.png"
-        with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
-            mock_config_manager.return_value.workspace_path = tmp_path
+        with patch(CURRENT_ENGINE_PATH) as mock_config_manager:
+            mock_config_manager.return_value.config_manager.workspace_path = tmp_path
             result = File(str(abs_path)).resolve()
 
         assert Path(result) == abs_path
 
     def test_resolve_anchors_relative_path_to_workspace(self, tmp_path: Path) -> None:
         """A workspace-relative path resolves against the workspace, not the process CWD."""
-        with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
-            mock_config_manager.return_value.workspace_path = tmp_path
+        with patch(CURRENT_ENGINE_PATH) as mock_config_manager:
+            mock_config_manager.return_value.config_manager.workspace_path = tmp_path
             result = File("outputs/images/result.png").resolve()
 
         assert Path(result) == tmp_path / "outputs" / "images" / "result.png"
@@ -1172,8 +1168,8 @@ class TestFileResolveUrls:
         """The reported repro: a Decode Media output wired into a video-processing node."""
         url = "http://localhost:8124/workspace/staticfiles/clip.mp4?t=1786574231"
 
-        with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
-            mock_config_manager.return_value.workspace_path = tmp_path
+        with patch(CURRENT_ENGINE_PATH) as mock_config_manager:
+            mock_config_manager.return_value.config_manager.workspace_path = tmp_path
             result = File(url).resolve()
 
         assert Path(result) == tmp_path / "staticfiles" / "clip.mp4"
@@ -1186,8 +1182,8 @@ class TestFileResolveUrls:
         """
         url = "http://localhost:8124/workspace/staticfiles/clip.mp4?t=1786574231"
 
-        with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
-            mock_config_manager.return_value.workspace_path = tmp_path
+        with patch(CURRENT_ENGINE_PATH) as mock_config_manager:
+            mock_config_manager.return_value.config_manager.workspace_path = tmp_path
             result = File(url).resolve()
 
         assert "http:" not in result
@@ -1203,12 +1199,12 @@ class TestFileResolveUrls:
         url = "http://localhost:8124/workspace/staticfiles/clip.mp4?t=1786574231"
         driver = StaticServerFileDriver()
 
-        with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
-            mock_config_manager.return_value.workspace_path = tmp_path
+        with patch(CURRENT_ENGINE_PATH) as mock_config_manager:
+            mock_config_manager.return_value.config_manager.workspace_path = tmp_path
             resolved = File(url).resolve()
 
-        with patch(STATIC_SERVER_CONFIG_MANAGER_PATH) as mock_config_manager:
-            mock_config_manager.return_value.workspace_path = tmp_path
+        with patch(STATIC_SERVER_CURRENT_ENGINE_PATH) as mock_config_manager:
+            mock_config_manager.return_value.config_manager.workspace_path = tmp_path
             driver_path = driver._resolve_to_local_path(url)
 
         assert Path(resolved) == driver_path
@@ -1220,8 +1216,8 @@ class TestFileResolveUrls:
         """
         url = "https://example.com/videos/clip.mp4"
 
-        with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
-            mock_config_manager.return_value.workspace_path = tmp_path
+        with patch(CURRENT_ENGINE_PATH) as mock_config_manager:
+            mock_config_manager.return_value.config_manager.workspace_path = tmp_path
             result = File(url).resolve()
 
         assert result == url
@@ -1230,8 +1226,8 @@ class TestFileResolveUrls:
         """A signed URL's query string is load-bearing and must survive intact."""
         url = "https://example.com/videos/clip.mp4?token=abc123&expires=1786574231"
 
-        with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
-            mock_config_manager.return_value.workspace_path = tmp_path
+        with patch(CURRENT_ENGINE_PATH) as mock_config_manager:
+            mock_config_manager.return_value.config_manager.workspace_path = tmp_path
             result = File(url).resolve()
 
         assert result == url
@@ -1240,8 +1236,8 @@ class TestFileResolveUrls:
         """A localhost URL that isn't a static-file URL names no workspace file."""
         url = "http://localhost:8124/api/videos/clip.mp4"
 
-        with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
-            mock_config_manager.return_value.workspace_path = tmp_path
+        with patch(CURRENT_ENGINE_PATH) as mock_config_manager:
+            mock_config_manager.return_value.config_manager.workspace_path = tmp_path
             result = File(url).resolve()
 
         assert result == url
@@ -1250,8 +1246,8 @@ class TestFileResolveUrls:
         """The pre-existing file:// behavior is unchanged."""
         target = tmp_path / "outputs" / "clip.mp4"
 
-        with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
-            mock_config_manager.return_value.workspace_path = tmp_path
+        with patch(CURRENT_ENGINE_PATH) as mock_config_manager:
+            mock_config_manager.return_value.config_manager.workspace_path = tmp_path
             result = File(target.as_uri()).resolve()
 
         assert Path(result) == target
@@ -1261,8 +1257,8 @@ class TestFileResolveUrls:
 
         `C://outputs/clip.mp4` is the spelling a naive `://` check misreads.
         """
-        with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
-            mock_config_manager.return_value.workspace_path = tmp_path
+        with patch(CURRENT_ENGINE_PATH) as mock_config_manager:
+            mock_config_manager.return_value.config_manager.workspace_path = tmp_path
             result = File("C://outputs/clip.mp4").resolve()
 
         assert result != "C://outputs/clip.mp4"
@@ -1270,8 +1266,8 @@ class TestFileResolveUrls:
 
     def test_resolve_relative_path_still_anchors_to_workspace(self, tmp_path: Path) -> None:
         """Non-URL locations are unaffected by the URL branch."""
-        with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
-            mock_config_manager.return_value.workspace_path = tmp_path
+        with patch(CURRENT_ENGINE_PATH) as mock_config_manager:
+            mock_config_manager.return_value.config_manager.workspace_path = tmp_path
             result = File("outputs/clip.mp4").resolve()
 
         assert Path(result) == tmp_path / "outputs" / "clip.mp4"
@@ -1292,7 +1288,7 @@ def _jpeg_bytes() -> bytes:
 
 
 @pytest.fixture
-def _registered_providers(engine: Engine) -> None:
+def _registered_providers() -> None:
     """Ensure default artifact providers are registered with the ArtifactManager.
 
     Validation goes through ``ArtifactManager.sniff_extension``, which dispatches
@@ -1300,6 +1296,7 @@ def _registered_providers(engine: Engine) -> None:
     happens on ``AppInitializationComplete``, which doesn't fire in unit tests,
     so we register the default providers manually here.
     """
+    from griptape_nodes.retained_mode.engine import current_engine
     from griptape_nodes.retained_mode.events.artifact_events import RegisterArtifactProviderRequest
     from griptape_nodes.retained_mode.managers.artifact_providers import (
         AudioArtifactProvider,
@@ -1307,7 +1304,7 @@ def _registered_providers(engine: Engine) -> None:
         VideoArtifactProvider,
     )
 
-    artifact_manager = engine.artifact_manager
+    artifact_manager = current_engine().artifact_manager
     for provider_class in (ImageArtifactProvider, VideoArtifactProvider, AudioArtifactProvider):
         artifact_manager.on_handle_register_artifact_provider_request(
             RegisterArtifactProviderRequest(provider_class=provider_class)

--- a/tests/unit/servers/test_static.py
+++ b/tests/unit/servers/test_static.py
@@ -56,12 +56,17 @@ class TestWorkspaceStaticFiles:
     """Test that WorkspaceStaticFiles resolves the served directory live, per request."""
 
     def _patch_workspace(self, workspace: Path) -> AbstractContextManager[MagicMock]:
-        """Patch ConfigManager().workspace_path to return the given directory."""
+        """Point the served workspace at the given directory.
+
+        Patches the ambient engine lookup rather than the GriptapeNodes facade: this module reads
+        its managers off the engine, because the facade's worker guard keys off a process-wide
+        in-node-execution refcount and would raise on uvicorn's thread while any node ran.
+        """
         config_manager = MagicMock()
         config_manager.workspace_path = workspace
-        griptape_nodes = MagicMock()
-        griptape_nodes.ConfigManager.return_value = config_manager
-        return patch("griptape_nodes.servers.static.GriptapeNodes", griptape_nodes)
+        engine = MagicMock()
+        engine.config_manager = config_manager
+        return patch("griptape_nodes.servers.static.current_engine", return_value=engine)
 
     def test_lookup_follows_workspace_change(self, tmp_path: Path) -> None:
         """A file written under the new workspace resolves after the workspace changes at runtime."""

--- a/tests/unit/utils/test_async_utils.py
+++ b/tests/unit/utils/test_async_utils.py
@@ -1,0 +1,54 @@
+"""Tests for `call_function`, the dispatcher every registered callback goes through."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from griptape_nodes.utils.async_utils import call_function
+
+INPUT = 21
+DOUBLED = 42
+
+
+class TestCallFunction:
+    @pytest.mark.asyncio
+    async def test_calls_a_sync_function(self) -> None:
+        assert await call_function(lambda value: value * 2, INPUT) == DOUBLED
+
+    @pytest.mark.asyncio
+    async def test_awaits_an_async_function(self) -> None:
+        async def double(value: int) -> int:
+            return value * 2
+
+        assert await call_function(double, INPUT) == DOUBLED
+
+    @pytest.mark.asyncio
+    async def test_awaits_a_callable_object_with_an_async_call(self) -> None:
+        """The shape that broke every worker: a handler that is an instance, not a function.
+
+        `inspect.iscoroutinefunction` inspects the object rather than its `__call__`, so an
+        instance like this reads as synchronous. Returning its coroutine unawaited handed a
+        coroutine object onward as if it were the result, and the first attribute access on
+        the "result" failed far from the cause.
+        """
+
+        class Handler:
+            async def __call__(self, value: int) -> int:
+                return value * 2
+
+        assert await call_function(Handler(), INPUT) == DOUBLED
+
+    @pytest.mark.asyncio
+    async def test_passes_keyword_arguments_through(self) -> None:
+        def combine(first: str, *, second: str) -> str:
+            return first + second
+
+        assert await call_function(combine, "a", second="b") == "ab"
+
+    @pytest.mark.asyncio
+    async def test_a_sync_function_returning_a_plain_value_is_not_awaited(self) -> None:
+        """Only awaitables are awaited; ordinary values pass straight through."""
+        sentinel: dict[str, Any] = {"not": "awaitable"}
+        assert await call_function(lambda: sentinel) is sentinel


### PR DESCRIPTION
Part of griptape-ai/internal#214 — the contract's enforcement and the wire it depends on. (Stack position map at the bottom.)

Forwarding-by-default (#5409) made "every request a node can issue survives the cattrs round trip" a hard requirement, and four review rounds each found another violation of it. This PR is those findings, fixed at the causes. It also implements the **broad facade guard**: all 27 manager accessors now raise during worker node execution — this is required for exec-dep workers to be correct (silently-wrong local answers are worse than errors), not part of the future workers-v2 contract.

## Routing (`worker_routing.py`)

`LOCAL_ONLY_REQUEST_TYPES` is now **derived, not listed**, because the list kept being incomplete:

- **every filesystem request answers locally.** The workspace is shared on disk, so the local answer was already correct — and forwarding was destructive: `content` is `str | bytes`, and the wire form base64s bytes into a JSON string that cattrs resolves back to `str`, so a worker's writes landed as mojibake with no error anywhere. `OpenAssociatedFileRequest` is the one deliberate exception: opening a file in the user's app belongs where the user is.
- **anything carrying a `MacroPath` answers locally**, wherever it is defined — a `MacroPath` wraps a `ParsedMacro`, which will not serialize, so a forwarded request hung the worker until the timeout.
- **anything registering a Python class** (`provider_class: type`) answers locally: cattrs has no hook for `type`, and the point of the request is a process-local registry.
- **project reads answer locally.** A worker adopts the orchestrator's project; forwarding also corrupted the answer (`project_info` is annotated under `TYPE_CHECKING`, so the converter's NameError fallback returned a raw dict, and every sidecar-metadata write in a worker silently wrote nothing).

## Dispatch, converter, guard, static server

- `call_function` awaited on what the *callable* looked like; a dataclass with `async def __call__` looks synchronous, so `RemoteHandler`'s coroutine came back unawaited and **every worker died at boot on its first dispatched request**. It now awaits what the call returns.
- The converter's NameError fallback now reports the first payload of each class that actually arrives with an unstructured field — and only when a field can genuinely degrade, so aliases of builtins stay quiet.
- **Broad guard**: every facade manager accessor raises during worker execution, naming the request to use. `StaticFilesManager` is the one decided exception (shared workspace on disk — its answers are real). A registry sweep test pins the breadth so a new accessor cannot ship unguarded. The old blocker (PNG-metadata save path) was dissolved by main's #5389.
- `files/` and `servers/static.py` read managers off the ambient engine: their reads sit under a worker's save path, and the guard keys off a process-wide in-node-execution refcount. The storage drivers themselves are untouched — #5406's injected managers supersede the ambient-engine version of this fix. `utils/artifact_normalization.py` migrates and comes off the TID251 allowlist.
- Static server handover: the spawn environment's URL now outranks the payload's — payload-first made the engine branch unreachable and left one repo's code as the only thing between a worker and an ephemeral-port URL that dies with it.

## Tests

Wire rules are pinned by derivation-driven tests that sweep the payload registry rather than restating a source list; the corruption mechanisms are pinned so the exclusions cannot be "fixed" by re-routing; the behavior suite gains binary round-trip, secrets, unshippable-output, and precedence coverage. Verified end-to-end by the 33-check live harness against a real spawned worker.

> **Merge note.** This stack lands as a unit. Intermediate tips are not intended as shippable states: #5409 forwards OS file requests until #5426 makes them local, and #5390 through #5468 splice `.venv-exec` onto a worker's `sys.path` until #5472 retires that mechanism — a running interpreter cannot be handed a library's own dependency versions that way, because `sys.modules` never reconsiders a module already imported. The orchestrator installing the execution set is therefore the intended end state, not a step: it has to be the builder, since the worker receives that directory as `PYTHONPATH` and so cannot create it.

## Stack

| # | PR | Branch |
|---|----|--------|
| 1 | #5390 | `feat/venue-exec-deps` |
| 2 | #5391 | `feat/venue-reentrancy` |
| 3 | #5402 | `feat/venue-worker-mvp` |
| 4 | #5409 | `feat/venue-worker-behavior-suite` |
| 5 | #5425 | `feat/exe-types-engine-injection` |
| 6 | #5426 ← this | `feat/worker-wire-hardening` |
| 7 | #5427 | `feat/library-exec-lifecycle` |
| 8 | #5428 | `fix/failed-nodes-leave-resolving` |
| 9 | #5430 | `feat/parameter-structure-contract` |
