### PR TITLE
Parameter structure derives from parameter values: state it, enforce it, honor it

### DIFF
--- a/docs/development/custom_nodes/node_isolation_with_workers.md
+++ b/docs/development/custom_nodes/node_isolation_with_workers.md
@@ -227,28 +227,80 @@ bus:
 
 Issue the request via `GriptapeNodes.handle_request(...)` from
 inside `process`. The handler-side path propagates the change back
-to the orchestrator. Worker subprocesses pick up the new parameter
-list on the next execute. The
+to the orchestrator. The
 [`parameter-mutation-during-aprocess`](strict_mode.md) rule fires
 on direct in-execute mutations and tells you which one to use.
 
-**`before_value_set` / `after_value_set` do not fire on editor
-changes for isolated libraries.** These hooks run inside the worker
-subprocess, on the temporary copy of your node built for each
-execute. The orchestrator holds only a stub copy of your node class
-— parameters, no code — so it never calls your overrides when a
-user edits a value in the editor. Transforming an incoming value
-still works: the hooks run as inputs are applied, just before
-`process`. But a parameter-list change made inside them is
-discarded with the temporary node. It skips the
-[`parameter-mutation-during-aprocess`](strict_mode.md) rule, and it
-does not propagate either.
+**The change lands on the orchestrator's node, not the one that is
+running.** That is the same rule as everywhere else here — the
+orchestrator holds the authoritative node — but it has a
+consequence worth stating outright: you cannot read the parameter
+back during the execution that added it.
+`self.get_parameter_by_name("new_param")` returns `None` in the
+worker even though the request succeeded and the editor is already
+showing the parameter.
 
-The practical consequence: hooks that adjust the parameter list in
-response to user input (for example, showing or hiding fields when
-a dropdown changes) only work in Shared mode. For an isolated
-library, define the full parameter list statically in `__init__`.
-Overriding a value hook fires the
+It does not reappear on the next execute either. Each execution
+builds a fresh worker-side copy from the node class, so parameter
+*structure* never carries forward — only values do.
+
+This is the contract, stated once: **a node's parameter structure
+must be a deterministic function of its parameter values.** Create
+parameters in `__init__`, or create and remove them from a value
+hook based on the values being set — the pattern the diffusers VAE
+decoder uses, rebuilding its output parameters from the pipeline
+value whenever it is set. Structure written that way needs no
+syncing at all: the same derivation runs on the orchestrator's
+node at edit time and again on the fresh worker copy as its values
+hydrate, so every copy converges on the same shape. Structure that
+exists only because something added it once — by request, from
+`process`, in a previous session — is history, not derivation, and
+history does not carry.
+
+Hydration honors the contract from its side. Values are applied in
+passes until the structure settles, so a value for a derived
+parameter works even when it arrives before the value that derives
+it — including chains, where one derived parameter's hook creates
+the next. A value for a parameter
+that nothing on the copy derives — most commonly one a user added
+in the editor — is left unapplied for that run, with a warning
+naming the parameter; it does not fail the execution, and the
+authoritative value on the orchestrator is untouched.
+
+### Value hooks: it depends on which kind of library
+
+**Execution-dependency libraries** (the ones that declare
+`pip_dependencies_exec`) keep real node classes on the
+orchestrator, so `before_value_set` / `after_value_set` fire there
+when a user edits a value, exactly as they do for a Shared
+library. Hooks that adjust the parameter list in response to user
+input — showing or hiding fields when a dropdown changes, growing
+a list — work normally at edit time.
+
+Two things to know about those hooks at *execution* time:
+
+- They also run in the worker, as inputs are applied. The
+    orchestrator skips hooks for a value that has not changed, but
+    the worker's node is freshly built, so every value looks new and
+    every hook runs. Keep them cheap and idempotent.
+- Anything they do to the node object there is discarded with the
+    temporary node. A parameter-list change made from a hook during
+    execution follows the rule above: route it through the request
+    bus if it needs to persist, and do not expect to read it back in
+    that same execution.
+
+**Legacy worker-mode libraries** (Isolated mode, chosen by
+`worker_mode_override` or `suggested_worker_mode`) behave
+differently, because the orchestrator holds only a stub copy of
+your node class — parameters, no code — so it never calls your
+overrides when a user edits a value. Transforming an incoming
+value still works, since the hooks run as inputs are applied just
+before `process`, but a parameter-list change made inside them is
+discarded with the temporary node: it skips the
+[`parameter-mutation-during-aprocess`](strict_mode.md) rule and
+does not propagate either. For those libraries, define the full
+parameter list statically in `__init__`. Overriding a value hook
+fires the
 [`value-hooks-execute-only-on-worker`](strict_mode.md) warning at
 library load.
 

