### PR TITLE
An unmet resource requirement costs execution, never editing

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -802,26 +802,29 @@ class LibraryManager(EngineScoped):
         """
         if library_name:
             library_info = self.get_library_info_by_library_name(library_name)
+            # Checked ahead of the worker lookup because execution can be unavailable for
+            # reasons that have nothing to do with a worker -- a declared resource this machine
+            # does not have -- and those apply to an in-process library too, which never reaches
+            # the branch below.
+            if library_info and library_info.execution_unavailable_reason:
+                msg = (
+                    f"Library '{library_name}' cannot run right now: "
+                    f"{library_info.execution_unavailable_reason} Editing its nodes still works, "
+                    "and a saved workflow keeps them."
+                )
+                raise RuntimeError(msg)
             if library_info and library_info.executes_in_worker:
                 wm = self._worker_manager
                 if wm:
                     worker = wm.get_worker_for_key(library_name)
                     if worker:
                         return worker
-                    # Distinguish "not ready yet" from "went away", which read identically
-                    # before: a library whose worker had been evicted reported that it might
-                    # still be starting up, forever.
-                    if library_info.execution_unavailable_reason:
-                        msg = (
-                            f"Library '{library_name}' cannot run right now: "
-                            f"{library_info.execution_unavailable_reason} Editing its nodes still "
-                            "works, and a saved workflow keeps them."
-                        )
-                    else:
-                        msg = (
-                            f"Library '{library_name}' requires a dedicated worker process "
-                            "that is not yet registered. The worker may still be starting up."
-                        )
+                    # A reason set on the library was already reported above, so reaching here
+                    # means there is none: the worker genuinely has not registered yet.
+                    msg = (
+                        f"Library '{library_name}' requires a dedicated worker process "
+                        "that is not yet registered. The worker may still be starting up."
+                    )
                     raise RuntimeError(msg)
                 msg = (
                     f"Library '{library_name}' requires a dedicated worker process. "
@@ -2469,12 +2472,19 @@ class LibraryManager(EngineScoped):
                             library_requirements, library_data.name
                         )
                         if requirements_check_result is not None:
-                            library_info.fitness = LibraryManager.LibraryFitness.UNUSABLE
+                            # A declared resource this machine does not have costs EXECUTION, not
+                            # loading. Nothing about a missing GPU stops the orchestrator importing
+                            # base-clean node modules, drawing their parameters, or saving a
+                            # workflow that uses them -- and refusing to register took all of that
+                            # away, leaving placeholder nodes reading "Library not found" on every
+                            # machine that was only ever going to edit. It is the same rule the
+                            # engine applies to a dependency that will not install: the capability
+                            # gates the run, and the artist finds out when they run.
+                            library_info.fitness = LibraryManager.LibraryFitness.FLAWED
                             library_info.problems.append(requirements_check_result)
-                            library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.FAILURE
-                            self._library_file_path_to_info[library_info.library_path] = library_info
-                            details = f"Library '{library_data.name}' requirements not met: {library_requirements}"
-                            return RegisterLibraryFromFileResultFailure(result_details=details)
+                            library_info.execution_unavailable_reason = self._describe_unmet_requirements(
+                                requirements_check_result
+                            )
 
                     library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.EVALUATED
 
@@ -2983,6 +2993,31 @@ class LibraryManager(EngineScoped):
         logger.debug("Created virtual environment at %s", library_venv_path)
 
         return LibraryVenvInitResult(python_path=venv_python_path(library_venv_path), reused=False)
+
+    @staticmethod
+    def _describe_unmet_requirements(problem: IncompatibleRequirementsProblem) -> str:
+        """Phrase an unmet resource requirement for whoever has to act on it.
+
+        The raw dicts read like internals ("{'compute': (['cuda'], 'has_any')}"), so the
+        capability and what this machine actually reports are named plainly instead.
+        """
+
+        def render(value: Any) -> str:
+            # Capability values arrive as enums and nested tuples; their reprs
+            # ("<ComputeBackend.MPS: 'mps'>") have no business in a message an artist reads.
+            if isinstance(value, (list, tuple)):
+                return ", ".join(render(item) for item in value)
+            return str(getattr(value, "value", value))
+
+        wanted = ", ".join(
+            f"{capability} {render(value[0] if isinstance(value, (list, tuple)) else value)}"
+            for capability, value in problem.requirements.items()
+        )
+        have = (
+            ", ".join(f"{key} {render(value)}" for key, value in problem.system_capabilities.items())
+            or "nothing detectable"
+        )
+        return f"it needs {wanted}, and this machine has {have}."
 
     def _check_library_requirements(
         self, requirements: dict[str, Any], library_name: str

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -883,6 +883,29 @@ class LibraryManager(EngineScoped):
                 and library_info.library_name
                 and not self._is_worker
             ):
+                # A declared resource this machine does not have makes the whole spawn pointless:
+                # get_worker_for_library refuses on that reason before it ever consults a worker,
+                # so the process would resolve and download an entire execution environment --
+                # torch, gigabytes -- to serve nothing. Checked before the lifecycle moves below,
+                # because a legacy worker-mode library parked in WORKER_PENDING with no spawn
+                # coming would block boot for the whole startup grace.
+                #
+                # Only for libraries whose nodes already exist here. A legacy worker-mode library
+                # has none: the orchestrator skips its node modules entirely and its classes arrive
+                # as stubs from the worker's LibraryLoadedNotification. Skipping its spawn would
+                # leave the library with no node types at all -- an empty entry in the sidebar and
+                # placeholder nodes in any workflow using it. It still cannot execute, because the
+                # reset below preserves its refusal.
+                has_unmet_requirement = any(
+                    isinstance(problem, IncompatibleRequirementsProblem) for problem in library_info.problems
+                )
+                if has_unmet_requirement and not library_info.requires_worker:
+                    logger.info(
+                        "Not starting a worker for library '%s': %s",
+                        library_info.library_name,
+                        library_info.execution_unavailable_reason,
+                    )
+                    continue
                 # Legacy worker-mode libraries load AS the worker confirms (stubs meanwhile),
                 # so their lifecycle gates on the spawn. Exec-deps libraries loaded real
                 # nodes locally already: the worker gates execution availability only, and
@@ -896,12 +919,17 @@ class LibraryManager(EngineScoped):
                 # "Library not found". This event is set by the worker's LibraryLoadedNotification,
                 # and the execute path waits on it (wait_for_worker_library_load).
                 library_info.worker_ready = asyncio.Event()
-                # A fresh attempt, so whatever made execution unavailable before no longer
-                # describes the situation. Deliberately not conditioned on the result:
-                # StartWorkerRequest only SCHEDULES the spawn and always reports success, so a
-                # spawn that dies records its own reason from the task's exception handler
-                # (WorkerManager._log_spawn_error) rather than being inferred from here.
-                library_info.execution_unavailable_reason = None
+                # A fresh attempt, so an account of a PREVIOUS one no longer describes the
+                # situation. Not conditioned on the result: StartWorkerRequest only SCHEDULES the
+                # spawn and always reports success, so a spawn that dies records its own reason
+                # from the task's exception handler (WorkerManager._log_spawn_error).
+                #
+                # An unmet requirement is not an account of an attempt -- the machine still lacks
+                # the resource -- and it is the ONLY gate get_worker_for_library has. Clearing it
+                # would leave a legacy worker-mode library, whose spawn is deliberately not
+                # skipped above, dispatching to a worker that cannot load it.
+                if not has_unmet_requirement:
+                    library_info.execution_unavailable_reason = None
                 await self.engine.ahandle_request(StartWorkerRequest(library_name=library_info.library_name))
 
     def on_worker_evicted(self, worker_engine_id: str, library_name: str | None) -> None:

--- a/tests/e2e/test_exec_dep_worker_routing.py
+++ b/tests/e2e/test_exec_dep_worker_routing.py
@@ -22,7 +22,7 @@ import logging
 import shutil
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 import pytest
 
@@ -62,6 +62,7 @@ def _register(  # noqa: PLR0913 (a test-library builder; each knob is one manife
     name: str,
     exec_dependencies: list[str] | None = None,
     edit_dependencies: list[str] | None = None,
+    required_resources: dict[str, object] | None = None,
 ) -> str:
     """Register a fixture library, optionally declaring execution dependencies."""
     library_dir = tmp_path / name.replace(" ", "_")
@@ -83,6 +84,8 @@ def _register(  # noqa: PLR0913 (a test-library builder; each knob is one manife
             build_wheel(wheel_dir, dep, "1.0.0")
         dependencies["pip_install_flags"] = offline_install_flags(wheel_dir)
     schema["metadata"]["dependencies"] = dependencies
+    if required_resources is not None:
+        schema["metadata"]["resources"] = {"required": required_resources}
     library_json = library_dir / "griptape_nodes_library.json"
     library_json.write_text(json.dumps(schema, indent=2))
     shutil.copy(fixture_dir / node_file, library_dir / node_file)
@@ -369,6 +372,66 @@ class TestParameterBehaviorsSurviveOnRealClasses:
 
         assert not isinstance(result, SendNodeMessageResultSuccess)
         assert "no handler was available" in str(result.result_details)
+
+
+class TestUnmetResourcesCostExecutionNotLoading:
+    """A capability this machine lacks must not take the library away.
+
+    Nothing about a missing GPU stops the orchestrator importing base-clean node modules,
+    drawing their parameters, or saving a workflow that uses them. Refusing to REGISTER took
+    all of that away: fitness UNUSABLE, no node types, and placeholder nodes reading "Library
+    not found" on every machine that was only ever going to edit. This is the same rule the
+    engine applies to a dependency that will not install -- the capability gates the run.
+    """
+
+    IMPOSSIBLE_COMPUTE: ClassVar[dict[str, object]] = {"compute": [["definitely-not-a-real-backend"], "has_any"]}
+
+    def test_the_library_still_registers_and_its_nodes_still_load(self, tmp_path: Path) -> None:
+        library_json = _register(
+            tmp_path,
+            fixture_dir=BEHAVIOR_FIXTURE,
+            node_file="behavior_preservation_node.py",
+            name="Unmet Resources",
+            required_resources=self.IMPOSSIBLE_COMPUTE,
+        )
+
+        info = _library_info(library_json)
+        assert info.lifecycle_state is not LibraryManager.LibraryLifecycleState.FAILURE
+        assert info.fitness is LibraryManager.LibraryFitness.FLAWED
+        node = LibraryRegistry.create_node(
+            node_type="BehaviorPreservationNode", name="editable", specific_library_name="Unmet Resources"
+        )
+        assert node.get_parameter_by_name("mode") is not None
+
+    def test_execution_refuses_and_names_the_capability(self, tmp_path: Path) -> None:
+        _register(
+            tmp_path,
+            fixture_dir=BEHAVIOR_FIXTURE,
+            node_file="behavior_preservation_node.py",
+            name="Unmet Resources Refuses",
+            required_resources=self.IMPOSSIBLE_COMPUTE,
+        )
+
+        with pytest.raises(RuntimeError) as excinfo:
+            current_engine().library_manager.get_worker_for_library("Unmet Resources Refuses")
+
+        message = str(excinfo.value)
+        assert "definitely-not-a-real-backend" in message, "the artist is not told what is missing"
+        assert "Editing its nodes still works" in message
+
+    def test_a_library_whose_resources_are_met_is_unaffected(self, tmp_path: Path) -> None:
+        """The gate must not fire for a requirement this machine does satisfy."""
+        library_json = _register(
+            tmp_path,
+            fixture_dir=BEHAVIOR_FIXTURE,
+            node_file="behavior_preservation_node.py",
+            name="Met Resources",
+            required_resources={"compute": [["cpu"], "has_any"]},
+        )
+
+        info = _library_info(library_json)
+        assert info.execution_unavailable_reason is None
+        assert info.fitness is LibraryManager.LibraryFitness.GOOD
 
 
 class TestUnshippableOutputGuardrail:

--- a/tests/unit/retained_mode/managers/test_library_worker_config.py
+++ b/tests/unit/retained_mode/managers/test_library_worker_config.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any, cast
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from griptape_nodes.node_library.library_registry import Dependencies, LibraryMetadata
 from griptape_nodes.retained_mode.events.app_events import LibraryLoadedNotification
+from griptape_nodes.retained_mode.managers.fitness_problems.libraries import (
+    IncompatibleRequirementsProblem,
+)
 from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
 
 
@@ -149,6 +152,7 @@ class TestOnLibraryLoadedNotification:
         )
 
     @pytest.mark.asyncio
+    @pytest.mark.asyncio
     async def test_updates_fitness_and_lifecycle_to_loaded(self) -> None:
         mgr = _make_library_manager()
         lib_info = self._make_lib_info("my_lib")
@@ -159,6 +163,7 @@ class TestOnLibraryLoadedNotification:
         assert lib_info.lifecycle_state == LibraryManager.LibraryLifecycleState.LOADED
         assert lib_info.fitness == LibraryManager.LibraryFitness.GOOD
 
+    @pytest.mark.asyncio
     @pytest.mark.asyncio
     async def test_a_worker_does_not_overwrite_a_locally_derived_fitness(self) -> None:
         """An exec-deps library's fitness is the orchestrator's own finding, not the worker's.
