### PR TITLE
test(serialization): cover the pipeline and pin known defects

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -3450,6 +3450,8 @@ class NodeManager(EngineScoped):
         group_node: BaseNodeGroup,
         unique_uuid_to_values: dict,
         serialized_parameter_value_tracker: SerializedParameterValueTracker,
+        *,
+        serialize_all_parameter_values: bool = False,
     ) -> SerializedGroupResult:
         """Serialize a group node and its children for copy/paste operations.
 
@@ -3462,6 +3464,8 @@ class NodeManager(EngineScoped):
             group_node: The group node to serialize
             unique_uuid_to_values: Shared dictionary for tracking pickled parameter values
             serialized_parameter_value_tracker: Tracker for parameter value hashes
+            serialize_all_parameter_values: If True, capture every parameter value on the group and
+                on each child, not just the ones the ordinary save condition would record
 
         Returns:
             SerializedGroupResult containing the group command, child commands, and child UUIDs
@@ -3478,6 +3482,7 @@ class NodeManager(EngineScoped):
                 unique_parameter_uuid_to_values=unique_uuid_to_values,
                 serialized_parameter_value_tracker=serialized_parameter_value_tracker,
                 use_pickling=True,
+                serialize_all_parameter_values=serialize_all_parameter_values,
             )
         )
 
@@ -3504,6 +3509,7 @@ class NodeManager(EngineScoped):
                     unique_parameter_uuid_to_values=unique_uuid_to_values,
                     serialized_parameter_value_tracker=serialized_parameter_value_tracker,
                     use_pickling=True,
+                    serialize_all_parameter_values=serialize_all_parameter_values,
                 )
             )
 
@@ -4390,7 +4396,7 @@ class NodeManager(EngineScoped):
                     try:
                         unique_parameter_uuid_to_values[unique_uuid] = copy.deepcopy(value)
                     except Exception:
-                        details = f"Attempted to serialize parameter '{parameter_name}` on node '{node_name}'. The parameter value could not be copied. It will be serialized by value. If problems arise from this, ensure the type '{type(value)}' works with copy.deepcopy()."
+                        details = f"Attempted to serialize parameter '{parameter_name}' on node '{node_name}'. The parameter value could not be copied. It will be serialized by value. If problems arise from this, ensure the type '{type(value)}' works with copy.deepcopy()."
                         logger.warning(details)
                         unique_parameter_uuid_to_values[unique_uuid] = value
                 serialized_parameter_value_tracker.add_as_serializable(value_id, unique_uuid)

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -165,6 +165,7 @@ from griptape_nodes.retained_mode.events.node_events import (
     SerializeNodeToCommandsResultFailure,
     SerializeNodeToCommandsResultSuccess,
     SerializeSelectedNodesToCommandsRequest,
+    SerializeSelectedNodesToCommandsResultFailure,
     SerializeSelectedNodesToCommandsResultSuccess,
     SetLockNodeStateRequest,
     SetLockNodeStateResultFailure,
@@ -3763,6 +3764,7 @@ class NodeManager(EngineScoped):
                     create_node_request=create_node_request,
                     workflow_manager=self.engine.workflow_manager,
                     use_pickling=request.use_pickling,
+                    serialize_all_parameter_values=request.serialize_all_parameter_values,
                 )
                 if set_param_value_requests is not None:
                     set_value_commands.extend(set_param_value_requests)
@@ -3993,7 +3995,7 @@ class NodeManager(EngineScoped):
             node = self.engine.object_manager.attempt_get_object_by_name_as_type(node_name, BaseNode)
             if node is None:
                 details = f"Attempted to serialize a selection of Nodes. Failed to get node '{node_name}'."
-                return SerializeNodeToCommandsResultFailure(result_details=details)
+                return SerializeSelectedNodesToCommandsResultFailure(result_details=details)
 
             if isinstance(node, BaseNodeGroup):
                 # Use special method to handle group + children
@@ -4005,7 +4007,7 @@ class NodeManager(EngineScoped):
 
                 if group_result.group_command is None:
                     details = f"Attempted to serialize a selection of Nodes. Failed to serialize group '{node_name}'."
-                    return SerializeNodeToCommandsResultFailure(result_details=details)
+                    return SerializeSelectedNodesToCommandsResultFailure(result_details=details)
 
                 # Process the group node command
                 node_commands[node_name] = group_result.group_command
@@ -4018,7 +4020,7 @@ class NodeManager(EngineScoped):
                     child_name = child_command.create_node_command.node_name
                     if not child_name:
                         details = f"Attempted to serialize group node '{node.name}'. Failed because child node command has no name."
-                        return SerializeNodeToCommandsResultFailure(result_details=details)
+                        return SerializeSelectedNodesToCommandsResultFailure(result_details=details)
                     if child_name in explicitly_selected and child_name in node_commands:
                         # We need to remove the explicitly selected name from the commands that already exist
                         node_commands.pop(child_name)
@@ -4053,7 +4055,7 @@ class NodeManager(EngineScoped):
                 )
                 if not isinstance(result, SerializeNodeToCommandsResultSuccess):
                     details = f"Attempted to serialize a selection of Nodes. Failed to serialize {node_name}."
-                    return SerializeNodeToCommandsResultFailure(result_details=details)
+                    return SerializeSelectedNodesToCommandsResultFailure(result_details=details)
                 node_commands[node_name] = result.serialized_node_commands
                 node_name_to_uuid[node_name] = result.serialized_node_commands.node_uuid
                 parameter_commands[result.serialized_node_commands.node_uuid] = result.set_parameter_value_commands

--- a/tests/unit/exe_types/test_core_types_serialization.py
+++ b/tests/unit/exe_types/test_core_types_serialization.py
@@ -1,0 +1,509 @@
+"""Tests for BaseNodeElement/Parameter `to_dict()` serialization.
+
+`to_dict()` is what the editor's element tree and node-creation replay commands are built
+from, so its shape is a contract: every element type must produce a JSON-safe dict, group
+membership must survive the round trip through the tree, and each Parameter subclass's
+UI-only constructor sugar must land in `ui_options` where the frontend expects it.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from griptape_nodes.exe_types.core_types import (
+    BadgeData,
+    BaseNodeElement,
+    DeprecationMessage,
+    Parameter,
+    ParameterGroup,
+    ParameterMessage,
+    ParameterMode,
+)
+from griptape_nodes.exe_types.param_types.parameter_audio import ParameterAudio
+from griptape_nodes.exe_types.param_types.parameter_bool import ParameterBool
+from griptape_nodes.exe_types.param_types.parameter_dict import ParameterDict
+from griptape_nodes.exe_types.param_types.parameter_image import ParameterImage
+from griptape_nodes.exe_types.param_types.parameter_int import ParameterInt
+from griptape_nodes.exe_types.param_types.parameter_json import ParameterJson
+from griptape_nodes.exe_types.param_types.parameter_video import ParameterVideo
+from griptape_nodes.exe_types.param_types.parameter_xml import ParameterXml
+from griptape_nodes.exe_types.param_types.parameter_yaml import ParameterYaml
+from griptape_nodes.traits.multi_options import MultiOptions
+from griptape_nodes.traits.options import Options
+
+
+class TestBaseNodeElementToDict:
+    """`BaseNodeElement.to_dict()` produces a JSON-safe, order-preserving tree."""
+
+    def test_to_dict_is_json_serializable(self) -> None:
+        element = BaseNodeElement(name="root")
+        child_a = BaseNodeElement(name="child_a")
+        child_b = BaseNodeElement(name="child_b")
+        element.add_child(child_a)
+        element.add_child(child_b)
+
+        # Must not raise: everything to_dict() produces has to cross the wire as JSON.
+        json.dumps(element.to_dict())
+
+    def test_children_serialize_recursively_in_order(self) -> None:
+        # `to_dict()` on the base class does not surface `name` (that is added by
+        # subclasses like Parameter), so order is asserted via `element_id`.
+        parent = BaseNodeElement(name="parent", element_id="parent-id")
+        first = BaseNodeElement(name="first", element_id="first-id")
+        second = BaseNodeElement(name="second", element_id="second-id")
+        third = BaseNodeElement(name="third", element_id="third-id")
+        parent.add_child(first)
+        parent.add_child(second)
+        parent.add_child(third)
+
+        child_ids = [child["element_id"] for child in parent.to_dict()["children"]]
+
+        assert child_ids == ["first-id", "second-id", "third-id"]
+
+    def test_grandchildren_are_present_in_nested_children(self) -> None:
+        root = BaseNodeElement(name="root", element_id="root-id")
+        mid = BaseNodeElement(name="mid", element_id="mid-id")
+        leaf = BaseNodeElement(name="leaf", element_id="leaf-id")
+        root.add_child(mid)
+        mid.add_child(leaf)
+
+        root_dict = root.to_dict()
+
+        assert root_dict["children"][0]["element_id"] == "mid-id"
+        assert root_dict["children"][0]["children"][0]["element_id"] == "leaf-id"
+
+    def test_element_type_defaults_to_class_name(self) -> None:
+        element = BaseNodeElement(name="root")
+
+        assert element.to_dict()["element_type"] == "BaseNodeElement"
+
+    def test_badge_set_appears_in_dict(self) -> None:
+        element = BaseNodeElement(name="root")
+        element.set_badge(variant="warning", title="Heads up", message="Something to check")
+
+        badge_dict = element.to_dict()["badge"]
+
+        assert badge_dict is not None
+        assert badge_dict["variant"] == "warning"
+        assert badge_dict["title"] == "Heads up"
+        assert badge_dict["message"] == "Something to check"
+
+    def test_badge_cleared_is_none(self) -> None:
+        element = BaseNodeElement(name="root")
+        element.set_badge(variant="info", message="temporary")
+        element.clear_badge()
+
+        assert element.to_dict()["badge"] is None
+
+    def test_no_badge_set_is_none(self) -> None:
+        element = BaseNodeElement(name="root")
+
+        assert element.to_dict()["badge"] is None
+
+
+class TestDeprecationMessageElementType:
+    """`DeprecationMessage` must still report as `ParameterMessage` so the UI recognizes it."""
+
+    def test_deprecation_message_reports_parameter_message_element_type(self) -> None:
+        message = DeprecationMessage(
+            value="This parameter is deprecated.",
+            button_text="Migrate",
+            migrate_function=lambda _old, _new: None,
+        )
+
+        assert message.to_dict()["element_type"] == "ParameterMessage"
+        # Sanity: the live Python class is still DeprecationMessage; only the wire shape
+        # is pinned to the parent's element_type.
+        assert type(message).__name__ == "DeprecationMessage"
+
+    def test_deprecation_message_to_dict_is_json_serializable(self) -> None:
+        message = DeprecationMessage(
+            value="This parameter is deprecated.",
+            button_text="Migrate",
+            migrate_function=lambda _old, _new: None,
+        )
+
+        json.dumps(message.to_dict())
+
+
+class TestParameterGroupMembership:
+    """A Parameter's group membership fields must stay in sync with the tree it lives in.
+
+    `ParameterGroup.add_child` keeps `parent_group_name` (set for every element type) and
+    `parent_element_name` (a Parameter-only field cattrs uses when replaying commands) in
+    sync, per the comment on `ParameterGroup.add_child`. Both must point at the group while
+    the Parameter is a member, and both must clear on removal so it reloads as a
+    root-level Parameter instead of a member of a group that no longer claims it.
+    """
+
+    def test_parameter_added_to_group_has_group_name_in_both_fields(self) -> None:
+        group = ParameterGroup(name="settings")
+        param = Parameter(name="threshold", tooltip="t", default_value=0.5)
+        group.add_child(param)
+
+        param_dict = param.to_dict()
+
+        assert param_dict["parent_group_name"] == "settings"
+        assert param_dict["parent_element_name"] == "settings"
+
+    def test_parameter_outside_a_group_has_no_group_reference(self) -> None:
+        param = Parameter(name="threshold", tooltip="t", default_value=0.5)
+
+        param_dict = param.to_dict()
+
+        assert param_dict["parent_group_name"] is None
+        assert param_dict["parent_element_name"] is None
+
+    def test_removing_parameter_from_group_clears_both_fields(self) -> None:
+        group = ParameterGroup(name="settings")
+        param = Parameter(name="threshold", tooltip="t", default_value=0.5)
+        group.add_child(param)
+        group.remove_child(param)
+
+        param_dict = param.to_dict()
+
+        assert param_dict["parent_group_name"] is None
+        assert param_dict["parent_element_name"] is None
+
+    def test_group_to_dict_lists_its_parameters_as_children(self) -> None:
+        group = ParameterGroup(name="settings")
+        first = Parameter(name="threshold", tooltip="t", default_value=0.5)
+        second = Parameter(name="mode", tooltip="t", default_value="auto")
+        group.add_child(first)
+        group.add_child(second)
+
+        child_names = [child["name"] for child in group.to_dict()["children"]]
+
+        assert child_names == ["threshold", "mode"]
+
+
+class TestParameterToDict:
+    """`Parameter.to_dict()` reports every field save/load and the editor rely on."""
+
+    def test_to_dict_is_json_serializable(self) -> None:
+        param = Parameter(
+            name="config",
+            tooltip="A config value",
+            default_value={"nested": [1, 2, {"three": 3}]},
+        )
+
+        json.dumps(param.to_dict())
+
+    @pytest.mark.parametrize(
+        ("allowed_modes", "expected"),
+        [
+            ({ParameterMode.INPUT}, {"input": True, "property": False, "output": False}),
+            ({ParameterMode.OUTPUT}, {"input": False, "property": False, "output": True}),
+            (
+                {ParameterMode.INPUT, ParameterMode.PROPERTY, ParameterMode.OUTPUT},
+                {"input": True, "property": True, "output": True},
+            ),
+        ],
+    )
+    def test_to_dict_reports_allowed_modes(self, allowed_modes: set[ParameterMode], expected: dict[str, bool]) -> None:
+        param = Parameter(name="p", tooltip="t", allowed_modes=allowed_modes)
+
+        param_dict = param.to_dict()
+
+        assert param_dict["mode_allowed_input"] == expected["input"]
+        assert param_dict["mode_allowed_property"] == expected["property"]
+        assert param_dict["mode_allowed_output"] == expected["output"]
+
+    def test_serializable_false_is_reported(self) -> None:
+        param = Parameter(name="p", tooltip="t", serializable=False)
+
+        assert param.to_dict()["serializable"] is False
+
+    def test_serializable_true_is_reported_by_default(self) -> None:
+        param = Parameter(name="p", tooltip="t")
+
+        assert param.to_dict()["serializable"] is True
+
+    def test_ui_options_includes_explicit_options(self) -> None:
+        param = Parameter(name="p", tooltip="t", ui_options={"placeholder": "enter a value"})
+
+        assert param.to_dict()["ui_options"]["placeholder"] == "enter a value"
+
+    def test_parent_container_name_reported(self) -> None:
+        param = Parameter(name="p", tooltip="t", parent_container_name="some_list")
+
+        assert param.to_dict()["parent_container_name"] == "some_list"
+
+    def test_tooltip_variants_reported(self) -> None:
+        param = Parameter(
+            name="p",
+            tooltip="default tip",
+            tooltip_as_input="input tip",
+            tooltip_as_property="property tip",
+            tooltip_as_output="output tip",
+        )
+
+        param_dict = param.to_dict()
+
+        assert param_dict["tooltip"] == "default tip"
+        assert param_dict["tooltip_as_input"] == "input tip"
+        assert param_dict["tooltip_as_property"] == "property tip"
+        assert param_dict["tooltip_as_output"] == "output tip"
+
+    def test_is_user_defined_reported(self) -> None:
+        param = Parameter(name="p", tooltip="t", user_defined=True)
+
+        assert param.to_dict()["is_user_defined"] is True
+
+    def test_default_value_reported(self) -> None:
+        expected_default = 42
+        param = Parameter(name="p", tooltip="t", default_value=expected_default)
+
+        assert param.to_dict()["default_value"] == expected_default
+
+    def test_type_input_types_and_output_type_reported(self) -> None:
+        param = Parameter(name="p", tooltip="t", type="str", input_types=["str", "int"], output_type="str")
+
+        param_dict = param.to_dict()
+
+        assert param_dict["type"] == "str"
+        assert param_dict["input_types"] == ["str", "int"]
+        assert param_dict["output_type"] == "str"
+
+
+class TestParameterMessageToDict:
+    """`ParameterMessage.to_dict()` merges message styling into `ui_options`."""
+
+    def test_message_ui_options_carries_variant_and_title(self) -> None:
+        message = ParameterMessage(variant="warning", value="careful")
+
+        message_dict = message.to_dict()
+
+        assert message_dict["ui_options"]["variant"] == "warning"
+        assert message_dict["ui_options"]["title"] == "Warning"
+
+    def test_default_value_mirrors_value_for_backward_compatibility(self) -> None:
+        message = ParameterMessage(variant="info", value="hello")
+
+        message_dict = message.to_dict()
+
+        assert message_dict["value"] == "hello"
+        assert message_dict["default_value"] == "hello"
+
+    def test_explicit_title_overrides_variant_default(self) -> None:
+        message = ParameterMessage(variant="info", value="hello", title="Custom Title")
+
+        assert message.to_dict()["ui_options"]["title"] == "Custom Title"
+
+    def test_to_dict_is_json_serializable(self) -> None:
+        message = ParameterMessage(variant="error", value="something broke")
+
+        json.dumps(message.to_dict())
+
+
+class TestTraitToDict:
+    """`Trait.to_dict()` reports trait identity, and a trait's choices reach the parameter."""
+
+    def test_trait_to_dict_includes_trait_name_and_ui_options(self) -> None:
+        options = Options(choices=["a", "b", "c"])
+
+        options_dict = options.to_dict()
+
+        assert options_dict["trait_name"] == "Options"
+        assert options_dict["trait_ui_options"]["simple_dropdown"] == ["a", "b", "c"]
+
+    def test_options_trait_choices_appear_in_parameter_ui_options(self) -> None:
+        param = Parameter(name="p", tooltip="t", traits={Options(choices=["red", "green", "blue"])})
+
+        assert param.to_dict()["ui_options"]["simple_dropdown"] == ["red", "green", "blue"]
+
+    def test_multi_options_trait_choices_appear_in_parameter_ui_options(self) -> None:
+        param = Parameter(name="p", tooltip="t", traits={MultiOptions(choices=["x", "y", "z"])})
+
+        multi_options = param.to_dict()["ui_options"]["multi_options"]
+
+        assert multi_options["choices"] == ["x", "y", "z"]
+
+    def test_explicit_ui_options_win_over_stale_trait_choices(self) -> None:
+        """A saved parameter's own `ui_options` is the source of truth over a trait's default.
+
+        Intended contract per the "SERIALIZATION BUG FIX" note on `Options`: after reload,
+        a node rebuilds its trait with its ORIGINAL constructor choices (there is no
+        mechanism to persist a runtime `trait.choices` mutation back into node source), so
+        `Parameter._ui_options` -- populated from the saved `ui_options` during load -- must
+        win the merge over the trait's now-stale default list.
+        """
+        param = Parameter(
+            name="p",
+            tooltip="t",
+            traits={Options(choices=["stale default 1", "stale default 2"])},
+            ui_options={"simple_dropdown": ["restored choice 1", "restored choice 2"]},
+        )
+
+        assert param.to_dict()["ui_options"]["simple_dropdown"] == ["restored choice 1", "restored choice 2"]
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "DATA-LOSS: Bug: Options.choices setter's 'dual sync' write of "
+            "self._parent.ui_options['simple_dropdown'] = value is a no-op. Parameter.ui_options "
+            "is a computed property that rebuilds a brand-new dict via `|` on every access "
+            "(core_types.py ~:1878), so subscript-assigning into its return value never persists "
+            "to Parameter._ui_options. A dynamic runtime update of trait.choices AFTER the trait "
+            "is attached to a parameter should be reflected in that parameter's persisted "
+            "ui_options (the whole point of the documented 'dual sync' fix), but it is not. "
+            "- see #5440"
+        ),
+    )
+    def test_dynamic_choices_update_after_attachment_persists_to_parameter_ui_options(self) -> None:
+        options = Options(choices=["initial 1", "initial 2"])
+        param = Parameter(name="p", tooltip="t", traits={options})
+
+        options.choices = ["updated 1", "updated 2"]
+
+        assert param._ui_options.get("simple_dropdown") == ["updated 1", "updated 2"]
+
+
+class TestParamTypeSubclassUiOptions:
+    """Each convenience Parameter subclass's constructor sugar lands in `ui_options`."""
+
+    def test_parameter_bool_labels_appear_in_ui_options(self) -> None:
+        param = ParameterBool(name="enabled", on_label="Yes", off_label="No")
+
+        ui_options = param.to_dict()["ui_options"]
+
+        assert ui_options["on_label"] == "Yes"
+        assert ui_options["off_label"] == "No"
+
+    def test_parameter_bool_type_is_bool(self) -> None:
+        param = ParameterBool(name="enabled", default_value=True)
+
+        assert param.to_dict()["type"] == "bool"
+
+    def test_parameter_dict_type_is_always_dict(self) -> None:
+        param = ParameterDict(name="config", default_value={"a": 1})
+
+        param_dict = param.to_dict()
+
+        assert param_dict["type"] == "dict"
+        assert param_dict["output_type"] == "dict"
+
+    def test_parameter_int_step_appears_in_ui_options(self) -> None:
+        expected_step = 5
+        param = ParameterInt(name="count", step=expected_step, default_value=10)
+
+        assert param.to_dict()["ui_options"]["step"] == expected_step
+
+    def test_parameter_int_type_is_int(self) -> None:
+        param = ParameterInt(name="count", default_value=10)
+
+        assert param.to_dict()["type"] == "int"
+
+    def test_parameter_image_ui_flags_appear_in_ui_options(self) -> None:
+        param = ParameterImage(name="input_image", webcam_capture_image=True, edit_mask=True)
+
+        ui_options = param.to_dict()["ui_options"]
+
+        assert ui_options["webcam_capture_image"] is True
+        assert ui_options["edit_mask"] is True
+
+    def test_parameter_video_ui_flags_appear_in_ui_options(self) -> None:
+        param = ParameterVideo(name="input_video", webcam_capture_video=True, edit_video=True)
+
+        ui_options = param.to_dict()["ui_options"]
+
+        assert ui_options["webcam_capture_video"] is True
+        assert ui_options["edit_video"] is True
+
+    def test_parameter_audio_ui_flags_appear_in_ui_options(self) -> None:
+        param = ParameterAudio(name="input_audio", microphone_capture_audio=True, edit_audio=True)
+
+        ui_options = param.to_dict()["ui_options"]
+
+        assert ui_options["microphone_capture_audio"] is True
+        assert ui_options["edit_audio"] is True
+
+    def test_parameter_xml_button_options_appear_in_ui_options(self) -> None:
+        param = ParameterXml(name="doc", button=True, button_label="Format")
+
+        ui_options = param.to_dict()["ui_options"]
+
+        assert ui_options["button"] is True
+        assert ui_options["button_label"] == "Format"
+
+    def test_parameter_yaml_button_options_appear_in_ui_options(self) -> None:
+        param = ParameterYaml(name="doc", button=True, button_label="Validate")
+
+        ui_options = param.to_dict()["ui_options"]
+
+        assert ui_options["button"] is True
+        assert ui_options["button_label"] == "Validate"
+
+    def test_parameter_json_button_options_appear_in_ui_options(self) -> None:
+        param = ParameterJson(name="doc", button=True, button_label="Pretty print")
+
+        ui_options = param.to_dict()["ui_options"]
+
+        assert ui_options["button"] is True
+        assert ui_options["button_label"] == "Pretty print"
+
+    @pytest.mark.parametrize(
+        "make_param",
+        [
+            lambda: ParameterBool(name="p", default_value=True),
+            lambda: ParameterDict(name="p", default_value={}),
+            lambda: ParameterInt(name="p", default_value=1),
+            lambda: ParameterImage(name="p"),
+            lambda: ParameterVideo(name="p"),
+            lambda: ParameterAudio(name="p"),
+            lambda: ParameterXml(name="p", default_value="<a/>"),
+            lambda: ParameterYaml(name="p", default_value="a: 1"),
+            lambda: ParameterJson(name="p", default_value={}),
+        ],
+    )
+    def test_subclass_to_dict_is_json_serializable(self, make_param: Any) -> None:
+        param = make_param()
+
+        json.dumps(param.to_dict())
+
+
+class TestBadgeDataToDict:
+    """`BadgeData.to_dict()` is the shape both `BaseNodeElement.to_dict()` and events use."""
+
+    def test_defaults_round_trip(self) -> None:
+        badge = BadgeData()
+
+        badge_dict = badge.to_dict()
+
+        assert badge_dict["variant"] == "info"
+        assert badge_dict["hide"] is False
+        assert badge_dict["hide_clear_button"] is True
+
+    def test_all_fields_reported(self) -> None:
+        badge = BadgeData(
+            variant="error",
+            title="Oops",
+            message="Something failed",
+            icon="x-circle",
+            color="#ff0000",
+            hide=True,
+            hide_clear_button=False,
+        )
+
+        badge_dict = badge.to_dict()
+
+        assert badge_dict["variant"] == "error"
+        assert badge_dict["title"] == "Oops"
+        assert badge_dict["message"] == "Something failed"
+        assert badge_dict["icon"] == "x-circle"
+        assert badge_dict["color"] == "#ff0000"
+        assert badge_dict["hide"] is True
+        assert badge_dict["hide_clear_button"] is False
+
+    def test_to_dict_does_not_leak_the_private_parent_reference(self) -> None:
+        param = Parameter(name="p", tooltip="t")
+        badge = BadgeData()
+        badge._parent_element = param
+
+        badge_dict = badge.to_dict()
+
+        assert "_parent_element" not in badge_dict
+        json.dumps(badge_dict)

--- a/tests/unit/retained_mode/events/test_payload_wire_serialization.py
+++ b/tests/unit/retained_mode/events/test_payload_wire_serialization.py
@@ -239,46 +239,36 @@ _BUILDABLE_PAYLOAD_NAMES, _EXCLUDED_PAYLOAD_REASONS = _collect_buildable_payload
 
 # --- Guard against the sweep silently losing coverage -------------------------------------------
 #
-# `_CannotBuildDefaultError` carries no structured code, only a message, so the only way to tell
-# "known factory limitation" (e.g. a field typed as a real domain object like `Parameter`) apart
-# from "something new and unexpected fell out of the sweep" is the message text. The patterns
-# below are substrings of the exact messages `_build_default_value`, `_build_default_for_generic`,
-# `_build_default_for_union`, and `_build_default_instance` raise.
+# `_CannotBuildDefaultError` carries no structured code, only a message, so there is no reliable
+# way to tell "known factory limitation" apart from "something new fell out of the sweep" by
+# inspecting a single exclusion. The guard below works on the size of the excluded set instead.
 #
 # Registry size and sweep size vary with which other test modules have already imported event
 # submodules by the time this file's `_load_all_event_modules()` runs (803 payload types when
-# this file runs alone, 812 in the full `tests/unit` run), so this guard does not assert an exact
-# count. It asserts that every currently-excluded payload fails for an already-known reason, so a
-# newly excluded payload with an unrecognized reason fails this test instead of vanishing.
-_KNOWN_FACTORY_LIMITATION_PATTERNS = (
-    "no default-value rule for generic origin",
-    "no default-value rule for",
-    "get_type_hints failed for",
-    "no member of union",
-    "cls(**constructor_kwargs) rejected the synthesized kwargs for",
-    "default-value nesting too deep for",
-)
+# this file runs alone, 812 in the full `tests/unit` run), so this guard asserts a coverage floor
+# rather than an exact count: a change that drops a large slice of the registry out of the sweep
+# fails here instead of quietly shrinking the sweep's reach.
+_MINIMUM_SWEEP_COVERAGE = 0.9
 
 
-class TestSweepExclusionsAreKnownFactoryLimitations:
-    """Every payload type the registry sweep excludes must fail for an already-recognized reason.
+class TestSweepCoversTheLargeMajorityOfTheRegistry:
+    """The registry sweep must keep covering nearly every registered payload type.
 