--- a/src/griptape_nodes/common/strict_mode_checks.py
+++ b/src/griptape_nodes/common/strict_mode_checks.py
@@ -102,14 +102,28 @@ RULES: dict[str, StrictModeRule] = {
         correctness=False,
         description=(
             "A node called add_parameter or remove_parameter during "
-            "aprocess. On the worker these changes are local to the "
-            "transient node and do not sync back to the orchestrator."
+            "aprocess, which violates the structure contract: a "
+            "node's parameter structure must be a deterministic "
+            "function of its parameter values, created in __init__ or "
+            "by a value hook. Structure created anywhere else cannot "
+            "survive, because each execution builds a fresh copy from "
+            "the node class and only VALUES carry over (hydration "
+            "re-runs the hooks, which is how derived structure "
+            "reappears). A direct mutation during aprocess is local "
+            "to the transient copy and never syncs; the request-driven "
+            "path syncs to the orchestrator but is not readable back "
+            "on the executing copy, and does not reappear on later "
+            "executions either."
         ),
         remediation_template=(
             "Node '{node_name}' (type '{node_class}') mutated parameter "
             "'{parameter_name}' during aprocess via {mutation}. Emit "
             "AddParameterToNodeRequest or RemoveParameterFromNodeRequest "
-            "to propagate the change to the orchestrator."
+            "to propagate the change to the orchestrator. Note that the "
+            "change reaches the orchestrator's node, not this one: do "
+            "not read the parameter back locally. Each execution builds "
+            "a fresh copy from the node class, so the parameter exists "
+            "here only if __init__ or a value hook re-creates it."
         ),
     ),
     "worker-reach-into-orchestrator": StrictModeRule(

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -3429,24 +3429,9 @@ class NodeManager(EngineScoped):
         with scope_cm:
             # Rehydrate serialized artifacts that crossed the orchestrator->worker JSON boundary.
             parameter_values = hydrate_parameter_values(request.parameter_values)
-            for param_name, value in parameter_values.items():
-                # Skip when the node already holds this value. The local path
-                # calls ExecuteNodeRequest with dict(node.parameter_values) on
-                # the same in-memory instance, so every iteration would be a
-                # no-op mutation that still ran before/after_value_set hooks
-                # and emitted a lifecycle event -- observably breaking nodes
-                # like LoadImage. On the worker the node is fresh, so current
-                # is _PARAM_MISSING and the normal set path runs.
-                current = node.parameter_values.get(param_name, _PARAM_MISSING)
-                if current is value or current == value:
-                    continue
-                try:
-                    node.set_parameter_value(param_name, value)
-                except Exception as e:
-                    return ExecuteNodeResultFailure(
-                        result_details=f"Attempted to set parameter '{param_name}' on node '{node_name}'. Failed with error: {e}",
-                        exception=e,
-                    )
+            hydration_failure = self._apply_hydrated_values(node, node_name, parameter_values)
+            if hydration_failure is not None:
+                return hydration_failure
             # Materialize parameter defaults into parameter_values so that user
             # process() code reading self.parameter_values[name] directly (rather
             # than via get_parameter_value) sees the default. Newly-dropped nodes
@@ -3492,6 +3477,71 @@ class NodeManager(EngineScoped):
             parameter_output_values=dict(node.parameter_output_values),
             result_details=f"Node '{node_name}' executed successfully.",
         )