@@ -180,6 +185,7 @@ class TestOnLibraryLoadedNotification:
         assert lib_info.lifecycle_state == LibraryManager.LibraryLifecycleState.LOADED
 
     @pytest.mark.asyncio
+    @pytest.mark.asyncio
     async def test_accepts_flawed_fitness(self) -> None:
         mgr = _make_library_manager()
         lib_info = self._make_lib_info("my_lib")
@@ -192,6 +198,7 @@ class TestOnLibraryLoadedNotification:
         assert lib_info.lifecycle_state == LibraryManager.LibraryLifecycleState.LOADED
         assert lib_info.fitness == LibraryManager.LibraryFitness.FLAWED
 
+    @pytest.mark.asyncio
     @pytest.mark.asyncio
     async def test_does_nothing_for_unknown_library(self) -> None:
         mgr = _make_library_manager()
@@ -400,3 +407,82 @@ class TestOnWorkerEvicted:
         manager = _make_library_manager()
         manager.on_worker_evicted("worker-1", "Never Registered")
         manager.on_worker_evicted("worker-1", None)
+
+
+class TestSpawnSkipForUnmetRequirements:
+    """A pointless spawn is skipped -- but only where the nodes already exist locally.
+
+    An exec-dependencies library loaded real node classes on the orchestrator, so a worker it can
+    never use costs a whole execution environment -- torch, gigabytes -- for nothing. A legacy
+    worker-mode library is the opposite: the orchestrator skips its node modules entirely and its
+    classes arrive as stubs from the worker, so skipping the spawn would leave it with no node
+    types at all.
+    """
+
+    def _manager(self, *, requires_worker: bool, unmet: bool) -> LibraryManager:
+        manager = _make_library_manager()
+        manager._engine = MagicMock()  # type: ignore[assignment]
+        manager._engine.ahandle_request = AsyncMock()  # type: ignore[union-attr]
+        info = LibraryManager.LibraryInfo(
+            lifecycle_state=LibraryManager.LibraryLifecycleState.LOADED,
+            fitness=LibraryManager.LibraryFitness.GOOD,
+            library_path="/some/path.json",
+            is_sandbox=False,
+            library_name="Lib",
+            requires_worker=requires_worker,
+            executes_in_worker=True,
+        )
+        if unmet:
+            info.problems = [
+                IncompatibleRequirementsProblem(
+                    requirements={"compute": (["cuda"], "has_any")},
+                    system_capabilities={"compute": ["cpu"]},
+                )
+            ]
+            info.execution_unavailable_reason = "it needs compute cuda, and this machine has cpu."
+        manager._library_file_path_to_info["/some/path.json"] = info
+        return manager
+
+    @pytest.mark.asyncio
+    async def test_exec_deps_library_with_unmet_requirements_is_not_spawned(self) -> None:
+        manager = self._manager(requires_worker=False, unmet=True)
+
+        await manager._start_workers()
+
+        cast("MagicMock", manager._engine).ahandle_request.assert_not_awaited()
+        info = manager._library_file_path_to_info["/some/path.json"]
+        assert info.execution_unavailable_reason is not None, "the local refusal must survive"
+
+    @pytest.mark.asyncio
+    async def test_legacy_worker_library_still_spawns_even_when_unmet(self) -> None:
+        """Its nodes come from the worker, so no spawn means no node types at all."""
+        manager = self._manager(requires_worker=True, unmet=True)
+
+        await manager._start_workers()
+
+        cast("MagicMock", manager._engine).ahandle_request.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_the_spawn_a_legacy_library_still_gets_does_not_clear_its_refusal(self) -> None:
+        """execution_unavailable_reason is the only gate get_worker_for_library has.
+
+        This library's spawn is deliberately not skipped, so clearing the reason on a fresh attempt
+        would let execution dispatch to a worker that cannot load it. An unmet requirement is a
+        standing fact about the machine, not an account of a previous attempt.
+        """
+        manager = self._manager(requires_worker=True, unmet=True)
+
+        await manager._start_workers()
+
+        info = manager._library_file_path_to_info["/some/path.json"]
+        assert info.execution_unavailable_reason is not None
+
+    @pytest.mark.asyncio
+    async def test_a_library_with_met_requirements_spawns(self) -> None:
+        manager = self._manager(requires_worker=False, unmet=False)
+
+        await manager._start_workers()
+
+        cast("MagicMock", manager._engine).ahandle_request.assert_awaited_once()
+        # Nothing standing in the way, so a stale account of a previous attempt is cleared.
+        assert manager._library_file_path_to_info["/some/path.json"].execution_unavailable_reason is None