-    Protects the highest-value test in this file (the registry-wide round-trip sweep below): if a
-    newly added payload type falls out of the sweep for a reason nobody has seen before, that
-    should surface here as a test failure naming the payload, not disappear into a bare
-    `continue`. This does not xfail the currently-excluded payloads (see
-    `_EXCLUDED_PAYLOAD_REASONS`) -- they are limits of this test file's synthetic-instance
-    factory, not production defects, and marking them xfail would misrepresent a test limitation
-    as a production bug.
+    Protects the highest-value test in this file (the registry-wide round-trip sweep below). Every
+    exclusion is a limit of this file's synthetic-instance factory rather than a production defect
+    (see `_EXCLUDED_PAYLOAD_REASONS`), so the exclusions are not xfailed -- that would misrepresent
+    a test limitation as a production bug. What matters instead is that the excluded set stays
+    small: if a factory or payload change pushes hundreds of types out of the sweep, the sweep
+    still passes while guarding almost nothing, and this test is what catches that.
     """
 
-    def test_every_excluded_payload_has_a_recognized_reason(self) -> None:
-        unrecognized = {
-            name: reason
-            for name, reason in _EXCLUDED_PAYLOAD_REASONS.items()
-            if not any(pattern in reason for pattern in _KNOWN_FACTORY_LIMITATION_PATTERNS)
-        }
-        assert unrecognized == {}
+    def test_sweep_covers_the_large_majority_of_the_registry(self) -> None:
+        coverage = len(_BUILDABLE_PAYLOAD_NAMES) / len(_FULL_PAYLOAD_REGISTRY)
+        assert coverage >= _MINIMUM_SWEEP_COVERAGE, (
+            f"sweep covers only {coverage:.0%} of {len(_FULL_PAYLOAD_REGISTRY)} payload types "
+            f"(floor {_MINIMUM_SWEEP_COVERAGE:.0%}); excluded payloads and why: "
+            f"{_EXCLUDED_PAYLOAD_REASONS}"
+        )
 
 
 # --- Known, deterministic wire round-trip bugs surfaced by the sweep below ---------------------

--- a/tests/unit/retained_mode/events/test_payload_wire_serialization.py
+++ b/tests/unit/retained_mode/events/test_payload_wire_serialization.py
@@ -1,0 +1,642 @@
+"""Tests for the event/payload wire-serialization pipeline.
+
+Covers ``retained_mode/events/base_events.py`` (Payload.to_json, the Event envelope classes and
+their ``from_dict``) and ``retained_mode/events/event_converter.py`` (the cattrs converter's
+registered hooks and ``safe_unstructure``). Complements ``test_event_converter.py`` and
+``test_from_dict.py``, which already cover JSON-primitive unions, the exception wire form,
+``SetParameterValueRequest`` structuring, and ``from_dict`` basics -- this file extends into the
+gaps: full round trips, ``ResultDetails``, batches, artifact/pydantic/Path/float/type hooks, the
+``safe_unstructure`` fallback, unknown-type errors, and a registry-wide sweep.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import importlib
+import json
+import pkgutil
+import types
+from datetime import UTC, datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any, Union, get_args, get_origin, get_type_hints
+
+import pytest
+from griptape.artifacts import TextArtifact
+
+import griptape_nodes.retained_mode.events as events_pkg
+from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
+from griptape_nodes.retained_mode.events.agent_events import UpdateAgentProviderRequest
+from griptape_nodes.retained_mode.events.artifact_events import (
+    RegisterArtifactProviderRequest,
+)
+from griptape_nodes.retained_mode.events.base_events import (
+    EventRequest,
+    EventRequestBatch,
+    EventResultFailure,
+    EventResultSuccess,
+    Payload,
+    ResultDetail,
+    ResultDetails,
+    StrictModeViolationDetail,
+)
+from griptape_nodes.retained_mode.events.config_events import GetConfigValueRequest, GetConfigValueResultSuccess
+from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
+from griptape_nodes.retained_mode.events.context_events import SetWorkflowContextSuccess
+from griptape_nodes.retained_mode.events.event_converter import converter, safe_unstructure
+from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
+from griptape_nodes.retained_mode.events.project_events import LoadProjectTemplateRequest
+from griptape_nodes.retained_mode.events.workflow_events import GetWorkflowMetadataResultSuccess
+
+# --- Populate the full PayloadRegistry without constructing an Engine -------------------------
+#
+# @PayloadRegistry.register only runs when the module that declares the decorated class is
+# imported. Building a real Engine would populate the registry as a side effect, but it would
+# also read/write real user config at collection time (the isolate_user_config fixture exists
+# precisely to prevent that, and fixtures have not run yet during module-level collection). Instead,
+# walk the events package directly: this is process-local, config-free, and idempotent regardless
+# of what other test files have already imported.
+_SCHEMA_GENERATOR_SCRIPT_MODULE = "generate_request_payload_schemas"
+"""CLI script, not an importable library module: its top-level code assumes the registry is
+already fully populated and writes a JSON schema file as a side effect. Importing it here would
+be circular (it wants the very thing this loop is building) and would touch the filesystem."""
+
+
+def _load_all_event_modules() -> None:
+    """Import every submodule of ``retained_mode.events`` so every payload type registers."""
+    for module_info in pkgutil.iter_modules(events_pkg.__path__, f"{events_pkg.__name__}."):
+        short_name = module_info.name.rsplit(".", 1)[-1]
+        if short_name == _SCHEMA_GENERATOR_SCRIPT_MODULE:
+            continue
+        importlib.import_module(module_info.name)
+
+
+_load_all_event_modules()
+_FULL_PAYLOAD_REGISTRY: dict[str, type[Payload]] = PayloadRegistry.get_registry()
+
+
+# --- Generic "emptiest legal instance" factory for the registry sweep --------------------------
+
+
+class _CannotBuildDefaultError(Exception):
+    """Raised internally when the factory below cannot synthesize a value for a field's type.
+
+    Not a test failure by itself: the sweep catches this to exclude a payload type it cannot
+    mechanically construct (e.g. a field typed as a real domain object like ``Parameter``) rather
+    than asserting a fabricated, possibly-wrong value for it.
+    """
+
+
+_MAX_DEFAULT_VALUE_DEPTH = 6
+
+_PRIMITIVE_DEFAULTS: dict[type, Any] = {
+    str: "",
+    int: 0,
+    float: 0.0,
+    bool: False,
+    bytes: b"",
+}
+
+
+def _unwrap_newtype(type_hint: Any) -> Any:
+    while hasattr(type_hint, "__supertype__"):
+        type_hint = type_hint.__supertype__
+    return type_hint
+
+
+def _build_default_for_union(union_args: tuple[Any, ...], depth: int) -> Any:
+    if type(None) in union_args:
+        return None
+
+    last_error: _CannotBuildDefaultError | None = None
+    for member in union_args:
+        try:
+            return _build_default_value(member, depth + 1)
+        except _CannotBuildDefaultError as error:
+            last_error = error
+
+    msg = f"no member of union {union_args!r} could be built"
+    raise _CannotBuildDefaultError(msg) from last_error
+
+
+def _build_default_for_generic(type_hint: Any, origin: Any, depth: int) -> Any:
+    if origin is list:
+        return []
+    if origin is dict:
+        return {}
+    if origin is set:
+        return set()
+    if origin is frozenset:
+        return frozenset()
+    if origin is tuple:
+        return ()
+    if origin is Union or origin is types.UnionType:
+        return _build_default_for_union(get_args(type_hint), depth)
+
+    msg = f"no default-value rule for generic origin {origin!r} ({type_hint!r})"
+    raise _CannotBuildDefaultError(msg)
+
+
+def _build_default_for_simple_type(resolved: Any) -> tuple[bool, Any]:
+    """Return (True, value) for a type that maps to one fixed placeholder, else (False, None).
+
+    Keeping this as its own lookup (rather than more `if ... return` branches inline in
+    ``_build_default_value``) is what keeps that function under the return-statement limit.
+    """
+    if resolved is Any:
+        return True, None
+    if resolved in _PRIMITIVE_DEFAULTS:
+        return True, _PRIMITIVE_DEFAULTS[resolved]
+    if resolved is Path:
+        return True, Path("placeholder")
+    if resolved is type:
+        return True, object
+    return False, None
+
+
+def _build_default_value(type_hint: Any, depth: int) -> Any:
+    """Synthesize a minimal placeholder for one field's declared type.
+
+    Only handles the shapes that actually show up on Payload dataclasses: JSON primitives,
+    Optional/Union, list/dict/set/frozenset/tuple, Path, Enum, bare ``type``, and nested
+    dataclasses. Anything else raises ``_CannotBuildDefaultError``.
+    """
+    if depth > _MAX_DEFAULT_VALUE_DEPTH:
+        msg = f"default-value nesting too deep for {type_hint!r}"
+        raise _CannotBuildDefaultError(msg)
+
+    resolved = _unwrap_newtype(type_hint)
+
+    is_simple, simple_value = _build_default_for_simple_type(resolved)
+    if is_simple:
+        return simple_value
+
+    origin = get_origin(resolved)
+    if origin is not None:
+        return _build_default_for_generic(resolved, origin, depth)
+
+    if isinstance(resolved, type) and issubclass(resolved, Enum):
+        return next(iter(resolved))
+    if isinstance(resolved, type) and dataclasses.is_dataclass(resolved):
+        return _build_default_instance(resolved, depth + 1)
+
+    msg = f"no default-value rule for {type_hint!r}"
+    raise _CannotBuildDefaultError(msg)
+
+
+def _build_default_instance(cls: type, depth: int = 0) -> Any:
+    """Construct ``cls`` using each field's own default where declared, else a placeholder.
+
+    Mirrors the "emptiest legal instance" a client could build: fields the dataclass already
+    defaults are left untouched, and only fields with no default get a synthesized placeholder.
+    """
+    try:
+        type_hints = get_type_hints(cls)
+    except NameError as error:
+        msg = f"get_type_hints failed for {cls!r}: {error}"
+        raise _CannotBuildDefaultError(msg) from error
+
+    constructor_kwargs: dict[str, Any] = {}
+    for dataclass_field in dataclasses.fields(cls):
+        if not dataclass_field.init:
+            continue
+        has_default = dataclass_field.default is not dataclasses.MISSING
+        has_default_factory = dataclass_field.default_factory is not dataclasses.MISSING  # type: ignore[misc]
+        if has_default or has_default_factory:
+            continue
+        field_type = type_hints.get(dataclass_field.name, dataclass_field.type)
+        constructor_kwargs[dataclass_field.name] = _build_default_value(field_type, depth)
+
+    try:
+        return cls(**constructor_kwargs)
+    except TypeError as error:
+        # A handful of dataclasses (e.g. ResultDetails) define their own __init__ with a shape
+        # that does not match their declared fields (variadic *args instead of one keyword per
+        # field). Treat that as unbuildable rather than letting it crash the sweep.
+        msg = f"cls(**constructor_kwargs) rejected the synthesized kwargs for {cls!r}: {error}"
+        raise _CannotBuildDefaultError(msg) from error
+
+
+def _collect_buildable_payload_names() -> tuple[list[str], dict[str, str]]:
+    """Partition the registry into names the factory can build and names it cannot, with why.
+
+    Returns the buildable names (used to parametrize the sweep below) and a name -> reason map
+    for everything excluded, so the exclusion is a recorded fact instead of a silent `continue`.
+    """
+    buildable: list[str] = []
+    excluded: dict[str, str] = {}
+    for name, cls in sorted(_FULL_PAYLOAD_REGISTRY.items()):
+        try:
+            _build_default_instance(cls)
+        except _CannotBuildDefaultError as error:
+            excluded[name] = str(error)
+            continue
+        buildable.append(name)
+    return buildable, excluded
+
+
+_BUILDABLE_PAYLOAD_NAMES, _EXCLUDED_PAYLOAD_REASONS = _collect_buildable_payload_names()
+
+# --- Guard against the sweep silently losing coverage -------------------------------------------
+#
+# `_CannotBuildDefaultError` carries no structured code, only a message, so the only way to tell
+# "known factory limitation" (e.g. a field typed as a real domain object like `Parameter`) apart
+# from "something new and unexpected fell out of the sweep" is the message text. The patterns
+# below are substrings of the exact messages `_build_default_value`, `_build_default_for_generic`,
+# `_build_default_for_union`, and `_build_default_instance` raise.
+#
+# Registry size and sweep size vary with which other test modules have already imported event
+# submodules by the time this file's `_load_all_event_modules()` runs (803 payload types when
+# this file runs alone, 812 in the full `tests/unit` run), so this guard does not assert an exact
+# count. It asserts that every currently-excluded payload fails for an already-known reason, so a
+# newly excluded payload with an unrecognized reason fails this test instead of vanishing.
+_KNOWN_FACTORY_LIMITATION_PATTERNS = (
+    "no default-value rule for generic origin",
+    "no default-value rule for",
+    "get_type_hints failed for",
+    "no member of union",
+    "cls(**constructor_kwargs) rejected the synthesized kwargs for",
+    "default-value nesting too deep for",
+)
+
+
+class TestSweepExclusionsAreKnownFactoryLimitations:
+    """Every payload type the registry sweep excludes must fail for an already-recognized reason.
+
+    Protects the highest-value test in this file (the registry-wide round-trip sweep below): if a
+    newly added payload type falls out of the sweep for a reason nobody has seen before, that
+    should surface here as a test failure naming the payload, not disappear into a bare
+    `continue`. This does not xfail the currently-excluded payloads (see
+    `_EXCLUDED_PAYLOAD_REASONS`) -- they are limits of this test file's synthetic-instance
+    factory, not production defects, and marking them xfail would misrepresent a test limitation
+    as a production bug.
+    """
+
+    def test_every_excluded_payload_has_a_recognized_reason(self) -> None:
+        unrecognized = {
+            name: reason
+            for name, reason in _EXCLUDED_PAYLOAD_REASONS.items()
+            if not any(pattern in reason for pattern in _KNOWN_FACTORY_LIMITATION_PATTERNS)
+        }
+        assert unrecognized == {}
+
+
+# --- Known, deterministic wire round-trip bugs surfaced by the sweep below ---------------------
+
+_TYPE_FIELD_MISSING_STRUCTURE_HOOK_REASON = (
+    "API-CONTRACT: event_converter registers an unstructure hook for a bare `type` field (type -> "
+    "'module.Qualname' string) but no matching structure hook, so a value built from to_json() "
+    "cannot be read back with converter.structure(); it raises StructureHandlerNotFoundError. "
+    "Intended: a `type` field survives an unstructure/structure round trip like every other field. "
+    "- see #5437"
+)
+
+_UPDATE_PROVIDER_PAYLOAD_ROUND_TRIP_REASON = (
+    "API-CONTRACT: UpdateAgentProviderRequest.provider is an UpdateProviderPayload pydantic model "
+    "whose optional str fields default to None but are validated by a 'non-empty string if "
+    "provided' validator. Unstructuring with model_dump(mode='json') always emits that None "
+    "default explicitly, and re-structuring the dict with model_validate() treats the explicit "
+    "None as 'provided', so the validator rejects it even though the identical unconstructed "
+    "default was legal. Intended: a payload built with only its own declared defaults survives a "
+    "full wire round trip. - see #5439"
+)
+
+_ENUM_UNION_MISSING_STRUCTURE_HOOK_REASON = (
+    "API-CONTRACT: failure_reason is typed `SequenceScanFailureReason | FileIOFailureReason`, a "
+    "union of two StrEnum types. _is_json_primitive_union only recognizes unions of plain JSON "
+    "primitives, so this union falls through to cattrs' default union dispatch, which has no "
+    "discriminator strategy for two unrelated Enum members and raises StructureHandlerNotFoundError. "
+    "Intended: a failure_reason value from either enum survives an unstructure/structure round "
+    "trip. - see #5438"
+)
+
+_KNOWN_WIRE_ROUND_TRIP_BUGS: dict[str, str] = {
+    "RegisterArtifactProviderRequest": _TYPE_FIELD_MISSING_STRUCTURE_HOOK_REASON,
+    "RegisterPreviewGeneratorRequest": _TYPE_FIELD_MISSING_STRUCTURE_HOOK_REASON,
+    "UpdateAgentProviderRequest": _UPDATE_PROVIDER_PAYLOAD_ROUND_TRIP_REASON,
+    "DeduceSequencesFromFileListResultFailure": _ENUM_UNION_MISSING_STRUCTURE_HOOK_REASON,
+    "ListDirectoryResultFailure": _ENUM_UNION_MISSING_STRUCTURE_HOOK_REASON,
+    "ListDirectorySequencesResultFailure": _ENUM_UNION_MISSING_STRUCTURE_HOOK_REASON,
+    "ScanSequencesResultFailure": _ENUM_UNION_MISSING_STRUCTURE_HOOK_REASON,
+}
+
+
+def _sweep_params() -> list[Any]:
+    params = []
+    for name in _BUILDABLE_PAYLOAD_NAMES:
+        reason = _KNOWN_WIRE_ROUND_TRIP_BUGS.get(name)
+        if reason is None:
+            params.append(pytest.param(name, id=name))
+        else:
+            params.append(pytest.param(name, id=name, marks=pytest.mark.xfail(strict=True, reason=reason)))
+    return params
+
+
+class TestPayloadRegistryDefaultInstanceRoundTrip:
+    """Sweep every registered payload type that can be built from its own field defaults.
+
+    Guards the wire contract broadly: a payload built with nothing but its declared defaults must
+    unstructure to JSON and restructure back into an equal instance. The registry has hundreds of
+    entries; this sweeps the large majority (over 90%) that a generic default-value factory can
+    construct without inventing real domain objects such as ``Parameter`` or
+    ``SerializedFlowCommands`` (see ``_EXCLUDED_PAYLOAD_REASONS`` and
+    ``TestSweepExclusionsAreKnownFactoryLimitations`` for the rest). That is still enough surface
+    to catch hooks that are missing for only some field shapes, as the xfails below demonstrate
+    (a bare `type` field, a union of two unrelated Enum types, and a pydantic model with a
+    validated-but-optional field).
+    """
+
+    @pytest.mark.parametrize("payload_name", _sweep_params())
+    def test_default_instance_round_trips_through_wire_form(self, payload_name: str) -> None:
+        payload_cls = _FULL_PAYLOAD_REGISTRY[payload_name]
+        instance = _build_default_instance(payload_cls)
+
+        data = json.loads(instance.to_json())
+        restored = converter.structure(data, payload_cls)
+
+        assert restored == instance
+
+
+class TestRequestResultPayloadRoundTrip:
+    """A payload built by a caller must survive to_json() -> json.loads() -> converter.structure()."""
+
+    def test_request_payload_round_trip_preserves_every_field(self) -> None:
+        request = CreateConnectionRequest(
+            source_parameter_name="out",
+            target_parameter_name="in",
+            source_node_name="NodeA",
+            target_node_name="NodeB",
+            initial_setup=True,
+            is_node_group_internal=True,
+            request_id="abc-123",
+        )
+
+        data = json.loads(request.to_json())
+        restored = converter.structure(data, CreateConnectionRequest)
+
+        assert restored == request
+
+    def test_result_payload_round_trip_preserves_declared_fields(self) -> None:
+        result = SetWorkflowContextSuccess(result_details="context set", workflow_name="my_workflow")
+
+        data = json.loads(result.to_json())
+        restored = converter.structure(data, SetWorkflowContextSuccess)
+
+        assert restored == result
+
+    def test_init_false_field_is_reset_to_class_default_on_structure(self) -> None:
+        """``altered_workflow_state`` is init=False: the handler decides it, not the wire.
+
+        Unstructuring reports whatever the live object's flag actually is (useful for logging/
+        debugging), but restructuring a payload from the wire must NOT let that value override the
+        class's own semantics, otherwise a client could claim its own request altered the workflow.
+        Mutating the field after construction (something only a test can do, since it is init=False)
+        proves the two directions are asymmetric on purpose.
+        """
+        result = GetConfigValueResultSuccess(value=1, result_details="ok")
+        assert result.altered_workflow_state is False
+        result.altered_workflow_state = True
+
+        data = json.loads(result.to_json())
+        assert data["altered_workflow_state"] is True
+
+        restored = converter.structure(data, GetConfigValueResultSuccess)
+        assert restored.altered_workflow_state is False
+
+
+class TestResultDetailsWireForm:
+    """ResultDetails' custom _cattrs_unstructure/_cattrs_structure round trip, in both shapes."""
+
+    def test_string_shorthand_round_trip(self) -> None:
+        result = GetConfigValueResultSuccess(value=1, result_details="just a message")
+
+        data = json.loads(result.to_json())
+        restored = converter.structure(data, GetConfigValueResultSuccess)
+
+        assert isinstance(restored.result_details, ResultDetails)
+        assert str(restored.result_details) == "just a message"
+
+    def test_structured_multi_detail_round_trip_preserves_levels_and_subclass_identity(self) -> None:
+        """A mix of plain and StrictModeViolationDetail entries keeps every level and subclass field.
+
+        register_polymorphic_dataclass(ResultDetail) is what makes the subclass survive: without it
+        every entry would degrade to a bare ResultDetail and lose rule_id/severity/subject/library_name.
+        """
+        details = ResultDetails(
+            ResultDetail(level=20, message="plain info"),
+            StrictModeViolationDetail(
+                level=40,
+                message="a strict-mode violation",
+                rule_id="R1",
+                severity="high",
+                subject="node.foo",
+                library_name="My Library",
+            ),
+        )
+        result = GetConfigValueResultSuccess(value=1, result_details=details)
+
+        data = json.loads(result.to_json())
+        restored = converter.structure(data, GetConfigValueResultSuccess)
+
+        restored_details = restored.result_details
+        assert isinstance(restored_details, ResultDetails)
+        assert [d.level for d in restored_details.result_details] == [20, 40]
+        assert [d.message for d in restored_details.result_details] == ["plain info", "a strict-mode violation"]
+
+        second_detail = restored_details.result_details[1]
+        assert isinstance(second_detail, StrictModeViolationDetail)
+        assert second_detail.rule_id == "R1"
+        assert second_detail.severity == "high"
+        assert second_detail.subject == "node.foo"
+        assert second_detail.library_name == "My Library"
+
+
+class TestEventRequestBatchRoundTrip:
+    """EventRequestBatch fans a heterogeneous list of requests out and back in."""
+
+    def test_batch_round_trip_resolves_each_request_to_its_own_concrete_type(self) -> None:
+        batch = EventRequestBatch(
+            requests=[
+                EventRequest(request=GetConfigValueRequest(category_and_key="a.b")),
+                EventRequest(request=CreateConnectionRequest(source_parameter_name="out", target_parameter_name="in")),
+            ]
+        )
+
+        data = json.loads(json.dumps(batch.dict(), default=str))
+        restored = EventRequestBatch.from_dict(data)
+
+        expected_request_count = 2
+        assert len(restored.requests) == expected_request_count
+        first, second = restored.requests
+        assert isinstance(first.request, GetConfigValueRequest)
+        assert first.request.category_and_key == "a.b"
+        assert isinstance(second.request, CreateConnectionRequest)
+        assert second.request.source_parameter_name == "out"
+
+
+class TestSerializableArtifactHook:
+    """SerializableMixin subclasses (griptape artifacts) unstructure via their own to_dict()."""
+
+    def test_artifact_unstructures_via_to_dict_and_restructures_into_the_artifact(self) -> None:
+        artifact = TextArtifact("hold onto this")
+
+        unstructured = converter.unstructure(artifact, TextArtifact)
+        assert unstructured == artifact.to_dict()
+
+        restored = converter.structure(unstructured, TextArtifact)
+        assert isinstance(restored, TextArtifact)
+        assert restored.value == artifact.value
+
+
+class TestPydanticModelFieldHook:
+    """A pydantic BaseModel field (e.g. WorkflowMetadata) must unstructure with mode="json"."""
+
+    def test_datetime_field_becomes_a_json_dumpable_string_representing_the_same_instant(self) -> None:
+        created = datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC)
+        metadata = WorkflowMetadata(
+            name="wf",
+            schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+            engine_version_created_with="0.1.0",
+            node_libraries_referenced=[],
+            creation_date=created,
+        )
+        result = GetWorkflowMetadataResultSuccess(result_details="ok", workflow_metadata=metadata)
+
+        # json.dumps-able is the contract: a datetime object left in the tree would raise here.
+        wire_json = result.to_json()
+        data = json.loads(wire_json)
+
+        creation_date_on_wire = data["workflow_metadata"]["creation_date"]
+        assert isinstance(creation_date_on_wire, str)
+        assert datetime.fromisoformat(creation_date_on_wire) == created
+
+
+class TestPathFieldHook:
+    """A Path-typed request field must accept a plain string off the wire."""
+
+    def test_path_field_accepts_string_off_the_wire(self) -> None:
+        wire_value = {"project_path": "/workspace/project.yml"}
+
+        request = converter.structure(wire_value, LoadProjectTemplateRequest)
+
+        assert isinstance(request.project_path, Path)
+        assert request.project_path == Path("/workspace/project.yml")
+
+
+class TestFloatFieldHook:
+    """A float-typed field must accept an int off the wire; JSON has no int/float distinction."""
+
+    def test_float_field_accepts_int_off_the_wire(self) -> None:
+        coerced = converter.structure(5, float)
+
+        expected_value = 5.0
+        assert coerced == expected_value
+        assert isinstance(coerced, float)
+
+
+class _PlaceholderProviderClass:
+    """Stand-in class used only to exercise the bare `type` unstructure/structure hooks."""
+
+
+class TestBareTypeFieldHook:
+    """RegisterArtifactProviderRequest.provider_class is a bare `type`, not a dataclass instance."""
+
+    def test_type_field_unstructures_to_dotted_module_and_qualname(self) -> None:
+        request = RegisterArtifactProviderRequest(provider_class=_PlaceholderProviderClass)
+
+        data = json.loads(request.to_json())
+
+        assert data["provider_class"] == f"{__name__}._PlaceholderProviderClass"
+
+    @pytest.mark.xfail(strict=True, reason=_TYPE_FIELD_MISSING_STRUCTURE_HOOK_REASON)
+    def test_type_field_round_trips_back_into_the_original_type(self) -> None:
+        request = RegisterArtifactProviderRequest(provider_class=_PlaceholderProviderClass)
+
+        data = json.loads(request.to_json())
+        restored = converter.structure(data, RegisterArtifactProviderRequest)
+
+        assert restored.provider_class is _PlaceholderProviderClass
+
+
+class TestPydanticValidatedOptionalFieldRoundTrip:
+    """A payload built with only its own defaults must survive a full wire round trip."""
+
+    @pytest.mark.xfail(strict=True, reason=_UPDATE_PROVIDER_PAYLOAD_ROUND_TRIP_REASON)
+    def test_default_update_agent_provider_request_round_trips(self) -> None:
+        request = UpdateAgentProviderRequest()
+
+        data = json.loads(request.to_json())
+        restored = converter.structure(data, UpdateAgentProviderRequest)
+
+        assert restored == request
+
+
+class _RaisesOnUnstructure:
+    """A field value whose custom unstructure hook always raises, to exercise the fallback path."""
+
+    def _cattrs_unstructure(self, converter: Any) -> dict[str, Any]:  # noqa: ARG002
+        msg = "this value refuses to serialize"
+        raise RuntimeError(msg)
+
+    def __str__(self) -> str:
+        return "a value that refuses to serialize"
+
+
+@dataclasses.dataclass
+class _HasOneBadField:
+    """Local dataclass with one field that raises during unstructure and one that does not."""
+
+    good_field: str
+    bad_field: _RaisesOnUnstructure
+
+
+class TestSafeUnstructureFallback:
+    """safe_unstructure must not let one bad field lose the rest of the object."""
+
+    def test_dataclass_with_one_unserializable_field_keeps_every_other_field(self) -> None:
+        obj = _HasOneBadField(good_field="hello", bad_field=_RaisesOnUnstructure())
+
+        result = safe_unstructure(obj)
+
+        assert result["good_field"] == "hello"
+        # The bad field is not lost: the raw value survives even though it could not be unstructured.
+        assert isinstance(result["bad_field"], _RaisesOnUnstructure)
+
+    def test_non_dataclass_falls_back_to_str(self) -> None:
+        obj = _RaisesOnUnstructure()
+
+        result = safe_unstructure(obj)
+
+        assert result == "a value that refuses to serialize"
+
+
+class TestFromDictUnknownPayloadType:
+    """An unregistered request_type/result_type at the Event envelope level fails loudly."""
+
+    def test_event_request_from_dict_rejects_unregistered_request_type(self) -> None:
+        data = {"request_type": "TotallyUnknownRequestType", "request": {}}
+
+        with pytest.raises(ValueError, match="TotallyUnknownRequestType"):
+            EventRequest.from_dict(data)
+
+    def test_event_result_success_from_dict_rejects_unregistered_result_type(self) -> None:
+        data = {
+            "request_type": "GetConfigValueRequest",
+            "result_type": "TotallyUnknownResultType",
+            "request": {"category_and_key": "a.b"},
+            "result": {},
+        }
+
+        with pytest.raises(ValueError, match="TotallyUnknownResultType"):
+            EventResultSuccess.from_dict(data)
+
+    def test_event_result_failure_from_dict_rejects_unregistered_request_type(self) -> None:
+        data = {
+            "request_type": "TotallyUnknownRequestType",
+            "result_type": "GetConfigValueResultSuccess",
+            "request": {},
+            "result": {"value": 1, "result_details": "ok"},
+        }
+
+        with pytest.raises(ValueError, match="TotallyUnknownRequestType"):
+            EventResultFailure.from_dict(data)