+
+    def _apply_hydrated_values(
+        self, node: BaseNode, node_name: str, parameter_values: dict[str, Any]
+    ) -> ExecuteNodeResultFailure | None:
+        """Apply hydrated parameter values to an executing node. Returns a failure or None.
+
+        Applied in passes until a fixpoint, because parameter STRUCTURE derives from values
+        (the authoring contract): setting a value fires the node's value hooks, and hooks are
+        where a node like the diffusers VAE decoder creates the parameters its other values
+        belong to. A fresh worker-side node starts with only its __init__ shape, so a value
+        for a derived parameter can arrive before the value that derives it -- hydration
+        order is dict order, which promises nothing. Each pass sets every value whose
+        parameter exists (running the derivations) and defers the rest; deferred values are
+        retried as long as a pass made progress, so a derivation CHAIN (provider creates
+        model, model creates options) hydrates fully no matter how the values were ordered.
+        Termination is guaranteed: a productive pass strictly shrinks the deferred set, and
+        an unproductive one ends the loop.
+
+        A value still unclaimed after both passes belongs to a parameter nothing on this copy
+        derives -- most often one added to the authoritative node by request (a user-added
+        parameter in the editor, or a node that added one mid-execution and expected it to
+        persist). Skipped rather than failed: the authoritative value is untouched on the
+        orchestrator, and failing here made any user-added parameter fatal to a worker-routed
+        node. The warning names the contract so the author of a node that MEANT this
+        parameter to exist knows what to change.
+        """
+        pending = parameter_values
+        deferred: dict[str, Any] = {}
+        made_progress = True
+        while pending and made_progress:
+            deferred = {}
+            made_progress = False
+            for param_name, value in pending.items():
+                if node.get_parameter_by_name(param_name) is None:
+                    deferred[param_name] = value
+                    continue
+                made_progress = True
+                # Skip when the node already holds this value. The local path calls
+                # ExecuteNodeRequest with dict(node.parameter_values) on the same in-memory
+                # instance, so every iteration would be a no-op mutation that still ran
+                # before/after_value_set hooks and emitted a lifecycle event -- observably
+                # breaking nodes like LoadImage. On the worker the node is fresh, so current
+                # is _PARAM_MISSING and the normal set path runs.
+                current = node.parameter_values.get(param_name, _PARAM_MISSING)
+                if current is value or current == value:
+                    continue
+                try:
+                    node.set_parameter_value(param_name, value)
+                except Exception as e:
+                    return ExecuteNodeResultFailure(
+                        result_details=f"Attempted to set parameter '{param_name}' on node '{node_name}'. Failed with error: {e}",
+                        exception=e,
+                    )
+            pending = deferred
+        for param_name in deferred:
+            logger.warning(
+                "Node '%s' received a value for parameter '%s', which does not exist on the "
+                "executing copy and was not created by its value hooks. The value was left "
+                "unapplied for this run. Parameter structure must derive from parameter "
+                "values (created in __init__ or by a value hook); a parameter added only by "
+                "request does not carry over to execution.",
+                node_name,
+                param_name,
+            )
+        return None
 
     @staticmethod
     def _unshippable_output_names(node: BaseNode) -> list[str]:

--- a/tests/e2e/fixtures/worker_behavior_library/griptape_nodes_library.json
+++ b/tests/e2e/fixtures/worker_behavior_library/griptape_nodes_library.json
@@ -114,6 +114,15 @@
         "description": "Writes binary through File and verifies it survived",
         "display_name": "WriteBytesNode"
       }
+    },
+    {
+      "class_name": "DerivedStructureNode",
+      "file_path": "worker_behavior_nodes.py",
+      "metadata": {
+        "category": "test",
+        "description": "Derives parameter structure from a value",
+        "display_name": "DerivedStructureNode"
+      }
     }
   ]
 }

--- a/tests/e2e/fixtures/worker_behavior_library/worker_behavior_nodes.py
+++ b/tests/e2e/fixtures/worker_behavior_library/worker_behavior_nodes.py
@@ -10,6 +10,10 @@ the minimal fixtures did not cover:
   refused and a local read would answer from the wrong process.
 - ``UnshippableOutputNode``: outputs a value its author declared unserializable, which a
   worker must refuse to ship rather than drop on the wire.
