### PR TITLE
fix(publishing): register libraries before building workflow

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -3633,7 +3633,6 @@ class WorkflowManager(EngineScoped):
             )
         )
 
-        # `await build_workflow()` constructs the graph before the executor runs;
         # build_workflow() is the async function emitted by _generate_workflow_file_content
         # that contains all graph-building requests.
         await_main_call = ast.Expr(
@@ -3646,13 +3645,17 @@ class WorkflowManager(EngineScoped):
             )
         )
 
+        # Build the graph inside the executor's context manager. Entering it activates
+        # the project passed via --project-file-path, and only then is a bundle's own
+        # griptape_nodes_config.json read, which is what registers the bundle's required
+        # node libraries.
+        with_stmt.body = [await_main_call, ensure_context_call, *with_stmt.body]
+
         # === Generate async aexecute_workflow function ===
         async_func_def = ast.AsyncFunctionDef(
             name="aexecute_workflow",
             args=args,
             body=[
-                await_main_call,
-                ensure_context_call,
                 executor_assign,
                 with_stmt,
                 return_stmt,
@@ -4252,10 +4255,12 @@ class WorkflowManager(EngineScoped):
         # Emit `await GriptapeNodes.ahandle_request(RegisterLibraryFromFileRequest(...))` once
         # per declared library so build_workflow() registers its own dependencies before any
         # CreateNodeRequest runs. Without this, running the workflow file as a standalone script
-        # (uv run workflow.py) would have no libraries registered when nodes are created, since
-        # LocalWorkflowExecutor's __aenter__ runs after build_workflow() and is gated by
-        # skip_library_loading=True. perform_discovery_if_not_found=True lets the registration
-        # find the library JSON via the engine's normal config-driven discovery path.
+        # (uv run workflow.py) would have no libraries registered when nodes are created:
+        # LocalWorkflowExecutor is constructed with skip_library_loading=True, so app
+        # initialization deliberately loads none. perform_discovery_if_not_found=True lets the
+        # registration find the library JSON via the engine's normal config-driven discovery
+        # path, which resolves against the bundle's own config layer -- activated by entering
+        # the executor's context manager, which build_workflow() now runs inside.
         if library_names:
             import_recorder.add_from_import(
                 "griptape_nodes.retained_mode.events.library_events", "RegisterLibraryFromFileRequest"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -11,6 +11,7 @@ import pytest
 import griptape_nodes.retained_mode.managers.config_manager as config_manager_module
 import griptape_nodes.retained_mode.managers.secrets_manager as secrets_manager_module
 from griptape_nodes.node_library.library_registry import LibraryRegistry
+from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
 from griptape_nodes.retained_mode.engine import current_engine, reset_root_engine
 from griptape_nodes.retained_mode.events.connection_events import (
     CreateConnectionRequest,
@@ -36,11 +37,13 @@ def _isolated_engine_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Ite
     background threads segfault the child at interpreter shutdown.
 
     Dropping the root engine forces the managers to re-initialize against the patched paths
-    and gives each test a fresh object registry. ``LibraryRegistry`` keeps its state in
-    ``ClassVar`` dicts that the engine does not own, so it is reset explicitly.
+    and gives each test a fresh object registry. ``LibraryRegistry`` and ``WorkflowRegistry``
+    keep their state in ``ClassVar`` dicts that the engine does not own, so they are reset
+    explicitly.
     """
     reset_root_engine()
     LibraryRegistry._clear()
+    WorkflowRegistry.clear_user_workflows()
 
     for key in list(os.environ):
         if key.startswith(("GT_CLOUD_", "GTN_CONFIG_")):
@@ -57,6 +60,7 @@ def _isolated_engine_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Ite
     finally:
         reset_root_engine()
         LibraryRegistry._clear()
+        WorkflowRegistry.clear_user_workflows()
 
 
 @pytest.fixture

--- a/tests/e2e/test_workflow_bundle.py
+++ b/tests/e2e/test_workflow_bundle.py
@@ -1,0 +1,233 @@
+"""End-to-end coverage for the self-contained bundle `WorkflowPackager` produces.
+
+``package_to_folder`` is what every publisher composes with: it copies the workflow file and
+its libraries into a destination folder and writes the ``griptape_nodes_config.json``,
+``project.yml``, ``.env`` and ``pyproject.toml`` that make the folder runnable on its own.
+These tests package a real saved workflow through it and then run the bundle the way a
+publisher's entrypoint would.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+from typing import TYPE_CHECKING, NamedTuple
+
+import pytest
+import yaml
+
+from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
+from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
+from griptape_nodes.retained_mode.events.workflow_events import SaveWorkflowRequest, SaveWorkflowResultSuccess
+from griptape_nodes.retained_mode.publishing.workflow_packager import WorkflowPackager
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from griptape_nodes.retained_mode.engine import Engine
+
+# Timeout with thread dump.
+pytestmark = pytest.mark.timeout(300, method="thread")
+
+FIXTURE_LIBRARY_DIR = Path(__file__).parent / "fixtures" / "workflow_node_library"
+FIXTURE_LIBRARY_JSON_TEMPLATE = FIXTURE_LIBRARY_DIR / "griptape_nodes_library.json"
+FIXTURE_NODE_FILE = FIXTURE_LIBRARY_DIR / "workflow_node_nodes.py"
+FIXTURE_WORKFLOW_FILE = FIXTURE_LIBRARY_DIR / "shout_workflow.py"
+LIBRARY_NAME = "Workflow Node Library"
+WORKFLOW_NAME = "bundle_e2e_workflow"
+
+
+class PackagedBundle(NamedTuple):
+    """What a packaging run left on disk, plus the values needed to run it."""
+
+    directory: Path
+    workflow_file_name: str
+    library_paths: list[str]
+
+
+@pytest.fixture
+def published_bundle(package_bundle: Callable[..., PackagedBundle]) -> PackagedBundle:
+    """Package the Start -> Shout -> End workflow into a bundle folder."""
+    return package_bundle(WORKFLOW_NAME, _build_shout_flow)
+
+
+@pytest.fixture
+def package_bundle(
+    tmp_path: Path, engine: Engine, materialize_library: Callable[..., Path]
+) -> Callable[..., PackagedBundle]:
+    """Return a factory that registers the fixture library, saves a workflow, and packages it.
+
+    ``build_flow`` receives the engine and the name of a freshly created top-level flow and is
+    responsible for populating it; everything around it (library registration, save, packaging)
+    is the same for any graph.
+    """
+
+    def _package(workflow_name: str, build_flow: Callable[[Engine, str], None]) -> PackagedBundle:
+        library_json = materialize_library(
+            tmp_path / "library",
+            template=FIXTURE_LIBRARY_JSON_TEMPLATE,
+            node_file=FIXTURE_NODE_FILE,
+            extra_files=[FIXTURE_WORKFLOW_FILE],
+        )
+        register_result = engine.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+        assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
+
+        engine.context_manager.push_workflow(workflow_name=workflow_name)
+        flow_result = engine.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="ControlFlow_1", set_as_new_context=False)
+        )
+        assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
+        build_flow(engine, flow_result.flow_name)
+
+        # package_to_folder reads the workflow off the registry and refuses an unsaved one, so
+        # the save is what gives the packager a file_path to copy.
+        save_result = engine.handle_request(SaveWorkflowRequest(file_name=workflow_name))
+        assert isinstance(save_result, SaveWorkflowResultSuccess), save_result
+
+        workflow = WorkflowRegistry.get_workflow_by_name(save_result.workflow_name)
+        bundle_dir = tmp_path / "bundle"
+        library_paths = WorkflowPackager(save_result.workflow_name).package_to_folder(bundle_dir, workflow)
+        return PackagedBundle(
+            directory=bundle_dir,
+            workflow_file_name=Path(save_result.file_path).name,
+            library_paths=library_paths,
+        )
+
+    return _package
+
+
+def _build_shout_flow(engine: Engine, flow_name: str) -> None:
+    """Wire Start -> Shout -> End into `flow_name`.
+
+    The Start/End pair is what gives the saved workflow a shape, and only a shape-bearing
+    workflow gets the ``__main__`` block that makes the packaged file runnable.
+    """
+
+    def _create(node_type: str, node_name: str) -> str:
+        result = engine.handle_request(
+            CreateNodeRequest(
+                node_type=node_type,
+                specific_library_name=LIBRARY_NAME,
+                node_name=node_name,
+                override_parent_flow_name=flow_name,
+            )
+        )
+        assert isinstance(result, CreateNodeResultSuccess), result
+        return result.node_name
+
+    def _connect(source_node: str, source_param: str, target_node: str, target_param: str) -> None:
+        result = engine.handle_request(
+            CreateConnectionRequest(
+                source_node_name=source_node,
+                source_parameter_name=source_param,
+                target_node_name=target_node,
+                target_parameter_name=target_param,
+            )
+        )
+        assert result.succeeded(), result
+
+    start_node = _create("TextStartNode", "Start Flow")
+    shout_node = _create("ShoutNode", "Shout")
+    end_node = _create("TextEndNode", "End Flow")
+
+    _connect(start_node, "exec_out", shout_node, "exec_in")
+    _connect(shout_node, "exec_out", end_node, "exec_in")
+    _connect(start_node, "text", shout_node, "text")
+    _connect(shout_node, "shouted", end_node, "result")
+
+
+def test_package_to_folder_writes_a_complete_bundle(published_bundle: PackagedBundle) -> None:
+    """Every file a standalone bundle needs is present and internally consistent."""
+    bundle = published_bundle.directory
+
+    assert (bundle / published_bundle.workflow_file_name).is_file()
+    assert (bundle / "libraries").is_dir()
+    config_path = bundle / "griptape_nodes_config.json"
+    assert config_path.is_file()
+    project_path = bundle / "project.yml"
+    assert project_path.is_file()
+    env_path = bundle / ".env"
+    assert env_path.is_file()
+    pyproject_path = bundle / "pyproject.toml"
+    assert pyproject_path.is_file()
+
+    config = json.loads(config_path.read_text())
+    assert config["workspace_directory"] == "."
+    assert config["enable_workspace_file_watching"] is False
+    app_init = config["app_events"]["on_app_initialization_complete"]
+    assert app_init["workflows_to_register"] == []
+    assert app_init["libraries_to_register"] == published_bundle.library_paths
+
+    # Bundle-relative, so the folder stays runnable after being copied to another machine.
+    for library_path in app_init["libraries_to_register"]:
+        assert not Path(library_path).is_absolute(), library_path
+        assert library_path == Path(library_path).as_posix(), library_path
+        assert (bundle / library_path).is_file(), library_path
+
+    project = yaml.safe_load(project_path.read_text())
+    assert project, "project.yml must not be empty"
+
+    env_lines = env_path.read_text().splitlines()
+    assert "GTN_CONFIG_WORKSPACE_DIRECTORY='.'" in env_lines
+    assert "GTN_ENABLE_WORKSPACE_FILE_WATCHING='false'" in env_lines
+
+    pyproject = tomllib.loads(pyproject_path.read_text())
+    dependencies = pyproject["project"]["dependencies"]
+    assert any(dependency.startswith("griptape-nodes-engine") for dependency in dependencies), dependencies
+
+
+def test_packaged_bundle_registers_libraries_on_a_clean_machine(
+    tmp_path: Path,
+    published_bundle: PackagedBundle,
+    engine_subprocess_env: Callable[..., dict[str, str]],
+) -> None:
+    """Running a bundle where nothing else is registered must still load its own libraries.
+
+    The engine writes no entrypoint of its own, so this replicates what the standard library's
+    ``LocalPublisher._write_entrypoint`` puts around a bundle: point
+    ``GTN_CONFIG_WORKSPACE_DIRECTORY`` at the bundle folder, pass ``--project-file-path``, and
+    run the workflow file from inside the folder.
+
+    Deliberately run under ``sys.executable`` with no ``uv sync`` and no venv: the bundle's
+    ``pyproject.toml`` pins ``griptape-nodes-engine`` to a GitHub commit sha, so syncing would
+    exercise the published engine instead of this working tree.
+    """
+    # An empty XDG config home is the whole point: with the library registered at the user
+    # level the bundle's own config layer would never be needed and the test proves nothing.
+    clean_config_home = tmp_path / "clean_xdg_config"
+    clean_config_home.mkdir()
+    env = engine_subprocess_env(
+        XDG_CONFIG_HOME=str(clean_config_home),
+        GTN_CONFIG_WORKSPACE_DIRECTORY=str(published_bundle.directory),
+    )
+
+    result = subprocess.run(  # noqa: S603 - subprocess input is constructed inside the test
+        [
+            sys.executable,
+            str(published_bundle.directory / published_bundle.workflow_file_name),
+            "--project-file-path",
+            str(published_bundle.directory / "project.yml"),
+        ],
+        cwd=published_bundle.directory,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=False,
+    )
+
+    diagnostic = (
+        f"bundle exit code: {result.returncode}\n--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+    )
+    assert result.returncode == 0, diagnostic
+    assert "not found (discovery was attempted)" not in result.stderr, diagnostic
+    assert "Error Proxy" not in result.stderr, diagnostic

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -2110,11 +2110,15 @@ class TestWorkflowManager:
         assert len(build_workflow.body) == 1
         assert isinstance(build_workflow.body[0], ast.Pass)
 
-    def test_generate_workflow_file_content_aexecute_awaits_build_workflow_first(self, engine: Engine) -> None:
-        """aexecute_workflow must `await build_workflow()` before running the executor.
+    def test_generate_workflow_file_content_aexecute_builds_inside_executor_context(self, engine: Engine) -> None:
+        """aexecute_workflow must `await build_workflow()` inside the executor's `async with`.
 
-        Shape-bearing workflows emit execute_workflow + aexecute_workflow, and the async
-        version is expected to construct the graph before invoking the executor.
+        Entering the executor context is what activates the project passed via
+        `--project-file-path`, and only then is a packaged bundle's own
+        griptape_nodes_config.json read -- which is what registers the bundle's libraries.
+        Building the graph before entering would create nodes from libraries nothing has
+        registered yet, so a bundle run on a machine that does not already know those
+        libraries comes up full of Error Proxy nodes.
         """
         content = self._generate(engine, with_shape=True)
         module = ast.parse(content)
@@ -2122,7 +2126,17 @@ class TestWorkflowManager:
         aexecute = next(
             node for node in module.body if isinstance(node, ast.AsyncFunctionDef) and node.name == "aexecute_workflow"
         )
-        first_stmt = aexecute.body[0]
+        async_with = next(stmt for stmt in aexecute.body if isinstance(stmt, ast.AsyncWith))
+
+        # Nothing may await build_workflow() outside the executor context.
+        outside = [stmt for stmt in aexecute.body if stmt is not async_with]
+        assert not any(
+            isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "build_workflow"
+            for stmt in outside
+            for node in ast.walk(stmt)
+        ), ast.unparse(aexecute)
+
+        first_stmt = async_with.body[0]
         # Expected shape: `await build_workflow()`
         assert isinstance(first_stmt, ast.Expr)
         assert isinstance(first_stmt.value, ast.Await)


### PR DESCRIPTION
Closes #4647.  Note that both the cloud publisher and the Nuke publisher don't suffer this bug - they explicitly work around it - whereas the standard library "Publish to Folder" has no such workaround and exhibits the failure (see Testing, below).

The generated `build_workflow()` in a serialised workflow attempts to register the workflow's node library dependencies, providing the names (not paths) of the required libraries. This requires those libraries to either already be known by the engine, or to be discoverable.

When discovering, the engine's `LibraryManager` looks in `ConfigManager` for the "libraries_to_register" key, which contains paths to libraries. These paths are walked to create an index, and this index used to register the library.

A published bundle's `griptape_nodes_config.json` is what feeds the bundled library paths as "libraries_to_register" to `ConfigManager`. So this must be read _before_ the workflow is built, so that the required libraries can be found.

If the config is not read before the workflow is constructed, then the workflow may still run if the user workspace happens to have the required libraries available (in which case the bundled libraries remain unused).

However, on a different machine or under isolation, the bundled workflow fails to find its required libraries, even though they're right next to the workflow, inside the bundle.

It is the `LocalWorkflowExecutor` that loads the config from disk as part of project activation in its `__aenter__`. So workflow construction must happen after this.

So move the `build_workflow()` call inside the executor context, ensuring that the project config has been read before attempting to load libraries.

## Testing

An e2e test is included. in particular `test_packaged_bundle_registers_libraries_on_a_clean_machine` fails prior to this PR.

For a manual smoke test:

* Create a simple workflow then "Publish to Folder" in the Griptape Nodes UI, call it `my_workflow` and place in `/tmp`
* Run in an isolated environment: `docker run --rm -it -v /tmp/my_workflow:/bundle python:3.12 sh -c 'pip install uv && cd /bundle && uv sync && uv run python run.py'`
* This will fail prior to this PR due to supposedly missing libraries, despite them being in the bundle.