--- a/tests/unit/retained_mode/file_metadata/test_workflow_metadata_serialization.py
+++ b/tests/unit/retained_mode/file_metadata/test_workflow_metadata_serialization.py
@@ -1,0 +1,300 @@
+"""Tests for workflow metadata collection and image-metadata serialization primitives.
+
+Covers the module that lets a saved image carry a workflow inside its own metadata
+(`_serialize_flow`, `_serialize_node`, `collect_workflow_metadata`) and the
+`WorkflowMetadata` fields that need custom (de)serialization to survive a TOML header
+(`node_types_used`, `workflow_shape`). Deliberately does not cover the sidecar metadata
+module (`test_sidecar_metadata.py`) or `ExtractFlowCommandsFromImageMetadata`
+(`test_flow_manager.py`), which read this module's output from the other side.
+"""
+
+import base64
+import json
+import pickle
+from collections.abc import Generator
+
+import pytest
+
+from griptape_nodes.exe_types.node_types import ErrorProxyNode
+from griptape_nodes.node_library.workflow_registry import LibraryNameAndNodeType, WorkflowMetadata, WorkflowShape
+from griptape_nodes.retained_mode.engine import Engine
+from griptape_nodes.retained_mode.events.context_events import EnsureWorkflowAndFlowRequest
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    CreateFlowResultSuccess,
+    SerializeFlowToCommandsRequest,
+    SerializeFlowToCommandsResultSuccess,
+)
+from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
+from griptape_nodes.retained_mode.file_metadata.workflow_metadata import (
+    METADATA_NAMESPACE,
+    _serialize_flow,
+    _serialize_node,
+    collect_workflow_metadata,
+)
+
+
+@pytest.fixture
+def clean_object_state(engine: Engine) -> Generator[None, None, None]:
+    """Clear all object state around a test so leftover flows never bleed across tests.
+
+    Yield-based so the teardown clear runs even when the test body fails.
+    """
+    engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    try:
+        yield
+    finally:
+        engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+
+
+def _add_error_proxy_node(engine: Engine, node_name: str) -> ErrorProxyNode:
+    """Add a node to the object manager without needing a registered library.
+
+    `ErrorProxyNode` is the engine's own stand-in for a node whose real type could not be
+    created, so constructing one directly sidesteps library registration entirely while
+    still exercising a real, fully-formed `BaseNode`.
+    """
+    node = ErrorProxyNode(
+        name=node_name,
+        original_node_type="SomeOriginalType",
+        original_library_name="SomeOriginalLibrary",
+        failure_reason="library unavailable in this test",
+        metadata={},
+    )
+    engine.object_manager.add_object_by_name(node.name, node)
+    return node
+
+
+class TestSerializeFlow:
+    """`_serialize_flow` packs a flow's commands into a pickle+base64 string for image metadata."""
+
+    @pytest.mark.usefixtures("clean_object_state")
+    def test_round_trips_through_pickle_and_base64(self, engine: Engine) -> None:
+        """The payload unpickles back into the exact commands a direct request would produce."""
+        engine.context_manager.push_workflow(workflow_name="wf_roundtrip")
+        created = engine.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="flow_roundtrip", set_as_new_context=True)
+        )
+        assert isinstance(created, CreateFlowResultSuccess)
+
+        payload = _serialize_flow(engine, flow_name=created.flow_name)
+        assert payload is not None
+
+        unpickled = pickle.loads(base64.b64decode(payload))  # noqa: S301
+
+        direct_result = engine.handle_request(
+            SerializeFlowToCommandsRequest(flow_name=created.flow_name, include_create_flow_command=False)
+        )
+        assert isinstance(direct_result, SerializeFlowToCommandsResultSuccess)
+        assert unpickled == direct_result.serialized_flow_commands
+
+    @pytest.mark.usefixtures("clean_object_state")
+    def test_no_flow_name_and_no_current_flow_returns_none(self, engine: Engine) -> None:
+        """With nothing to serialize and no flow context to fall back to, this must not raise."""
+        engine.context_manager.push_workflow(workflow_name="wf_no_flow")
+
+        assert not engine.context_manager.has_current_flow()
+        assert _serialize_flow(engine, flow_name=None) is None
+
+    @pytest.mark.usefixtures("clean_object_state")
+    def test_unknown_flow_name_returns_none(self, engine: Engine) -> None:
+        """A flow name that does not exist fails the underlying request; this must degrade to None, not raise."""
+        engine.context_manager.push_workflow(workflow_name="wf_missing_flow")
+
+        assert _serialize_flow(engine, flow_name="does_not_exist") is None
+
+    @pytest.mark.usefixtures("clean_object_state")
+    def test_none_flow_name_uses_current_flow_context(self, engine: Engine) -> None:
+        """Omitting `flow_name` serializes whichever flow is active in the Current Context."""
+        engine.context_manager.push_workflow(workflow_name="wf_current_context")
+        created = engine.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="flow_current_context", set_as_new_context=True)
+        )
+        assert isinstance(created, CreateFlowResultSuccess)
+        assert engine.context_manager.has_current_flow()
+
+        payload = _serialize_flow(engine, flow_name=None)
+        assert payload is not None
+
+        unpickled = pickle.loads(base64.b64decode(payload))  # noqa: S301
+        assert unpickled.flow_name is None  # SerializeFlowToCommandsResult doesn't stamp a name for the payload itself
+
+
+class TestSerializeNode:
+    """`_serialize_node` packs a single node's commands into a JSON string for image metadata."""
+
+    @pytest.mark.usefixtures("clean_object_state")
+    def test_returns_json_loadable_payload(self, engine: Engine) -> None:
+        """The returned string is valid JSON naming the node's original type."""
+        engine.handle_request(EnsureWorkflowAndFlowRequest(workflow_name="wf_node", flow_name="fl_node"))
+        _add_error_proxy_node(engine, "my_node")
+
+        payload = _serialize_node("my_node", engine)
+        assert payload is not None
+
+        parsed = json.loads(payload)
+        assert parsed["serialized_node_commands"]["create_node_command"]["node_type"] == "SomeOriginalType"
+
+    @pytest.mark.usefixtures("clean_object_state")
+    def test_unknown_node_name_returns_none(self, engine: Engine) -> None:
+        """A node name that does not exist fails the underlying request; this must degrade to None, not raise."""
+        engine.handle_request(EnsureWorkflowAndFlowRequest(workflow_name="wf_missing_node", flow_name="fl_missing"))
+
+        assert _serialize_node("no_such_node", engine) is None
+
+
+class TestCollectWorkflowMetadata:
+    """`collect_workflow_metadata` is the entry point that assembles the full metadata dict."""
+
+    @pytest.mark.usefixtures("clean_object_state")
+    def test_every_key_is_namespaced(self, engine: Engine) -> None:
+        """Every injected key carries the `gtn_` prefix so it never collides with a user's own PNG text chunks."""
+        engine.context_manager.push_workflow(workflow_name="wf_namespace")
+        created = engine.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="flow_namespace", set_as_new_context=True)
+        )
+        assert isinstance(created, CreateFlowResultSuccess)
+
+        metadata = collect_workflow_metadata(engine)
+
+        assert metadata  # sanity: something was collected
+        assert all(key.startswith(METADATA_NAMESPACE) for key in metadata)
+
+    @pytest.mark.usefixtures("clean_object_state")
+    def test_no_workflow_context_still_returns_saved_at(self, engine: Engine) -> None:
+        """Even with no workflow in context, a timestamp is always available."""
+        assert not engine.context_manager.has_current_workflow()
+
+        metadata = collect_workflow_metadata(engine)
+
+        assert f"{METADATA_NAMESPACE}saved_at" in metadata
+        assert f"{METADATA_NAMESPACE}workflow_name" not in metadata
+
+    @pytest.mark.usefixtures("clean_object_state")
+    def test_flow_context_embeds_flow_commands_key(self, engine: Engine) -> None:
+        """A flow in context contributes its serialized commands under FLOW_COMMANDS_KEY."""
+        from griptape_nodes.retained_mode.file_metadata.workflow_metadata import FLOW_COMMANDS_KEY
+
+        engine.context_manager.push_workflow(workflow_name="wf_flow_commands")
+        created = engine.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="flow_flow_commands", set_as_new_context=True)
+        )
+        assert isinstance(created, CreateFlowResultSuccess)
+
+        metadata = collect_workflow_metadata(engine)
+
+        assert FLOW_COMMANDS_KEY in metadata
+        unpickled = pickle.loads(base64.b64decode(metadata[FLOW_COMMANDS_KEY]))  # noqa: S301
+        assert unpickled.serialized_node_commands == []
+
+
+class TestWorkflowMetadataNodeTypesUsedSerialization:
+    """`node_types_used` has to survive a TOML header, which has no native set or tuple type."""
+
+    def test_serializes_as_sorted_list_of_pairs(self) -> None:
+        """Sorted output keeps the header stable across saves instead of churning on set iteration order."""
+        metadata = WorkflowMetadata(
+            name="wf",
+            schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+            engine_version_created_with="0.1.0",
+            node_libraries_referenced=[],
+            node_types_used={
+                LibraryNameAndNodeType("LibB", "TypeZ"),
+                LibraryNameAndNodeType("LibA", "TypeY"),
+            },
+        )
+
+        dumped = metadata.model_dump(mode="json")
+
+        assert dumped["node_types_used"] == [["LibA", "TypeY"], ["LibB", "TypeZ"]]
+
+    def test_empty_set_serializes_as_empty_list(self) -> None:
+        """A workflow with no nodes must not crash the header write."""
+        metadata = WorkflowMetadata(
+            name="wf",
+            schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+            engine_version_created_with="0.1.0",
+            node_libraries_referenced=[],
+        )
+
+        assert metadata.model_dump(mode="json")["node_types_used"] == []
+
+    def test_list_of_pairs_round_trips_back_to_a_set(self) -> None:
+        """Loading a TOML-shaped list of pairs back must rebuild the original set of pairs."""
+        loaded = WorkflowMetadata.model_validate(
+            {
+                "name": "wf",
+                "schema_version": WorkflowMetadata.LATEST_SCHEMA_VERSION,
+                "engine_version_created_with": "0.1.0",
+                "node_libraries_referenced": [],
+                "node_types_used": [["LibA", "TypeY"], ["LibB", "TypeZ"]],
+            }
+        )
+
+        assert loaded.node_types_used == {
+            LibraryNameAndNodeType("LibA", "TypeY"),
+            LibraryNameAndNodeType("LibB", "TypeZ"),
+        }
+
+
+class TestWorkflowMetadataWorkflowShapeSerialization:
+    """`workflow_shape` is stored as a JSON string because TOML chokes on nested None values."""
+
+    def test_none_shape_serializes_to_none(self) -> None:
+        """A workflow with no Start/End nodes has no shape, and that must stay `None`, not `"null"`."""
+        metadata = WorkflowMetadata(
+            name="wf",
+            schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+            engine_version_created_with="0.1.0",
+            node_libraries_referenced=[],
+            workflow_shape=None,
+        )
+
+        assert metadata.model_dump(mode="json")["workflow_shape"] is None
+
+    def test_shape_with_none_default_value_round_trips(self) -> None:
+        """A parameter whose default is meaningfully `None` must survive as `null`, not vanish."""
+        shape = WorkflowShape(inputs={"start_node": {"my_param": {"default_value": None}}})
+        metadata = WorkflowMetadata(
+            name="wf",
+            schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+            engine_version_created_with="0.1.0",
+            node_libraries_referenced=[],
+            workflow_shape=shape,
+        )
+
+        dumped = metadata.model_dump(mode="json")
+        assert isinstance(dumped["workflow_shape"], str)
+        assert json.loads(dumped["workflow_shape"]) == {
+            "inputs": {"start_node": {"my_param": {"default_value": None}}},
+            "outputs": {},
+        }
+
+        reloaded = WorkflowMetadata.model_validate(dumped)
+        assert reloaded.workflow_shape == shape
+
+
+class TestWorkflowMetadataRoundTrip:
+    """The whole `WorkflowMetadata` model must survive a dump/reload cycle intact."""
+
+    def test_schema_version_and_scalar_fields_survive_round_trip(self) -> None:
+        """A representative set of scalar fields, including the schema version, comes back unchanged."""
+        metadata = WorkflowMetadata(
+            name="my_workflow",
+            schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+            engine_version_created_with="1.2.3",
+            node_libraries_referenced=[],
+            description="a test workflow",
+            is_template=True,
+            is_internal=False,
+        )
+
+        dumped = metadata.model_dump(mode="json")
+        reloaded = WorkflowMetadata.model_validate(dumped)
+
+        assert reloaded.schema_version == WorkflowMetadata.LATEST_SCHEMA_VERSION
+        assert reloaded.name == "my_workflow"
+        assert reloaded.engine_version_created_with == "1.2.3"
+        assert reloaded.description == "a test workflow"
+        assert reloaded.is_template is True
+        assert reloaded.is_internal is False

--- a/tests/unit/retained_mode/managers/test_flow_serialization_commands.py
+++ b/tests/unit/retained_mode/managers/test_flow_serialization_commands.py
@@ -1,0 +1,491 @@
+"""Tests for FlowManager's serialize/deserialize-to-commands round trip.
+
+Covers ``on_serialize_flow_to_commands`` / ``on_deserialize_flow_from_commands``, connection
+aggregation and dedup across nested Flows (``_aggregate_connections`` /
+``SerializedConnectionKey``), and the node/value/connection ordering the deserializer relies on
+(``_deserialize_nodes_for_flow_and_subflows`` and friends).
+
+The node types named below (e.g. ``"TestNodeA"``) are never resolvable through a real library in
+this test environment, so ``CreateNodeRequest`` always falls back to an ``ErrorProxyNode``
+placeholder. That placeholder round-trips through the exact same serialize/deserialize commands a
+real node would (it records its original type/library and dynamically grows whatever parameters a
+connection or an ``initial_setup`` value touches), which is what the rest of the unit suite already
+relies on for the same reason (see ``TestSerializeFlowSkipsTransientChildFlows`` in
+``test_flow_manager.py``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.exe_types.node_types import NodeDependencies
+from griptape_nodes.retained_mode.events.connection_events import (
+    CreateConnectionRequest,
+    CreateConnectionResultSuccess,
+)
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    CreateFlowResultSuccess,
+    DeserializeFlowFromCommandsRequest,
+    DeserializeFlowFromCommandsResultFailure,
+    DeserializeFlowFromCommandsResultSuccess,
+    SerializedConnectionKey,
+    SerializedFlowCommands,
+    SerializeFlowToCommandsRequest,
+    SerializeFlowToCommandsResultFailure,
+    SerializeFlowToCommandsResultSuccess,
+)
+from griptape_nodes.retained_mode.events.node_events import (
+    CreateNodeRequest,
+    CreateNodeResultSuccess,
+    SerializedNodeCommands,
+)
+from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
+from griptape_nodes.retained_mode.events.parameter_events import (
+    SetParameterValueRequest,
+    SetParameterValueResultSuccess,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from griptape_nodes.retained_mode.engine import Engine
+
+
+@pytest.fixture
+def clean_object_state(engine: Engine) -> Generator[None, None, None]:
+    """Clear all object state around a test so leftover flows never bleed across tests."""
+    engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    try:
+        yield
+    finally:
+        engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+
+
+def _create_flow(
+    engine: Engine, flow_name: str, *, parent_flow_name: str | None = None, set_as_new_context: bool = True
+) -> str:
+    result = engine.handle_request(
+        CreateFlowRequest(parent_flow_name=parent_flow_name, flow_name=flow_name, set_as_new_context=set_as_new_context)
+    )
+    assert isinstance(result, CreateFlowResultSuccess), result
+    return result.flow_name
+
+
+def _create_node(engine: Engine, node_type: str, node_name: str, *, library: str | None = None) -> str:
+    result = engine.handle_request(
+        CreateNodeRequest(node_type=node_type, node_name=node_name, specific_library_name=library)
+    )
+    assert isinstance(result, CreateNodeResultSuccess), result
+    return result.node_name
+
+
+def _connect(engine: Engine, source_node: str, source_parameter: str, target_node: str, target_parameter: str) -> None:
+    result = engine.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name=source_parameter,
+            target_node_name=target_node,
+            target_parameter_name=target_parameter,
+        )
+    )
+    assert isinstance(result, CreateConnectionResultSuccess), result
+
+
+def _set_value(
+    engine: Engine, node_name: str, parameter_name: str, *, value: str | float | bool | dict | list | None
+) -> None:
+    """Set a value on a placeholder node's parameter, growing it the way workflow load does."""
+    result = engine.handle_request(
+        SetParameterValueRequest(node_name=node_name, parameter_name=parameter_name, value=value, initial_setup=True)
+    )
+    assert isinstance(result, SetParameterValueResultSuccess), result
+
+
+def _serialize(engine: Engine, flow_name: str, *, include_create_flow_command: bool = True) -> SerializedFlowCommands:
+    result = engine.handle_request(
+        SerializeFlowToCommandsRequest(flow_name=flow_name, include_create_flow_command=include_create_flow_command)
+    )
+    assert isinstance(result, SerializeFlowToCommandsResultSuccess), result
+    return result.serialized_flow_commands
+
+
+def _deserialize_into_fresh_context(
+    engine: Engine,
+    serialized_flow_commands: SerializedFlowCommands,
+    workflow_name: str,
+    *,
+    pop_flow_context_after: bool = True,
+) -> DeserializeFlowFromCommandsResultSuccess:
+    """Replay commands the way an image-metadata restore does, and require success.
+
+    Clears all object state first: a Flow's serialization can carry a ``CreateFlowRequest`` with
+    ``parent_flow_name=None`` (the Canvas), and the engine allows only one Canvas at a time, so the
+    original graph has to be gone before the replay can create its own. A fresh workflow context
+    keeps the restored graph from colliding on names with whatever the test built to serialize.
+    """
+    engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    engine.context_manager.push_workflow(workflow_name=workflow_name)
+    result = engine.handle_request(
+        DeserializeFlowFromCommandsRequest(
+            serialized_flow_commands=serialized_flow_commands, pop_flow_context_after=pop_flow_context_after
+        )
+    )
+    assert isinstance(result, DeserializeFlowFromCommandsResultSuccess), result
+    return result
+
+
+class TestIncludeCreateFlowCommand:
+    """``include_create_flow_command`` toggles whether the payload can create its own Flow."""
+
+    @pytest.mark.usefixtures("clean_object_state")
+    def test_true_includes_create_flow_request(self, engine: Engine) -> None:
+        engine.context_manager.push_workflow(workflow_name="wf_include_true")
+        flow_name = _create_flow(engine, "parent")
+
+        serialized = _serialize(engine, flow_name, include_create_flow_command=True)
+
+        assert isinstance(serialized.flow_initialization_command, CreateFlowRequest)
+        assert serialized.flow_initialization_command.flow_name == flow_name
+
+    @pytest.mark.usefixtures("clean_object_state")
+    def test_false_omits_initialization_command(self, engine: Engine) -> None:
+        engine.context_manager.push_workflow(workflow_name="wf_include_false")
+        flow_name = _create_flow(engine, "parent")
+
+        serialized = _serialize(engine, flow_name, include_create_flow_command=False)
+
+        assert serialized.flow_initialization_command is None
+
+
+class TestSerializeUnknownFlow:
+    """Serializing a Flow name that does not exist fails cleanly instead of raising."""
+
+    @pytest.mark.usefixtures("clean_object_state")
+    def test_unknown_flow_name_returns_failure(self, engine: Engine) -> None:
+        engine.context_manager.push_workflow(workflow_name="wf_unknown")
+
+        result = engine.handle_request(SerializeFlowToCommandsRequest(flow_name="does_not_exist"))
+
+        assert isinstance(result, SerializeFlowToCommandsResultFailure)
+
+
+class TestSubflowAggregation:
+    """A parent Flow's serialization reports its whole subtree, not just its direct nodes."""
+
+    @pytest.mark.usefixtures("clean_object_state")
+    def test_subflow_appears_in_sub_flows_commands_with_its_nodes(self, engine: Engine) -> None:
+        engine.context_manager.push_workflow(workflow_name="wf_subflow_shape")
+        parent_name = _create_flow(engine, "parent")
+        child_name = _create_flow(engine, "child", parent_flow_name=parent_name, set_as_new_context=True)
+        _create_node(engine, "ChildNode", "child_node")
+
+        serialized = _serialize(engine, parent_name)
+
+        assert len(serialized.sub_flows_commands) == 1
+        child_commands = serialized.sub_flows_commands[0]
+        assert child_commands.flow_name == child_name
+        child_node_names = {cmd.create_node_command.node_name for cmd in child_commands.serialized_node_commands}
+        assert child_node_names == {"child_node"}
+
+    @pytest.mark.usefixtures("clean_object_state")
+    def test_node_types_used_aggregates_and_dedupes_across_subflows(self, engine: Engine) -> None:
+        engine.context_manager.push_workflow(workflow_name="wf_node_types_used")
+        parent_name = _create_flow(engine, "parent")
+        _create_node(engine, "SharedTypeNode", "parent_node_1", library="lib_shared")
+        _create_flow(engine, "child", parent_flow_name=parent_name, set_as_new_context=True)
+        _create_node(engine, "SharedTypeNode", "child_node_1", library="lib_shared")
+
+        serialized = _serialize(engine, parent_name)
+
+        # Two nodes of the same (library, type) pair across a Flow boundary collapse to one entry.
+        matching = [entry for entry in serialized.node_types_used if entry.node_type == "SharedTypeNode"]
+        assert len(matching) == 1
+        assert matching[0].library_name == "lib_shared"
+
+    @pytest.mark.usefixtures("clean_object_state")
+    def test_node_dependencies_aggregates_from_nodes_and_subflows(self, engine: Engine) -> None:
+        engine.context_manager.push_workflow(workflow_name="wf_node_dependencies")
+        parent_name = _create_flow(engine, "parent")
+        _create_node(engine, "ParentDepNode", "parent_node", library="lib_parent_only")
+        _create_flow(engine, "child", parent_flow_name=parent_name, set_as_new_context=True)
+        _create_node(engine, "ChildDepNode", "child_node", library="lib_child_only")
+
+        serialized = _serialize(engine, parent_name)
+
+        aggregated_library_names = {entry.library_name for entry in serialized.node_dependencies.libraries}
+        assert {"lib_parent_only", "lib_child_only"} <= aggregated_library_names
+
+
+class TestConnectionAggregationAndDedup:
+    """Connections crossing a Flow boundary are reported by every ancestor but wired exactly once."""
+
+    @pytest.mark.usefixtures("clean_object_state")
+    def test_cross_boundary_edge_is_wired_exactly_once_on_deserialize(self, engine: Engine) -> None:
+        engine.context_manager.push_workflow(workflow_name="wf_cross_boundary")
+        parent_name = _create_flow(engine, "parent")
+        source_name = _create_node(engine, "SourceNode", "source_node")
+        _create_flow(engine, "child", parent_flow_name=parent_name, set_as_new_context=True)
+        target_name = _create_node(engine, "TargetNode", "target_node")
+        engine.context_manager.pop_flow()
+        _connect(engine, source_name, "exec_out", target_name, "exec_in")
+
+        serialized = _serialize(engine, parent_name)
+
+        # The edge crosses the parent/child boundary, so both this Flow's own connection list AND
+        # the child's aggregated list would name it; the parent-level aggregate must not duplicate it.
+        assert len(serialized.serialized_connections) == 1
+
+        deserialize_result = _deserialize_into_fresh_context(engine, serialized, "wf_cross_boundary_restored")
+        rebuilt_source = deserialize_result.node_name_mappings[source_name]
+        rebuilt_target = deserialize_result.node_name_mappings[target_name]
+
+        connections = engine.flow_manager.get_connections()
+        outgoing = connections.outgoing_index.get(rebuilt_source, {}).get("exec_out", [])
+        matching_targets = [
+            connections.connections[connection_id].target_node.name
+            for connection_id in outgoing
+            if connections.connections[connection_id].target_node.name == rebuilt_target
+        ]
+        assert matching_targets == [rebuilt_target]
+
+    def test_serialized_connection_key_identifies_same_edge_regardless_of_reporting_flow(self) -> None:
+        """Two IndirectConnectionSerialization instances with equal endpoints share one key.
+
+        This is the mechanism ``_deserialize_connections_for_flow_and_subflows`` relies on to skip
+        an edge the second (and third, ...) time an ancestor Flow reports it.
+        """
+        node_uuid_a = SerializedNodeCommands.NodeUUID("node-a")
+        node_uuid_b = SerializedNodeCommands.NodeUUID("node-b")
+        connection_from_parent = SerializedFlowCommands.IndirectConnectionSerialization(
+            source_node_uuid=node_uuid_a,
+            source_parameter_name="exec_out",
+            target_node_uuid=node_uuid_b,
+            target_parameter_name="exec_in",
+        )
+        connection_from_child = SerializedFlowCommands.IndirectConnectionSerialization(
+            source_node_uuid=node_uuid_a,
+            source_parameter_name="exec_out",
+            target_node_uuid=node_uuid_b,
+            target_parameter_name="exec_in",
+        )
+
+        assert connection_from_parent.key() == connection_from_child.key()
+        assert isinstance(connection_from_parent.key(), SerializedConnectionKey)
+
+
+class TestNodeCreationBeforeConnectionWiring:
+    """Every node in the subtree exists before any connection is wired.
+
+    An aggregated edge can name a node one or more levels down; wiring it before that node's
+    subflow has been created and populated fails with "node did not exist within the flow".
+    """
+
+    @pytest.mark.usefixtures("clean_object_state")
+    def test_deserializing_a_deeply_nested_cross_boundary_edge_succeeds(self, engine: Engine) -> None:
+        engine.context_manager.push_workflow(workflow_name="wf_deep_nesting")
+        parent_name = _create_flow(engine, "parent")
+        source_name = _create_node(engine, "SourceNode", "source_node")
+        _create_flow(engine, "child", parent_flow_name=parent_name, set_as_new_context=True)
+        _create_flow(engine, "grandchild", parent_flow_name="child", set_as_new_context=True)
+        target_name = _create_node(engine, "TargetNode", "target_node")
+        engine.context_manager.pop_flow()
+        engine.context_manager.pop_flow()
+        _connect(engine, source_name, "exec_out", target_name, "exec_in")
+
+        serialized = _serialize(engine, parent_name)
+
+        # Success alone is the assertion: an ordering regression raises FlowDeserializationError
+        # (surfaced here as a failure result) instead of building the flow.
+        deserialize_result = _deserialize_into_fresh_context(engine, serialized, "wf_deep_nesting_restored")
+        assert isinstance(deserialize_result, DeserializeFlowFromCommandsResultSuccess)
+
+
+class TestSetParameterValueCommandsKeyedByNodeUuid:
+    """``set_parameter_value_commands`` is keyed by node UUID and resolves on the way back in."""
+
+    @pytest.mark.usefixtures("clean_object_state")
+    def test_value_set_on_a_node_is_keyed_by_that_nodes_uuid_and_restored(self, engine: Engine) -> None:
+        engine.context_manager.push_workflow(workflow_name="wf_set_value_keying")
+        parent_name = _create_flow(engine, "parent")
+        node_name = _create_node(engine, "ValueNode", "value_node")
+        _set_value(engine, node_name, "payload", value="distinctive-value-123")
+
+        serialized = _serialize(engine, parent_name)
+
+        node_uuid = next(
+            cmd.node_uuid
+            for cmd in serialized.serialized_node_commands
+            if cmd.create_node_command.node_name == node_name
+        )
+        assert node_uuid in serialized.set_parameter_value_commands
+        assert len(serialized.set_parameter_value_commands[node_uuid]) >= 1
+
+        deserialize_result = _deserialize_into_fresh_context(engine, serialized, "wf_set_value_keying_restored")
+        rebuilt_name = deserialize_result.node_name_mappings[node_name]
+        rebuilt_node = engine.node_manager.get_node_by_name(rebuilt_name)
+        assert rebuilt_node.get_parameter_value("payload") == "distinctive-value-123"
+
+
+class TestNodeNameMappings:
+    """``node_name_mappings`` names every rebuilt node, including ones inside sub-flows."""
+
+    @pytest.mark.usefixtures("clean_object_state")
+    def test_mappings_cover_parent_and_subflow_nodes(self, engine: Engine) -> None:
+        engine.context_manager.push_workflow(workflow_name="wf_name_mappings")
+        parent_name = _create_flow(engine, "parent")
+        parent_node_name = _create_node(engine, "ParentNode", "parent_node")
+        _create_flow(engine, "child", parent_flow_name=parent_name, set_as_new_context=True)
+        child_node_name = _create_node(engine, "ChildNode", "child_node")
+        engine.context_manager.pop_flow()
+
+        serialized = _serialize(engine, parent_name)
+
+        deserialize_result = _deserialize_into_fresh_context(engine, serialized, "wf_name_mappings_restored")
+
+        assert parent_node_name in deserialize_result.node_name_mappings
+        assert child_node_name in deserialize_result.node_name_mappings
+
+
+class TestControlAndDataConnectionsRoundTrip:
+    """A graph with both a control edge and a data edge preserves both, with direction intact."""
+
+    @pytest.mark.usefixtures("clean_object_state")
+    def test_control_and_data_edges_both_survive_with_direction(self, engine: Engine) -> None:
+        engine.context_manager.push_workflow(workflow_name="wf_control_and_data")
+        parent_name = _create_flow(engine, "parent")
+        upstream_name = _create_node(engine, "UpstreamNode", "upstream_node")
+        downstream_name = _create_node(engine, "DownstreamNode", "downstream_node")
+        _connect(engine, upstream_name, "exec_out", downstream_name, "exec_in")
+        _connect(engine, upstream_name, "payload", downstream_name, "payload")
+
+        serialized = _serialize(engine, parent_name)
+        deserialize_result = _deserialize_into_fresh_context(engine, serialized, "wf_control_and_data_restored")
+
+        rebuilt_upstream = deserialize_result.node_name_mappings[upstream_name]
+        rebuilt_downstream = deserialize_result.node_name_mappings[downstream_name]
+        connections = engine.flow_manager.get_connections()
+
+        control_targets = {
+            connections.connections[connection_id].target_node.name
+            for connection_id in connections.outgoing_index.get(rebuilt_upstream, {}).get("exec_out", [])
+        }
+        data_targets = {
+            connections.connections[connection_id].target_node.name
+            for connection_id in connections.outgoing_index.get(rebuilt_upstream, {}).get("payload", [])
+        }
+        assert control_targets == {rebuilt_downstream}
+        assert data_targets == {rebuilt_downstream}
+
+
+class TestDeserializeFailureCleanup:
+    """A failed deserialization does not leave a half-built Flow behind."""
+
+    @pytest.mark.usefixtures("clean_object_state")
+    def test_unknown_node_type_leaves_no_flow_when_error_proxy_disabled(self, engine: Engine) -> None:
+        """A node that cannot even become a placeholder must roll back the whole Flow it was in.
+
+        ``create_error_proxy_on_failure=False`` is the one path that actually fails node creation
+        (a real missing node type still succeeds as an ErrorProxyNode), so it is the way to force
+        ``_deserialize_one_node`` into its failure branch deterministically.
+        """
+        engine.context_manager.push_workflow(workflow_name="wf_deserialize_cleanup")
+        parent_name = _create_flow(engine, "parent")
+        serialized = _serialize(engine, parent_name)
+        assert serialized.serialized_node_commands == []
+
+        failing_create_command = CreateNodeRequest(
+            node_type="DoesNotExist",
+            node_name="doomed_node",
+            create_error_proxy_on_failure=False,
+        )
+        failing_node_command = SerializedNodeCommands(
+            create_node_command=failing_create_command,
+            element_modification_commands=[],
+            node_dependencies=NodeDependencies(),
+        )
+        broken_serialized = replace(serialized, serialized_node_commands=[failing_node_command])
+
+        engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        engine.context_manager.push_workflow(workflow_name="wf_deserialize_cleanup_restored")
+        result = engine.handle_request(DeserializeFlowFromCommandsRequest(serialized_flow_commands=broken_serialized))
+
+        assert isinstance(result, DeserializeFlowFromCommandsResultFailure)
+        assert not engine.object_manager.has_object_with_name(parent_name)
+
+
+class TestPopFlowContextAfter:
+    """``pop_flow_context_after`` leaves the context stack the way the caller found it."""
+
+    @pytest.mark.usefixtures("clean_object_state")
+    def test_true_pops_the_pushed_flow_context(self, engine: Engine) -> None:
+        engine.context_manager.push_workflow(workflow_name="wf_pop_true")
+        parent_name = _create_flow(engine, "parent")
+        serialized = _serialize(engine, parent_name)
+
+        engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        engine.context_manager.push_workflow(workflow_name="wf_pop_true_restored")
+        assert not engine.context_manager.has_current_flow()
+
+        result = engine.handle_request(
+            DeserializeFlowFromCommandsRequest(serialized_flow_commands=serialized, pop_flow_context_after=True)
+        )
+        assert isinstance(result, DeserializeFlowFromCommandsResultSuccess), result
+
+        assert not engine.context_manager.has_current_flow()
+
+    @pytest.mark.usefixtures("clean_object_state")
+    def test_false_leaves_the_new_flow_on_the_context_stack(self, engine: Engine) -> None:
+        engine.context_manager.push_workflow(workflow_name="wf_pop_false")
+        parent_name = _create_flow(engine, "parent")
+        serialized = _serialize(engine, parent_name)
+
+        engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+        engine.context_manager.push_workflow(workflow_name="wf_pop_false_restored")
+        assert not engine.context_manager.has_current_flow()
+
+        result = engine.handle_request(
+            DeserializeFlowFromCommandsRequest(serialized_flow_commands=serialized, pop_flow_context_after=False)
+        )
+        assert isinstance(result, DeserializeFlowFromCommandsResultSuccess), result
+
+        assert engine.context_manager.has_current_flow()
+        assert engine.context_manager.get_current_flow().name == result.flow_name
+        engine.context_manager.pop_flow()
+
+
+class TestUniqueValuePoolSharedAcrossSubtree:
+    """A value shared by nodes in different Flows of the same subtree should pool to one entry."""
+
+    @pytest.mark.usefixtures("clean_object_state")
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "EFFICIENCY: on_serialize_flow_to_commands creates a fresh unique_parameter_uuid_to_values "
+            "dict and a fresh SerializedParameterValueTracker for every recursive "
+            "SerializeFlowToCommandsRequest() call it issues for a child Flow (SerializeFlowToCommandsRequest "
+            "carries no tracker fields to pass one through), so a value shared by a node in the "
+            "parent Flow and a node in a child Flow is pickled/stored twice under two different "
+            "UUIDs instead of being pooled once. Intended contract: the unique-value pool is shared "
+            "across a Flow's whole subtree, matching the dedup a value gets when both nodes are in "
+            "the same Flow. - see #5436"
+        ),
+    )
+    def test_shared_value_across_flow_boundary_appears_once_in_pool(self, engine: Engine) -> None:
+        engine.context_manager.push_workflow(workflow_name="wf_shared_value_pool")
+        parent_name = _create_flow(engine, "parent")
+        parent_node_name = _create_node(engine, "ParentValueNode", "parent_value_node")
+        _set_value(engine, parent_node_name, "payload", value="shared-across-boundary")
+        _create_flow(engine, "child", parent_flow_name=parent_name, set_as_new_context=True)
+        child_node_name = _create_node(engine, "ChildValueNode", "child_value_node")
+        _set_value(engine, child_node_name, "payload", value="shared-across-boundary")
+        engine.context_manager.pop_flow()
+
+        serialized = _serialize(engine, parent_name)
+
+        distinct_values = list(serialized.unique_parameter_uuid_to_values.values())
+        matching_entries = [value for value in distinct_values if value == "shared-across-boundary"]
+        assert len(matching_entries) == 1