### PR DESCRIPTION
Part of griptape-ai/internal#215 (on top of #5430).

A library can declare the resources it needs — platform, arch, OS version, compute backend — and an unmet declaration failed **registration**: fitness `UNUSABLE`, lifecycle `FAILURE`, no node types at all.

So a workflow built on a CUDA machine could not be *opened* on a laptop without one. Not "could not be run" — could not be opened. Every node from that library became a placeholder reading "Library not found", which sends the reader hunting for a library sitting right there in their config.

## The rule

Nothing about a missing GPU stops the orchestrator importing base-clean node modules, drawing their parameters, connecting them, or saving the result. The capability is what `process` needs, so **it gates the run** — the same rule this stack already applies to a dependency that will not install (#5427: "a broken execution dependency costs execution, never editing"). A missing GPU is the same class of thing.

An unmet requirement now:
- records its `IncompatibleRequirementsProblem` (so the settings panel still shows it),
- marks the library **FLAWED** — loaded, with something wrong — instead of UNUSABLE,
- sets `execution_unavailable_reason`, and execution refuses with it.

The refusal check moved **ahead of the worker lookup**, because a resource is unavailable whether or not a worker is involved: an in-process library never reached the old worker-only branch. The worker branch keeps its own message for the case it actually describes — a worker that has not registered yet.

## The message

The raw dicts read like internals (`{'compute': (['cuda'], 'has_any')}`) and the capability values are enums whose reprs are worse (`<ComputeBackend.MPS: 'mps'>`), so both sides render plainly:

> Library 'SAM3 Library' cannot run right now: it needs compute cuda, and this machine has platform darwin, arch arm64, version 25.6.0, compute cpu, mps. Editing its nodes still works, and a saved workflow keeps them.

## Verified against a real library

SAM3 declares `compute: [["cuda"], "has_any"]`. On macOS, before: registration failed outright. After: loads FLAWED with all three node types instantiating (16, 17, 18 parameters), and executing one refuses with the sentence above.

Three tests pin the two halves plus the requirement-met case, and all three fail if the gate moves back to load time.

## Stack

| # | PR | Branch |
|---|----|--------|
| 1 | #5390 | `feat/venue-exec-deps` |
| 2 | #5391 | `feat/venue-reentrancy` |
| 3 | #5402 | `feat/venue-worker-mvp` |
| 4 | #5409 | `feat/venue-worker-behavior-suite` |
| 5 | #5425 | `feat/exe-types-engine-injection` |
| 6 | #5426 | `feat/worker-wire-hardening` |
| 7 | #5427 | `feat/library-exec-lifecycle` |
| 8 | #5428 | `fix/failed-nodes-leave-resolving` |
| 9 | #5430 | `feat/parameter-structure-contract` |
| 10 | **this** | `feat/resources-gate-execution` |
