### PR TITLE
fix: return a failure result when a request handler raises, instead of dropping the reply

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -425,7 +425,6 @@ class EventManager(EngineScoped):
                         f"'{type(request).__name__}'. Failed because hook "
                         f"'{getattr(hook, '__name__', hook)}' raised {type(exc).__name__}: {exc}"
                     )
-                    logging.getLogger("griptape_nodes").exception(msg)
                     return GenericResultFailure(exception=exc, result_details=msg)
                 if short_circuit is not None:
                     return short_circuit
@@ -448,8 +447,8 @@ class EventManager(EngineScoped):
         operation, because the result has already been returned. Specifically:
 
         - It fires for both success and failure results, including when the handler
-          raised (in that case the payload is an equivalent `GenericResultFailure`, not
-          the identical object the client received).
+          raised (in that case the payload is the `GenericResultFailure` synthesized for
+          the client).
         - `request` and `result` must be treated as read-only. The same `request` object
           is referenced by the result event still queued for the client, so mutating it
           corrupts what the client sees.
@@ -531,31 +530,6 @@ class EventManager(EngineScoped):
                 )
                 continue
             self._schedule_post_dispatch_hook(request_type, callback, request, result, active)
-
-    def _fire_post_dispatch_hooks_for_handler_exception(self, request: RequestPayload, exception: Exception) -> None:
-        """Notify hooks that no result event will be built for this request.
-
-        Neither dispatch method catches handler exceptions -- they propagate to
-        `Engine.handle_request`, which logs and returns a synthesized failure. Without
-        this the most interesting failure mode would be invisible to hooks. The payload is
-        equivalent to the one the client receives, not the identical object, which is why
-        `add_post_dispatch_hook` says so explicitly.
-
-        The caller's `try` covers the parameter-change flush as well as the handler, so a
-        handler that returned a result and then had `_flush_tracked_parameter_changes`
-        raise also lands here. That is deliberate: the exception escapes either way, the
-        client gets a synthesized failure either way, and hooks reporting success for a
-        request the client saw fail would be worse than the coarser attribution.
-        """
-        result_details = f"Unhandled exception while processing {type(request).__name__}: {exception}"
-        # `_handle_request_core` scrubs the request on its way to building the result event,
-        # but a raising handler never gets there. Without this, hooks would be the one place
-        # an omitted field still surfaces -- and those fields are omitted precisely because
-        # they are sensitive or bulky.
-        self._scrub_omitted_request_fields(request)
-        self._fire_post_dispatch_hooks(
-            request, GenericResultFailure(exception=exception, result_details=result_details)
-        )
 
     def _scrub_omitted_request_fields(self, request: RequestPayload) -> None:
         """Null out the request fields marked `omit_from_result`, in place.
@@ -1016,15 +990,38 @@ class EventManager(EngineScoped):
         repeated here. Without the skip every violation would log
         twice -- once from the reporter and once from this loop.
 
+        A dispatcher-synthesized failure also gets its traceback attached, because nothing else
+        logs one: a handler that authors its own failure logs whatever it wants to, and
+        attaching frames to those too would duplicate what those call sites already emit.
+
         Args:
             result: The result payload containing details to log
         """
         if isinstance(result.result_details, ResultDetails):
             logger = logging.getLogger("griptape_nodes")
+            exc_info = self._exception_for_logging(result)
             for detail in result.result_details.result_details:
                 if isinstance(detail, StrictModeViolationDetail):
                     continue