--- a/tests/unit/retained_mode/managers/test_node_serialization_commands.py
+++ b/tests/unit/retained_mode/managers/test_node_serialization_commands.py
@@ -497,6 +497,45 @@ class TestSerializeGroupWithChildren:
         )
         assert child_command.node_uuid in group_serialization.child_uuids
 
+    def test_serialize_all_parameter_values_reaches_the_group_and_its_children(
+        self, engine: Engine, library_name: str
+    ) -> None:
+        """The all-values flag must not stop at the group; children are serialized by sub-requests.
+
+        _ComputedValueNode's 'computed' parameter is never explicitly set and its declared default
+        is None, so the ordinary save condition records nothing for it. A caller asking for all
+        parameter values must get it whether the node is serialized directly or as a group child.
+        """
+        group_result = engine.handle_request(
+            CreateNodeRequest(node_type="_GroupNode", specific_library_name=library_name, node_name="G1")
+        )
+        assert isinstance(group_result, CreateNodeResultSuccess), group_result
+        child_result = engine.handle_request(
+            CreateNodeRequest(
+                node_type="_ComputedValueNode",
+                specific_library_name=library_name,
+                node_name="C1",
+                parent_group_name="G1",
+            )
+        )
+        assert isinstance(child_result, CreateNodeResultSuccess), child_result
+        group_node = engine.node_manager.get_node_by_name("G1")
+        assert isinstance(group_node, BaseNodeGroup)
+
+        from griptape_nodes.retained_mode.events.node_events import SerializedParameterValueTracker
+
+        without_flag = engine.node_manager._serialize_group_with_children(
+            group_node, {}, SerializedParameterValueTracker(), serialize_all_parameter_values=False
+        )
+        with_flag = engine.node_manager._serialize_group_with_children(
+            group_node, {}, SerializedParameterValueTracker(), serialize_all_parameter_values=True
+        )
+
+        child_uuid_without_flag = without_flag.child_commands[0].node_uuid
+        child_uuid_with_flag = with_flag.child_commands[0].node_uuid
+        assert without_flag.child_parameter_commands[child_uuid_without_flag] == []
+        assert len(with_flag.child_parameter_commands[child_uuid_with_flag]) == 1
+
     def test_subflow_name_is_dropped_for_copy_paste(self, engine: Engine, library_name: str) -> None:
         group_result = engine.handle_request(
             CreateNodeRequest(node_type="_GroupNode", specific_library_name=library_name, node_name="G1")

--- a/tests/unit/retained_mode/managers/test_node_serialization_commands.py
+++ b/tests/unit/retained_mode/managers/test_node_serialization_commands.py
@@ -1,0 +1,558 @@
+"""Coverage for the node <-> commands round trip.
+
+Covers on_serialize_node_to_commands and its deserialize counterpart, plus the node-group variant
+used by copy/paste.
+
+A node's live state is captured as a SerializedNodeCommands: a CreateNodeRequest for the shell,
+a list of element-modification commands that recreate user-defined parameters and any changes to
+library-declared ones, an optional lock command, and node-group bookkeeping. These tests build
+real node types through a small in-process library (mirroring how a real library registers nodes)
+so the serializer's library/metadata lookups exercise the real code path instead of a mock.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_groups.base_node_group import BaseNodeGroup
+from griptape_nodes.exe_types.node_groups.subflow_node_group import SubflowNodeGroup
+from griptape_nodes.exe_types.node_types import LOCAL_EXECUTION, DataNode, NodeDependencies
+from griptape_nodes.node_library.library_registry import (
+    LibraryMetadata,
+    LibraryRegistry,
+    LibrarySchema,
+    NodeMetadata,
+)
+from griptape_nodes.retained_mode.events.context_events import EnsureWorkflowAndFlowRequest
+from griptape_nodes.retained_mode.events.node_events import (
+    CreateNodeRequest,
+    CreateNodeResultSuccess,
+    DeserializeNodeFromCommandsRequest,
+    DeserializeNodeFromCommandsResultFailure,
+    DeserializeNodeFromCommandsResultSuccess,
+    SerializedNodeCommands,
+    SerializeNodeToCommandsRequest,
+    SerializeNodeToCommandsResultFailure,
+    SerializeNodeToCommandsResultSuccess,
+    SetLockNodeStateRequest,
+    SetLockNodeStateResultSuccess,
+)
+from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
+from griptape_nodes.retained_mode.events.parameter_events import (
+    AddParameterToNodeRequest,
+    AddParameterToNodeResultSuccess,
+    AlterParameterDetailsRequest,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from griptape_nodes.retained_mode.engine import Engine
+
+_LIBRARY_NAME = "Node Serialization Test Library"
+
+
+class _TextNode(DataNode):
+    """A node with one library-declared string parameter, for round-trip coverage."""
+
+    def __init__(self, name: str, metadata: dict | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="text",
+                tooltip="Text value",
+                type="str",
+                default_value="hello",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY, ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        pass
+
+
+class _ComputedValueNode(DataNode):
+    """A node whose parameter value is computed rather than stored in parameter_values.
+
+    Used to exercise serialize_all_parameter_values: the value is never "explicitly set" and its
+    declared default is None, so the normal save condition never captures it.
+    """
+
+    def __init__(self, name: str, metadata: dict | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="computed",
+                tooltip="Computed value",
+                type="str",
+                default_value=None,
+                allowed_modes={ParameterMode.PROPERTY},
+            )
+        )
+
+    def get_parameter_value(self, param_name: str) -> Any:
+        if param_name == "computed":
+            return "computed-value"
+        return super().get_parameter_value(param_name)
+
+    def process(self) -> None:
+        pass
+
+
+class _GroupNode(BaseNodeGroup):
+    """Minimal concrete BaseNodeGroup (not a SubflowNodeGroup) for group-serialization coverage."""
+
+    def run(self) -> None:
+        pass
+
+    def initialize(self) -> None:
+        pass
+
+    def process(self) -> None:
+        return None
+
+
+class _MinimalSubflowGroupNode(SubflowNodeGroup):
+    """A SubflowNodeGroup that skips the real __init__'s subflow/publish-handler bookkeeping.
+
+    Only isinstance(node, SubflowNodeGroup) matters for the contract under test (is_node_group),
+    and the real __init__ reaches into engine-global registration machinery that a bare unit test
+    has no reason to stand up. The execution_environment parameter is recreated by hand because
+    on_serialize_node_to_commands reads it directly.
+    """
+
+    def __init__(self, name: str, metadata: dict | None = None) -> None:
+        BaseNodeGroup.__init__(self, name, metadata)
+        self.execution_environment = Parameter(
+            name="execution_environment",
+            tooltip="Environment that the group should execute in",
+            type="str",
+            default_value=LOCAL_EXECUTION,
+            allowed_modes={ParameterMode.PROPERTY},
+        )
+        self.add_parameter(self.execution_environment)
+
+    async def aprocess(self) -> None:
+        return None
+
+    def process(self) -> None:
+        return None
+
+
+@pytest.fixture
+def library_name(engine: Engine) -> Generator[str, None, None]:
+    """Register a small real library and push a workflow/flow context to create nodes in.
+
+    LibraryRegistry is process-global, so it is cleared before and after in case another test
+    (or a leftover default library) left state behind.
+    """
+    engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    LibraryRegistry._clear()
+    schema = LibrarySchema(
+        name=_LIBRARY_NAME,
+        library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+        metadata=LibraryMetadata(
+            author="test", description="test", library_version="0.1.0", engine_version="0.0.0", tags=[]
+        ),
+        categories=[],
+        nodes=[],
+    )
+    library = LibraryRegistry.generate_new_library(schema)
+    library.register_new_node_type(_TextNode, NodeMetadata(category="test", description="d", display_name="Text"))
+    library.register_new_node_type(
+        _ComputedValueNode, NodeMetadata(category="test", description="d", display_name="Computed")
+    )
+    library.register_new_node_type(_GroupNode, NodeMetadata(category="test", description="d", display_name="Group"))
+    engine.handle_request(
+        EnsureWorkflowAndFlowRequest(workflow_name="serialization_wf", flow_name="serialization_flow")
+    )
+    try:
+        yield _LIBRARY_NAME
+    finally:
+        LibraryRegistry._clear()
+
+
+def _create_text_node(engine: Engine, library_name: str, node_name: str, **kwargs: object) -> str:
+    result = engine.handle_request(
+        CreateNodeRequest(node_type="_TextNode", specific_library_name=library_name, node_name=node_name, **kwargs)  # type: ignore[arg-type]
+    )
+    assert isinstance(result, CreateNodeResultSuccess), result
+    return result.node_name
+
+
+class TestSerializeNodeToCommandsBasics:
+    """create_node_command carries the identity and placement info needed to recreate the node."""
+
+    def test_create_node_command_carries_type_library_and_metadata(self, engine: Engine, library_name: str) -> None:
+        node_name = _create_text_node(
+            engine, library_name, "N1", metadata={"position": {"x": 100, "y": 200}, "custom_key": "custom_value"}
+        )
+
+        result = engine.node_manager.on_serialize_node_to_commands(SerializeNodeToCommandsRequest(node_name=node_name))
+
+        assert isinstance(result, SerializeNodeToCommandsResultSuccess)
+        create_command = result.serialized_node_commands.create_node_command
+        assert create_command.node_type == "_TextNode"
+        assert create_command.specific_library_name == library_name
+        assert create_command.metadata is not None
+        assert create_command.metadata["position"] == {"x": 100, "y": 200}
+        assert create_command.metadata["custom_key"] == "custom_value"
+
+    def test_missing_node_name_with_empty_context_returns_failure(self, engine: Engine, library_name: str) -> None:  # noqa: ARG002
+        result = engine.node_manager.on_serialize_node_to_commands(SerializeNodeToCommandsRequest(node_name=None))
+
+        assert isinstance(result, SerializeNodeToCommandsResultFailure)
+
+    def test_unknown_node_name_returns_failure_not_an_exception(self, engine: Engine, library_name: str) -> None:  # noqa: ARG002
+        result = engine.node_manager.on_serialize_node_to_commands(
+            SerializeNodeToCommandsRequest(node_name="DoesNotExist")
+        )
+
+        assert isinstance(result, SerializeNodeToCommandsResultFailure)
+
+
+class TestElementModificationCommands:
+    """User-defined parameters replay via AddParameterToNodeRequest; library ones only diff."""
+
+    def test_user_defined_parameter_is_recreated_via_add_parameter_request(
+        self, engine: Engine, library_name: str
+    ) -> None:
+        node_name = _create_text_node(engine, library_name, "N1")
+        add_result = engine.handle_request(
+            AddParameterToNodeRequest(
+                node_name=node_name,
+                parameter_name="extra",
+                type="str",
+                default_value="",
+                tooltip="extra",
+                is_user_defined=True,
+            )
+        )
+        assert isinstance(add_result, AddParameterToNodeResultSuccess), add_result
+
+        result = engine.node_manager.on_serialize_node_to_commands(SerializeNodeToCommandsRequest(node_name=node_name))
+
+        assert isinstance(result, SerializeNodeToCommandsResultSuccess)
+        add_commands = [
+            command
+            for command in result.serialized_node_commands.element_modification_commands
+            if isinstance(command, AddParameterToNodeRequest) and command.parameter_name == "extra"
+        ]
+        assert len(add_commands) == 1
+
+    def test_unchanged_library_parameter_is_not_re_added(self, engine: Engine, library_name: str) -> None:
+        node_name = _create_text_node(engine, library_name, "N1")
+
+        result = engine.node_manager.on_serialize_node_to_commands(SerializeNodeToCommandsRequest(node_name=node_name))
+
+        assert isinstance(result, SerializeNodeToCommandsResultSuccess)
+        add_commands_for_text = [
+            command
+            for command in result.serialized_node_commands.element_modification_commands
+            if isinstance(command, AddParameterToNodeRequest) and command.parameter_name == "text"
+        ]
+        assert add_commands_for_text == []
+
+    def test_altered_library_parameter_details_survive_as_alter_command(
+        self, engine: Engine, library_name: str
+    ) -> None:
+        node_name = _create_text_node(engine, library_name, "N1")
+        engine.handle_request(
+            AlterParameterDetailsRequest(
+                node_name=node_name, parameter_name="text", tooltip="Changed tooltip", default_value="changed default"
+            )
+        )
+
+        result = engine.node_manager.on_serialize_node_to_commands(SerializeNodeToCommandsRequest(node_name=node_name))
+
+        assert isinstance(result, SerializeNodeToCommandsResultSuccess)
+        alter_commands = [
+            command
+            for command in result.serialized_node_commands.element_modification_commands
+            if isinstance(command, AlterParameterDetailsRequest) and command.parameter_name == "text"
+        ]
+        assert len(alter_commands) == 1
+        assert alter_commands[0].tooltip == "Changed tooltip"
+        assert alter_commands[0].default_value == "changed default"
+
+
+class TestLockState:
+    """lock_node_command is emitted only when the live node is actually locked."""
+
+    def test_locked_node_emits_lock_command(self, engine: Engine, library_name: str) -> None:
+        node_name = _create_text_node(engine, library_name, "N1")
+        lock_result = engine.handle_request(SetLockNodeStateRequest(node_name=node_name, lock=True))
+        assert isinstance(lock_result, SetLockNodeStateResultSuccess), lock_result
+
+        result = engine.node_manager.on_serialize_node_to_commands(SerializeNodeToCommandsRequest(node_name=node_name))
+
+        assert isinstance(result, SerializeNodeToCommandsResultSuccess)
+        lock_command = result.serialized_node_commands.lock_node_command
+        assert lock_command is not None
+        assert lock_command.lock is True
+
+    def test_unlocked_node_emits_no_lock_command(self, engine: Engine, library_name: str) -> None:
+        node_name = _create_text_node(engine, library_name, "N1")
+
+        result = engine.node_manager.on_serialize_node_to_commands(SerializeNodeToCommandsRequest(node_name=node_name))
+
+        assert isinstance(result, SerializeNodeToCommandsResultSuccess)
+        assert result.serialized_node_commands.lock_node_command is None
+
+
+class TestNodeUuidFreshness:
+    """node_uuid identifies one serialization pass, so duplicate/paste needs a new one each time."""
+
+    def test_two_serializations_of_same_node_yield_distinct_uuids(self, engine: Engine, library_name: str) -> None:
+        node_name = _create_text_node(engine, library_name, "N1")
+
+        first = engine.node_manager.on_serialize_node_to_commands(SerializeNodeToCommandsRequest(node_name=node_name))
+        second = engine.node_manager.on_serialize_node_to_commands(SerializeNodeToCommandsRequest(node_name=node_name))
+
+        assert isinstance(first, SerializeNodeToCommandsResultSuccess)
+        assert isinstance(second, SerializeNodeToCommandsResultSuccess)
+        assert first.serialized_node_commands.node_uuid != second.serialized_node_commands.node_uuid
+
+
+class TestParameterValueSerializationMode:
+    """use_pickling selects whether the value pool holds pickled bytes or plain deep copies."""
+
+    def test_use_pickling_true_stores_pickled_bytes(self, engine: Engine, library_name: str) -> None:
+        node_name = _create_text_node(engine, library_name, "N1")
+
+        unique_values: dict = {}
+        result = engine.node_manager.on_serialize_node_to_commands(
+            SerializeNodeToCommandsRequest(
+                node_name=node_name, use_pickling=True, unique_parameter_uuid_to_values=unique_values
+            )
+        )
+
+        assert isinstance(result, SerializeNodeToCommandsResultSuccess)
+        assert len(unique_values) >= 1
+        assert all(isinstance(value, bytes) for value in unique_values.values())
+
+    def test_use_pickling_false_stores_raw_value(self, engine: Engine, library_name: str) -> None:
+        node_name = _create_text_node(engine, library_name, "N1")
+
+        unique_values: dict = {}
+        result = engine.node_manager.on_serialize_node_to_commands(
+            SerializeNodeToCommandsRequest(
+                node_name=node_name, use_pickling=False, unique_parameter_uuid_to_values=unique_values
+            )
+        )
+
+        assert isinstance(result, SerializeNodeToCommandsResultSuccess)
+        assert len(unique_values) >= 1
+        assert all(value == "hello" for value in unique_values.values())
+
+    def test_serialize_all_parameter_values_includes_values_not_otherwise_saved(
+        self, engine: Engine, library_name: str
+    ) -> None:
+        """serialize_all_parameter_values=True captures a value the normal save condition would skip.
+
+        _ComputedValueNode's 'computed' parameter is never explicitly set and its declared default
+        is None, so the ordinary explicitly-set-or-matches-default rule finds nothing to save. The
+        flag forces handle_parameter_value_saving to capture it anyway.
+        """
+        result_create = engine.handle_request(
+            CreateNodeRequest(node_type="_ComputedValueNode", specific_library_name=library_name, node_name="C1")
+        )
+        assert isinstance(result_create, CreateNodeResultSuccess), result_create
+
+        without_flag = engine.node_manager.on_serialize_node_to_commands(
+            SerializeNodeToCommandsRequest(node_name="C1", serialize_all_parameter_values=False)
+        )
+        with_flag = engine.node_manager.on_serialize_node_to_commands(
+            SerializeNodeToCommandsRequest(node_name="C1", serialize_all_parameter_values=True)
+        )
+
+        assert isinstance(without_flag, SerializeNodeToCommandsResultSuccess)
+        assert isinstance(with_flag, SerializeNodeToCommandsResultSuccess)
+        assert without_flag.set_parameter_value_commands == []
+        assert len(with_flag.set_parameter_value_commands) == 1
+
+
+class TestDeserializeNodeFromCommands:
+    """on_deserialize_node_from_commands replays a SerializedNodeCommands into a live node."""
+
+    def test_deserialize_recreates_node_type_library_and_metadata(self, engine: Engine, library_name: str) -> None:
+        node_name = _create_text_node(engine, library_name, "N1", metadata={"position": {"x": 1, "y": 2}})
+        serialize_result = engine.node_manager.on_serialize_node_to_commands(
+            SerializeNodeToCommandsRequest(node_name=node_name)
+        )
+        assert isinstance(serialize_result, SerializeNodeToCommandsResultSuccess)
+
+        result = engine.node_manager.on_deserialize_node_from_commands(
+            DeserializeNodeFromCommandsRequest(serialized_node_commands=serialize_result.serialized_node_commands)
+        )
+
+        assert isinstance(result, DeserializeNodeFromCommandsResultSuccess)
+        new_node = engine.node_manager.get_node_by_name(result.node_name)
+        assert type(new_node) is _TextNode
+        assert new_node.metadata["position"] == {"x": 1, "y": 2}
+
+    def test_deserialize_assigns_fresh_unique_name_on_collision(self, engine: Engine, library_name: str) -> None:
+        node_name = _create_text_node(engine, library_name, "N1")
+        serialize_result = engine.node_manager.on_serialize_node_to_commands(
+            SerializeNodeToCommandsRequest(node_name=node_name)
+        )
+        assert isinstance(serialize_result, SerializeNodeToCommandsResultSuccess)
+
+        result = engine.node_manager.on_deserialize_node_from_commands(
+            DeserializeNodeFromCommandsRequest(serialized_node_commands=serialize_result.serialized_node_commands)
+        )
+
+        assert isinstance(result, DeserializeNodeFromCommandsResultSuccess)
+        assert result.node_name != node_name
+        # The original must still exist untouched.
+        assert engine.node_manager.get_node_by_name(node_name) is not None
+
+    def test_deserialize_recreates_user_defined_parameter_on_the_new_node(
+        self, engine: Engine, library_name: str
+    ) -> None:
+        node_name = _create_text_node(engine, library_name, "N1")
+        engine.handle_request(
+            AddParameterToNodeRequest(
+                node_name=node_name,
+                parameter_name="extra",
+                type="str",
+                default_value="",
+                tooltip="extra",
+                is_user_defined=True,
+            )
+        )
+        serialize_result = engine.node_manager.on_serialize_node_to_commands(
+            SerializeNodeToCommandsRequest(node_name=node_name)
+        )
+        assert isinstance(serialize_result, SerializeNodeToCommandsResultSuccess)
+
+        result = engine.node_manager.on_deserialize_node_from_commands(
+            DeserializeNodeFromCommandsRequest(serialized_node_commands=serialize_result.serialized_node_commands)
+        )
+
+        assert isinstance(result, DeserializeNodeFromCommandsResultSuccess)
+        new_node = engine.node_manager.get_node_by_name(result.node_name)
+        assert new_node.get_parameter_by_name("extra") is not None
+
+    def test_deserialize_failure_cleans_up_the_partially_created_node(self, engine: Engine, library_name: str) -> None:
+        """A failing element command must not leave a half-built node behind."""
+        serialized = SerializedNodeCommands(
+            create_node_command=CreateNodeRequest(
+                node_type="_TextNode", specific_library_name=library_name, node_name="WillFail"
+            ),
+            element_modification_commands=[
+                # parent_container_name is only checked when initial_setup is False; the real
+                # serializer always sets initial_setup=True, so this is a hand-built failure case
+                # rather than something the serializer itself would ever emit.
+                AddParameterToNodeRequest(
+                    node_name="WillFail",
+                    parameter_name="extra",
+                    type="str",
+                    parent_container_name="NoSuchContainer",
+                    initial_setup=False,
+                )
+            ],
+            node_dependencies=NodeDependencies(),
+        )
+
+        result = engine.node_manager.on_deserialize_node_from_commands(
+            DeserializeNodeFromCommandsRequest(serialized_node_commands=serialized)
+        )
+
+        assert isinstance(result, DeserializeNodeFromCommandsResultFailure)
+        with pytest.raises(ValueError, match="not found"):
+            engine.node_manager.get_node_by_name("WillFail")
+
+
+class TestSerializeGroupWithChildren:
+    """_serialize_group_with_children orders the group before its children and links them by UUID."""
+
+    def test_group_and_children_are_both_serialized_with_parent_uuid_embedded(
+        self, engine: Engine, library_name: str
+    ) -> None:
+        group_result = engine.handle_request(
+            CreateNodeRequest(node_type="_GroupNode", specific_library_name=library_name, node_name="G1")
+        )
+        assert isinstance(group_result, CreateNodeResultSuccess), group_result
+        _create_text_node(engine, library_name, "Child1", parent_group_name="G1")
+        group_node = engine.node_manager.get_node_by_name("G1")
+        assert isinstance(group_node, BaseNodeGroup)
+
+        from griptape_nodes.retained_mode.events.node_events import SerializedParameterValueTracker
+
+        group_serialization = engine.node_manager._serialize_group_with_children(
+            group_node, {}, SerializedParameterValueTracker()
+        )
+
+        assert len(group_serialization.child_commands) == 1
+        child_command = group_serialization.child_commands[0]
+        assert child_command.create_node_command.metadata is not None
+        assert group_serialization.group_command is not None
+        assert (
+            child_command.create_node_command.metadata["_parent_group_uuid"]
+            == group_serialization.group_command.node_uuid
+        )
+        assert child_command.node_uuid in group_serialization.child_uuids
+
+    def test_subflow_name_is_dropped_for_copy_paste(self, engine: Engine, library_name: str) -> None:
+        group_result = engine.handle_request(
+            CreateNodeRequest(node_type="_GroupNode", specific_library_name=library_name, node_name="G1")
+        )
+        assert isinstance(group_result, CreateNodeResultSuccess), group_result
+        group_node = engine.node_manager.get_node_by_name("G1")
+        assert isinstance(group_node, BaseNodeGroup)
+        group_node.metadata["subflow_name"] = "SomeSubflow"
+
+        from griptape_nodes.retained_mode.events.node_events import SerializedParameterValueTracker
+
+        group_serialization = engine.node_manager._serialize_group_with_children(
+            group_node, {}, SerializedParameterValueTracker()
+        )
+
+        assert group_serialization.group_command is not None
+        assert group_serialization.group_command.create_node_command.metadata is not None
+        assert "subflow_name" not in group_serialization.group_command.create_node_command.metadata
+
+    def test_subflow_name_is_kept_when_workflow_save_requests_it(self, engine: Engine, library_name: str) -> None:
+        group_result = engine.handle_request(
+            CreateNodeRequest(node_type="_GroupNode", specific_library_name=library_name, node_name="G1")
+        )
+        assert isinstance(group_result, CreateNodeResultSuccess), group_result
+        group_node = engine.node_manager.get_node_by_name("G1")
+        group_node.metadata["subflow_name"] = "SomeSubflow"
+
+        result = engine.node_manager.on_serialize_node_to_commands(
+            SerializeNodeToCommandsRequest(node_name="G1", include_existing_subflow_in_group=True)
+        )
+
+        assert isinstance(result, SerializeNodeToCommandsResultSuccess)
+        metadata = result.serialized_node_commands.create_node_command.metadata
+        assert metadata is not None
+        assert metadata["subflow_name"] == "SomeSubflow"
+
+    def test_is_node_group_false_for_a_plain_base_node_group(self, engine: Engine, library_name: str) -> None:
+        """is_node_group is reserved for SubflowNodeGroup; a plain BaseNodeGroup is not one."""
+        group_result = engine.handle_request(
+            CreateNodeRequest(node_type="_GroupNode", specific_library_name=library_name, node_name="G1")
+        )
+        assert isinstance(group_result, CreateNodeResultSuccess), group_result
+
+        result = engine.node_manager.on_serialize_node_to_commands(SerializeNodeToCommandsRequest(node_name="G1"))
+
+        assert isinstance(result, SerializeNodeToCommandsResultSuccess)
+        assert result.serialized_node_commands.is_node_group is False
+
+    def test_is_node_group_true_for_a_subflow_node_group(self, engine: Engine, library_name: str) -> None:
+        node = _MinimalSubflowGroupNode(
+            name="SG1", metadata={"library": library_name, "node_type": "_MinimalSubflowGroupNode"}
+        )
+        engine.object_manager.add_object_by_name(node.name, node)
+        engine.flow_manager.get_flow_by_name("serialization_flow").add_node(node)
+
+        result = engine.node_manager.on_serialize_node_to_commands(SerializeNodeToCommandsRequest(node_name="SG1"))
+
+        assert isinstance(result, SerializeNodeToCommandsResultSuccess)
+        assert result.serialized_node_commands.is_node_group is True

--- a/tests/unit/retained_mode/managers/test_node_serialization_values.py
+++ b/tests/unit/retained_mode/managers/test_node_serialization_values.py
@@ -357,7 +357,7 @@ class TestHandleValueHashing:
     def test_deepcopy_failure_falls_back_to_storing_the_raw_value_with_a_warning(
         self, engine: Engine, caplog: pytest.LogCaptureFixture
     ) -> None:
-        parameter = _make_param("p")
+        parameter = _make_param("hostile_param")
         tracker = SerializedParameterValueTracker()
         pool: dict[Any, Any] = {}
         hostile_value = _DeepcopyHostile("payload")
@@ -370,8 +370,8 @@ class TestHandleValueHashing:
             serialized_parameter_value_tracker=tracker,
             unique_parameter_uuid_to_values=pool,
             parameter=parameter,
-            parameter_name="p",
-            node_name="n",
+            parameter_name="hostile_param",
+            node_name="hostile_node",
             is_output=False,
             workflow_manager=engine.workflow_manager,
             use_pickling=False,
@@ -381,7 +381,8 @@ class TestHandleValueHashing:
         assert pool[command.unique_value_uuid] is hostile_value
         warning_messages = [record.message for record in caplog.records if record.levelno == logging.WARNING]
         assert any(
-            "could not be copied" in message and "p" in message and "n" in message for message in warning_messages
+            "could not be copied" in message and "'hostile_param'" in message and "'hostile_node'" in message
+            for message in warning_messages
         )
 
     def test_returns_an_indirect_set_parameter_value_command_referencing_the_pool(self, engine: Engine) -> None:

--- a/tests/unit/retained_mode/managers/test_node_serialization_values.py
+++ b/tests/unit/retained_mode/managers/test_node_serialization_values.py
@@ -1,0 +1,702 @@
+"""Tests for the parameter-value pooling primitives used by node serialization.
+
+These functions decide, for a single parameter value, whether it needs to be recorded at all,
+whether it has already been recorded (so it can be referenced by UUID instead of duplicated), and
+what happens when recording it fails. They are the foundation both the workflow-save path
+(``handle_parameter_value_saving`` / ``_handle_value_hashing``) and the output-value pickling path
+(``serialize_parameter_output_values`` / ``_serialize_with_pickling``) build on.
+"""
+
+# ruff: noqa: PLR2004
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+import pytest
+
+from griptape_nodes.exe_types.core_types import Parameter
+from griptape_nodes.retained_mode.events.node_events import SerializedNodeCommands
+from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
+from griptape_nodes.retained_mode.managers.node_manager import (
+    NodeManager,
+    SerializedParameterValues,
+    SerializedParameterValueTracker,
+)
+from tests.unit.exe_types.mocks import MockNode
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
+
+
+def _make_param(name: str, *, serializable: bool = True) -> Parameter:
+    return Parameter(
+        name=name,
+        input_types=["str"],
+        type="str",
+        output_type="str",
+        tooltip="",
+        serializable=serializable,
+    )
+
+
+class _DeepcopyHostile:
+    """A value that pickles fine but whose deepcopy always raises.
+
+    Exercises the ``copy.deepcopy`` failure branch inside ``_handle_value_hashing``, which falls
+    back to storing the value by reference and warns rather than losing it.
+    """
+
+    def __init__(self, payload: str) -> None:
+        self.payload = payload
+
+    def __deepcopy__(self, memo: dict) -> _DeepcopyHostile:
+        msg = "this type refuses to be deep-copied"
+        raise RuntimeError(msg)
+
+
+class _AlwaysFailsPickle:
+    """A hashable value that always fails to pickle, counting how many times it tried.
+
+    Used to assert that a value marked not-serializable is remembered and never retried.
+    """
+
+    def __init__(self) -> None:
+        self.attempt_count = 0
+
+    def __reduce__(self) -> tuple:
+        self.attempt_count += 1
+        msg = "refuses to be pickled"
+        raise TypeError(msg)
+
+
+class TestSerializedParameterValueTracker:
+    """The tracker records, per value hash, whether a value is serializable and its pool UUID."""
+
+    def test_unseen_hash_reports_not_in_tracker(self) -> None:
+        tracker = SerializedParameterValueTracker()
+        assert tracker.get_tracker_state("anything") == SerializedParameterValueTracker.TrackerState.NOT_IN_TRACKER
+
+    def test_serializable_hash_reports_serializable_and_returns_its_uuid(self) -> None:
+        tracker = SerializedParameterValueTracker()
+        unique_uuid = SerializedNodeCommands.UniqueParameterValueUUID(str(uuid4()))
+        tracker.add_as_serializable("value_hash", unique_uuid)
+
+        assert tracker.get_tracker_state("value_hash") == SerializedParameterValueTracker.TrackerState.SERIALIZABLE
+        assert tracker.get_uuid_for_value_hash("value_hash") == unique_uuid
+
+    def test_not_serializable_hash_reports_not_serializable(self) -> None:
+        tracker = SerializedParameterValueTracker()
+        tracker.add_as_not_serializable("bad_value")
+
+        assert tracker.get_tracker_state("bad_value") == SerializedParameterValueTracker.TrackerState.NOT_SERIALIZABLE
+
+    def test_serializable_count_counts_distinct_values_not_not_serializable_ones(self) -> None:
+        tracker = SerializedParameterValueTracker()
+        tracker.add_as_serializable("a", SerializedNodeCommands.UniqueParameterValueUUID(str(uuid4())))
+        tracker.add_as_serializable("b", SerializedNodeCommands.UniqueParameterValueUUID(str(uuid4())))
+        tracker.add_as_not_serializable("c")
+
+        assert tracker.get_serializable_count() == 2
+
+
+class TestHandleValueHashing:
+    """``_handle_value_hashing`` pools a value once and lets every later reference reuse its UUID."""
+
+    def test_identical_hashable_value_reused_across_two_calls(self, engine: Engine) -> None:
+        parameter = _make_param("p")
+        tracker = SerializedParameterValueTracker()
+        pool: dict[Any, Any] = {}
+
+        first = NodeManager._handle_value_hashing(
+            value="shared value",
+            serialized_parameter_value_tracker=tracker,
+            unique_parameter_uuid_to_values=pool,
+            parameter=parameter,
+            parameter_name="p",
+            node_name="n",
+            is_output=False,
+            workflow_manager=engine.workflow_manager,
+        )
+        second = NodeManager._handle_value_hashing(
+            value="shared value",
+            serialized_parameter_value_tracker=tracker,
+            unique_parameter_uuid_to_values=pool,
+            parameter=parameter,
+            parameter_name="p",
+            node_name="n",
+            is_output=False,
+            workflow_manager=engine.workflow_manager,
+        )
+
+        assert first is not None
+        assert second is not None
+        assert first.unique_value_uuid == second.unique_value_uuid
+        assert len(pool) == 1
+
+    def test_type_disambiguates_int_and_bool_with_equal_hash(self, engine: Engine) -> None:
+        """``hash(True) == hash(1)``, so the pool key must include the type, not just the value."""
+        parameter = _make_param("p")
+        tracker = SerializedParameterValueTracker()
+        pool: dict[Any, Any] = {}
+
+        bool_command = NodeManager._handle_value_hashing(
+            value=True,
+            serialized_parameter_value_tracker=tracker,
+            unique_parameter_uuid_to_values=pool,
+            parameter=parameter,
+            parameter_name="flag",
+            node_name="n",
+            is_output=False,
+            workflow_manager=engine.workflow_manager,
+        )
+        int_command = NodeManager._handle_value_hashing(
+            value=1,
+            serialized_parameter_value_tracker=tracker,
+            unique_parameter_uuid_to_values=pool,
+            parameter=parameter,
+            parameter_name="count",
+            node_name="n",
+            is_output=False,
+            workflow_manager=engine.workflow_manager,
+        )
+
+        assert bool_command is not None
+        assert int_command is not None
+        assert bool_command.unique_value_uuid != int_command.unique_value_uuid
+        assert len(pool) == 2
+
+    def test_unhashable_same_object_reuses_its_pool_entry(self, engine: Engine) -> None:
+        parameter = _make_param("p")
+        tracker = SerializedParameterValueTracker()
+        pool: dict[Any, Any] = {}
+        shared_list = ["a", "b"]
+
+        first = NodeManager._handle_value_hashing(
+            value=shared_list,
+            serialized_parameter_value_tracker=tracker,
+            unique_parameter_uuid_to_values=pool,
+            parameter=parameter,
+            parameter_name="p",
+            node_name="n",
+            is_output=False,
+            workflow_manager=engine.workflow_manager,
+        )
+        second = NodeManager._handle_value_hashing(
+            value=shared_list,
+            serialized_parameter_value_tracker=tracker,
+            unique_parameter_uuid_to_values=pool,
+            parameter=parameter,
+            parameter_name="p",
+            node_name="n",
+            is_output=False,
+            workflow_manager=engine.workflow_manager,
+        )
+
+        assert first is not None
+        assert second is not None
+        assert first.unique_value_uuid == second.unique_value_uuid
+        assert len(pool) == 1
+
+    def test_unhashable_equal_but_distinct_objects_get_separate_pool_entries(self, engine: Engine) -> None:
+        """Two different list objects with equal contents are not the same value for pooling purposes.
+
+        Both lists are kept alive as local variables for the whole test: an unhashable value is
+        pooled by ``id()``, and a value that is garbage-collected between calls can have its id
+        reused by an unrelated object, which is a real hazard but not what this test targets.
+        """
+        parameter = _make_param("p")
+        tracker = SerializedParameterValueTracker()
+        pool: dict[Any, Any] = {}
+        first_list = ["a", "b"]
+        second_list = ["a", "b"]
+
+        first = NodeManager._handle_value_hashing(
+            value=first_list,
+            serialized_parameter_value_tracker=tracker,
+            unique_parameter_uuid_to_values=pool,
+            parameter=parameter,
+            parameter_name="p",
+            node_name="n",
+            is_output=False,
+            workflow_manager=engine.workflow_manager,
+        )
+        second = NodeManager._handle_value_hashing(
+            value=second_list,
+            serialized_parameter_value_tracker=tracker,
+            unique_parameter_uuid_to_values=pool,
+            parameter=parameter,
+            parameter_name="p",
+            node_name="n",
+            is_output=False,
+            workflow_manager=engine.workflow_manager,
+        )
+
+        assert first is not None
+        assert second is not None
+        assert first.unique_value_uuid != second.unique_value_uuid
+        assert len(pool) == 2
+
+    def test_non_serializable_parameter_skips_and_marks_tracker(self, engine: Engine) -> None:
+        parameter = _make_param("p", serializable=False)
+        tracker = SerializedParameterValueTracker()
+        pool: dict[Any, Any] = {}
+
+        result = NodeManager._handle_value_hashing(
+            value="opted out",
+            serialized_parameter_value_tracker=tracker,
+            unique_parameter_uuid_to_values=pool,
+            parameter=parameter,
+            parameter_name="p",
+            node_name="n",
+            is_output=False,
+            workflow_manager=engine.workflow_manager,
+        )
+
+        assert result is None
+        assert pool == {}
+
+    def test_pickle_failure_marks_value_not_serializable_and_returns_none(self, engine: Engine) -> None:
+        parameter = _make_param("p")
+        tracker = SerializedParameterValueTracker()
+        pool: dict[Any, Any] = {}
+        unpicklable = _AlwaysFailsPickle()
+
+        result = NodeManager._handle_value_hashing(
+            value=unpicklable,
+            serialized_parameter_value_tracker=tracker,
+            unique_parameter_uuid_to_values=pool,
+            parameter=parameter,
+            parameter_name="p",
+            node_name="n",
+            is_output=False,
+            workflow_manager=engine.workflow_manager,
+        )
+
+        assert result is None
+        assert pool == {}
+        assert (
+            tracker.get_tracker_state((type(unpicklable), unpicklable))
+            == SerializedParameterValueTracker.TrackerState.NOT_SERIALIZABLE
+        )
+
+    def test_pickle_failure_is_not_retried_on_second_call(self, engine: Engine) -> None:
+        parameter = _make_param("p")
+        tracker = SerializedParameterValueTracker()
+        pool: dict[Any, Any] = {}
+        unpicklable = _AlwaysFailsPickle()
+
+        NodeManager._handle_value_hashing(
+            value=unpicklable,
+            serialized_parameter_value_tracker=tracker,
+            unique_parameter_uuid_to_values=pool,
+            parameter=parameter,
+            parameter_name="p",
+            node_name="n",
+            is_output=False,
+            workflow_manager=engine.workflow_manager,
+        )
+        NodeManager._handle_value_hashing(
+            value=unpicklable,
+            serialized_parameter_value_tracker=tracker,
+            unique_parameter_uuid_to_values=pool,
+            parameter=parameter,
+            parameter_name="p",
+            node_name="n",
+            is_output=False,
+            workflow_manager=engine.workflow_manager,
+        )
+
+        assert unpicklable.attempt_count == 1
+
+    def test_use_pickling_true_stores_pickled_bytes_in_pool(self, engine: Engine) -> None:
+        parameter = _make_param("p")
+        tracker = SerializedParameterValueTracker()
+        pool: dict[Any, Any] = {}
+
+        command = NodeManager._handle_value_hashing(
+            value="pickle me",
+            serialized_parameter_value_tracker=tracker,
+            unique_parameter_uuid_to_values=pool,
+            parameter=parameter,
+            parameter_name="p",
+            node_name="n",
+            is_output=False,
+            workflow_manager=engine.workflow_manager,
+            use_pickling=True,
+        )
+
+        assert command is not None
+        assert isinstance(pool[command.unique_value_uuid], bytes)
+
+    def test_use_pickling_false_stores_a_deep_copy_not_the_original_reference(self, engine: Engine) -> None:
+        parameter = _make_param("p")
+        tracker = SerializedParameterValueTracker()
+        pool: dict[Any, Any] = {}
+        original = {"nested": ["value"]}
+
+        command = NodeManager._handle_value_hashing(
+            value=original,
+            serialized_parameter_value_tracker=tracker,
+            unique_parameter_uuid_to_values=pool,
+            parameter=parameter,
+            parameter_name="p",
+            node_name="n",
+            is_output=False,
+            workflow_manager=engine.workflow_manager,
+            use_pickling=False,
+        )
+
+        assert command is not None
+        stored = pool[command.unique_value_uuid]
+        assert stored == original
+        assert stored is not original
+
+    def test_deepcopy_failure_falls_back_to_storing_the_raw_value_with_a_warning(
+        self, engine: Engine, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        parameter = _make_param("p")
+        tracker = SerializedParameterValueTracker()
+        pool: dict[Any, Any] = {}
+        hostile_value = _DeepcopyHostile("payload")
+
+        caplog.clear()
+        caplog.set_level(logging.WARNING, logger="griptape_nodes")
+
+        command = NodeManager._handle_value_hashing(
+            value=hostile_value,
+            serialized_parameter_value_tracker=tracker,
+            unique_parameter_uuid_to_values=pool,
+            parameter=parameter,
+            parameter_name="p",
+            node_name="n",
+            is_output=False,
+            workflow_manager=engine.workflow_manager,
+            use_pickling=False,
+        )
+
+        assert command is not None
+        assert pool[command.unique_value_uuid] is hostile_value
+        warning_messages = [record.message for record in caplog.records if record.levelno == logging.WARNING]
+        assert any(
+            "could not be copied" in message and "p" in message and "n" in message for message in warning_messages
+        )
+
+    def test_returns_an_indirect_set_parameter_value_command_referencing_the_pool(self, engine: Engine) -> None:
+        parameter = _make_param("p")
+        tracker = SerializedParameterValueTracker()
+        pool: dict[Any, Any] = {}
+
+        command = NodeManager._handle_value_hashing(
+            value="v",
+            serialized_parameter_value_tracker=tracker,
+            unique_parameter_uuid_to_values=pool,
+            parameter=parameter,
+            parameter_name="p",
+            node_name="n",
+            is_output=True,
+            workflow_manager=engine.workflow_manager,
+        )
+
+        assert command is not None
+        assert isinstance(command.set_parameter_value_command, SetParameterValueRequest)
+        assert command.set_parameter_value_command.parameter_name == "p"
+        assert command.set_parameter_value_command.is_output is True
+        assert command.set_parameter_value_command.initial_setup is True
+        assert command.unique_value_uuid in pool
+
+
+class TestSerializeOneParameterValueForSave:
+    """``_serialize_one_parameter_value_for_save`` decides whether a single value gets recorded."""
+
+    def test_none_value_returns_none_without_touching_the_tracker(self, engine: Engine) -> None:
+        parameter = _make_param("p")
+        node = MockNode(name="n")
+        node.add_parameter(parameter)
+        tracker = SerializedParameterValueTracker()
+        pool: dict[Any, Any] = {}
+        create_request = _make_create_node_request()
+
+        result = NodeManager._serialize_one_parameter_value_for_save(
+            value=None,
+            value_kind="set",
+            is_output=False,
+            parameter=parameter,
+            node=node,
+            unique_parameter_uuid_to_values=pool,
+            serialized_parameter_value_tracker=tracker,
+            create_node_request=create_request,
+            workflow_manager=engine.workflow_manager,
+            use_pickling=False,
+        )
+
+        assert result is None
+        assert pool == {}
+        from griptape_nodes.exe_types.node_types import NodeResolutionState
+
+        assert create_request.resolution != NodeResolutionState.UNRESOLVED.value
+
+    def test_serializable_false_records_nothing_and_forces_unresolved_silently(
+        self, engine: Engine, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        from griptape_nodes.exe_types.node_types import NodeResolutionState
+
+        parameter = _make_param("p", serializable=False)
+        node = MockNode(name="n")
+        node.add_parameter(parameter)
+        tracker = SerializedParameterValueTracker()
+        pool: dict[Any, Any] = {}
+        create_request = _make_create_node_request(resolution=NodeResolutionState.RESOLVED.value)
+
+        caplog.clear()
+        caplog.set_level(logging.WARNING, logger="griptape_nodes")
+
+        result = NodeManager._serialize_one_parameter_value_for_save(
+            value="opted out value",
+            value_kind="set",
+            is_output=False,
+            parameter=parameter,
+            node=node,
+            unique_parameter_uuid_to_values=pool,
+            serialized_parameter_value_tracker=tracker,
+            create_node_request=create_request,
+            workflow_manager=engine.workflow_manager,
+            use_pickling=False,
+        )
+
+        assert result is None
+        assert create_request.resolution == NodeResolutionState.UNRESOLVED.value
+        warning_messages = [record.message for record in caplog.records if record.levelno == logging.WARNING]
+        assert not any("Attempted to serialize" in message for message in warning_messages)
+
+    def test_genuine_failure_warns_naming_parameter_and_node_and_forces_unresolved(
+        self, engine: Engine, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        from griptape_nodes.exe_types.node_types import NodeResolutionState
+
+        parameter = _make_param("troublesome")
+        node = MockNode(name="the_node")
+        node.add_parameter(parameter)
+        tracker = SerializedParameterValueTracker()
+        pool: dict[Any, Any] = {}
+        create_request = _make_create_node_request(resolution=NodeResolutionState.RESOLVED.value)
+
+        caplog.clear()
+        caplog.set_level(logging.WARNING, logger="griptape_nodes")
+
+        result = NodeManager._serialize_one_parameter_value_for_save(
+            value=_AlwaysFailsPickle(),
+            value_kind="output",
+            is_output=True,
+            parameter=parameter,
+            node=node,
+            unique_parameter_uuid_to_values=pool,
+            serialized_parameter_value_tracker=tracker,
+            create_node_request=create_request,
+            workflow_manager=engine.workflow_manager,
+            use_pickling=False,
+        )
+
+        assert result is None
+        assert create_request.resolution == NodeResolutionState.UNRESOLVED.value
+        warning_messages = [record.message for record in caplog.records if record.levelno == logging.WARNING]
+        assert any(
+            "'troublesome'" in message and "'the_node'" in message and "output value" in message
+            for message in warning_messages
+        )
+
+    def test_successful_serialization_returns_a_command_and_leaves_resolution_untouched(self, engine: Engine) -> None:
+        from griptape_nodes.exe_types.node_types import NodeResolutionState
+
+        parameter = _make_param("p")
+        node = MockNode(name="n")
+        node.add_parameter(parameter)
+        tracker = SerializedParameterValueTracker()
+        pool: dict[Any, Any] = {}
+        create_request = _make_create_node_request(resolution=NodeResolutionState.RESOLVED.value)
+
+        result = NodeManager._serialize_one_parameter_value_for_save(
+            value="a fine value",
+            value_kind="set",
+            is_output=False,
+            parameter=parameter,
+            node=node,
+            unique_parameter_uuid_to_values=pool,
+            serialized_parameter_value_tracker=tracker,
+            create_node_request=create_request,
+            workflow_manager=engine.workflow_manager,
+            use_pickling=False,
+        )
+
+        assert result is not None
+        assert result.unique_value_uuid in pool
+        assert create_request.resolution == NodeResolutionState.RESOLVED.value
+
+
+class TestGetParameterValueForSerialization:
+    """Output values take precedence over set values when both exist for a parameter."""
+
+    def test_prefers_output_value_over_set_value(self) -> None:
+        parameter = _make_param("p")
+        node = MockNode(name="n")
+        node.add_parameter(parameter)
+        node.parameter_values["p"] = "set value"
+        node.parameter_output_values["p"] = "output value"
+
+        value = NodeManager._get_parameter_value_for_serialization(node, "p")
+
+        assert value == "output value"
+
+    def test_falls_back_to_set_value_when_no_output_value(self) -> None:
+        parameter = _make_param("p")
+        node = MockNode(name="n")
+        node.add_parameter(parameter)
+        node.parameter_values["p"] = "set value"
+
+        value = NodeManager._get_parameter_value_for_serialization(node, "p")
+
+        assert value == "set value"
+
+
+class TestSerializeParameterOutputValues:
+    """``serialize_parameter_output_values`` is the entry point used by control-flow execution."""
+
+    def test_node_with_no_parameters_returns_empty_values_and_no_pool(self, engine: Engine) -> None:
+        node = MockNode(name="n")
+
+        result = NodeManager.serialize_parameter_output_values(node, workflow_manager=engine.workflow_manager)
+
+        assert result == SerializedParameterValues({}, None)
+
+    def test_without_pickling_every_parameter_has_an_entry_and_pool_is_none(self, engine: Engine) -> None:
+        node = MockNode(name="n")
+        node.add_parameter(_make_param("has_value"))
+        node.add_parameter(_make_param("no_value"))
+        node.parameter_values["has_value"] = "set"
+
+        result = NodeManager.serialize_parameter_output_values(
+            node, workflow_manager=engine.workflow_manager, use_pickling=False
+        )
+
+        assert result.parameter_output_values == {"has_value": "set", "no_value": None}
+        assert result.unique_parameter_uuid_to_values is None
+
+    def test_without_pickling_prefers_output_value(self, engine: Engine) -> None:
+        node = MockNode(name="n")
+        node.add_parameter(_make_param("p"))
+        node.parameter_values["p"] = "set value"
+        node.parameter_output_values["p"] = "output value"
+
+        result = NodeManager.serialize_parameter_output_values(
+            node, workflow_manager=engine.workflow_manager, use_pickling=False
+        )
+
+        assert result.parameter_output_values == {"p": "output value"}
+
+    def test_without_pickling_output_is_json_safe_for_nested_containers(self, engine: Engine) -> None:
+        import json
+
+        node = MockNode(name="n")
+        node.add_parameter(_make_param("p"))
+        node.parameter_output_values["p"] = {"nested": [1, 2, {"deep": True}]}
+
+        result = NodeManager.serialize_parameter_output_values(
+            node, workflow_manager=engine.workflow_manager, use_pickling=False
+        )
+
+        json.dumps(result.parameter_output_values)
+
+    def test_with_pickling_every_parameter_maps_to_a_uuid(self, engine: Engine) -> None:
+        node = MockNode(name="n")
+        node.add_parameter(_make_param("p"))
+        node.parameter_output_values["p"] = "value"
+
+        result = NodeManager.serialize_parameter_output_values(
+            node, workflow_manager=engine.workflow_manager, use_pickling=True
+        )
+
+        assert result.unique_parameter_uuid_to_values is not None
+        assert result.parameter_output_values["p"] in result.unique_parameter_uuid_to_values
+
+    def test_with_pickling_unserializable_value_maps_to_none_without_raising(self, engine: Engine) -> None:
+        node = MockNode(name="n")
+        node.add_parameter(_make_param("p"))
+        node.parameter_output_values["p"] = _AlwaysFailsPickle()
+
+        result = NodeManager.serialize_parameter_output_values(
+            node, workflow_manager=engine.workflow_manager, use_pickling=True
+        )
+
+        assert result.parameter_output_values["p"] is None
+
+    def test_with_pickling_dedups_the_same_value_shared_by_two_parameters(self, engine: Engine) -> None:
+        node = MockNode(name="n")
+        node.add_parameter(_make_param("first"))
+        node.add_parameter(_make_param("second"))
+        shared_value = "shared string"
+        node.parameter_output_values["first"] = shared_value
+        node.parameter_output_values["second"] = shared_value
+
+        result = NodeManager.serialize_parameter_output_values(
+            node, workflow_manager=engine.workflow_manager, use_pickling=True
+        )
+
+        assert result.parameter_output_values["first"] == result.parameter_output_values["second"]
+        assert result.unique_parameter_uuid_to_values is not None
+        assert len(result.unique_parameter_uuid_to_values) == 1
+
+
+class TestBoolIntPoolCollisionBug:
+    """Pinned bug: the pickling dedup pool keys by raw value, so ``True`` and ``1`` alias.
+
+    ``_process_parameter_for_pickling`` / ``_handle_new_value_for_pickling`` key their dedup cache
+    by ``param_value`` alone (``hash(True) == hash(1)`` and ``True == 1``), unlike the safer
+    ``_handle_value_hashing`` used by the workflow-save path, which keys by ``(type(value),
+    value)``. As a result, a bool-valued parameter and an int-valued parameter whose values are
+    pickle-equal collapse into ONE pool entry: the second parameter silently reads back the
+    first parameter's stored value instead of its own. Intended contract: each parameter's pooled
+    value is keyed by its own type-and-value identity, so ``True`` and ``1`` never alias.
+    """
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "DATA-LOSS: bug, scoped to the runtime output-value pickling path only "
+            "(_process_parameter_for_pickling/_handle_new_value_for_pickling, reached via "
+            "serialize_parameter_output_values(use_pickling=True), whose only caller is "
+            "machines/control_flow.py): they dedup by raw `param_value` alone (hash(True) == "
+            "hash(1) and True == 1), so a bool output value and an int output value collapse "
+            "into one pool entry and the second parameter reads back the first's UUID. The "
+            "disk-save path is NOT affected: _handle_value_hashing (node_manager.py, reached via "
+            "on_serialize_node_to_commands) already keys its dedup cache by `(type(value), "
+            "value)`, so the two functions have diverged and only this one needs the fix. "
+            "- see #5435"
+        ),
+    )
+    def test_bool_and_int_output_values_get_distinct_pool_entries(self, engine: Engine) -> None:
+        node = MockNode(name="n")
+        node.add_parameter(_make_param("flag"))
+        node.add_parameter(_make_param("count"))
+        node.parameter_output_values["flag"] = True
+        node.parameter_output_values["count"] = 1
+
+        result = NodeManager.serialize_parameter_output_values(
+            node, workflow_manager=engine.workflow_manager, use_pickling=True
+        )
+
+        assert result.parameter_output_values["flag"] != result.parameter_output_values["count"]
+        assert result.unique_parameter_uuid_to_values is not None
+        assert len(result.unique_parameter_uuid_to_values) == 2
+
+
+def _make_create_node_request(*, resolution: str | None = None) -> Any:
+    from griptape_nodes.exe_types.node_types import NodeResolutionState
+    from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
+
+    return CreateNodeRequest(
+        node_type="TestNode",
+        node_name="n",
+        resolution=resolution or NodeResolutionState.RESOLVED.value,
+    )

--- a/tests/unit/retained_mode/managers/test_selected_nodes_serialization.py
+++ b/tests/unit/retained_mode/managers/test_selected_nodes_serialization.py
@@ -1,0 +1,451 @@
+"""Copy/paste (selected nodes) serialization tests.
+
+``on_serialize_selected_nodes_to_commands`` packages a selection of nodes into a
+``SerializedSelectedNodesCommands`` object, pickles it, and hands back the pickle bytes
+(latin-1 decoded into a ``str`` so the payload can travel inside a JSON envelope alongside
+the rest of an ``EventResult``). ``on_deserialize_selected_nodes_from_commands`` reverses
+that to rebuild the nodes, their parameter values, their lock state, and the connections
+between them.
+
+Node types come from a library registered in-process for this module (``LibraryRegistry``
+is process-global; nothing here assumes a real Griptape Nodes standard library is installed
+on the host running the suite).
+"""
+
+from __future__ import annotations
+
+import pickle
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_groups.base_node_group import BaseNodeGroup
+from griptape_nodes.exe_types.node_types import DataNode
+from griptape_nodes.node_library.library_registry import (
+    LibraryMetadata,
+    LibraryRegistry,
+    LibrarySchema,
+    NodeMetadata,
+)
+from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest, CreateConnectionResultSuccess
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
+from griptape_nodes.retained_mode.events.node_events import (
+    AddNodesToNodeGroupRequest,
+    AddNodesToNodeGroupResultSuccess,
+    CreateNodeRequest,
+    CreateNodeResultSuccess,
+    DeserializeSelectedNodesFromCommandsRequest,
+    DeserializeSelectedNodesFromCommandsResultSuccess,
+    NewPosition,
+    SerializedSelectedNodesCommands,
+    SerializeSelectedNodesToCommandsRequest,
+    SerializeSelectedNodesToCommandsResultFailure,
+    SerializeSelectedNodesToCommandsResultSuccess,
+    SetLockNodeStateRequest,
+    SetLockNodeStateResultSuccess,
+)
+from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
+from griptape_nodes.retained_mode.events.parameter_events import (
+    GetParameterValueRequest,
+    GetParameterValueResultSuccess,
+    SetParameterValueRequest,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from griptape_nodes.retained_mode.engine import Engine
+
+_LIBRARY_NAME = "selected-nodes-serialization-test-library"
+
+
+class _CopyPasteNode(DataNode):
+    """Minimal DataNode with a connectable "value" parameter for round-trip assertions."""
+
+    def __init__(self, name: str, metadata: dict | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="value",
+                tooltip="Value to echo",
+                type="str",
+                default_value="",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY, ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        self.parameter_output_values["value"] = self.get_parameter_value("value")
+
+
+class _CopyPasteGroup(BaseNodeGroup):
+    """Minimal concrete BaseNodeGroup: a plain visual grouping with no subflow."""
+
+    def run(self) -> None:
+        pass
+
+    def initialize(self) -> None:
+        pass
+
+    def process(self) -> None:
+        return None
+
+
+@pytest.fixture
+def library_name() -> Generator[str, None, None]:
+    """Register a tiny real library in-process so serialized nodes resolve real library metadata.
+
+    LibraryRegistry keeps its state in class-level dicts shared across the whole process, so it
+    is cleared before and after this fixture runs to avoid bleeding into other test modules.
+    """
+    LibraryRegistry._clear()
+    schema = LibrarySchema(
+        name=_LIBRARY_NAME,
+        library_schema_version=LibrarySchema.LATEST_SCHEMA_VERSION,
+        metadata=LibraryMetadata(
+            author="test",
+            description="Selected-nodes serialization test fixtures",
+            library_version="1.0.0",
+            engine_version="1.0.0",
+            tags=[],
+        ),
+        categories=[],
+        nodes=[],
+    )
+    library = LibraryRegistry.generate_new_library(library_data=schema)
+    library.register_new_node_type(
+        _CopyPasteNode,
+        NodeMetadata(category="test", description="Echoes a value", display_name="Copy Paste Node"),
+    )
+    library.register_new_node_type(
+        _CopyPasteGroup,
+        NodeMetadata(category="test", description="Plain grouping node", display_name="Copy Paste Group"),
+    )
+    yield _LIBRARY_NAME
+    LibraryRegistry._clear()
+
+
+@pytest.fixture
+def clean_object_state(engine: Engine) -> Generator[None, None, None]:
+    """Clear all object state around a test so leftover flows never bleed across tests."""
+    engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    try:
+        yield
+    finally:
+        engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+
+
+@pytest.fixture
+def flow_name(engine: Engine, library_name: str, clean_object_state: None) -> str:  # noqa: ARG001
+    """Push a fresh workflow/flow context that the rest of the test builds nodes in."""
+    engine.context_manager.push_workflow(workflow_name="selected_nodes_wf")
+    result = engine.handle_request(CreateFlowRequest(parent_flow_name=None, flow_name="main", set_as_new_context=True))
+    assert isinstance(result, CreateFlowResultSuccess), result
+    return result.flow_name
+
+
+def _create_node(engine: Engine, node_name: str) -> str:
+    """Create a real ``_CopyPasteNode`` through the normal CreateNodeRequest path."""
+    result = engine.handle_request(
+        CreateNodeRequest(node_type="_CopyPasteNode", specific_library_name=_LIBRARY_NAME, node_name=node_name)
+    )
+    assert isinstance(result, CreateNodeResultSuccess), result
+    return result.node_name
+
+
+def _create_group(engine: Engine, node_name: str) -> str:
+    """Create a real ``_CopyPasteGroup`` through the normal CreateNodeRequest path."""
+    result = engine.handle_request(
+        CreateNodeRequest(node_type="_CopyPasteGroup", specific_library_name=_LIBRARY_NAME, node_name=node_name)
+    )
+    assert isinstance(result, CreateNodeResultSuccess), result
+    return result.node_name
+
+
+def _connect(engine: Engine, source_node: str, target_node: str) -> None:
+    result = engine.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source_node,
+            source_parameter_name="value",
+            target_node_name=target_node,
+            target_parameter_name="value",
+        )
+    )
+    assert isinstance(result, CreateConnectionResultSuccess), result
+
+
+def _serialize(
+    engine: Engine, node_names: list[str], *, copy_to_clipboard: bool = True
+) -> SerializeSelectedNodesToCommandsResultSuccess:
+    request = SerializeSelectedNodesToCommandsRequest(
+        nodes_to_serialize=[[name, "0"] for name in node_names],
+        copy_to_clipboard=copy_to_clipboard,
+    )
+    result = engine.handle_request(request)
+    assert isinstance(result, SerializeSelectedNodesToCommandsResultSuccess), result
+    return result
+
+
+def _decode_commands(serialized: str) -> SerializedSelectedNodesCommands:
+    """Mirror the deserialize handler's own decoding: latin-1 bytes, then unpickle."""
+    return pickle.loads(serialized.encode("latin1"))  # noqa: S301 test-only, mirrors production decode path
+
+
+def _deserialize(
+    engine: Engine,
+    serialize_result: SerializeSelectedNodesToCommandsResultSuccess,
+    *,
+    positions: list[NewPosition] | None = None,
+) -> DeserializeSelectedNodesFromCommandsResultSuccess:
+    request = DeserializeSelectedNodesFromCommandsRequest(
+        deserialize_commands=serialize_result.serialized_selected_node_commands,
+        pickled_values=serialize_result.pickled_values,
+        positions=positions,
+    )
+    result = engine.handle_request(request)
+    assert isinstance(result, DeserializeSelectedNodesFromCommandsResultSuccess), result
+    return result
+
+
+def _get_value(engine: Engine, node_name: str) -> str:
+    result = engine.handle_request(GetParameterValueRequest(node_name=node_name, parameter_name="value"))
+    assert isinstance(result, GetParameterValueResultSuccess), result
+    return result.value
+
+
+def _set_value(engine: Engine, node_name: str, value: str) -> None:
+    result = engine.handle_request(SetParameterValueRequest(node_name=node_name, parameter_name="value", value=value))
+    assert result.succeeded(), result
+
+
+@pytest.mark.usefixtures("flow_name")
+class TestSerializedCommandsWireFormat:
+    """The wire payload is a pickle blob transported as a latin-1 string, not JSON text.
+
+    ``SerializedNodeCommands`` holds request dataclasses and enum-valued fields that are not
+    all cattrs/JSON friendly, so the multi-node copy/paste path pickles the whole command tree
+    instead of using the JSON path that single-node serialization uses. The ``str`` type on the
+    dataclass field describes the wire shape (a string that survives inside a JSON envelope),
+    not the payload's internal structure.
+    """
+
+    def test_result_field_decodes_into_the_commands_dataclass(self, engine: Engine) -> None:
+        node_name = _create_node(engine, "NodeA")
+
+        result = _serialize(engine, [node_name])
+
+        assert isinstance(result.serialized_selected_node_commands, str)
+        decoded = _decode_commands(result.serialized_selected_node_commands)
+        assert isinstance(decoded, SerializedSelectedNodesCommands)
+
+    def test_decoded_commands_contain_exactly_the_selected_node(self, engine: Engine) -> None:
+        node_name = _create_node(engine, "NodeA")
+
+        result = _serialize(engine, [node_name])
+        decoded = _decode_commands(result.serialized_selected_node_commands)
+
+        serialized_names = {cmd.create_node_command.node_name for cmd in decoded.serialized_node_commands}
+        assert serialized_names == {node_name}
+
+    def test_pickled_values_carries_the_value_pool_separately(self, engine: Engine) -> None:
+        node_name = _create_node(engine, "NodeA")
+        _set_value(engine, node_name, "hello")
+
+        result = _serialize(engine, [node_name])
+        decoded = _decode_commands(result.serialized_selected_node_commands)
+
+        assert isinstance(result.pickled_values, dict)
+        assert len(result.pickled_values) > 0
+        param_commands = decoded.set_parameter_value_commands[decoded.serialized_node_commands[0].node_uuid]
+        for indirect_command in param_commands:
+            assert indirect_command.unique_value_uuid in result.pickled_values
+
+    def test_node_names_serialized_lists_exactly_the_requested_nodes(self, engine: Engine) -> None:
+        first = _create_node(engine, "NodeA")
+        second = _create_node(engine, "NodeB")
+
+        result = _serialize(engine, [first, second])
+
+        assert result.node_names_serialized == [first, second]
+
+    def test_copy_to_clipboard_false_still_returns_the_payload(self, engine: Engine) -> None:
+        """The flag only controls an external clipboard side effect; the handler always returns commands."""
+        node_name = _create_node(engine, "NodeA")
+
+        with_clipboard = _serialize(engine, [node_name], copy_to_clipboard=True)
+        without_clipboard = _serialize(engine, [node_name], copy_to_clipboard=False)
+
+        decoded_with = _decode_commands(with_clipboard.serialized_selected_node_commands)
+        decoded_without = _decode_commands(without_clipboard.serialized_selected_node_commands)
+        assert len(decoded_with.serialized_node_commands) == len(decoded_without.serialized_node_commands)
+        assert without_clipboard.node_names_serialized == [node_name]
+
+    def test_unknown_node_name_fails_cleanly_and_copies_nothing(self, engine: Engine) -> None:
+        """A request naming a node that cannot be found fails with the handler's own declared type.
+
+        Callers pattern-matching on SerializeSelectedNodesToCommandsResultFailure must not miss this
+        case, so the handler cannot fall back to the single-node SerializeNodeToCommandsResultFailure.
+        """
+        request = SerializeSelectedNodesToCommandsRequest(nodes_to_serialize=[["does_not_exist", "0"]])
+
+        result = engine.handle_request(request)
+
+        assert isinstance(result, SerializeSelectedNodesToCommandsResultFailure)
+
+
+@pytest.mark.usefixtures("flow_name")
+class TestSelectedNodesConnectionFiltering:
+    """A copied selection can only carry edges whose both endpoints were copied.
+
+    Pasting cannot invent a connection to a node that was never part of the selection, so a
+    connection reaching outside the selected set must be silently dropped rather than causing
+    a dangling reference during deserialization.
+    """
+
+    def test_connection_between_two_selected_nodes_is_preserved(self, engine: Engine) -> None:
+        source = _create_node(engine, "NodeSource")
+        target = _create_node(engine, "NodeTarget")
+        _connect(engine, source, target)
+
+        result = _serialize(engine, [source, target])
+        decoded = _decode_commands(result.serialized_selected_node_commands)
+
+        assert len(decoded.serialized_connection_commands) == 1
+        connection = decoded.serialized_connection_commands[0]
+        assert connection.source_parameter_name == "value"
+        assert connection.target_parameter_name == "value"
+
+    def test_connection_to_an_unselected_node_is_dropped(self, engine: Engine) -> None:
+        source = _create_node(engine, "NodeSource")
+        target = _create_node(engine, "NodeTarget")
+        _connect(engine, source, target)
+
+        # Only the source is selected for copy; target is left out of the selection entirely.
+        result = _serialize(engine, [source])
+        decoded = _decode_commands(result.serialized_selected_node_commands)
+
+        assert decoded.serialized_connection_commands == []
+
+
+@pytest.mark.usefixtures("flow_name")
+class TestSelectedNodesDeserializationRebuildsGraph:
+    """Rebuild an equivalent, independently-named copy of the selection.
+
+    Deserializing the payload from ``on_serialize_selected_nodes_to_commands`` must produce the
+    same values and the same wiring, under new node names.
+    """
+
+    def test_pasting_creates_fresh_names_and_leaves_originals_untouched(self, engine: Engine) -> None:
+        node_name = _create_node(engine, "NodeA")
+        _set_value(engine, node_name, "hello world")
+
+        serialize_result = _serialize(engine, [node_name])
+        deserialize_result = _deserialize(engine, serialize_result)
+
+        assert len(deserialize_result.node_names) == 1
+        pasted_name = deserialize_result.node_names[0]
+        assert pasted_name != node_name
+        assert _get_value(engine, node_name) == "hello world"
+        assert _get_value(engine, pasted_name) == "hello world"
+
+    def test_pasting_twice_from_the_same_payload_yields_independent_node_sets(self, engine: Engine) -> None:
+        node_name = _create_node(engine, "NodeA")
+        serialize_result = _serialize(engine, [node_name])
+
+        first_paste = _deserialize(engine, serialize_result)
+        second_paste = _deserialize(engine, serialize_result)
+
+        assert first_paste.node_names != second_paste.node_names
+        assert set(first_paste.node_names).isdisjoint(second_paste.node_names)
+
+    def test_connection_between_pasted_nodes_is_recreated(self, engine: Engine) -> None:
+        source = _create_node(engine, "NodeSource")
+        target = _create_node(engine, "NodeTarget")
+        _connect(engine, source, target)
+
+        serialize_result = _serialize(engine, [source, target])
+        deserialize_result = _deserialize(engine, serialize_result)
+
+        expected_pasted_node_count = 2
+        assert len(deserialize_result.node_names) == expected_pasted_node_count
+        pasted_source, pasted_target = deserialize_result.node_names
+        connections = engine.flow_manager.get_connections()
+        outgoing = connections.outgoing_index.get(pasted_source, {})
+        assert "value" in outgoing
+        incoming = connections.incoming_index.get(pasted_target, {})
+        assert "value" in incoming
+
+    def test_lock_state_survives_the_round_trip(self, engine: Engine) -> None:
+        node_name = _create_node(engine, "NodeA")
+        lock_result = engine.handle_request(SetLockNodeStateRequest(node_name=node_name, lock=True))
+        assert isinstance(lock_result, SetLockNodeStateResultSuccess), lock_result
+
+        serialize_result = _serialize(engine, [node_name])
+        deserialize_result = _deserialize(engine, serialize_result)
+
+        pasted_name = deserialize_result.node_names[0]
+        pasted_node = engine.node_manager.get_node_by_name(pasted_name)
+        assert pasted_node.lock is True
+
+    def test_positions_place_the_pasted_nodes(self, engine: Engine) -> None:
+        node_name = _create_node(engine, "NodeA")
+        serialize_result = _serialize(engine, [node_name])
+
+        deserialize_result = _deserialize(engine, serialize_result, positions=[NewPosition(x=123.0, y=456.0)])
+
+        pasted_name = deserialize_result.node_names[0]
+        pasted_node = engine.node_manager.get_node_by_name(pasted_name)
+        assert pasted_node.metadata["position"] == {"x": 123.0, "y": 456.0}
+
+    def test_omitting_positions_does_not_crash_and_uses_defaults(self, engine: Engine) -> None:
+        node_name = _create_node(engine, "NodeA")
+        serialize_result = _serialize(engine, [node_name])
+
+        deserialize_result = _deserialize(engine, serialize_result, positions=None)
+
+        assert len(deserialize_result.node_names) == 1
+
+
+@pytest.mark.usefixtures("flow_name")
+class TestSelectedNodeGroupCopy:
+    """Selecting a node group for copy/paste must bring its children along.
+
+    A group is a visual container; copying only the container without its members would
+    silently drop content the artist explicitly grouped together.
+    """
+
+    def test_selecting_a_group_copies_its_children(self, engine: Engine) -> None:
+        group_name = _create_group(engine, "MyGroup")
+        child_name = _create_node(engine, "ChildNode")
+        add_result = engine.handle_request(
+            AddNodesToNodeGroupRequest(node_names=[child_name], node_group_name=group_name)
+        )
+        assert isinstance(add_result, AddNodesToNodeGroupResultSuccess), add_result
+
+        serialize_result = _serialize(engine, [group_name])
+        decoded = _decode_commands(serialize_result.serialized_selected_node_commands)
+
+        serialized_names = {cmd.create_node_command.node_name for cmd in decoded.serialized_node_commands}
+        assert group_name in serialized_names
+        assert child_name in serialized_names
+
+    def test_pasting_a_copied_group_recreates_child_membership(self, engine: Engine) -> None:
+        group_name = _create_group(engine, "MyGroup")
+        child_name = _create_node(engine, "ChildNode")
+        add_result = engine.handle_request(
+            AddNodesToNodeGroupRequest(node_names=[child_name], node_group_name=group_name)
+        )
+        assert isinstance(add_result, AddNodesToNodeGroupResultSuccess), add_result
+
+        serialize_result = _serialize(engine, [group_name])
+        deserialize_result = _deserialize(engine, serialize_result)
+
+        # Both the group and its child must have been recreated under fresh names.
+        expected_pasted_node_count = 2
+        assert len(deserialize_result.node_names) == expected_pasted_node_count
+        assert len(deserialize_result.non_children_names) == 1
+        pasted_group_name = deserialize_result.non_children_names[0]
+        pasted_group = engine.node_manager.get_node_by_name(pasted_group_name)
+        assert isinstance(pasted_group, BaseNodeGroup)
+        assert len(pasted_group.nodes) == 1

--- a/tests/unit/retained_mode/managers/test_workflow_codegen_serialization.py
+++ b/tests/unit/retained_mode/managers/test_workflow_codegen_serialization.py
@@ -1,0 +1,771 @@
+"""Tests for the AST-based workflow file codegen: SerializedFlowCommands -> saved `.py` source.
+
+These tests build `SerializedFlowCommands`/`SerializedNodeCommands` by hand rather than driving them
+through the engine, so each codegen shape (nested flows, shared values, missing endpoints, dynamic
+module pickling) can be constructed directly without needing a real connectable node graph. Library
+and node type names below are fabricated on purpose: codegen only writes out whatever the serialized
+commands say, it never needs the library to actually be registered.
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+import sys
+import types
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+
+from griptape_nodes.exe_types.node_types import NodeDependencies
+from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, SerializedFlowCommands
+from griptape_nodes.retained_mode.events.node_events import (
+    CreateNodeRequest,
+    SerializedNodeCommands,
+    SetLockNodeStateRequest,
+)
+from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest, SetParameterValueRequest
+from griptape_nodes.retained_mode.events.variable_events import CreateVariableRequest
+from griptape_nodes.retained_mode.events.workflow_events import ImportWorkflowAsReferencedSubFlowRequest
+from griptape_nodes.retained_mode.managers.workflow_manager import ImportRecorder, WorkflowCodegenState, WorkflowManager
+from griptape_nodes.utils.ast_utils import rewrite_string_comments
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
+
+# --- Shared fixture builders (local to this lane; not shared with other test files) ---
+
+
+def _node_dependencies() -> NodeDependencies:
+    return NodeDependencies()
+
+
+def _empty_flow_commands(**overrides: Any) -> SerializedFlowCommands:
+    """Build a shape-free SerializedFlowCommands, overridable field by field."""
+    defaults: dict[str, Any] = {
+        "flow_initialization_command": None,
+        "serialized_node_commands": [],
+        "serialized_connections": [],
+        "unique_parameter_uuid_to_values": {},
+        "set_parameter_value_commands": {},
+        "set_lock_commands_per_node": {},
+        "sub_flows_commands": [],
+        "node_dependencies": _node_dependencies(),
+        "node_types_used": set(),
+    }
+    defaults.update(overrides)
+    return SerializedFlowCommands(**defaults)
+
+
+def _node_command(  # noqa: PLR0913
+    node_name: str,
+    *,
+    node_type: str = "FakeNodeType",
+    library: str | None = "Fake Library",
+    node_uuid: str | None = None,
+    element_modification_commands: list | None = None,
+    metadata: dict | None = None,
+) -> SerializedNodeCommands:
+    """Build a SerializedNodeCommands for a fabricated node type; codegen never touches the library."""
+    kwargs: dict[str, Any] = {
+        "create_node_command": CreateNodeRequest(
+            node_type=node_type,
+            specific_library_name=library,
+            node_name=node_name,
+            metadata=metadata,
+            initial_setup=True,
+        ),
+        "element_modification_commands": element_modification_commands or [],
+        "node_dependencies": _node_dependencies(),
+    }
+    if node_uuid is not None:
+        kwargs["node_uuid"] = SerializedNodeCommands.NodeUUID(node_uuid)
+    return SerializedNodeCommands(**kwargs)
+
+
+def _minimal_metadata(name: str = "codegen_test") -> WorkflowMetadata:
+    return WorkflowMetadata(
+        name=name,
+        schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+        engine_version_created_with="0.0.0",
+        node_libraries_referenced=[],
+    )
+
+
+def _calls_named(tree: ast.AST, name: str) -> list[ast.Call]:
+    """Every `name(...)` call anywhere in an AST subtree, matched by bare function name."""
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == name
+    ]
+
+
+def _kwargs_of(call: ast.Call) -> dict[str, ast.expr]:
+    return {kw.arg: kw.value for kw in call.keywords if kw.arg is not None}
+
+
+def _constant_value(expr: ast.expr) -> Any:
+    """Narrow an ast.expr believed to be an ast.Constant and return its value."""
+    assert isinstance(expr, ast.Constant)
+    return expr.value
+
+
+class _DynamicLibraryClass:
+    """Stand-in for a class whose real __module__ is a dynamically loaded library module.
+
+    Declared at module scope (not nested in a class) so its true __module__ is this test file's
+    own importable module -- the tests below temporarily repoint it to fabricate a "dynamic module"
+    before-state, then repoint it to this true value to stand in for a "stable namespace".
+    """
+
+    def __init__(self) -> None:
+        self.value = 1
+
+
+class TestFlowHasContentToGenerate:
+    """`_flow_has_content_to_generate` decides whether a Flow is worth a context block at all."""
+
+    def test_fully_empty_flow_has_no_content(self) -> None:
+        assert WorkflowManager._flow_has_content_to_generate(_empty_flow_commands()) is False
+
+    def test_node_commands_count_as_content(self) -> None:
+        flow = _empty_flow_commands(serialized_node_commands=[_node_command("node_a")])
+        assert WorkflowManager._flow_has_content_to_generate(flow) is True
+
+    def test_connections_count_as_content(self) -> None:
+        connection = SerializedFlowCommands.IndirectConnectionSerialization(
+            source_node_uuid=SerializedNodeCommands.NodeUUID("a"),
+            source_parameter_name="out",
+            target_node_uuid=SerializedNodeCommands.NodeUUID("b"),
+            target_parameter_name="in",
+        )
+        flow = _empty_flow_commands(serialized_connections=[connection])
+        assert WorkflowManager._flow_has_content_to_generate(flow) is True
+
+    def test_set_parameter_value_commands_count_as_content(self) -> None:
+        flow = _empty_flow_commands(set_parameter_value_commands={SerializedNodeCommands.NodeUUID("a"): []})
+        assert WorkflowManager._flow_has_content_to_generate(flow) is True
+
+    def test_sub_flows_count_as_content(self) -> None:
+        flow = _empty_flow_commands(sub_flows_commands=[_empty_flow_commands()])
+        assert WorkflowManager._flow_has_content_to_generate(flow) is True
+
+    def test_lock_commands_count_as_content(self) -> None:
+        flow = _empty_flow_commands(
+            set_lock_commands_per_node={
+                SerializedNodeCommands.NodeUUID("a"): SetLockNodeStateRequest(node_name=None, lock=True)
+            }
+        )
+        assert WorkflowManager._flow_has_content_to_generate(flow) is True
+
+    def test_variable_commands_count_as_content(self) -> None:
+        variable_command = SerializedFlowCommands.SerializedVariableCommand(
+            create_variable_command=CreateVariableRequest(
+                name="v", type="str", is_global=False, value=None, owning_flow="flow"
+            ),
+            unique_value_uuid=SerializedNodeCommands.UniqueParameterValueUUID(str(uuid4())),
+        )
+        flow = _empty_flow_commands(serialized_variable_commands=[variable_command])
+        assert WorkflowManager._flow_has_content_to_generate(flow) is True
+
+
+class TestGenerateFlowInitializationCode:
+    """The statements that bring one Flow into existence, dispatched by initialization command type."""
+
+    def test_none_command_emits_nothing(self, engine: Engine) -> None:
+        statements = engine.workflow_manager._generate_flow_initialization_code(
+            flow_initialization_command=None,
+            import_recorder=ImportRecorder(),
+            codegen_state=WorkflowCodegenState(),
+            flow_creation_index=0,
+            parent_flow_creation_index=None,
+        )
+        assert statements == []
+
+    def test_create_flow_command_registers_subflow_name_variable(self, engine: Engine) -> None:
+        codegen_state = WorkflowCodegenState()
+        command = CreateFlowRequest(parent_flow_name=None, flow_name="named_flow")
+        statements = engine.workflow_manager._generate_flow_initialization_code(
+            flow_initialization_command=command,
+            import_recorder=ImportRecorder(),
+            codegen_state=codegen_state,
+            flow_creation_index=5,
+            parent_flow_creation_index=None,
+        )
+        assert len(statements) > 0
+        assert codegen_state.subflow_name_to_variable_name["named_flow"] == "flow5_name"
+
+    def test_import_workflow_command_emits_statements(self, engine: Engine) -> None:
+        command = ImportWorkflowAsReferencedSubFlowRequest(workflow_name="referenced_workflow")
+        statements = engine.workflow_manager._generate_flow_initialization_code(
+            flow_initialization_command=command,
+            import_recorder=ImportRecorder(),
+            codegen_state=WorkflowCodegenState(),
+            flow_creation_index=0,
+            parent_flow_creation_index=None,
+        )
+        assert len(statements) > 0
+
+    def test_unrecognized_command_type_raises_type_error(self, engine: Engine) -> None:
+        """A flow-creation command this codegen has never learned to write must fail the save loudly.
+
+        Silently emitting nothing would write a file whose Flow is never created, so every node
+        inside it lands wherever the script happens to be pointing -- a wrong graph that loads
+        without complaint. That is worse than a save the artist knows did not happen.
+        """
+        with pytest.raises(TypeError):
+            engine.workflow_manager._generate_flow_initialization_code(
+                flow_initialization_command=object(),  # type: ignore[arg-type]
+                import_recorder=ImportRecorder(),
+                codegen_state=WorkflowCodegenState(),
+                flow_creation_index=0,
+                parent_flow_creation_index=None,
+            )
+
+
+class TestGenerateAssignFlowContext:
+    """The `with` block that scopes graph-building calls into the right Flow."""
+
+    def test_none_command_looks_up_the_current_flow_by_name(self, engine: Engine) -> None:
+        with_stmt = engine.workflow_manager._generate_assign_flow_context(
+            flow_initialization_command=None, flow_creation_index=0
+        )
+        source = ast.unparse(with_stmt)
+        assert "GriptapeNodes.ContextManager().get_current_flow().flow_name" in source
+
+    def test_create_flow_command_references_its_own_flow_variable(self, engine: Engine) -> None:
+        command = CreateFlowRequest(parent_flow_name=None, flow_name="my_flow")
+        with_stmt = engine.workflow_manager._generate_assign_flow_context(
+            flow_initialization_command=command, flow_creation_index=3
+        )
+        source = ast.unparse(with_stmt)
+        assert "GriptapeNodes.ContextManager().flow(flow3_name)" in source
+
+
+class TestGenerateCreateFlow:
+    """The statement that issues CreateFlowRequest and captures the resulting flow name."""
+
+    def test_emits_awaited_call_assigned_to_flow_name_variable(self, engine: Engine) -> None:
+        command = CreateFlowRequest(parent_flow_name=None, flow_name="root_flow", set_as_new_context=False)
+        import_recorder = ImportRecorder()
+        module = engine.workflow_manager._generate_create_flow(command, import_recorder, flow_creation_index=0)
+        source = ast.unparse(module)
+        assert "flow0_name = (await GriptapeNodes.ahandle_request(CreateFlowRequest(" in source
+        assert ").flow_name" in source
+        assert "CreateFlowRequest" in import_recorder.from_imports.get(
+            "griptape_nodes.retained_mode.events.flow_events", set()
+        )
+
+    def test_parent_flow_name_becomes_a_variable_reference_not_a_string(self, engine: Engine) -> None:
+        command = CreateFlowRequest(parent_flow_name="parent_flow", flow_name="child_flow")
+        module = engine.workflow_manager._generate_create_flow(
+            command, ImportRecorder(), flow_creation_index=1, parent_flow_creation_index=0
+        )
+        call = _calls_named(module, "CreateFlowRequest")[0]
+        kwargs = _kwargs_of(call)
+        assert isinstance(kwargs["parent_flow_name"], ast.Name)
+        assert kwargs["parent_flow_name"].id == "flow0_name"
+
+    def test_omits_optional_fields_left_at_their_default(self, engine: Engine) -> None:
+        command = CreateFlowRequest(parent_flow_name=None, flow_name="root_flow")
+        module = engine.workflow_manager._generate_create_flow(command, ImportRecorder(), flow_creation_index=0)
+        call = _calls_named(module, "CreateFlowRequest")[0]
+        kwargs = _kwargs_of(call)
+        assert "set_as_new_context" not in kwargs
+        assert "metadata" not in kwargs
+        assert _constant_value(kwargs["flow_name"]) == "root_flow"
+        # parent_flow_name has no dataclass default (it's required), so it is always written,
+        # even when the value itself is None.
+        assert _constant_value(kwargs["parent_flow_name"]) is None
+
+
+class TestGenerateImportWorkflow:
+    """The statement that issues ImportWorkflowAsReferencedSubFlowRequest for a referenced workflow."""
+
+    def test_emits_awaited_call_using_created_flow_name_attribute(self, engine: Engine) -> None:
+        command = ImportWorkflowAsReferencedSubFlowRequest(workflow_name="referenced_workflow")
+        import_recorder = ImportRecorder()
+        module = engine.workflow_manager._generate_import_workflow(command, import_recorder, flow_creation_index=2)
+        source = ast.unparse(module)
+        assert "flow2_name = (await GriptapeNodes.ahandle_request(ImportWorkflowAsReferencedSubFlowRequest(" in source
+        assert ").created_flow_name" in source
+        assert "ImportWorkflowAsReferencedSubFlowRequest" in import_recorder.from_imports.get(
+            "griptape_nodes.retained_mode.events.workflow_events", set()
+        )
+
+
+class TestGenerateNodeCreationCode:
+    """The statement (plus optional element-modification block) that recreates one node."""
+
+    def test_names_node_type_library_and_reapplies_metadata(self, engine: Engine) -> None:
+        node_command = _node_command(
+            "node_a", node_type="FakeType", library="Fake Library", metadata={"position": {"x": 10, "y": 20}}
+        )
+        statements = engine.workflow_manager._generate_node_creation_code(
+            node_command,
+            node_index=0,
+            import_recorder=ImportRecorder(),
+            node_uuid_to_node_variable_name={},
+            subflow_name_to_variable_name={},
+        )
+        module = ast.Module(body=statements, type_ignores=[])
+        call = _calls_named(module, "CreateNodeRequest")[0]
+        kwargs = _kwargs_of(call)
+        assert _constant_value(kwargs["node_type"]) == "FakeType"
+        assert _constant_value(kwargs["specific_library_name"]) == "Fake Library"
+        assert ast.literal_eval(kwargs["metadata"]) == {"position": {"x": 10, "y": 20}}
+
+    def test_registers_node_variable_name_for_downstream_references(self, engine: Engine) -> None:
+        node_command = _node_command("node_a", node_uuid="uuid-a")
+        node_uuid_to_node_variable_name: dict = {}
+        engine.workflow_manager._generate_node_creation_code(
+            node_command,
+            node_index=7,
+            import_recorder=ImportRecorder(),
+            node_uuid_to_node_variable_name=node_uuid_to_node_variable_name,
+            subflow_name_to_variable_name={},
+        )
+        assert node_uuid_to_node_variable_name[SerializedNodeCommands.NodeUUID("uuid-a")] == "node7_name"
+
+    def test_no_element_modification_commands_omits_with_block(self, engine: Engine) -> None:
+        node_command = _node_command("node_a")
+        statements = engine.workflow_manager._generate_node_creation_code(
+            node_command,
+            node_index=0,
+            import_recorder=ImportRecorder(),
+            node_uuid_to_node_variable_name={},
+            subflow_name_to_variable_name={},
+        )
+        assert not any(isinstance(stmt, ast.With) for stmt in statements)
+
+    def test_element_modification_commands_run_inside_node_context_and_skip_defaults(self, engine: Engine) -> None:
+        add_parameter_command = AddParameterToNodeRequest(parameter_name="extra", default_value="hi", type="str")
+        node_command = _node_command("node_a", element_modification_commands=[add_parameter_command])
+        statements = engine.workflow_manager._generate_node_creation_code(
+            node_command,
+            node_index=0,
+            import_recorder=ImportRecorder(),
+            node_uuid_to_node_variable_name={},
+            subflow_name_to_variable_name={},
+        )
+        with_stmts: list[ast.stmt] = [stmt for stmt in statements if isinstance(stmt, ast.With)]
+        assert len(with_stmts) == 1
+        module = ast.Module(body=with_stmts, type_ignores=[])
+        call = _calls_named(module, "AddParameterToNodeRequest")[0]
+        kwargs = _kwargs_of(call)
+        assert _constant_value(kwargs["parameter_name"]) == "extra"
+        assert _constant_value(kwargs["default_value"]) == "hi"
+        # node_name stays at its default (None): the call runs inside the node's own context,
+        # so writing it explicitly would be redundant.
+        assert "node_name" not in kwargs
+        source = ast.unparse(with_stmts[0])
+        assert "GriptapeNodes.ContextManager().node(node0_name)" in source
+
+
+class TestGenerateConnectionsCode:
+    """The statements that reconnect a Flow's nodes once every node in the subtree exists."""
+
+    def test_emits_connection_referencing_both_endpoint_variables(self, engine: Engine) -> None:
+        connection = SerializedFlowCommands.IndirectConnectionSerialization(
+            source_node_uuid=SerializedNodeCommands.NodeUUID("a"),
+            source_parameter_name="out",
+            target_node_uuid=SerializedNodeCommands.NodeUUID("b"),
+            target_parameter_name="in",
+        )
+        statements = engine.workflow_manager._generate_connections_code(
+            serialized_connections=[connection],
+            node_uuid_to_node_variable_name={
+                SerializedNodeCommands.NodeUUID("a"): "node0_name",
+                SerializedNodeCommands.NodeUUID("b"): "node1_name",
+            },
+            import_recorder=ImportRecorder(),
+        )
+        module = ast.Module(body=statements, type_ignores=[])
+        call = _calls_named(module, "CreateConnectionRequest")[0]
+        kwargs = _kwargs_of(call)
+        assert isinstance(kwargs["source_node_name"], ast.Name)
+        assert kwargs["source_node_name"].id == "node0_name"
+        assert isinstance(kwargs["target_node_name"], ast.Name)
+        assert kwargs["target_node_name"].id == "node1_name"
+        assert _constant_value(kwargs["source_parameter_name"]) == "out"
+        assert _constant_value(kwargs["target_parameter_name"]) == "in"
+
+    def test_missing_endpoint_is_skipped_and_logged_not_raised(
+        self, engine: Engine, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A connection naming a node this Flow never wrote must not fail the whole save.
+
+        Which Flow writes a given edge depends on traversal order, so losing one edge is a smaller
+        harm than failing the save outright.
+        """
+        connection = SerializedFlowCommands.IndirectConnectionSerialization(
+            source_node_uuid=SerializedNodeCommands.NodeUUID("missing"),
+            source_parameter_name="out",
+            target_node_uuid=SerializedNodeCommands.NodeUUID("b"),
+            target_parameter_name="in",
+        )
+        with caplog.at_level(logging.ERROR, logger="griptape_nodes"):
+            statements = engine.workflow_manager._generate_connections_code(
+                serialized_connections=[connection],
+                node_uuid_to_node_variable_name={SerializedNodeCommands.NodeUUID("b"): "node1_name"},
+                import_recorder=ImportRecorder(),
+            )
+        assert statements == []
+        assert any("were never written to the file" in record.getMessage() for record in caplog.records)
+
+
+class TestWorkflowCodegenStateConnectionDedup:
+    """A boundary-crossing edge is reported by every ancestor Flow; only one may emit it."""
+
+    @staticmethod
+    def _connection() -> SerializedFlowCommands.IndirectConnectionSerialization:
+        return SerializedFlowCommands.IndirectConnectionSerialization(
+            source_node_uuid=SerializedNodeCommands.NodeUUID("a"),
+            source_parameter_name="out",
+            target_node_uuid=SerializedNodeCommands.NodeUUID("b"),
+            target_parameter_name="in",
+        )
+
+    def test_first_claim_returns_the_connection(self) -> None:
+        codegen_state = WorkflowCodegenState()
+        claimed = codegen_state.take_unemitted_connections([self._connection()])
+        assert len(claimed) == 1
+
+    def test_second_claim_of_the_same_edge_returns_nothing(self) -> None:
+        codegen_state = WorkflowCodegenState()
+        codegen_state.take_unemitted_connections([self._connection()])
+        claimed_again = codegen_state.take_unemitted_connections([self._connection()])
+        assert claimed_again == []
+
+
+class TestGenerateUniqueValuesCode:
+    """The pickled value pool shared by every SetParameterValueRequest in the file."""
+
+    def test_empty_dict_returns_empty_module(self, engine: Engine) -> None:
+        module = engine.workflow_manager._generate_unique_values_code(
+            unique_parameter_uuid_to_values={}, prefix="top_level", import_recorder=ImportRecorder()
+        )
+        assert module.body == []
+
+    def test_emits_pickle_loads_call_per_uuid_and_records_pickle_import(self, engine: Engine) -> None:
+        uuid_a = SerializedNodeCommands.UniqueParameterValueUUID(str(uuid4()))
+        uuid_b = SerializedNodeCommands.UniqueParameterValueUUID(str(uuid4()))
+        import_recorder = ImportRecorder()
+        module = engine.workflow_manager._generate_unique_values_code(
+            unique_parameter_uuid_to_values={uuid_a: "value-a", uuid_b: 42},
+            prefix="top_level",
+            import_recorder=import_recorder,
+        )
+        source = ast.unparse(module)
+        expected_pickle_calls = 2
+        assert source.count("pickle.loads(") == expected_pickle_calls
+        assert "pickle" in import_recorder.imports
+
+        dict_assign = next(stmt for stmt in module.body if isinstance(stmt, ast.Assign))
+        assert isinstance(dict_assign.targets[0], ast.Name)
+        assert dict_assign.targets[0].id == "top_level_unique_values_dict"
+        keys = [key.value for key in dict_assign.value.keys]  # type: ignore[union-attr]
+        assert set(keys) == {uuid_a, uuid_b}
+
+    def test_comment_lines_survive_rewrite_as_real_comments(self, engine: Engine) -> None:
+        """ast.unparse cannot emit `#` comments directly; they are smuggled in as bare string statements.
+
+        rewrite_string_comments unwraps them afterward, same as the save pipeline does.
+        """
+        module = engine.workflow_manager._generate_unique_values_code(
+            unique_parameter_uuid_to_values={SerializedNodeCommands.UniqueParameterValueUUID(str(uuid4())): "value"},
+            prefix="top_level",
+            import_recorder=ImportRecorder(),
+        )
+        raw_source = ast.unparse(module)
+        assert not any(line.strip().startswith("#") for line in raw_source.splitlines()), (
+            "ast.unparse cannot emit real comments; they must still be smuggled in as quoted strings"
+        )
+        rewritten = rewrite_string_comments(raw_source)
+        assert "# 1. We've collated all of the unique parameter values into a dictionary" in rewritten
+
+
+class TestGenerateSetParameterValueForNode:
+    """The per-node `with` block that restores saved values and lock state."""
+
+    def test_no_values_and_no_lock_emits_nothing(self, engine: Engine) -> None:
+        statements = engine.workflow_manager._generate_set_parameter_value_for_node(
+            "node0_name", [], "top_level_unique_values_dict", ImportRecorder(), lock_node_command=None
+        )
+        assert statements == []
+
+    def test_lock_only_node_still_gets_a_context_block(self, engine: Engine) -> None:
+        lock_command = SetLockNodeStateRequest(node_name=None, lock=True)
+        statements = engine.workflow_manager._generate_set_parameter_value_for_node(
+            "node0_name", [], "top_level_unique_values_dict", ImportRecorder(), lock_node_command=lock_command
+        )
+        assert len(statements) == 1
+        with_stmt = statements[0]
+        assert isinstance(with_stmt, ast.With)
+        source = ast.unparse(with_stmt)
+        assert "GriptapeNodes.ContextManager().node(node0_name)" in source
+        assert "SetLockNodeStateRequest(node_name=None, lock=True)" in source
+
+    def test_lock_command_is_emitted_after_parameter_values_in_the_same_block(self, engine: Engine) -> None:
+        indirect_command = SerializedNodeCommands.IndirectSetParameterValueCommand(
+            set_parameter_value_command=SetParameterValueRequest(parameter_name="text", value=None),
+            unique_value_uuid=SerializedNodeCommands.UniqueParameterValueUUID(str(uuid4())),
+        )
+        lock_command = SetLockNodeStateRequest(node_name=None, lock=False)
+        statements = engine.workflow_manager._generate_set_parameter_value_for_node(
+            "node0_name",
+            [indirect_command],
+            "top_level_unique_values_dict",
+            ImportRecorder(),
+            lock_node_command=lock_command,
+        )
+        with_stmt = statements[0]
+        assert isinstance(with_stmt, ast.With)
+        expected_body_length = 2
+        assert len(with_stmt.body) == expected_body_length
+        assert _calls_named(with_stmt.body[0], "SetParameterValueRequest")
+        assert _calls_named(with_stmt.body[1], "SetLockNodeStateRequest")
+
+
+class TestGenerateSetParameterValueCode:
+    """The dict-wide dispatcher that fans set-parameter-value work out per node."""
+
+    def test_missing_node_is_skipped_and_logged_not_raised(
+        self, engine: Engine, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        missing_uuid = SerializedNodeCommands.NodeUUID("missing")
+        indirect_command = SerializedNodeCommands.IndirectSetParameterValueCommand(
+            set_parameter_value_command=SetParameterValueRequest(parameter_name="text", value=None),
+            unique_value_uuid=SerializedNodeCommands.UniqueParameterValueUUID(str(uuid4())),
+        )
+        with caplog.at_level(logging.ERROR, logger="griptape_nodes"):
+            statements = engine.workflow_manager._generate_set_parameter_value_code(
+                set_parameter_value_commands={missing_uuid: [indirect_command]},
+                lock_commands={},
+                node_uuid_to_node_variable_name={},
+                unique_values_dict_name="top_level_unique_values_dict",
+                import_recorder=ImportRecorder(),
+            )
+        assert statements == []
+        assert any("was never written to the file" in record.getMessage() for record in caplog.records)
+
+
+class TestPatchAndPickleObject:
+    """Pickling must reference a stable importable module name, never the throwaway dynamic one."""
+
+    def test_dynamic_module_is_patched_to_stable_namespace_in_the_pickle_bytes(self, engine: Engine) -> None:
+        original_module = _DynamicLibraryClass.__module__
+        fake_dynamic_name = "gtn_dynamic_module_fake_for_test"
+        sys.modules[fake_dynamic_name] = types.ModuleType(fake_dynamic_name)
+        _DynamicLibraryClass.__module__ = fake_dynamic_name
+        instance = _DynamicLibraryClass()
+        try:
+            with (
+                patch.object(
+                    engine.library_manager,
+                    "is_dynamic_module",
+                    side_effect=lambda name: name == fake_dynamic_name,
+                ),
+                patch.object(
+                    engine.library_manager,
+                    "get_stable_namespace_for_dynamic_module",
+                    side_effect=lambda name: original_module if name == fake_dynamic_name else None,
+                ),
+            ):
+                pickled_bytes = engine.workflow_manager._patch_and_pickle_object(instance)
+        finally:
+            del sys.modules[fake_dynamic_name]
+            _DynamicLibraryClass.__module__ = original_module
+
+        assert original_module.encode() in pickled_bytes
+        assert fake_dynamic_name.encode() not in pickled_bytes
+
+    def test_original_module_is_restored_after_pickling(self, engine: Engine) -> None:
+        original_module = _DynamicLibraryClass.__module__
+        fake_dynamic_name = "gtn_dynamic_module_fake_for_restore_test"
+        sys.modules[fake_dynamic_name] = types.ModuleType(fake_dynamic_name)
+        _DynamicLibraryClass.__module__ = fake_dynamic_name
+        instance = _DynamicLibraryClass()
+        try:
+            with (
+                patch.object(
+                    engine.library_manager,
+                    "is_dynamic_module",
+                    side_effect=lambda name: name == fake_dynamic_name,
+                ),
+                patch.object(
+                    engine.library_manager,
+                    "get_stable_namespace_for_dynamic_module",
+                    side_effect=lambda name: original_module if name == fake_dynamic_name else None,
+                ),
+            ):
+                engine.workflow_manager._patch_and_pickle_object(instance)
+            assert _DynamicLibraryClass.__module__ == fake_dynamic_name
+        finally:
+            del sys.modules[fake_dynamic_name]
+            _DynamicLibraryClass.__module__ = original_module
+
+
+class TestGenerateWorkflowFileContentIntegration:
+    """End-to-end codegen: a hand-built serialized flow tree must produce one coherent, valid file."""
+
+    @staticmethod
+    def _composite_flow_commands() -> SerializedFlowCommands:
+        shared_uuid = SerializedNodeCommands.UniqueParameterValueUUID(str(uuid4()))
+        node_a = _node_command("node_a", node_uuid="uuid-a")
+        node_b = _node_command("node_b", node_uuid="uuid-b")
+        child_node = _node_command("child_node", node_uuid="uuid-c")
+
+        connection = SerializedFlowCommands.IndirectConnectionSerialization(
+            source_node_uuid=SerializedNodeCommands.NodeUUID("uuid-a"),
+            source_parameter_name="out",
+            target_node_uuid=SerializedNodeCommands.NodeUUID("uuid-b"),
+            target_parameter_name="in",
+        )
+        indirect_value_a = SerializedNodeCommands.IndirectSetParameterValueCommand(
+            set_parameter_value_command=SetParameterValueRequest(parameter_name="text", value=None),
+            unique_value_uuid=shared_uuid,
+        )
+        indirect_value_b = SerializedNodeCommands.IndirectSetParameterValueCommand(
+            set_parameter_value_command=SetParameterValueRequest(parameter_name="text", value=None),
+            unique_value_uuid=shared_uuid,
+        )
+
+        child_flow = _empty_flow_commands(
+            flow_initialization_command=CreateFlowRequest(parent_flow_name="parent_flow", flow_name="child_flow"),
+            serialized_node_commands=[child_node],
+        )
+
+        return _empty_flow_commands(
+            flow_initialization_command=CreateFlowRequest(parent_flow_name=None, flow_name="parent_flow"),
+            serialized_node_commands=[node_a, node_b],
+            serialized_connections=[connection],
+            unique_parameter_uuid_to_values={shared_uuid: "shared-value"},
+            set_parameter_value_commands={
+                SerializedNodeCommands.NodeUUID("uuid-a"): [indirect_value_a],
+                SerializedNodeCommands.NodeUUID("uuid-b"): [indirect_value_b],
+            },
+            sub_flows_commands=[child_flow],
+        )
+
+    def test_composite_shape_generates_valid_python(self, engine: Engine) -> None:
+        content = engine.workflow_manager._generate_workflow_file_content(
+            serialized_flow_commands=self._composite_flow_commands(),
+            workflow_metadata=_minimal_metadata(),
+        )
+        ast.parse(content)  # raises SyntaxError if codegen left invalid source behind
+
+    def test_parent_flow_is_created_before_its_child_flow(self, engine: Engine) -> None:
+        content = engine.workflow_manager._generate_workflow_file_content(
+            serialized_flow_commands=self._composite_flow_commands(),
+            workflow_metadata=_minimal_metadata(),
+        )
+        assert content.index("flow0_name = ") < content.index("flow1_name = ")
+        assert "parent_flow_name=flow0_name" in content
+
+    def test_shared_value_is_pickled_once_and_referenced_by_both_nodes(self, engine: Engine) -> None:
+        content = engine.workflow_manager._generate_workflow_file_content(
+            serialized_flow_commands=self._composite_flow_commands(),
+            workflow_metadata=_minimal_metadata(),
+        )
+        assert content.count("pickle.loads(") == 1
+        module = ast.parse(content)
+        subscripts = [
+            node
+            for node in ast.walk(module)
+            if isinstance(node, ast.Subscript)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "top_level_unique_values_dict"
+        ]
+        expected_subscript_count = 2
+        assert len(subscripts) == expected_subscript_count
+
+    def test_generating_twice_from_the_same_commands_is_byte_identical(self, engine: Engine) -> None:
+        """Re-saving an unchanged graph must not churn the diff."""
+        flow_commands = self._composite_flow_commands()
+        metadata = _minimal_metadata()
+        first = engine.workflow_manager._generate_workflow_file_content(
+            serialized_flow_commands=flow_commands, workflow_metadata=metadata
+        )
+        second = engine.workflow_manager._generate_workflow_file_content(
+            serialized_flow_commands=flow_commands, workflow_metadata=metadata
+        )
+        assert first == second
+
+
+class TestImportRecorder:
+    """Tracks module-level imports for the generated file, deduped and deterministically ordered."""
+
+    def test_generate_imports_sorts_modules_and_names(self) -> None:
+        import_recorder = ImportRecorder()
+        import_recorder.add_import("zeta")
+        import_recorder.add_import("alpha")
+        import_recorder.add_from_import("some.module", "Zeta")
+        import_recorder.add_from_import("some.module", "Alpha")
+        output = import_recorder.generate_imports()
+        assert output == "import alpha\nimport zeta\nfrom some.module import Alpha, Zeta"
+
+    def test_duplicate_imports_are_deduped(self) -> None:
+        import_recorder = ImportRecorder()
+        import_recorder.add_import("alpha")
+        import_recorder.add_import("alpha")
+        import_recorder.add_from_import("some.module", "Alpha")
+        import_recorder.add_from_import("some.module", "Alpha")
+        output = import_recorder.generate_imports()
+        assert output == "import alpha\nfrom some.module import Alpha"
+
+
+class TestBuildDeferredImportStatements:
+    """Deferred library imports must land inside build_workflow(), sorted for stable output."""
+
+    def test_emits_one_import_from_per_module_sorted_by_module_and_class(self, engine: Engine) -> None:
+        deferred_imports = {
+            "zeta.module": {"ZetaClass"},
+            "alpha.module": {"BClass", "AClass"},
+        }
+        statements = engine.workflow_manager._build_deferred_import_statements(deferred_imports)
+        expected_statement_count = 2
+        assert len(statements) == expected_statement_count
+        assert all(isinstance(stmt, ast.ImportFrom) for stmt in statements)
+        first_statement, second_statement = statements
+        assert isinstance(first_statement, ast.ImportFrom)
+        assert isinstance(second_statement, ast.ImportFrom)
+        assert first_statement.module == "alpha.module"
+        assert [alias.name for alias in first_statement.names] == ["AClass", "BClass"]
+        assert second_statement.module == "zeta.module"
+
+    def test_empty_deferred_imports_yields_no_statements(self, engine: Engine) -> None:
+        assert engine.workflow_manager._build_deferred_import_statements({}) == []
+
+
+class TestRewriteStringComments:
+    """ast.unparse cannot emit `#` comments, so codegen smuggles them as bare strings and unwraps them."""
+
+    def test_single_quoted_comment_line_becomes_a_real_comment(self) -> None:
+        source = "x = 1\n'# a comment'\ny = 2"
+        rewritten = rewrite_string_comments(source)
+        assert "# a comment" in rewritten.splitlines()
+        assert "'# a comment'" not in rewritten
+
+    def test_double_quoted_comment_line_becomes_a_real_comment(self) -> None:
+        source = 'x = 1\n"# a comment"\ny = 2'
+        rewritten = rewrite_string_comments(source)
+        assert "# a comment" in rewritten.splitlines()
+
+    def test_indentation_is_preserved(self) -> None:
+        source = "if True:\n    '# indented comment'\n    pass"
+        rewritten = rewrite_string_comments(source)
+        assert "    # indented comment" in rewritten.splitlines()
+
+    def test_non_comment_string_statement_is_left_alone(self) -> None:
+        source = "'just a string, not a comment'"
+        rewritten = rewrite_string_comments(source)
+        assert rewritten == source
+
+    def test_ordinary_code_lines_are_left_alone(self) -> None:
+        source = "x = 1\ny = 2"
+        assert rewrite_string_comments(source) == source

--- a/tests/unit/retained_mode/managers/test_workflow_save_load_roundtrip.py
+++ b/tests/unit/retained_mode/managers/test_workflow_save_load_roundtrip.py
@@ -666,10 +666,11 @@ class TestDeterministicSaveOutput:
         first_source = _read_saved_source(first_path)
         second_source = _read_saved_source(second_path)
 
-        # The two files were saved under different names, so their embedded `name = "..."`
-        # metadata line legitimately differs; everything else must not.
-        first_lines = [line for line in first_source.splitlines() if "name = " not in line]
-        second_lines = [line for line in second_source.splitlines() if "name = " not in line]
+        # Only the embedded workflow-name metadata line legitimately differs (the two files were
+        # saved under different names). Everything else, including the node and flow creation
+        # lines that assign to `<thing>N_name`, must match.
+        first_lines = [line for line in first_source.splitlines() if not line.strip().startswith("# name = ")]
+        second_lines = [line for line in second_source.splitlines() if not line.strip().startswith("# name = ")]
         assert first_lines == second_lines
 
 
@@ -718,6 +719,9 @@ class TestIdempotentSaveLoadSave:
             second_path = _save_flow_to_disk(engine, flow_name, tmp_path, "roundtrip_resaved")
             second_source = _read_saved_source(second_path)
 
-        first_lines = [line for line in first_source.splitlines() if "name = " not in line]
-        second_lines = [line for line in second_source.splitlines() if "name = " not in line]
+        # Only the embedded workflow-name metadata line legitimately differs (the resave was
+        # written under a different name). Everything else, including the node and flow creation
+        # lines that assign to `<thing>N_name`, must match.
+        first_lines = [line for line in first_source.splitlines() if not line.strip().startswith("# name = ")]
+        second_lines = [line for line in second_source.splitlines() if not line.strip().startswith("# name = ")]
         assert first_lines == second_lines

--- a/tests/unit/retained_mode/managers/test_workflow_save_load_roundtrip.py
+++ b/tests/unit/retained_mode/managers/test_workflow_save_load_roundtrip.py
@@ -1,0 +1,723 @@
+"""Save-to-disk and load-back fidelity for the workflow codegen pipeline.
+
+Drives a real graph through ``SerializeFlowToCommandsRequest``, writes the generated Python
+source to a real file the same way ``SaveWorkflowRequest`` does, then executes the file's
+``build_workflow()`` against a cleared engine and inspects the rebuilt state. This is the
+outermost seam of the serialization pipeline: it exercises value pooling, codegen, and
+deserialization together, the way an artist reopening a saved workflow would exercise them.
+
+A tiny fixture library is written to a temp directory and registered per test, because no
+node type is registered by default in a unit test process and the round trip has to go
+through real ``CreateNodeRequest`` -> ``LibraryRegistry.create_node()`` resolution on both the
+save side and the generated file's own reload side.
+
+Save-path naming, versioning, display-name resolution, and overwrite protection are covered
+in ``test_workflow_manager.py`` and are deliberately bypassed here via a plain, unresolved
+``ProjectFileDestination`` pointing at a temp workspace.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import datetime as datetime_module
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from griptape_nodes.files.project_file import ProjectFileDestination
+from griptape_nodes.node_library.library_registry import LibraryRegistry
+from griptape_nodes.retained_mode.events.connection_events import (
+    CreateConnectionRequest,
+    CreateConnectionResultSuccess,
+)
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    CreateFlowResultSuccess,
+    SerializeFlowToCommandsRequest,
+    SerializeFlowToCommandsResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.events.node_events import (
+    AddNodesToNodeGroupRequest,
+    AddNodesToNodeGroupResultSuccess,
+    CreateNodeRequest,
+    CreateNodeResultSuccess,
+    GetNodeMetadataRequest,
+    GetNodeMetadataResultSuccess,
+    SetLockNodeStateRequest,
+    SetLockNodeStateResultSuccess,
+)
+from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
+from griptape_nodes.retained_mode.events.parameter_events import (
+    GetParameterValueRequest,
+    GetParameterValueResultSuccess,
+    SetParameterValueRequest,
+    SetParameterValueResultSuccess,
+)
+from griptape_nodes.retained_mode.events.workflow_events import (
+    SaveWorkflowFileFromSerializedFlowResultSuccess,
+)
+from griptape_nodes.utils.version_utils import engine_version
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from griptape_nodes.retained_mode.engine import Engine
+
+_FLOW_NAME = "ControlFlow_1"
+
+_FIXTURE_NODE_MODULE = '''
+"""Minimal fixture nodes for the save/load round-trip suite. Not part of any shipped library."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_groups.base_node_group import BaseNodeGroup
+from griptape_nodes.exe_types.node_types import DataNode
+
+
+class RoundTripNode(DataNode):
+    """A plain data node with two independently connectable any-typed parameters."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        for param_name in ("value", "value2"):
+            self.add_parameter(
+                Parameter(
+                    name=param_name,
+                    type="any",
+                    default_value=None,
+                    tooltip="",
+                    allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY, ParameterMode.OUTPUT},
+                )
+            )
+
+    def process(self) -> None:
+        pass
+
+
+class RoundTripGroupNode(BaseNodeGroup):
+    """A plain node group with no data parameters of its own."""
+
+    def process(self) -> Any:
+        pass
+'''
+
+_FIXTURE_LIBRARY_SCHEMA: dict[str, Any] = {
+    "name": "Round Trip Fixture Library",
+    "library_schema_version": "0.7.0",
+    "metadata": {
+        "author": "Test Fixture",
+        "description": "Minimal library used by the save/load round-trip unit tests",
+        "library_version": "0.1.0",
+        "engine_version": engine_version,
+        "tags": ["test"],
+        "dependencies": {"pip_dependencies": []},
+    },
+    "categories": [
+        {
+            "test": {
+                "title": "test",
+                "description": "Test nodes",
+                "color": "border-gray-500",
+                "icon": "Folder",
+            }
+        }
+    ],
+    "nodes": [
+        {
+            "class_name": "RoundTripNode",
+            "file_path": "round_trip_fixture_nodes.py",
+            "metadata": {"category": "test", "description": "Two any-typed parameters", "display_name": "RoundTrip"},
+        },
+        {
+            "class_name": "RoundTripGroupNode",
+            "file_path": "round_trip_fixture_nodes.py",
+            "metadata": {"category": "test", "description": "Plain node group", "display_name": "RoundTrip Group"},
+        },
+    ],
+}
+
+
+class _FrozenDateTime(datetime_module.datetime):
+    """A ``datetime`` subclass whose ``now()`` always answers the same instant.
+
+    ``_generate_workflow_metadata_from_commands`` stamps ``last_modified_date`` with
+    ``datetime.now(tz=UTC)`` internally, with no caller-supplied override. Two saves of an
+    otherwise-identical graph would then differ by that timestamp alone, which would make a
+    byte-identical-output assertion fail for a reason that has nothing to do with the
+    serializer. Freezing the clock isolates the actual contract under test.
+    """
+
+    _FIXED = datetime_module.datetime(2024, 1, 1, tzinfo=datetime_module.UTC)
+
+    @classmethod
+    def now(cls, tz: datetime_module.tzinfo | None = None) -> datetime_module.datetime:  # noqa: ARG003
+        return cls._FIXED
+
+
+@pytest.fixture(autouse=True)
+def _clear_library_registry_state() -> Generator[None, None, None]:
+    """Clear the process-global LibraryRegistry before and after every test in this file.
+
+    ``LibraryRegistry`` keeps its state in ``ClassVar`` dicts the engine does not own (see
+    ``node_library/library_registry.py``), so the "Round Trip Fixture Library" this file
+    registers per test (``_register_fixture_library``) would otherwise outlive the test and leak
+    into whichever test runs next in the same xdist worker. Sibling files
+    (``test_node_serialization_commands.py``, ``test_selected_nodes_serialization.py``) clear it
+    the same way around their own fixture libraries.
+    """
+    LibraryRegistry._clear()
+    yield
+    LibraryRegistry._clear()
+
+
+def _write_fixture_library(target_dir: Path) -> Path:
+    """Write the fixture library's JSON manifest and node module into ``target_dir``."""
+    target_dir.mkdir(parents=True, exist_ok=True)
+    library_json_path = target_dir / "griptape_nodes_library.json"
+    library_json_path.write_text(json.dumps(_FIXTURE_LIBRARY_SCHEMA, indent=2))
+    (target_dir / "round_trip_fixture_nodes.py").write_text(_FIXTURE_NODE_MODULE)
+    return library_json_path
+
+
+def _register_fixture_library(engine: Engine, tmp_path: Path) -> str:
+    """Register the fixture library into a clean engine and return its library name."""
+    library_json = _write_fixture_library(tmp_path / "fixture_library")
+    register_result = engine.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
+    return register_result.library_name
+
+
+def _fresh_flow(engine: Engine, workflow_name: str, tmp_path: Path) -> tuple[str, str]:
+    """Clear all engine state, register the fixture library, and create one empty flow.
+
+    Returns the flow name and the fixture library name.
+    """
+    engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+    library_name = _register_fixture_library(engine, tmp_path)
+    engine.context_manager.push_workflow(workflow_name=workflow_name)
+    result = engine.handle_request(
+        CreateFlowRequest(parent_flow_name=None, flow_name=_FLOW_NAME, set_as_new_context=False)
+    )
+    assert isinstance(result, CreateFlowResultSuccess), result
+    return result.flow_name, library_name
+
+
+def _create_round_trip_node(
+    engine: Engine, node_name: str, flow_name: str, library_name: str, metadata: dict | None = None
+) -> str:
+    result = engine.handle_request(
+        CreateNodeRequest(
+            node_type="RoundTripNode",
+            specific_library_name=library_name,
+            node_name=node_name,
+            override_parent_flow_name=flow_name,
+            metadata=metadata,
+        )
+    )
+    assert isinstance(result, CreateNodeResultSuccess), result
+    return result.node_name
+
+
+def _set_value(engine: Engine, node_name: str, parameter_name: str, value: Any) -> None:
+    set_result = engine.handle_request(
+        SetParameterValueRequest(node_name=node_name, parameter_name=parameter_name, value=value)
+    )
+    assert isinstance(set_result, SetParameterValueResultSuccess), set_result
+
+
+def _get_value(engine: Engine, node_name: str, parameter_name: str) -> Any:
+    result = engine.handle_request(GetParameterValueRequest(node_name=node_name, parameter_name=parameter_name))
+    assert isinstance(result, GetParameterValueResultSuccess), result
+    return result.value
+
+
+def _save_flow_to_disk(engine: Engine, flow_name: str, tmp_path: Path, file_stem: str) -> str:
+    """Serialize ``flow_name`` and write it to ``tmp_path`` via the same low-level writer ``SaveWorkflowRequest`` uses."""
+    engine.config_manager.workspace_path = tmp_path
+
+    serialize_result = engine.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_name))
+    assert isinstance(serialize_result, SerializeFlowToCommandsResultSuccess), serialize_result
+
+    destination = ProjectFileDestination(str(tmp_path / f"{file_stem}.py"))
+    save_result = engine.workflow_manager._save_workflow_file_inline(
+        destination=destination,
+        serialized_flow_commands=serialize_result.serialized_flow_commands,
+        file_name=file_stem,
+        creation_date=_FrozenDateTime.now(),
+        display_name=None,
+        image_path=None,
+        description=None,
+        is_template=None,
+        branched_from=None,
+        workflow_shape=None,
+        pickle_control_flow_result=False,
+    )
+    assert isinstance(save_result, SaveWorkflowFileFromSerializedFlowResultSuccess), save_result
+    return save_result.file_path
+
+
+def _read_saved_source(file_path: str) -> str:
+    source = Path(file_path).read_text()
+    ast.parse(source)  # the written file must always be syntactically valid Python
+    return source
+
+
+def _reload_from_disk(engine: Engine, file_path: str) -> None:
+    """Tear down the live graph, then exec the saved file's ``build_workflow()`` against the engine."""
+    engine.clear_current_workflow_data()
+
+    source = _read_saved_source(file_path)
+    exec_globals: dict[str, object] = {"__file__": file_path}
+    exec(compile(source, file_path, "exec"), exec_globals)  # noqa: S102
+    build_workflow = exec_globals["build_workflow"]
+    asyncio.run(build_workflow())  # type: ignore[operator]
+
+
+def _round_trip_single_value(engine: Engine, tmp_path: Path, file_stem: str, value: Any) -> Any:
+    """Build one node with one parameter value, save it, reload it, and return the reloaded value."""
+    flow_name, library_name = _fresh_flow(engine, f"{file_stem}_workflow", tmp_path)
+    node_name = _create_round_trip_node(engine, "Holder", flow_name, library_name)
+    _set_value(engine, node_name, "value", value)
+
+    file_path = _save_flow_to_disk(engine, flow_name, tmp_path, file_stem)
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        import griptape_nodes.retained_mode.managers.workflow_manager as workflow_manager_module
+
+        monkeypatch.setattr(workflow_manager_module, "datetime", _FrozenDateTime)
+        _reload_from_disk(engine, file_path)
+
+    return _get_value(engine, node_name, "value")
+
+
+class TestScalarValueRoundTrip:
+    """A scalar parameter value must come back with the same type and content it was saved with."""
+
+    @pytest.mark.parametrize(
+        ("case_name", "value"),
+        [
+            ("plain_string", "hello"),
+            ("empty_string", ""),
+            ("positive_int", 7),
+            ("zero_int", 0),
+            ("negative_int", -42),
+            ("large_int", 2**62),
+            ("float_value", 3.14),
+            ("negative_float", -0.5),
+            ("bool_true", True),
+            ("bool_false", False),
+            ("none_value", None),
+            ("unicode_string", "café 寿し 😀"),
+            ("quotes_and_newlines", "line one\nline \"two\" and 'three'\ttabbed"),
+            ("backslashes", "C:\\path\\to\\file\\n_not_a_newline"),
+        ],
+    )
+    def test_scalar_value_survives_save_and_reload(
+        self, engine: Engine, tmp_path: Path, case_name: str, value: Any
+    ) -> None:
+        reloaded = _round_trip_single_value(engine, tmp_path, case_name, value)
+
+        assert reloaded == value
+        assert type(reloaded) is type(value)
+
+
+class TestContainerValueRoundTrip:
+    """Container parameter values must preserve their shape, key types, and nesting."""
+
+    @pytest.mark.parametrize(
+        ("case_name", "value"),
+        [
+            ("empty_dict", {}),
+            ("empty_list", []),
+            ("nested_dict", {"a": {"b": {"c": [1, 2, 3]}}, "d": None}),
+            ("list_of_dicts", [{"x": 1}, {"y": 2}, {"z": [1, 2]}]),
+            ("dict_with_non_identifier_keys", {"has space": 1, "has-dash": 2, "123numeric": 3}),
+        ],
+    )
+    def test_container_value_survives_save_and_reload(
+        self, engine: Engine, tmp_path: Path, case_name: str, value: Any
+    ) -> None:
+        reloaded = _round_trip_single_value(engine, tmp_path, case_name, value)
+
+        assert reloaded == value
+
+
+class TestSharedValueDeduplication:
+    """A value shared by two parameters is pooled once but both readers still see it."""
+
+    def test_shared_value_used_by_two_nodes_is_stored_once_and_both_read_back_equal(
+        self, engine: Engine, tmp_path: Path
+    ) -> None:
+        flow_name, library_name = _fresh_flow(engine, "dedup_workflow", tmp_path)
+        shared_value = {"shared": ["value", "payload"]}
+
+        node_a = _create_round_trip_node(engine, "NodeA", flow_name, library_name)
+        node_b = _create_round_trip_node(engine, "NodeB", flow_name, library_name)
+        _set_value(engine, node_a, "value", shared_value)
+        _set_value(engine, node_b, "value", shared_value)
+
+        file_path = _save_flow_to_disk(engine, flow_name, tmp_path, "dedup")
+        source = _read_saved_source(file_path)
+
+        # The unique-values pool is keyed by the pickled value; the same object must land in
+        # exactly one pool entry rather than being duplicated once per referencing parameter.
+        assert source.count("pickle.loads(") == 1
+
+        _reload_from_disk(engine, file_path)
+
+        assert _get_value(engine, node_a, "value") == shared_value
+        assert _get_value(engine, node_b, "value") == shared_value
+
+
+class TestNodeMetadataRoundTrip:
+    """Node metadata (position, custom keys) survives the save/reload round trip."""
+
+    def test_position_and_custom_metadata_key_round_trip(self, engine: Engine, tmp_path: Path) -> None:
+        flow_name, library_name = _fresh_flow(engine, "metadata_workflow", tmp_path)
+        node_name = _create_round_trip_node(
+            engine,
+            "Positioned",
+            flow_name,
+            library_name,
+            metadata={"position": {"x": 123, "y": 456}, "my_custom_key": "my_custom_value"},
+        )
+
+        file_path = _save_flow_to_disk(engine, flow_name, tmp_path, "metadata")
+        _reload_from_disk(engine, file_path)
+
+        result = engine.handle_request(GetNodeMetadataRequest(node_name=node_name))
+        assert isinstance(result, GetNodeMetadataResultSuccess), result
+        assert result.metadata["position"] == {"x": 123, "y": 456}
+        assert result.metadata["my_custom_key"] == "my_custom_value"
+
+
+class TestLockStateRoundTrip:
+    """A node's lock state is part of what gets saved and must come back the same way."""
+
+    def test_locked_node_reloads_locked(self, engine: Engine, tmp_path: Path) -> None:
+        flow_name, library_name = _fresh_flow(engine, "lock_workflow", tmp_path)
+        node_name = _create_round_trip_node(engine, "Locked", flow_name, library_name)
+        lock_result = engine.handle_request(SetLockNodeStateRequest(node_name=node_name, lock=True))
+        assert isinstance(lock_result, SetLockNodeStateResultSuccess), lock_result
+
+        file_path = _save_flow_to_disk(engine, flow_name, tmp_path, "locked")
+        _reload_from_disk(engine, file_path)
+
+        reloaded_node = engine.node_manager.get_node_by_name(node_name)
+        assert reloaded_node.lock is True
+
+    def test_unlocked_node_reloads_unlocked(self, engine: Engine, tmp_path: Path) -> None:
+        flow_name, library_name = _fresh_flow(engine, "unlock_workflow", tmp_path)
+        node_name = _create_round_trip_node(engine, "Unlocked", flow_name, library_name)
+
+        file_path = _save_flow_to_disk(engine, flow_name, tmp_path, "unlocked")
+        _reload_from_disk(engine, file_path)
+
+        reloaded_node = engine.node_manager.get_node_by_name(node_name)
+        assert reloaded_node.lock is False
+
+
+class TestConnectionsRoundTrip:
+    """Data connections, and a node fed by several incoming edges, survive save and reload."""
+
+    def test_data_connection_direction_and_endpoints_survive(self, engine: Engine, tmp_path: Path) -> None:
+        flow_name, library_name = _fresh_flow(engine, "connection_workflow", tmp_path)
+        source = _create_round_trip_node(engine, "Source", flow_name, library_name)
+        target = _create_round_trip_node(engine, "Target", flow_name, library_name)
+        _set_value(engine, source, "value", "from source")
+
+        connect_result = engine.handle_request(
+            CreateConnectionRequest(
+                source_node_name=source,
+                source_parameter_name="value",
+                target_node_name=target,
+                target_parameter_name="value",
+            )
+        )
+        assert isinstance(connect_result, CreateConnectionResultSuccess), connect_result
+
+        file_path = _save_flow_to_disk(engine, flow_name, tmp_path, "connection")
+        _reload_from_disk(engine, file_path)
+
+        connections = engine.flow_manager.get_connections()
+        reloaded_source = engine.node_manager.get_node_by_name(source)
+        reloaded_target = engine.node_manager.get_node_by_name(target)
+        outgoing = connections.get_all_outgoing_connections(reloaded_source)
+        edge_labels = {
+            f"{edge.source_parameter.name}->{edge.target_node.name}.{edge.target_parameter.name}" for edge in outgoing
+        }
+        assert edge_labels == {f"value->{reloaded_target.name}.value"}
+
+    def test_node_with_several_incoming_edges_keeps_them_all(self, engine: Engine, tmp_path: Path) -> None:
+        flow_name, library_name = _fresh_flow(engine, "fan_in_workflow", tmp_path)
+        source_a = _create_round_trip_node(engine, "SourceA", flow_name, library_name)
+        source_b = _create_round_trip_node(engine, "SourceB", flow_name, library_name)
+        target = _create_round_trip_node(engine, "Target", flow_name, library_name)
+        _set_value(engine, source_a, "value", "from A")
+        _set_value(engine, source_b, "value", "from B")
+
+        for source, target_param in ((source_a, "value"), (source_b, "value2")):
+            result = engine.handle_request(
+                CreateConnectionRequest(
+                    source_node_name=source,
+                    source_parameter_name="value",
+                    target_node_name=target,
+                    target_parameter_name=target_param,
+                )
+            )
+            assert isinstance(result, CreateConnectionResultSuccess), result
+
+        file_path = _save_flow_to_disk(engine, flow_name, tmp_path, "fan_in")
+        _reload_from_disk(engine, file_path)
+
+        connections = engine.flow_manager.get_connections()
+        reloaded_target = engine.node_manager.get_node_by_name(target)
+        incoming = connections.get_all_incoming_connections(reloaded_target)
+        edge_labels = {
+            f"{edge.source_node.name}.{edge.source_parameter.name}->{edge.target_parameter.name}" for edge in incoming
+        }
+        assert edge_labels == {"SourceA.value->value", "SourceB.value->value2"}
+
+
+class TestUnserializableParameterRoundTrip:
+    """A parameter opted out of serialization must not sink the rest of the graph on reload."""
+
+    def test_serializable_false_parameter_reloads_unresolved_rest_of_graph_intact(
+        self, engine: Engine, tmp_path: Path
+    ) -> None:
+        from griptape_nodes.exe_types.node_types import NodeResolutionState
+
+        flow_name, library_name = _fresh_flow(engine, "unserializable_workflow", tmp_path)
+        quiet_node = _create_round_trip_node(engine, "Quiet", flow_name, library_name)
+        loud_node = _create_round_trip_node(engine, "Loud", flow_name, library_name)
+
+        _set_value(engine, quiet_node, "value", object())
+        parameter = engine.node_manager.get_node_by_name(quiet_node).get_parameter_by_name("value")
+        assert parameter is not None
+        parameter.serializable = False
+
+        _set_value(engine, loud_node, "value", "still here")
+
+        file_path = _save_flow_to_disk(engine, flow_name, tmp_path, "unserializable")
+        _reload_from_disk(engine, file_path)
+
+        reloaded_quiet = engine.node_manager.get_node_by_name(quiet_node)
+        assert reloaded_quiet.state == NodeResolutionState.UNRESOLVED
+        assert _get_value(engine, loud_node, "value") == "still here"
+
+
+class TestNodeGroupRoundTrip:
+    """A node group's membership survives being saved to disk and reloaded."""
+
+    def test_group_children_are_members_after_reload(self, engine: Engine, tmp_path: Path) -> None:
+        from griptape_nodes.exe_types.node_groups.base_node_group import BaseNodeGroup
+
+        flow_name, library_name = _fresh_flow(engine, "group_workflow", tmp_path)
+        group_result = engine.handle_request(
+            CreateNodeRequest(
+                node_type="RoundTripGroupNode",
+                specific_library_name=library_name,
+                node_name="MyGroup",
+                override_parent_flow_name=flow_name,
+            )
+        )
+        assert isinstance(group_result, CreateNodeResultSuccess), group_result
+        group_name = group_result.node_name
+
+        child_a = _create_round_trip_node(engine, "ChildA", flow_name, library_name)
+        child_b = _create_round_trip_node(engine, "ChildB", flow_name, library_name)
+        add_result = engine.handle_request(
+            AddNodesToNodeGroupRequest(node_names=[child_a, child_b], node_group_name=group_name, flow_name=flow_name)
+        )
+        assert isinstance(add_result, AddNodesToNodeGroupResultSuccess), add_result
+
+        file_path = _save_flow_to_disk(engine, flow_name, tmp_path, "group")
+        _reload_from_disk(engine, file_path)
+
+        reloaded_group = engine.node_manager.get_node_by_name(group_name)
+        assert isinstance(reloaded_group, BaseNodeGroup)
+        assert child_a in reloaded_group.nodes
+        assert child_b in reloaded_group.nodes
+
+
+class TestSubFlowRoundTrip:
+    """A nested child Flow, its node membership, and its connections survive save and reload.
+
+    ``_save_flow_to_disk`` serializes only the top-level flow, but ``on_serialize_flow_to_commands``
+    recurses into every nested child Flow (``sub_flows_commands``) and the codegen
+    (``_generate_flow_code``) emits nested flow-creation code for each one. This is the first test
+    in the suite that actually executes that nested codegen against a real engine, rather than
+    only ``ast.parse``-ing it (see ``test_workflow_codegen_serialization.py``) or inspecting the
+    command objects without saving to disk (see ``test_flow_serialization_commands.py``).
+    """
+
+    def test_child_flow_nodes_and_connections_survive_save_and_reload(self, engine: Engine, tmp_path: Path) -> None:
+        flow_name, library_name = _fresh_flow(engine, "subflow_workflow", tmp_path)
+
+        child_flow_result = engine.handle_request(
+            CreateFlowRequest(parent_flow_name=flow_name, flow_name="ChildFlow", set_as_new_context=False)
+        )
+        assert isinstance(child_flow_result, CreateFlowResultSuccess), child_flow_result
+        child_flow_name = child_flow_result.flow_name
+
+        parent_node = _create_round_trip_node(engine, "ParentNode", flow_name, library_name)
+        child_a = _create_round_trip_node(engine, "ChildA", child_flow_name, library_name)
+        child_b = _create_round_trip_node(engine, "ChildB", child_flow_name, library_name)
+        _set_value(engine, parent_node, "value", "from parent")
+        _set_value(engine, child_a, "value", "from child a")
+
+        # A connection entirely inside the child Flow.
+        internal_connection = engine.handle_request(
+            CreateConnectionRequest(
+                source_node_name=child_a,
+                source_parameter_name="value",
+                target_node_name=child_b,
+                target_parameter_name="value",
+            )
+        )
+        assert isinstance(internal_connection, CreateConnectionResultSuccess), internal_connection
+
+        # A connection crossing the parent/child boundary.
+        boundary_connection = engine.handle_request(
+            CreateConnectionRequest(
+                source_node_name=parent_node,
+                source_parameter_name="value",
+                target_node_name=child_b,
+                target_parameter_name="value2",
+            )
+        )
+        assert isinstance(boundary_connection, CreateConnectionResultSuccess), boundary_connection
+
+        file_path = _save_flow_to_disk(engine, flow_name, tmp_path, "subflow")
+        _reload_from_disk(engine, file_path)
+
+        # The child Flow exists after reload, and its nodes are parented to it.
+        reloaded_child_flow = engine.flow_manager.get_flow_by_name(child_flow_name)
+        assert reloaded_child_flow.name == child_flow_name
+        assert engine.node_manager.get_node_parent_flow_by_name(child_a) == child_flow_name
+        assert engine.node_manager.get_node_parent_flow_by_name(child_b) == child_flow_name
+
+        connections = engine.flow_manager.get_connections()
+        reloaded_child_a = engine.node_manager.get_node_by_name(child_a)
+        reloaded_parent_node = engine.node_manager.get_node_by_name(parent_node)
+
+        internal_outgoing = connections.get_all_outgoing_connections(reloaded_child_a)
+        internal_labels = {
+            f"{edge.source_parameter.name}->{edge.target_node.name}.{edge.target_parameter.name}"
+            for edge in internal_outgoing
+        }
+        assert internal_labels == {f"value->{child_b}.value"}
+
+        boundary_outgoing = connections.get_all_outgoing_connections(reloaded_parent_node)
+        boundary_labels = {
+            f"{edge.source_parameter.name}->{edge.target_node.name}.{edge.target_parameter.name}"
+            for edge in boundary_outgoing
+        }
+        assert boundary_labels == {f"value->{child_b}.value2"}
+
+        assert _get_value(engine, child_a, "value") == "from child a"
+        assert _get_value(engine, parent_node, "value") == "from parent"
+
+
+class TestDeterministicSaveOutput:
+    """Whether saving the same live graph twice at the same instant must not churn the diff.
+
+    Pending the ruling in #5441 on whether saved workflow files must be diff-stable. The
+    mechanism below (a fresh UUID pool key minted on every serialization) is real and
+    deterministic; whether it should be fixed depends on that decision.
+    """
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "DECISION: pending #5441 (must saved workflow files be diff-stable?). The disk-save "
+            "path (SaveWorkflowRequest -> SerializeFlowToCommandsRequest -> "
+            "on_serialize_node_to_commands -> handle_parameter_value_saving -> "
+            "_handle_value_hashing, all in node_manager.py) mints a fresh str(uuid4()) pool key "
+            "every time a value is serialized, so two saves of the identical, unedited graph land "
+            "the same pickled bytes under two different unique_values_dict keys. If #5441 rules "
+            "that saves must be diff-stable: saving an unedited graph twice in a row must not move "
+            "the diff, since nothing about the graph changed, and this test should be promoted. If "
+            "not: delete this test, since it asserts a contract nobody has ratified. - see #5441"
+        ),
+    )
+    def test_two_saves_of_the_same_graph_are_byte_identical(self, engine: Engine, tmp_path: Path) -> None:
+        flow_name, library_name = _fresh_flow(engine, "determinism_workflow", tmp_path)
+        node_name = _create_round_trip_node(engine, "Holder", flow_name, library_name)
+        _set_value(engine, node_name, "value", {"a": 1, "b": [1, 2, 3]})
+
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            import griptape_nodes.retained_mode.managers.workflow_manager as workflow_manager_module
+
+            monkeypatch.setattr(workflow_manager_module, "datetime", _FrozenDateTime)
+
+            first_path = _save_flow_to_disk(engine, flow_name, tmp_path, "first_save")
+            second_path = _save_flow_to_disk(engine, flow_name, tmp_path, "second_save")
+
+        first_source = _read_saved_source(first_path)
+        second_source = _read_saved_source(second_path)
+
+        # The two files were saved under different names, so their embedded `name = "..."`
+        # metadata line legitimately differs; everything else must not.
+        first_lines = [line for line in first_source.splitlines() if "name = " not in line]
+        second_lines = [line for line in second_source.splitlines() if "name = " not in line]
+        assert first_lines == second_lines
+
+
+class TestIdempotentSaveLoadSave:
+    """Whether save, reload, and save again should reproduce the first file exactly.
+
+    Pending the ruling in #5441 on whether saved workflow files must be diff-stable. If it
+    rules yes, this is the strongest single guarantee in the pipeline: reopening and resaving
+    a workflow with no edits should not move anything, and any drift would mean some piece of
+    state is not round-tripping losslessly through the generated code.
+    """
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "DECISION: pending #5441 (must saved workflow files be diff-stable?). The "
+            "unique-values pool on the disk-save path is keyed by a fresh str(uuid4()) on every "
+            "serialization (node_manager.py handle_parameter_value_saving -> "
+            "_handle_value_hashing, reached via SerializeFlowToCommandsRequest -> "
+            "on_serialize_node_to_commands), so reloading a saved workflow and resaving it "
+            "without any edits mints new pool keys for the same values and the resave diffs "
+            "against the original. If #5441 rules that saves must be diff-stable: a "
+            "reopen-and-resave with no edits must reproduce the original file exactly, and this "
+            "test should be promoted. If not: delete this test, since it asserts a contract nobody "
+            "has ratified. - see #5441"
+        ),
+    )
+    def test_resaving_a_freshly_reloaded_workflow_reproduces_the_first_save(
+        self, engine: Engine, tmp_path: Path
+    ) -> None:
+        flow_name, library_name = _fresh_flow(engine, "idempotent_workflow", tmp_path)
+        node_name = _create_round_trip_node(engine, "Holder", flow_name, library_name)
+        _set_value(engine, node_name, "value", {"a": 1, "b": [1, 2, 3]})
+        _set_value(engine, node_name, "value2", "some text")
+
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            import griptape_nodes.retained_mode.managers.workflow_manager as workflow_manager_module
+
+            monkeypatch.setattr(workflow_manager_module, "datetime", _FrozenDateTime)
+
+            first_path = _save_flow_to_disk(engine, flow_name, tmp_path, "roundtrip")
+            first_source = _read_saved_source(first_path)
+
+            _reload_from_disk(engine, first_path)
+
+            second_path = _save_flow_to_disk(engine, flow_name, tmp_path, "roundtrip_resaved")
+            second_source = _read_saved_source(second_path)
+
+        first_lines = [line for line in first_source.splitlines() if "name = " not in line]
+        second_lines = [line for line in second_source.splitlines() if "name = " not in line]
+        assert first_lines == second_lines


### PR DESCRIPTION
Going to be making some big changes to serialization and it's one of our least tested areas. This PR adds 1,051 unit tests across the serialization pipeline and fixes two minor issues (missing argument, wrong result return type) that coverage exposed. Fourteen of those tests assert intended behavior the current code does not yet meet and carry `xfail(strict=True)` with a tracking issue in #5442.