+- ``DerivedStructureNode``: the authoring contract's reference shape -- parameter structure
+  derives from parameter values. Its value hook creates and removes a parameter as a pure
+  function of ``shape``, so any fresh copy of the node converges on the right structure the
+  moment its values hydrate, in any order.
 - ``WriteBytesNode``: writes binary through ``File``, the ordinary way a node emits a file.
   Reads it back and reports whether the bytes survived, so a routing change that sends file
   I/O across the process boundary fails a test instead of silently writing mojibake.
@@ -237,6 +241,15 @@ class EditorBehaviorNode(DataNode):
                 allowed_modes={ParameterMode.OUTPUT},
             )
         )
+        self.add_parameter(
+            Parameter(
+                name="dynamic_visible_in_process",
+                type="bool",
+                default_value=False,
+                tooltip="Whether the parameter after_value_set added is visible to process()",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
         if parameter.name != "mode":
@@ -263,6 +276,13 @@ class EditorBehaviorNode(DataNode):
 
     def process(self) -> None:
         self.parameter_output_values["observed_mode"] = self.get_parameter_value("mode")
+        # Whether the parameter this node's own after_value_set added is present on the instance
+        # that is executing. In a worker the add is a REQUEST, and requests are answered by the
+        # orchestrator -- so the parameter can land on the orchestrator's node while this copy,
+        # the one running process(), never sees it.
+        self.parameter_output_values["dynamic_visible_in_process"] = (
+            self.get_parameter_by_name(self.DYNAMIC_PARAMETER) is not None
+        )
 
 
 class ReadSecretNode(DataNode):
@@ -371,3 +391,86 @@ class WriteBytesNode(DataNode):
         read_back = target.read_bytes()
         self.parameter_output_values["bytes_survived"] = read_back == self.PAYLOAD
         self.parameter_output_values["byte_count"] = len(read_back)
+
+
+class DerivedStructureNode(DataNode):
+    """Parameter structure as a deterministic function of parameter values.
+
+    This is the sanctioned dynamic-structure pattern (the diffusers VAE decoder's, minus the
+    pipeline): the value hook mutates the LOCAL node directly, so the derivation runs wherever
+    the values land -- on the orchestrator at edit time, and again on a fresh worker copy as
+    hydration applies the same values. Nothing needs to sync structure, because structure is
+    recomputed. Contrast EditorBehaviorNode, whose hook goes through a request and therefore
+    mutates only the authoritative node.
+    """
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="shape",
+                type="str",
+                default_value="plain",
+                tooltip="Set to 'expanded' to derive the extra parameter",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="echo",
+                type="str",
+                default_value="",
+                tooltip="Echoes the derived parameter's hydrated value",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="deep_echo",
+                type="str",
+                default_value="",
+                tooltip="Echoes the second-level derived parameter's hydrated value",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def after_value_set(self, parameter: Parameter, value: Any) -> None:
+        if parameter.name == "shape":
+            wants_derived = value == "expanded"
+            has_derived = self.get_parameter_by_name("derived_in") is not None
+            if wants_derived and not has_derived:
+                self.add_parameter(
+                    Parameter(
+                        name="derived_in",
+                        type="str",
+                        default_value="",
+                        tooltip="Exists exactly when shape is 'expanded'",
+                        allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                    )
+                )
+            elif not wants_derived and has_derived:
+                self.remove_parameter_element_by_name("derived_in")
+            return
+        if parameter.name == "derived_in":
+            # Second derivation level: the chain shape real dynamic UIs take (provider creates
+            # model, model creates options). Exists exactly when derived_in is 'deeper'.
+            wants_deep = value == "deeper"
+            has_deep = self.get_parameter_by_name("derived_deep") is not None
+            if wants_deep and not has_deep:
+                self.add_parameter(
+                    Parameter(
+                        name="derived_deep",
+                        type="str",
+                        default_value="",
+                        tooltip="Exists exactly when derived_in is 'deeper'",
+                        allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                    )
+                )
+            elif not wants_deep and has_deep:
+                self.remove_parameter_element_by_name("derived_deep")
+
+    def process(self) -> None:
+        derived = self.get_parameter_value("derived_in") if self.get_parameter_by_name("derived_in") else ""
+        self.parameter_output_values["echo"] = derived
+        deep = self.get_parameter_value("derived_deep") if self.get_parameter_by_name("derived_deep") else ""
+        self.parameter_output_values["deep_echo"] = deep

--- a/tests/e2e/test_worker_behavior_suite.py
+++ b/tests/e2e/test_worker_behavior_suite.py
@@ -17,6 +17,7 @@ nodes are instantiated and edited) and a worker (where ``process`` runs).
 from __future__ import annotations
 
 import json
+import logging
 import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -496,3 +497,90 @@ class TestBinaryFileWritesFromAWorker:
         result = await _execute("WriteBytesNode", "OrchestratorBytes")
 
         assert result.parameter_output_values["bytes_survived"] is True
+
+    @pytest.mark.asyncio
+    async def test_a_request_added_parameter_lands_authoritatively_not_locally(self) -> None:
+        """Execute the request-pattern node in the worker role and pin both halves.
+
+        EditorBehaviorNode's hook adds its dynamic parameter via AddParameterToNodeRequest.
+        During worker hydration that hook fires on the fresh executing copy; the request
+        resolves against the AUTHORITATIVE node (looked up by name), so the parameter lands
+        there while the copy that is running process() never sees it. That asymmetry is the
+        documented contract -- the live harness proves it across a real process boundary;
+        this pins it in-repo.
+        """
+        current_engine().library_manager._is_worker = True
+        registered = _make("EditorBehaviorNode", "RequestPathNode")
+
+        result = await _execute("EditorBehaviorNode", "RequestPathNode", mode="expand")
+
+        assert result.parameter_output_values["dynamic_visible_in_process"] is False
+        assert registered.get_parameter_by_name("dynamic_extra") is not None
+
+
+class TestStructureDerivesFromValues:
+    """The authoring contract: parameter structure is a deterministic function of values.
+
+    A fresh worker-side copy starts with only its __init__ shape and receives values in dict
+    order, which promises nothing. If a value for a derived parameter arrives before the value
+    that derives it, hydration must wait for the derivation rather than fail -- and a value for
+    a parameter nothing derives must cost that one value, not the run.
+    """
+
+    @pytest.mark.asyncio
+    async def test_hydration_order_cannot_defeat_derivation(self) -> None:
+        """The derived parameter's value arrives FIRST, before the value that creates it.
+
+        Single-pass hydration failed the whole execution here: `derived_in` does not exist on
+        the fresh copy until the `shape` hook runs, and setting a value on a missing parameter
+        raises. The second pass applies it after the derivation.
+        """
+        current_engine().library_manager._is_worker = True
+        _make("DerivedStructureNode", "DerivedOrder")
+
+        result = await _execute("DerivedStructureNode", "DerivedOrder", derived_in="payload", shape="expanded")
+
+        assert result.parameter_output_values["echo"] == "payload"
+
+    @pytest.mark.asyncio
+    async def test_a_derivation_chain_hydrates_in_the_most_adversarial_order(self) -> None:
+        """Depth two, values ordered deepest-first: the fixpoint must chase the chain.
+
+        `shape` derives `derived_in`, whose own hook derives `derived_deep` -- the shape real
+        dynamic UIs take (provider creates model, model creates options). A fixed two-pass
+        hydration claims `derived_in` on its second pass but leaves `derived_deep` an orphan,
+        silently running the node with its default; the contract puts no depth bound on
+        derivation, so hydration must not either.
+        """
+        current_engine().library_manager._is_worker = True
+        _make("DerivedStructureNode", "DerivedChain")
+
+        result = await _execute(
+            "DerivedStructureNode",
+            "DerivedChain",
+            derived_deep="from the bottom",
+            derived_in="deeper",
+            shape="expanded",
+        )
+
+        assert result.parameter_output_values["echo"] == "deeper"
+        assert result.parameter_output_values["deep_echo"] == "from the bottom"
+
+    @pytest.mark.asyncio
+    async def test_a_value_nothing_derives_is_skipped_not_fatal(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A parameter added to the authoritative node by request does not exist here.
+
+        The canonical producer is a user adding a parameter in the editor: the orchestrator's
+        node has it, values ship at execute, and the fresh worker copy has no hook that
+        re-creates it. Failing hydration made every such parameter fatal to a worker-routed
+        node; the contract's answer is that the value goes unapplied, loudly.
+        """
+        current_engine().library_manager._is_worker = True
+        _make("DerivedStructureNode", "DerivedGhost")
+
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+            result = await _execute("DerivedStructureNode", "DerivedGhost", ghost="orphaned", shape="plain")
+
+        assert result.parameter_output_values["echo"] == ""
+        assert "ghost" in caplog.text
+        assert "derive" in caplog.text


### PR DESCRIPTION
Part of griptape-ai/internal#214 — the execution contract for parameter structure. (Stack position map at the bottom.) Required for exec-dep workers to be correct with dynamic parameters — this is not the future workers-v2 contract.

## The contract, stated once

**A node's parameter structure is a deterministic function of its parameter values.** Each execution builds a fresh worker-side copy from the node class, and only *values* carry over. Structure created in `__init__` or by a value hook is re-derived on any copy the moment its values hydrate — the pattern the diffusers VAE decoder already uses, rebuilding its output parameters from the pipeline value. Structure that exists because something added it once (a request from `process`, a user in the editor, a previous session) is history, and history does not carry.

## Hydration honors the contract from its side

Values are applied in passes until the structure settles: setting a value fires the hooks that derive structure, and hydration order is dict order, which promises nothing — so a value for a derived parameter defers and is retried while passes make progress. That covers derivation CHAINS (provider creates model, model creates options) in any value order, not just depth one. Termination is guaranteed: a productive pass strictly shrinks the deferred set, an unproductive one ends the loop. A value still unclaimed when the structure settles is skipped with a warning naming the contract, **not a failure**: failing made every user-added editor parameter fatal to a worker-routed node, since nothing on a fresh copy re-creates those.

## Rule and docs

- `parameter-mutation-during-aprocess` now states the contract and the consequence an author would otherwise discover one execution too late: the request path syncs to the *orchestrator's* node, not the executing copy — not readable back in the same execution, and not present on the next one either.
- The isolation docs split their hooks section by library kind: execution-dependency libraries hold real classes on the orchestrator, so value hooks fire on editor edits exactly as for a Shared library (the legacy stub model's "hooks never fire at edit time" text was actively wrong for them); hooks also run in the worker during hydration where every value looks new — keep them cheap and idempotent.

## Tests

`DerivedStructureNode` is the contract's reference shape, with two derivation levels; its tests pin the hydration behaviors and **fail against the implementations they replaced** (verified by swapping each back in) — including a depth-two chain hydrated deepest-value-first, which fails under any fixed pass count. `EditorBehaviorNode` is also executed in the worker role, pinning that a parameter its hook adds *by request* lands on the authoritative node and is invisible to the copy running `process()`. `EditorBehaviorNode` reports whether the parameter its own hook added by request is visible to `process()` — pinned `False` in a worker, by design.

> **Merge note.** This stack lands as a unit. Intermediate tips are not intended as shippable states: #5409 forwards OS file requests until #5426 makes them local, and #5390 through #5468 splice `.venv-exec` onto a worker's `sys.path` until #5472 retires that mechanism — a running interpreter cannot be handed a library's own dependency versions that way, because `sys.modules` never reconsiders a module already imported. The orchestrator installing the execution set is therefore the intended end state, not a step: it has to be the builder, since the worker receives that directory as `PYTHONPATH` and so cannot create it.

## Stack

| # | PR | Branch |
|---|----|--------|
| 1 | #5390 | `feat/venue-exec-deps` |
| 2 | #5391 | `feat/venue-reentrancy` |
| 3 | #5402 | `feat/venue-worker-mvp` |
| 4 | #5409 | `feat/venue-worker-behavior-suite` |
| 5 | #5425 | `feat/exe-types-engine-injection` |
| 6 | #5426 | `feat/worker-wire-hardening` |
| 7 | #5427 | `feat/library-exec-lifecycle` |
| 8 | #5428 | `fix/failed-nodes-leave-resolving` |
| 9 | #5430 ← this | `feat/parameter-structure-contract` |