-                logger.log(detail.level, detail.message)
+                logger.log(detail.level, detail.message, exc_info=exc_info)
+                exc_info = None
+
+    @staticmethod
+    def _exception_for_logging(result: ResultPayload) -> Exception | None:
+        """The exception to attach as `exc_info`, or None to log the message alone.
+
+        Restricted to `GenericResultFailure`, which this manager synthesizes and nothing else
+        logs. A handler-authored failure carries an exception too, and several already log it.
+
+        A `ForwardedException` is constructed rather than raised, so `__traceback__` is None and
+        `exc_info` would render only "NoneType: None". Its frames survive the wire on the
+        `original_traceback` attribute instead, which nothing logs here.
+        """
+        if not isinstance(result, GenericResultFailure):
+            return None
+        if result.exception is None or result.exception.__traceback__ is None:
+            return None
+        return result.exception
 
     def _handle_request_core(
         self,
@@ -1044,8 +1041,14 @@ class EventManager(EngineScoped):
             if workflow_mgr.should_squelch_workflow_altered():
                 callback_result.altered_workflow_state = False
 
-            # Override failure log level if requested
-            if callback_result.failed() and request.failure_log_level is not None:
+            # Override failure log level if requested, except for a synthesized failure:
+            # `failure_log_level` silences failures its caller EXPECTS, so honoring it for an
+            # unhandled exception would hide a crash behind a level chosen for a routine miss.
+            if (
+                callback_result.failed()
+                and request.failure_log_level is not None
+                and not isinstance(callback_result, GenericResultFailure)
+            ):
                 self._override_result_log_level(callback_result, request.failure_log_level)
 
             # Log result details (after potential level override)
@@ -1082,6 +1085,22 @@ class EventManager(EngineScoped):
         self._fire_post_dispatch_hooks(request, callback_result)
 
         return result_event
+
+    def _result_for_handler_exception(
+        self, request: RP, exception: Exception, *, context: ResultContext
+    ) -> EventResultSuccess | EventResultFailure:
+        """Build the failure result event for a handler that raised instead of returning one.
+
+        An escaping exception leaves the response future of whoever is waiting on
+        `request_id`/`response_topic` unsettled forever. `_handle_request_core` is what addresses
+        the result to that caller, and logs it.
+        """
+        result_details = f"Unhandled exception while processing {type(request).__name__}: {exception}"
+        return self._handle_request_core(
+            request,
+            GenericResultFailure(exception=exception, result_details=result_details),
+            context=context,
+        )
 
     async def ahandle_request(
         self,
@@ -1130,8 +1149,7 @@ class EventManager(EngineScoped):
                     if type(result_payload) not in RESULT_TYPES_THAT_SKIP_FLUSH:
                         self._flush_tracked_parameter_changes()
             except Exception as exc:
-                self._fire_post_dispatch_hooks_for_handler_exception(request, exc)
-                raise
+                return self._result_for_handler_exception(request, exc, context=result_context)
 
             return self._handle_request_core(
                 request,
@@ -1187,8 +1205,7 @@ class EventManager(EngineScoped):
                     if type(result_payload) not in RESULT_TYPES_THAT_SKIP_FLUSH:
                         self._flush_tracked_parameter_changes()
             except Exception as exc:
-                self._fire_post_dispatch_hooks_for_handler_exception(request, exc)
-                raise
+                return self._result_for_handler_exception(request, exc, context=result_context)
 
             return self._handle_request_core(
                 request,

--- a/tests/unit/retained_mode/managers/test_event_manager.py
+++ b/tests/unit/retained_mode/managers/test_event_manager.py
@@ -14,6 +14,7 @@ from griptape_nodes.app.worker_routing import RemoteHandler
 from griptape_nodes.retained_mode.engine import Engine, current_engine
 from griptape_nodes.retained_mode.events.app_events import ConfigChanged
 from griptape_nodes.retained_mode.events.base_events import (
+    EventResultFailure,
     EventResultSuccess,
     ExecutionEvent,
     ExecutionGriptapeNodeEvent,
@@ -37,7 +38,7 @@ from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
     CheckpointFailure,
     CheckpointSubjectType,
 )
-from griptape_nodes.retained_mode.managers.event_manager import EventManager
+from griptape_nodes.retained_mode.managers.event_manager import EventManager, ResultContext
 
 
 class TestEventManagerBroadcasting:
@@ -947,16 +948,16 @@ class TestPostDispatchHooks:
         seen: list[ResultPayload] = []
         event_manager.add_post_dispatch_hook(_ProbeRequest, _RecordingHook(seen))
 
-        # The exception propagates to Engine.handle_request, which synthesizes the
-        # failure the client sees. Hooks get an equivalent payload rather than that one.
-        with pytest.raises(RuntimeError, match="handler exploded"):
-            event_manager.handle_request(_ProbeRequest())
+        event = event_manager.handle_request(_ProbeRequest())
 
+        assert event.result.failed()
         assert len(seen) == 1
         failure = seen[0]
         assert failure.failed()
         assert isinstance(failure, GenericResultFailure)
         assert isinstance(failure.exception, RuntimeError)
+        # Hooks see the very payload the client receives, not an equivalent copy.
+        assert failure is event.result
 
     @pytest.mark.asyncio
     async def test_hook_fires_when_an_async_handler_raises(self) -> None:
@@ -971,11 +972,72 @@ class TestPostDispatchHooks:
         seen: list[ResultPayload] = []
         event_manager.add_post_dispatch_hook(_ProbeRequest, _RecordingHook(seen))
 
-        with pytest.raises(RuntimeError, match="async handler exploded"):
-            await event_manager.ahandle_request(_ProbeRequest())
+        event = await event_manager.ahandle_request(_ProbeRequest())
 
+        assert event.result.failed()
         assert len(seen) == 1
         assert seen[0].failed()
+
+    def test_raising_handler_logs_its_failure_exactly_once_with_the_traceback(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """One record carrying both the message and the frames.
+
+        The traceback is often the only thing identifying a failure raised deep inside an
+        unrelated import, so it must survive without the message being logged twice.
+        """
+
+        def handler(_request: _ProbeRequest) -> _ProbeResult:
+            msg = "handler exploded"
+            raise RuntimeError(msg)
+
+        event_manager = self._manager_with_handler(handler)
+
+        with caplog.at_level(logging.ERROR, logger="griptape_nodes"):
+            event_manager.handle_request(_ProbeRequest())
+
+        records = [r for r in caplog.records if "handler exploded" in r.getMessage()]
+        assert len(records) == 1
+        assert records[0].exc_info is not None
+        assert "RuntimeError: handler exploded" in caplog.text
+
+    def test_unhandled_crash_ignores_the_caller_s_failure_log_level(self, caplog: pytest.LogCaptureFixture) -> None:
+        """`failure_log_level` silences failures the caller expects, not crashes.
+
+        Callers pass DEBUG to keep a routine miss (an absent config key, a probe) out of the
+        log. Honoring it for a synthesized failure would hide an unhandled exception and its
+        traceback behind a level chosen for something else entirely.
+        """
+
+        def handler(_request: _ProbeRequest) -> _ProbeResult:
+            msg = "handler exploded"
+            raise RuntimeError(msg)
+
+        event_manager = self._manager_with_handler(handler)
+
+        with caplog.at_level(logging.DEBUG, logger="griptape_nodes"):
+            event_manager.handle_request(_ProbeRequest(failure_log_level=logging.DEBUG))
+
+        records = [r for r in caplog.records if "handler exploded" in r.getMessage()]
+        assert [r.levelno for r in records] == [logging.ERROR]
+
+    def test_raising_handler_still_addresses_its_result_to_the_waiting_client(self) -> None:
+        """The IPC ingress replies on these, so a failure missing them is a dropped reply."""
+
+        def handler(_request: _ProbeRequest) -> _ProbeResult:
+            msg = "handler exploded"
+            raise RuntimeError(msg)
+
+        event_manager = self._manager_with_handler(handler)
+
+        event = event_manager.handle_request(
+            _ProbeRequest(),
+            result_context=ResultContext(request_id="req-1", response_topic="topic-1"),
+        )
+
+        assert isinstance(event, EventResultFailure)
+        assert event.request_id == "req-1"
+        assert event.response_topic == "topic-1"
 
     def test_hook_is_not_invoked_for_a_subclass_of_its_request_type(self) -> None:
         def handler(_request: _ProbeRequest) -> _ProbeResult:
@@ -1275,11 +1337,11 @@ class TestPostDispatchHooks:
         assert depths == [0]
 
     def test_omitted_request_fields_are_scrubbed_when_the_handler_raises(self) -> None:
-        """The scrub lives on the result-building path, which a raising handler skips.
+        """The scrub lives on the result-building path, which a raising handler also takes.
 
         `omit_from_result` exists to keep sensitive and bulky values out of anything
         downstream, so the exception path -- the one this feature advertises as its most
-        interesting case -- must not be the hole that leaks them to a library.
+        interesting case -- must not be the hole that leaks them to a library or a client.
         """
 
         def handler(_request: _OmitFieldProbeRequest) -> _ProbeResult:
@@ -1298,10 +1360,11 @@ class TestPostDispatchHooks:
 
         event_manager.add_post_dispatch_hook(_OmitFieldProbeRequest, hook)
 
-        with pytest.raises(RuntimeError):
-            event_manager.handle_request(_OmitFieldProbeRequest(secret="super-secret"))  # noqa: S106
+        event = event_manager.handle_request(_OmitFieldProbeRequest(secret="super-secret"))  # noqa: S106
 
         assert seen == [None]
+        assert isinstance(event.request, _OmitFieldProbeRequest)
+        assert event.request.secret is None
 
     def test_hook_runs_inline_when_the_stored_loop_is_open_but_never_driven(self) -> None:
         """`create_task` on an undriven loop returns a task that never executes.


### PR DESCRIPTION
## Problem

`EventManager.handle_request` / `ahandle_request` re-raised handler exceptions. The IPC ingress (`app._process_event_request`) dispatches through them with the caller's `request_id` / `response_topic` and is the one caller contractually obliged to always reply, so an escaping exception meant **no result event was ever published**. The failure surfaced only as a logged `Background task failed`, and the client's response future never settled.

In the editor that presents as a request that never finishes — a workflow load frozen partway with no error and no way to retry — rather than as a failed request.

## Cause

The safety net existed, but on the wrong entry point. `Engine.handle_request` / `ahandle_request` do wrap dispatch and synthesize a failure, but they return a bare `ResultPayload` and accept no `result_context`, so they carry no `request_id` or `response_topic`. The ingress needs those to address its reply, so it calls `EventManager.ahandle_request` directly, which was the path with no net.

`_run_pre_dispatch_hooks` already handled this exact hazard correctly for a raising *hook*, with a comment naming the hang. This makes the handler path consistent with it.

## Change

Both dispatch methods synthesize a `GenericResultFailure` and route it through `_handle_request_core`, which builds an `EventResultFailure` addressed to the waiting caller, applies the `omit_from_result` scrub, and fires post-dispatch hooks on their single normal path.

`_fire_post_dispatch_hooks_for_handler_exception` is removed. Its whole premise was that "neither dispatch method catches handler exceptions"; keeping it would double-fire every hook. Hooks now receive the same payload object the client receives, which the previous code could not promise.

Two things follow from routing through `_handle_request_core`, both required rather than incidental:

- **Traceback logging moves into `_log_result_details`.** `ResultPayloadFailure` promotes a string `result_details` to an ERROR-level detail that `_handle_request_core` already logs, so logging at the synthesis site duplicated the message; and once the exception stops escaping, nothing else records the frames. This also lets the pre-dispatch hook path drop its own `logger.exception`, which had the same duplicate-message shape. `_exception_for_logging` skips an exception with no `__traceback__`, since a `ForwardedException` rebuilt from the wire is constructed rather than raised and would render `NoneType: None`.
- **A synthesized failure is exempt from the requesting payload's `failure_log_level`.** That setting silences failures a caller *expects*, and `artifact_manager`, `library_manager` and `os_manager` all pass DEBUG for routine misses. Without the exemption this change would demote a crash and its traceback to DEBUG at those sites.

## Blast radius

Anything dispatching via `Engine.handle_request` / `GriptapeNodes.handle_request` (nearly all engine and node code) already received a synthesized failure payload, so its observable behavior is unchanged. Only direct `EventManager` callers see a difference: the IPC ingress, which wants exactly this, and tests.

## Tests

Existing tests that asserted the old raising contract now assert the returned failure; one additionally asserts the hook payload *is* the client's payload. New coverage: the failure is addressed with the caller's `request_id` / `response_topic`, and it is logged exactly once with its traceback attached and at ERROR despite a DEBUG `failure_log_level`.

`make test` green: 4721 unit, 9 integration (+6 xfailed), 32 e2e. `ruff` and `pyright` clean.

## Scope

Deliberately limited to the dropped reply. Three adjacent items surfaced during review and were cut back out of this PR:

- An unregistered request type still raises `TypeError` and hangs the ingress the same way. Pre-existing and separable.
- `Engine.handle_request`'s fallback still returns the abstract `ResultPayloadFailure`, which is not `PayloadRegistry`-registered and cannot round-trip the worker-forward path. Latent.
- The `failure_log_level` exemption keys on the payload type, so a handler that returns `GenericResultFailure` for a domain miss would also be exempted. No handler does today; making the invariant enforceable needs a field on the payload.

## Notes

Found while diagnosing a field report of a workflow load freezing partway through. The underlying `ImportError` there is a separate problem with its own fix; this is why it presented as an indefinite hang instead of an error.
