### PR TITLE
fix: keep the workflow context stack honest (hardening for desktop#406)

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/context_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/context_manager.py
@@ -302,9 +302,22 @@ class ContextManager(EngineScoped):
         workflow_name = None
         is_saved = None
         if self.has_current_workflow():
-            workflow_name = self.get_current_workflow_name()
-            if WorkflowRegistry.has_workflow_with_name(workflow_name):
-                is_saved = WorkflowRegistry.get_workflow_by_name(workflow_name).is_saved
+            candidate = self.get_current_workflow_name()
+            # Only report a context key the registry can still back. Editors treat any
+            # non-empty workflow_name here as "the engine has this open" and adopt it
+            # wholesale, so handing back an orphaned key makes them display -- and then
+            # re-open -- a workflow that cannot be loaded or saved. A key goes orphaned
+            # when the registry is rebuilt underneath a live context (workspace switch,
+            # registry refresh) or when a stack entry outlives its workflow.
+            if WorkflowRegistry.has_workflow_with_name(candidate):
+                workflow_name = candidate
+                is_saved = WorkflowRegistry.get_workflow_by_name(candidate).is_saved
+            else:
+                logger.warning(
+                    "Current workflow context '%s' has no entry in the Workflow Registry; reporting no active "
+                    "workflow rather than a name that cannot be resolved.",
+                    candidate,
+                )
         return GetWorkflowContextSuccess(
             workflow_name=workflow_name,
             is_saved=is_saved,
@@ -658,13 +671,7 @@ class ContextManager(EngineScoped):
                     if workflow.file_path is not None:
                         file_path = WorkflowRegistry.get_complete_file_path(workflow.file_path)
         elif file_path is not None:
-            resolved = canonicalize_for_identity(file_path)
-            workspace_path = canonicalize_for_identity(self.engine.config_manager.workspace_path)
-            if resolved.is_relative_to(workspace_path):
-                path_for_key = str(resolved.relative_to(workspace_path))
-            else:
-                path_for_key = str(resolved)
-            resolved_name = derive_registry_key(path_for_key)
+            resolved_name = self.registry_key_for_file(file_path)
         else:
             msg = "Either workflow_name or file_path must be provided."
             raise ValueError(msg)
@@ -672,6 +679,49 @@ class ContextManager(EngineScoped):
         workflow_context_state = self.WorkflowContextState(resolved_name, file_path=file_path)
         self._workflow_stack.append(workflow_context_state)
         return resolved_name
+
+    def registry_key_for_file(self, file_path: str) -> str:
+        """Derive the Workflow Registry key a workflow file would be pushed under.
+
+        The key is workspace-relative when the file lives under the active workspace, which
+        is what makes it stable across machines -- and what makes it go stale the moment the
+        workspace changes.
+        """
+        resolved = canonicalize_for_identity(file_path)
+        workspace_path = canonicalize_for_identity(self.engine.config_manager.workspace_path)
+        if resolved.is_relative_to(workspace_path):
+            path_for_key = str(resolved.relative_to(workspace_path))
+        else:
+            path_for_key = str(resolved)
+        return derive_registry_key(path_for_key)
+
+    def warn_if_foreign_workflow_context(self, file_path: str) -> str | None:
+        """Report when a workflow file is being executed under somebody else's context.
+
+        Generated workflow files only push their own context when the stack is empty, so a
+        context left behind by an earlier run silently becomes the name under which this
+        file's nodes load. Nothing downstream can tell the difference afterwards -- the
+        engine reports the stale name as the open workflow while the canvas shows this
+        file's graph. Surface it here rather than letting it pass unremarked.
+
+        Returns:
+            The current context name when it does not match this file, otherwise None.
+        """
+        if not self.has_current_workflow():
+            return None
+        current = self.get_current_workflow_name()
+        expected = self.registry_key_for_file(file_path)
+        if current == expected:
+            return None
+        logger.error(
+            "Workflow file '%s' is loading under the unrelated workflow context '%s' (expected '%s'). Its nodes "
+            "will be attributed to '%s'; the context should have been retired before this file ran.",
+            file_path,
+            current,
+            expected,
+            current,
+        )
+        return current
 
     def pop_workflow(self) -> str:
         """Pop the top Workflow from the stack.
@@ -688,6 +738,46 @@ class ContextManager(EngineScoped):
 
         workflow_context = self._workflow_stack.pop()
         return workflow_context._name
+
+    def clear_workflow_stack(self) -> list[str]:
+        """Drop every Workflow context, returning the names that were discarded.
+
+        Only for teardown paths that have already released the underlying objects
+        (see ClearAllObjectState). Callers that still hold flows or nodes should
+        retire them through `Engine.clear_current_workflow_data` instead.
+        """
+        discarded = [entry._name for entry in self._workflow_stack]
+        self._workflow_stack.clear()
+        return discarded
+
+    def reconcile_with_registry(self) -> list[str]:
+        """Drop context entries the Workflow Registry can no longer resolve.
+
+        A registry key is derived against whatever workspace was active at push time, so
+        rebuilding the registry underneath a live context (switching workspace, refreshing
+        the registry) strands the entries that were pushed before it. Those keys resolve to
+        nothing, but still answer `GetWorkflowContextRequest` and the heartbeat, which is how
+        an editor ends up opening a workflow nobody chose.
+
+        Returns:
+            The names that were discarded, outermost first.
+        """
+        surviving = []
+        discarded = []
+        for entry in self._workflow_stack:
+            if WorkflowRegistry.has_workflow_with_name(entry._name):
+                surviving.append(entry)
+            else:
+                discarded.append(entry._name)
+
+        if discarded:
+            logger.warning(
+                "Dropping %d workflow context(s) with no Workflow Registry entry: %s.",
+                len(discarded),
+                ", ".join(repr(name) for name in discarded),
+            )
+            self._workflow_stack = surviving
+        return discarded
 
     def push_flow(self, flow: ControlFlow) -> ControlFlow:
         """Push a new Flow context onto the stack for the current Workflow.

--- a/src/griptape_nodes/retained_mode/managers/project_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/project_manager.py
@@ -2908,6 +2908,12 @@ class ProjectManager(EngineScoped):
                 )
         if workspace_changed:
             await self.engine.workflow_manager.refresh_workflow_registry()
+            # Registry keys are derived against the active workspace, so rebuilding the
+            # registry for a new workspace strands every context entry pushed under the old
+            # one. A library reload would have cleared them (it clears all object state), but
+            # a workspace-only change does not -- leaving keys that resolve to nothing yet
+            # still answer GetWorkflowContext and the heartbeat.
+            self.engine.context_manager.reconcile_with_registry()
         return None
 
     def _project_checkpoint_attributes(self, project_id: ProjectID, *, name: str | None = None) -> dict[str, Any]:

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -871,6 +871,11 @@ class WorkflowManager(EngineScoped):
         # Resolve path using utility function
         workspace_path = self.engine.config_manager.workspace_path
         complete_file_path = resolve_workspace_path(Path(relative_file_path), workspace_path)
+        # A workflow file pushes its own context while it executes, and anything it raises
+        # skips the matching pop. Remember how deep we started so a failed run cannot leave
+        # half-entered contexts behind for the next caller to read as "the open workflow".
+        context_manager = self.engine.context_manager
+        entry_depth = len(context_manager._workflow_stack)
         try:
             async with await anyio.open_file(Path(complete_file_path), encoding="utf-8") as file:
                 workflow_content = await file.read()
@@ -908,9 +913,15 @@ class WorkflowManager(EngineScoped):
             await self._ensure_workflow_context_established()
 
         except Exception as e:
+            leaked = len(context_manager._workflow_stack) - entry_depth
+            for _ in range(max(leaked, 0)):
+                context_manager.pop_workflow()
+            details = f"Failed to run workflow on path '{complete_file_path}'. Exception: {e}"
+            if leaked > 0:
+                details += f" Discarded {leaked} workflow context(s) the failed run left behind."
             return WorkflowManager.WorkflowExecutionResult(
                 execution_successful=False,
-                execution_details=f"Failed to run workflow on path '{complete_file_path}'. Exception: {e}",
+                execution_details=details,
             )
         return WorkflowManager.WorkflowExecutionResult(
             execution_successful=True,
@@ -1056,6 +1067,16 @@ class WorkflowManager(EngineScoped):
                     details = f"Failed to clear the existing object state when preparing to run workflow '{request.workflow_name}'."
                     return RunWorkflowFromRegistryResultFailure(result_details=details)
 
+            # Retire the outgoing workflow before entering the new one. Only one Workflow may
+            # be in the Current Context (SetWorkflowContext enforces the same rule), so
+            # pushing without retiring buries the previous entry rather than replacing it --
+            # contradicting the warning above, and leaving a workflow the user already closed
+            # to resurface on the next pop and be reported as the open one. A clean slate has
+            # already emptied the stack, so this is a no-op on that path.
+            retired = self.engine.context_manager.clear_workflow_stack()
+            if retired:
+                logger.debug("Retired workflow context(s) %s before opening '%s'.", retired, request.workflow_name)
+
             # Let's run under the assumption that this Workflow will become our Current Context; if we fail, it will revert.
             self.engine.context_manager.push_workflow(request.workflow_name)
             # run file
@@ -1067,11 +1088,7 @@ class WorkflowManager(EngineScoped):
                     result_messages.append(ResultDetail(message=context_warning, level=logging.WARNING))
                 result_messages.append(ResultDetail(message=execution_result.execution_details, level=logging.ERROR))
 
-                # Attempt to clear everything out, as we modified the engine state getting here.
-                clear_all_request = ClearAllObjectStateRequest(i_know_what_im_doing=True)
-                clear_all_result = await self.engine.ahandle_request(clear_all_request)
-
-                # The clear-all above here wipes the ContextManager, so no need to do a pop_workflow().
+                await self._abandon_failed_registry_run(request.workflow_name, result_messages)
                 return RunWorkflowFromRegistryResultFailure(result_details=ResultDetails(*result_messages))
 
         # Success!
@@ -1080,6 +1097,31 @@ class WorkflowManager(EngineScoped):
             result_messages.append(ResultDetail(message=context_warning, level=logging.WARNING))
         result_messages.append(ResultDetail(message=execution_result.execution_details, level=logging.DEBUG))
         return RunWorkflowFromRegistryResultSuccess(result_details=ResultDetails(*result_messages))
+
+    async def _abandon_failed_registry_run(self, workflow_name: str, result_messages: list[ResultDetail]) -> None:
+        """Tear down the engine state a failed run from the registry left behind.
+
+        Appends to `result_messages` if the teardown itself could not complete.
+        """
+        # Attempt to clear everything out, as we modified the engine state getting here.
+        clear_all_request = ClearAllObjectStateRequest(i_know_what_im_doing=True)
+        clear_all_result = await self.engine.ahandle_request(clear_all_request)
+
+        # A successful clear-all wipes the ContextManager for us. A failed one does not, and
+        # leaves the workflow we just pushed sitting in the Current Context as though it had
+        # opened cleanly -- which is exactly the state that gets reported to the editor and
+        # re-opened later. Unwind it ourselves.
+        if not clear_all_result.succeeded():
+            stranded = self.engine.context_manager.clear_workflow_stack()
+            result_messages.append(
+                ResultDetail(
+                    message=(
+                        f"Failed to clear object state after workflow '{workflow_name}' failed to run; "
+                        f"discarded stranded workflow context(s) {stranded}."
+                    ),
+                    level=logging.ERROR,
+                )
+            )
 
     def _persist_external_workflow_registration(self, full_path: str) -> None:
         """Persist an out-of-workspace workflow path to global config so it survives restarts.
@@ -4289,10 +4331,28 @@ class WorkflowManager(EngineScoped):
         )
         ast.fix_missing_locations(push_call)
 
+        # A context already on the stack means this file is about to load its nodes under a
+        # name that is not its own -- the engine would then report that foreign name as the
+        # open workflow while this file's graph is what the user sees. The push stays guarded
+        # (a caller such as RunWorkflowFromRegistry legitimately enters the context first),
+        # but the mismatched case is no longer silent.
+        warn_call = ast.Expr(
+            value=ast.Call(
+                func=ast.Attribute(
+                    value=ast.Name(id="context_manager", ctx=ast.Load()),
+                    attr="warn_if_foreign_workflow_context",
+                    ctx=ast.Load(),
+                ),
+                args=[],
+                keywords=[ast.keyword(arg="file_path", value=ast.Name(id="__file__", ctx=ast.Load()))],
+            )
+        )
+        ast.fix_missing_locations(warn_call)
+
         if_stmt = ast.If(
             test=test,
             body=[push_call],
-            orelse=[],
+            orelse=[warn_call],
         )
         ast.fix_missing_locations(if_stmt)
         code_blocks.append(if_stmt)

--- a/tests/unit/retained_mode/managers/test_workflow_context_invariants.py
+++ b/tests/unit/retained_mode/managers/test_workflow_context_invariants.py
@@ -1,0 +1,309 @@
+"""Regression tests for the workflow-context invariants behind issue #406.
+
+https://github.com/griptape-ai/griptape-nodes-desktop/issues/406
+
+The engine answers "what workflow is open" out of `ContextManager._workflow_stack[-1]` --
+that is what `GetWorkflowContextRequest` returns and what the heartbeat reports as
+`current_workflow`. Every editor adoption path trusts that answer without checking it, so
+any stale or registry-orphaned entry left on the stack surfaces to the user as the editor
+opening a workflow they never chose. These tests pin the invariants that keep the stack
+honest: it replaces rather than accumulates, it unwinds on failure, and it never reports a
+name the registry cannot back.
+"""
+
+import ast
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from griptape_nodes.node_library.workflow_registry import WorkflowMetadata, WorkflowRegistry
+from griptape_nodes.retained_mode.engine import Engine
+from griptape_nodes.retained_mode.events.context_events import (
+    GetWorkflowContextRequest,
+    GetWorkflowContextSuccess,
+    SetWorkflowContextRequest,
+    SetWorkflowContextSuccess,
+)
+from griptape_nodes.retained_mode.events.workflow_events import RunWorkflowFromRegistryRequest
+from griptape_nodes.retained_mode.managers.workflow_manager import ImportRecorder, WorkflowManager
+
+
+def _register_workflow(workspace: Path, key: str) -> None:
+    """Register `key` against a stub file in `workspace`, the way a saved workflow appears."""
+    (workspace / f"{key}.py").write_text("# stub")
+    metadata = WorkflowMetadata(
+        name=key,
+        schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+        engine_version_created_with="test",
+        node_libraries_referenced=[],
+        creation_date=datetime.now(UTC),
+    )
+    WorkflowRegistry.generate_new_workflow(registry_key=key, metadata=metadata, file_path=f"{key}.py")
+
+
+def _drain(context_manager) -> None:  # noqa: ANN001
+    while context_manager.has_current_workflow():
+        context_manager.pop_workflow()
+
+
+class TestRunFromRegistryReplacesContext:
+    """`RunWorkflowFromRegistry` must replace the current workflow, not stack onto it.
+
+    Every one of these passes `run_with_clean_slate=False` explicitly. The request defaults
+    the flag to True, and a clean slate drains the whole context stack up front, which hides
+    the push/pop imbalance below. The editor happens to take the defaulted path today, so
+    this is a latent API-reachable defect rather than the one reported in #406 -- but the
+    handler is the single place the "current workflow" is established, and it should not
+    depend on a caller-supplied flag to avoid corrupting its own stack.
+    """
+
+    @pytest.mark.asyncio
+    async def test_repeated_runs_do_not_grow_the_workflow_stack(self, griptape_nodes: Engine, tmp_path: Path) -> None:
+        """Opening workflows back-to-back replaces the context rather than burying it.
+
+        The handler already warns "Replacing the old with the new", but only ever pushes.
+        Each open therefore buries the previous entry, and any later single pop resurfaces
+        a workflow the user closed long ago.
+        """
+        workflow_manager = griptape_nodes.WorkflowManager()
+        context_manager = griptape_nodes.ContextManager()
+        workflow_manager._workflows_loading_complete.set()
+        config_manager = griptape_nodes.ConfigManager()
+
+        original_workspace = config_manager.workspace_path
+        config_manager.workspace_path = tmp_path
+        try:
+            with patch.dict(WorkflowRegistry._workflows, {}, clear=True):
+                _register_workflow(tmp_path, "first")
+                _register_workflow(tmp_path, "second")
+
+                async def fake_run_workflow(relative_file_path: str) -> WorkflowManager.WorkflowExecutionResult:
+                    # A real workflow file finds a context already pushed by the caller, so
+                    # its own guarded push is a no-op. Model that: leave the stack alone.
+                    return WorkflowManager.WorkflowExecutionResult(
+                        execution_successful=True,
+                        execution_details=f"ran {relative_file_path}",
+                    )
+
+                with patch.object(workflow_manager, "run_workflow", fake_run_workflow):
+                    for key in ("first", "second"):
+                        result = await workflow_manager.on_run_workflow_from_registry_request(
+                            RunWorkflowFromRegistryRequest(workflow_name=key, run_with_clean_slate=False)
+                        )
+                        assert result.succeeded(), f"opening '{key}' failed: {result.result_details}"
+
+                assert context_manager.get_current_workflow_name() == "second"
+                assert len(context_manager._workflow_stack) == 1, (
+                    "opening a second workflow must retire the first, not bury it"
+                )
+        finally:
+            config_manager.workspace_path = original_workspace
+            _drain(context_manager)
+
+    @pytest.mark.asyncio
+    async def test_failed_run_does_not_leave_its_workflow_in_context(
+        self, griptape_nodes: Engine, tmp_path: Path
+    ) -> None:
+        """A workflow that fails to run must not stay in the Current Context.
+
+        The handler pushes optimistically and relies on a follow-up ClearAllObjectState to
+        undo it, but ignores whether that clear actually succeeded.
+        """
+        workflow_manager = griptape_nodes.WorkflowManager()
+        context_manager = griptape_nodes.ContextManager()
+        workflow_manager._workflows_loading_complete.set()
+        config_manager = griptape_nodes.ConfigManager()
+
+        original_workspace = config_manager.workspace_path
+        config_manager.workspace_path = tmp_path
+        try:
+            with patch.dict(WorkflowRegistry._workflows, {}, clear=True):
+                _register_workflow(tmp_path, "broken")
+
+                async def failing_run_workflow(relative_file_path: str) -> WorkflowManager.WorkflowExecutionResult:
+                    return WorkflowManager.WorkflowExecutionResult(
+                        execution_successful=False,
+                        execution_details=f"boom on {relative_file_path}",
+                    )
+
+                with patch.object(workflow_manager, "run_workflow", failing_run_workflow):
+                    result = await workflow_manager.on_run_workflow_from_registry_request(
+                        RunWorkflowFromRegistryRequest(workflow_name="broken", run_with_clean_slate=False)
+                    )
+
+                assert not result.succeeded()
+                assert not context_manager.has_current_workflow(), (
+                    "a workflow that failed to open must not remain the Current Context"
+                )
+        finally:
+            config_manager.workspace_path = original_workspace
+            _drain(context_manager)
+
+
+class TestGetWorkflowContextRegistryBacking:
+    """`GetWorkflowContext` must never report a name the registry cannot back."""
+
+    def test_reports_none_when_the_context_key_is_not_registered(self, griptape_nodes: Engine) -> None:
+        """A registry-orphaned stack entry is a phantom and must not be reported as open.
+
+        The editor treats any non-empty `workflow_name` as "the engine has this open" and
+        adopts it. Reporting a key with no registry entry hands the editor a workflow that
+        cannot be loaded, displayed, or saved.
+        """
+        context_manager = griptape_nodes.ContextManager()
+        _drain(context_manager)
+
+        with patch.dict(WorkflowRegistry._workflows, {}, clear=True):
+            context_manager.push_workflow(workflow_name="ghost_workflow")
+            try:
+                result = context_manager.on_get_workflow_context_request(GetWorkflowContextRequest())
+
+                assert isinstance(result, GetWorkflowContextSuccess)
+                assert result.workflow_name is None, (
+                    "an unregistered context key must be reported as 'no workflow open'"
+                )
+            finally:
+                _drain(context_manager)
+
+    def test_reports_a_brand_new_unsaved_workflow(self, griptape_nodes: Engine) -> None:
+        """Guard for the check above: a never-saved workflow is still registry-backed.
+
+        `SetWorkflowContext` auto-registers `unsaved:<uuid>` keys, so requiring registry
+        backing must not regress the blank-canvas flow.
+        """
+        context_manager = griptape_nodes.ContextManager()
+        _drain(context_manager)
+
+        try:
+            set_result = context_manager.on_set_workflow_context_request(SetWorkflowContextRequest())
+            assert isinstance(set_result, SetWorkflowContextSuccess)
+            assert set_result.workflow_name.startswith(WorkflowRegistry.UNSAVED_KEY_PREFIX)
+
+            get_result = context_manager.on_get_workflow_context_request(GetWorkflowContextRequest())
+
+            assert isinstance(get_result, GetWorkflowContextSuccess)
+            assert get_result.workflow_name == set_result.workflow_name
+        finally:
+            _drain(context_manager)
+
+
+class TestRunWorkflowUnwindsOnFailure:
+    """A workflow file that raises must not leave its own context behind."""
+
+    @pytest.mark.asyncio
+    async def test_failed_run_unwinds_contexts_the_workflow_file_pushed(
+        self, griptape_nodes: Engine, tmp_path: Path
+    ) -> None:
+        """Generated workflows push their own context; an exception skips the matching pop.
+
+        The push is emitted at the top of every serialized workflow, so anything that raises
+        while building the graph strands it. `run_workflow` swallows the exception into a
+        failure result, and the stranded entry then answers as the open workflow.
+        """
+        workflow_manager = griptape_nodes.WorkflowManager()
+        context_manager = griptape_nodes.ContextManager()
+        config_manager = griptape_nodes.ConfigManager()
+        _drain(context_manager)
+
+        workflow_file = tmp_path / "explodes.py"
+        workflow_file.write_text(
+            "from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes\n"
+            "context_manager = GriptapeNodes.ContextManager()\n"
+            "if not context_manager.has_current_workflow():\n"
+            "    context_manager.push_workflow(file_path=__file__)\n"
+            "raise RuntimeError('workflow blew up mid-build')\n"
+        )
+
+        original_workspace = config_manager.workspace_path
+        config_manager.workspace_path = tmp_path
+        try:
+            # Library resolution is not what is under test; the file declares no header.
+            async def no_library_work(**_kwargs: object) -> None:
+                return None
+
+            with patch.object(workflow_manager, "_ensure_libraries_for_workflow", no_library_work):
+                result = await workflow_manager.run_workflow(relative_file_path="explodes.py")
+
+            assert not result.execution_successful
+            assert not context_manager.has_current_workflow(), (
+                "a workflow that raised must not leave its context entered"
+            )
+        finally:
+            config_manager.workspace_path = original_workspace
+            _drain(context_manager)
+
+
+class TestReconcileWithRegistry:
+    """The context stack must not outlive the registry it was keyed against."""
+
+    def test_reconcile_drops_orphaned_contexts_and_keeps_backed_ones(
+        self, griptape_nodes: Engine, tmp_path: Path
+    ) -> None:
+        """Rebuilding the registry under a live context strands keys derived against the old one."""
+        context_manager = griptape_nodes.ContextManager()
+        config_manager = griptape_nodes.ConfigManager()
+        _drain(context_manager)
+
+        original_workspace = config_manager.workspace_path
+        config_manager.workspace_path = tmp_path
+        try:
+            with patch.dict(WorkflowRegistry._workflows, {}, clear=True):
+                _register_workflow(tmp_path, "still_here")
+                context_manager.push_workflow(workflow_name="went_away")
+                context_manager.push_workflow(workflow_name="still_here")
+
+                discarded = context_manager.reconcile_with_registry()
+
+                assert discarded == ["went_away"]
+                assert len(context_manager._workflow_stack) == 1
+                assert context_manager.get_current_workflow_name() == "still_here"
+        finally:
+            config_manager.workspace_path = original_workspace
+            _drain(context_manager)
+
+
+class TestForeignContextIsNotSilent:
+    """A workflow file must not quietly run under a context that is not its own."""
+
+    def test_generated_code_reports_a_foreign_context_instead_of_adopting_it(self, griptape_nodes: Engine) -> None:
+        """The emitted push is guarded; the guarded-out branch must say something."""
+        workflow_manager = griptape_nodes.WorkflowManager()
+        code_blocks = workflow_manager._generate_workflow_run_prerequisite_code(
+            import_recorder=ImportRecorder(),
+            library_names=[],
+        )
+        module = ast.Module(body=[n for n in code_blocks if isinstance(n, ast.stmt)], type_ignores=[])
+        ast.fix_missing_locations(module)
+        source = ast.unparse(module)
+        assert "push_workflow(file_path=__file__)" in source
+        assert "warn_if_foreign_workflow_context(file_path=__file__)" in source
+
+    def test_warn_returns_the_foreign_name_and_stays_quiet_when_it_matches(
+        self, griptape_nodes: Engine, tmp_path: Path
+    ) -> None:
+        context_manager = griptape_nodes.ContextManager()
+        config_manager = griptape_nodes.ConfigManager()
+        _drain(context_manager)
+
+        original_workspace = config_manager.workspace_path
+        config_manager.workspace_path = tmp_path
+        try:
+            own_file = tmp_path / "mine.py"
+            own_file.write_text("# stub")
+
+            # Nothing entered: the file will push for itself, so there is nothing to report.
+            assert context_manager.warn_if_foreign_workflow_context(str(own_file)) is None
+
+            # Its own context entered: still nothing to report.
+            context_manager.push_workflow(file_path=str(own_file))
+            assert context_manager.warn_if_foreign_workflow_context(str(own_file)) is None
+            _drain(context_manager)
+
+            # Somebody else's context entered: this is the #406 shape.
+            context_manager.push_workflow(workflow_name="Flix.2")
+            assert context_manager.warn_if_foreign_workflow_context(str(own_file)) == "Flix.2"
+        finally:
+            config_manager.workspace_path = original_workspace
+            _drain(context_manager)

--- a/tests/unit/retained_mode/managers/test_workflow_context_invariants.py
+++ b/tests/unit/retained_mode/managers/test_workflow_context_invariants.py
@@ -307,3 +307,54 @@ class TestForeignContextIsNotSilent:
         finally:
             config_manager.workspace_path = original_workspace
             _drain(context_manager)
+
+
+class TestProjectSwitchReconcilesContext:
+    """A project switch is a real, user-reachable way to strand a context key.
+
+    Registry keys are derived against the active workspace, so switching to a project
+    with a different workspace rebuilds the registry out from under whatever the user
+    had open. Only a *library* change clears object state (and with it the context);
+    a workspace-only switch does not, which leaves the outgoing project's key on the
+    stack -- still answering GetWorkflowContext, backed by nothing.
+    """
+
+    @pytest.mark.asyncio
+    async def test_workspace_only_switch_leaves_no_orphaned_context(
+        self, griptape_nodes: Engine, tmp_path: Path
+    ) -> None:
+        """The workspace-changed branch must retire keys the rebuilt registry cannot back."""
+        context_manager = griptape_nodes.ContextManager()
+        config_manager = griptape_nodes.ConfigManager()
+        project_manager = griptape_nodes.ProjectManager()
+        _drain(context_manager)
+
+        outgoing = tmp_path / "project_a"
+        incoming = tmp_path / "project_b"
+        outgoing.mkdir()
+        incoming.mkdir()
+
+        original_workspace = config_manager.workspace_path
+        config_manager.workspace_path = outgoing
+        try:
+            with patch.dict(WorkflowRegistry._workflows, {}, clear=True):
+                _register_workflow(outgoing, "Workflow_2")
+                context_manager.push_workflow(workflow_name="Workflow_2")
+
+                # The switch itself: new workspace, library config untouched.
+                config_manager.workspace_path = incoming
+                failure = await project_manager._reload_after_project_switch(
+                    "project-b",
+                    workspace_changed=True,
+                    library_config_changed=False,
+                )
+
+                assert failure is None
+                assert not WorkflowRegistry.has_workflow_with_name("Workflow_2")
+                assert not context_manager.has_current_workflow(), (
+                    "the outgoing project's workflow key survived the switch and would be "
+                    "reported as the open workflow in the incoming project"
+                )
+        finally:
+            config_manager.workspace_path = original_workspace
+            _drain(context_manager)

--- a/tests/unit/retained_mode/managers/test_workflow_context_invariants.py
+++ b/tests/unit/retained_mode/managers/test_workflow_context_invariants.py
@@ -358,3 +358,130 @@ class TestProjectSwitchReconcilesContext:
         finally:
             config_manager.workspace_path = original_workspace
             _drain(context_manager)
+
+
+class TestFailedRunIsNotReportedAsOpen:
+    """The user-visible symptom of #406: the engine names a workflow that failed to load.
+
+    `TestRunWorkflowUnwindsOnFailure` pins the stack depth by calling `run_workflow`
+    directly. These go the other way -- through the request handlers a client actually
+    sends, and asserting on what `GetWorkflowContext` reports, which is the answer every
+    editor adoption path consumes. Against the pre-fix engine both of these report
+    `'explodes'`: the workflow that just raised is announced as the one that is open.
+    """
+
+    @staticmethod
+    def _write_exploding_workflow(workspace: Path, key: str) -> None:
+        """A workflow file shaped like the engine's own codegen, that raises after its push."""
+        (workspace / f"{key}.py").write_text(
+            "from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes\n"
+            "context_manager = GriptapeNodes.ContextManager()\n"
+            "if not context_manager.has_current_workflow():\n"
+            "    context_manager.push_workflow(file_path=__file__)\n"
+            "raise RuntimeError('boom: simulated bad node library')\n"
+        )
+
+    @staticmethod
+    async def _reported_workflow(griptape_nodes: Engine) -> str | None:
+        result = await griptape_nodes.ahandle_request(GetWorkflowContextRequest())
+        assert isinstance(result, GetWorkflowContextSuccess)
+        return result.workflow_name
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("request_type", ["from_scratch", "with_current_state"])
+    async def test_failed_load_is_not_announced_as_the_open_workflow(
+        self, griptape_nodes: Engine, tmp_path: Path, request_type: str
+    ) -> None:
+        """Both file-path run handlers must leave nothing behind for the editor to adopt."""
+        from griptape_nodes.retained_mode.events.workflow_events import (
+            RunWorkflowFromScratchRequest,
+            RunWorkflowWithCurrentStateRequest,
+        )
+
+        context_manager = griptape_nodes.ContextManager()
+        config_manager = griptape_nodes.ConfigManager()
+        workflow_manager = griptape_nodes.WorkflowManager()
+        _drain(context_manager)
+
+        self._write_exploding_workflow(tmp_path, "explodes")
+
+        original_workspace = config_manager.workspace_path
+        config_manager.workspace_path = tmp_path
+        try:
+            # Library resolution is not what is under test; the file declares no header.
+            async def no_library_work(**_kwargs: object) -> None:
+                return None
+
+            request = (
+                RunWorkflowFromScratchRequest(file_path="explodes.py")
+                if request_type == "from_scratch"
+                else RunWorkflowWithCurrentStateRequest(file_path="explodes.py")
+            )
+            with patch.object(workflow_manager, "_ensure_libraries_for_workflow", no_library_work):
+                result = await griptape_nodes.ahandle_request(request)
+
+            assert result.failed(), "the workflow raises, so the run must be reported as a failure"
+            assert await self._reported_workflow(griptape_nodes) is None, (
+                f"{request_type}: the engine announced the workflow that just failed to load as the "
+                "open one -- every editor adoption path reads this answer and opens that workflow"
+            )
+            assert not context_manager.has_current_workflow(), (
+                f"{request_type}: the failed run stranded a context entry"
+            )
+        finally:
+            config_manager.workspace_path = original_workspace
+            _drain(context_manager)
+
+
+class TestImportUnderOpenWorkflowKeepsTheUsersWorkflow:
+    """Importing a sub-flow must not change which workflow the user is looking at.
+
+    The imported file runs under the parent's context by design -- its nodes belong to the
+    parent. What must hold is that the parent is still the reported workflow afterwards,
+    including when the import fails partway through.
+
+    Unlike the tests above, this one passes against the pre-fix engine too. It is a guard,
+    not a regression: retiring the stack before a run (so "replace" means replace) is the
+    kind of change that could plausibly unseat a parent mid-import, and this pins that it
+    does not.
+    """
+
+    @pytest.mark.asyncio
+    async def test_failed_subflow_import_leaves_the_parent_in_context(
+        self, griptape_nodes: Engine, tmp_path: Path
+    ) -> None:
+        """A sub-flow that raises must not displace or unseat the workflow that is open."""
+        from griptape_nodes.retained_mode.events.workflow_events import (
+            ImportWorkflowAsReferencedSubFlowRequest,
+        )
+
+        context_manager = griptape_nodes.ContextManager()
+        config_manager = griptape_nodes.ConfigManager()
+        _drain(context_manager)
+
+        original_workspace = config_manager.workspace_path
+        config_manager.workspace_path = tmp_path
+        try:
+            _register_workflow(tmp_path, "parent_open")
+            TestFailedRunIsNotReportedAsOpen._write_exploding_workflow(tmp_path, "child")
+            metadata = WorkflowMetadata(
+                name="child",
+                schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+                engine_version_created_with="test",
+                node_libraries_referenced=[],
+                creation_date=datetime.now(UTC),
+            )
+            WorkflowRegistry.generate_new_workflow(registry_key="child", metadata=metadata, file_path="child.py")
+
+            context_manager.push_workflow("parent_open")
+
+            await griptape_nodes.ahandle_request(ImportWorkflowAsReferencedSubFlowRequest(workflow_name="child"))
+
+            reported = await TestFailedRunIsNotReportedAsOpen._reported_workflow(griptape_nodes)
+            assert reported == "parent_open", (
+                f"a sub-flow import left {reported!r} as the open workflow; the user's own "
+                "workflow must survive the import, successful or not"
+            )
+        finally:
+            config_manager.workspace_path = original_workspace
+            _drain(context_manager)


### PR DESCRIPTION
> [!NOTE]
> AI-written, human-verified. I checked this against the code before posting.

Hardening for griptape-ai/griptape-nodes-desktop#406 — *Wrong workflow auto-opens after update restart and after Refresh Libraries*.

**This does not claim to close #406.** The reporter's exact trigger was never reproduced. What it does close is a real, separately-demonstrated defect of the same class, plus a cause-agnostic backstop that would have prevented the reported symptom regardless of what caused it.

## The shape of the bug

Every "what workflow is open" answer in the system comes from `ContextManager._workflow_stack[-1]` — that is what `GetWorkflowContextRequest` returns and what the heartbeat reports as `current_workflow`. It was never validated against the workflow registry and has no on-disk persistence, so a wrong answer can only come from a live engine whose stack was left in a bad state. Every editor adoption path trusts that answer without checking it.

## Changes

**A. `GetWorkflowContext` stops reporting names the registry cannot back** (`context_manager.py`). The registry lookup already existed but only guarded `is_saved`; the name was returned regardless. The check now gates the name too, and logs when it fires. This is the backstop: whatever puts a bad key on the stack, the engine no longer announces it as open.

**B. Stack maintenance helpers** (`context_manager.py`) — `clear_workflow_stack()` (none existed; `object_manager.py` open-coded a `while` drain), `reconcile_with_registry()`, `warn_if_foreign_workflow_context()`, and `registry_key_for_file()` lifted out of `push_workflow` as a pure refactor.

**C. Failure paths unwind** (`workflow_manager.py`). `run_workflow`'s bare `except` returned failure without unwinding the contexts the workflow file had pushed. `RunWorkflowFromRegistry` now retires the stack before pushing, so its own "Replacing the old with the new" log is finally true, and its failure path honors the `clear_all_result` it previously assigned and ignored.

**D. Generated workflow files no longer adopt a foreign context silently** (`workflow_manager.py` codegen). The emitted guard was `if not has_current_workflow(): push(...)`, so with a stale entry present a file skipped its own push and ran its nodes under someone else's name. It now warns on the mismatch. Verified firing against a real generated file.

**E. Workspace-only project switch reconciles** (`project_manager.py`). That branch calls `refresh_workflow_registry()`, which wipes the registry and left the stack holding an orphaned key.

## Evidence

A faulty workflow — real file, engine-generated, sabotaged one line after its push block — driven through all four `run_workflow` callers:

| Path | merge-base `8b2c6cd4` | `origin/main` | this branch |
|---|---|---|---|
| `RunWorkflowFromRegistry` (the editor's path) | clean, `None` | clean, `None` | clean, `None` |
| `RunWorkflowFromScratch` | **leaks → `'Flix.2'`** | **leaks → `'Flix.2'`** | clean, `None` |
| `RunWorkflowWithCurrentState` | **leaks → `'Flix.2'`** | **leaks → `'Flix.2'`** | clean, `None` |
| Import as sub-flow under an open workflow | `'Workflow_2'`, silent | `'Workflow_2'`, silent | `'Workflow_2'`, now logged |

Reporting `'Flix.2'` after `Flix.2` failed to load is the issue's exact symptom. It is still live on `main` today.

## Tests

12 in `tests/unit/retained_mode/managers/test_workflow_context_invariants.py`. Three were added last and verified red against merge-base `8b2c6cd4`, failing with `assert 'explodes' is None`. The sub-flow import test passes pre-fix as well — it is labeled in the code as a guard on the new retire-before-run behavior, not a regression test.

## Honest gaps

- The path the reporter actually used (Refresh Libraries → `RunWorkflowFromRegistry`) stayed clean even unfixed, on two machines. The argument for landing anyway is change A, which is cause-agnostic.
- Changes C's registry-failure branches only bite when the clear-all itself fails — a narrower window than the rest.
- The strongest single reviewer question: is returning `None` from `GetWorkflowContext` the right failure mode versus surfacing the unresolvable key? Callers read the name as truthy, so `None` is the safe default, but it does hide information.
