### PR TITLE
feat(config): support nested settings in GTN_CONFIG_ env vars

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -182,7 +182,7 @@ GTN_CONFIG_LIBRARY__LAZY_NODE_LOADING=false gtn
 GTN_CONFIG_AGENT__SYSTEM_PROMPT="Answer tersely." gtn
 ```
 
-A value is converted to the setting's declared type before it takes effect, so `false` for a boolean setting means `False` (not the truthy string `"false"`), and `30` for a number setting means the number `30`, not text.
+A value is converted to the setting's declared type before it takes effect, so `false` for a boolean setting means `False` (not the truthy string `"false"`), and `30` for a number setting means the number `30`, not text. That conversion does not reach an entry in a mapping-valued setting, such as `GTN_CONFIG_ARTIFACTS__SOME_KEY`: its value is typed to accept anything, so it arrives exactly as written, and a boolean or numeric mapping entry needs a config file instead.
 
 > **Two limits:**
 >

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -144,31 +144,52 @@ Here are a few scenarios to illustrate how configuration files are located and l
 
 ## Environment Variable Overrides
 
-A top-level configuration value can be set or overridden using an environment variable with the `GTN_CONFIG_` prefix. The key is the config setting name in uppercase:
+A configuration value can be set or overridden using an environment variable with the `GTN_CONFIG_` prefix. The key is the config setting name in uppercase:
 
 ```
 GTN_CONFIG_<SETTING_NAME>=<value>
 ```
 
+A nested setting (one that lives inside an object like `worker`, `agent`, or `library`) is reached with a double underscore (`__`) separating each level of the path, still uppercase:
+
+```
+GTN_CONFIG_<PARENT>__<SUB_KEY>=<value>
+```
+
+A double underscore is required rather than a single one because setting names already contain underscores. `GTN_CONFIG_WORKER_HEARTBEAT_TIMEOUT_S` would be ambiguous between a top-level setting named `worker_heartbeat_timeout_s` and `worker.heartbeat_timeout_s`. No setting name contains `__`, so it unambiguously marks where the path descends a level.
+
 Environment variable overrides have the **highest priority** — they win over user config files, project-adjacent config files, the per-project workspace override, and built-in defaults.
 
 Examples:
 
-| Setting               | Environment variable             |
-| --------------------- | -------------------------------- |
-| `workspace_directory` | `GTN_CONFIG_WORKSPACE_DIRECTORY` |
-| `libraries_directory` | `GTN_CONFIG_LIBRARIES_DIRECTORY` |
-| `project_file`        | `GTN_CONFIG_PROJECT_FILE`        |
-| `log_level`           | `GTN_CONFIG_LOG_LEVEL`           |
-| `storage_backend`     | `GTN_CONFIG_STORAGE_BACKEND`     |
+| Setting                      | Environment variable                     |
+| ---------------------------- | ---------------------------------------- |
+| `workspace_directory`        | `GTN_CONFIG_WORKSPACE_DIRECTORY`         |
+| `libraries_directory`        | `GTN_CONFIG_LIBRARIES_DIRECTORY`         |
+| `project_file`               | `GTN_CONFIG_PROJECT_FILE`                |
+| `log_level`                  | `GTN_CONFIG_LOG_LEVEL`                   |
+| `storage_backend`            | `GTN_CONFIG_STORAGE_BACKEND`             |
+| `worker.heartbeat_timeout_s` | `GTN_CONFIG_WORKER__HEARTBEAT_TIMEOUT_S` |
+| `library.lazy_node_loading`  | `GTN_CONFIG_LIBRARY__LAZY_NODE_LOADING`  |
+| `agent.system_prompt`        | `GTN_CONFIG_AGENT__SYSTEM_PROMPT`        |
 
 This is useful for scripted environments, containers, and CI/CD pipelines where you want to inject configuration without modifying any config files:
 
 ```bash
 GTN_CONFIG_PROJECT_FILE=/shared/studio-project.yml gtn
+GTN_CONFIG_WORKER__HEARTBEAT_TIMEOUT_S=30 gtn
+GTN_CONFIG_LIBRARY__LAZY_NODE_LOADING=false gtn
+GTN_CONFIG_AGENT__SYSTEM_PROMPT="Answer tersely." gtn
 ```
 
-> **Only top-level settings can be set this way.** `GTN_CONFIG_*` variables map to a single top-level config key; they cannot reach nested settings (anything under `app_events`, `worker`, or `agent`, such as `libraries_to_register`). To change a nested setting, edit a `griptape_nodes_config.json` file. The [Configuration Reference](../reference/configuration_reference.md) marks which settings have an environment variable.
+A value is converted to the setting's declared type before it takes effect, so `false` for a boolean setting means `False` (not the truthy string `"false"`), and `30` for a number setting means the number `30`, not text.
+
+> **Two limits:**
+>
+> 1. **List-valued settings, and any case-sensitive key.** A list has no string form the `Settings` model accepts, so a setting that holds a list, such as `app_events.on_app_initialization_complete.libraries_to_register` or `mcp_servers`, cannot be set from the environment. A *mapping*-valued setting is different: an entry can be set with `GTN_CONFIG_<NAME>__<KEY>=<value>`, e.g. `GTN_CONFIG_ARTIFACTS__SOME_KEY=1`. But the whole variable name is lowercased before it becomes a config key, so this only reaches an entry whose key is already lowercase. That makes `artifacts` usable this way, but makes `project_workspaces` (keys are case-sensitive project IDs or file paths) and `secrets_to_register` (uppercase secret names) unreliable in practice, and makes a case-sensitive path outside any declared setting, such as `nodes.<LibraryName>.<SECRET_NAME>`, unreachable outright. Edit a `griptape_nodes_config.json` file for any of these.
+> 1. **An unparsable value usually falls back to the config files. Four settings don't.** A value that doesn't fit a setting's type (e.g. `GTN_CONFIG_MAX_NODES_IN_PARALLEL=not-a-number`) is ignored with a warning, and the config-file layers supply the value instead. `log_level`, `workflow_execution_mode`, `thread_storage_backend`, and `library.dependency_install_behavior` are the exception: an unrecognized value for one of these silently becomes that setting's built-in default, with no warning and no config-file fallback.
+>
+> The [Configuration Reference](../reference/configuration_reference.md) lists the exact environment variable for every setting that has one, including the full `__` path for each nested sub-key.
 
 ### Recursive Discovery Depth (`discovery_max_depth`)
 

--- a/docs/reference/configuration_reference.md
+++ b/docs/reference/configuration_reference.md
@@ -3,7 +3,7 @@
 
 # Configuration Reference
 
-Every Griptape Nodes engine setting, grouped by category. Each setting can be placed in any `griptape_nodes_config.json` file (see [Engine Configuration](../guides/configuration.md) for the load order). Settings with a `GTN_CONFIG_*` env var can also be overridden from the environment; nested settings must be edited in a config file.
+Every Griptape Nodes engine setting, grouped by category. Each setting can be placed in any `griptape_nodes_config.json` file (see [Engine Configuration](../guides/configuration.md) for the load order). Settings with a `GTN_CONFIG_*` env var, including the `GTN_CONFIG_<NAME>__<SUB_KEY>` form for a nested setting's scalar sub-keys and the `GTN_CONFIG_<NAME>__<KEY>` form for a mapping-valued setting's entries, can also be overridden from the environment; list-valued settings must be edited in a config file. A mapping's keys are matched case-sensitively but the whole variable name is lowercased, so only an already-lowercase key is reachable from the environment (see the guide for details).
 
 ## File System
 
@@ -23,20 +23,20 @@ Directories and file paths for the application
 
 Configuration for application lifecycle events
 
-| Setting      | Type   | Default         | Environment variable           | Description                                                   |
-| ------------ | ------ | --------------- | ------------------------------ | ------------------------------------------------------------- |
-| `app_events` | object | (nested object) | n/a (nested; edit config file) | Nested settings; edit the sub-keys directly in a config file. |
+| Setting      | Type   | Default         | Environment variable                                                     | Description                                                                                                                      |
+| ------------ | ------ | --------------- | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `app_events` | object | (nested object) | `GTN_CONFIG_APP_EVENTS__ON_APP_INITIALIZATION_COMPLETE__REQUIRES_ENGINE` | Nested settings; the listed sub-keys can be set from the environment, and every sub-key can be edited directly in a config file. |
 
 ## Execution
 
 Workflow execution and processing settings
 
-| Setting                   | Type                                                   | Default         | Environment variable                 | Description                                                                                                                                                                                                             |
-| ------------------------- | ------------------------------------------------------ | --------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `log_level`               | one of `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG` | `"INFO"`        | `GTN_CONFIG_LOG_LEVEL`               | Logging verbosity for the engine. One of CRITICAL, ERROR, WARNING, INFO, or DEBUG, from least to most verbose.                                                                                                          |
-| `workflow_execution_mode` | one of `sequential`, `parallel`                        | `"sequential"`  | `GTN_CONFIG_WORKFLOW_EXECUTION_MODE` | Workflow execution mode for node processing. SEQUENTIAL mode uses ParallelResolutionMachine with max_nodes_in_parallel=1 to execute nodes one at a time. PARALLEL mode uses the configured max_nodes_in_parallel value. |
-| `max_nodes_in_parallel`   | integer                                                | `5`             | `GTN_CONFIG_MAX_NODES_IN_PARALLEL`   | Maximum number of nodes executing at a time for parallel execution.                                                                                                                                                     |
-| `worker`                  | object                                                 | (nested object) | n/a (nested; edit config file)       | Nested settings; edit the sub-keys directly in a config file.                                                                                                                                                           |
+| Setting                   | Type                                                   | Default         | Environment variable                                                                                                                | Description                                                                                                                                                                                                             |
+| ------------------------- | ------------------------------------------------------ | --------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `log_level`               | one of `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG` | `"INFO"`        | `GTN_CONFIG_LOG_LEVEL`                                                                                                              | Logging verbosity for the engine. One of CRITICAL, ERROR, WARNING, INFO, or DEBUG, from least to most verbose.                                                                                                          |
+| `workflow_execution_mode` | one of `sequential`, `parallel`                        | `"sequential"`  | `GTN_CONFIG_WORKFLOW_EXECUTION_MODE`                                                                                                | Workflow execution mode for node processing. SEQUENTIAL mode uses ParallelResolutionMachine with max_nodes_in_parallel=1 to execute nodes one at a time. PARALLEL mode uses the configured max_nodes_in_parallel value. |
+| `max_nodes_in_parallel`   | integer                                                | `5`             | `GTN_CONFIG_MAX_NODES_IN_PARALLEL`                                                                                                  | Maximum number of nodes executing at a time for parallel execution.                                                                                                                                                     |
+| `worker`                  | object                                                 | (nested object) | `GTN_CONFIG_WORKER__HEARTBEAT_INTERVAL_S`, `GTN_CONFIG_WORKER__HEARTBEAT_TIMEOUT_S`, `GTN_CONFIG_WORKER__HEARTBEAT_STARTUP_GRACE_S` | Nested settings; the listed sub-keys can be set from the environment, and every sub-key can be edited directly in a config file.                                                                                        |
 
 ## Storage
 
@@ -62,9 +62,9 @@ System resource requirements and limits
 
 Model Context Protocol server configurations
 
-| Setting       | Type  | Default | Environment variable           | Description                                          |
-| ------------- | ----- | ------- | ------------------------------ | ---------------------------------------------------- |
-| `mcp_servers` | array | `[]`    | n/a (nested; edit config file) | List of Model Context Protocol server configurations |
+| Setting       | Type  | Default | Environment variable                | Description                                          |
+| ------------- | ----- | ------- | ----------------------------------- | ---------------------------------------------------- |
+| `mcp_servers` | array | `[]`    | n/a (list/object; edit config file) | List of Model Context Protocol server configurations |
 
 ## Static Server
 
@@ -78,31 +78,31 @@ Static file server configuration for serving media assets
 
 Settings for artifact providers and preview generation
 
-| Setting     | Type   | Default | Environment variable           | Description                                                         |
-| ----------- | ------ | ------- | ------------------------------ | ------------------------------------------------------------------- |
-| `artifacts` | object | `{}`    | n/a (nested; edit config file) | Control how previews are generated for images and other media files |
+| Setting     | Type   | Default | Environment variable          | Description                                                         |
+| ----------- | ------ | ------- | ----------------------------- | ------------------------------------------------------------------- |
+| `artifacts` | object | `{}`    | `GTN_CONFIG_ARTIFACTS__<KEY>` | Control how previews are generated for images and other media files |
 
 ## Projects
 
 Project template configurations and registrations
 
-| Setting              | Type   | Default | Environment variable           | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| -------------------- | ------ | ------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `project_file`       | string | `null`  | `GTN_CONFIG_PROJECT_FILE`      | Path to the project file (griptape-nodes-project.yml) to load initially when the engine starts. When set, overrides the default location of \<workspace_directory>/griptape-nodes-project.yml. If the specified path does not exist, falls back to the workspace default. The sentinel value '<system-defaults>' means the engine deliberately stays on system defaults and suppresses the workspace-default fallback (so a workspace griptape-nodes-project.yml is not auto-discovered); this is what the engine persists when it is intentionally on system defaults. |
-| `project_workspaces` | object | `{}`    | n/a (nested; edit config file) | Mapping of project identifiers to workspace directory overrides. A key may be either a project ID or a project file path: it is first matched against loaded project IDs, and if none match, treated as a project file path. When a project is loaded, if it matches a key here, the corresponding value is used as the workspace directory instead of the project-adjacent config or auto-default.                                                                                                                                                                     |
+| Setting              | Type   | Default | Environment variable                   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| -------------------- | ------ | ------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `project_file`       | string | `null`  | `GTN_CONFIG_PROJECT_FILE`              | Path to the project file (griptape-nodes-project.yml) to load initially when the engine starts. When set, overrides the default location of \<workspace_directory>/griptape-nodes-project.yml. If the specified path does not exist, falls back to the workspace default. The sentinel value '<system-defaults>' means the engine deliberately stays on system defaults and suppresses the workspace-default fallback (so a workspace griptape-nodes-project.yml is not auto-discovered); this is what the engine persists when it is intentionally on system defaults. |
+| `project_workspaces` | object | `{}`    | `GTN_CONFIG_PROJECT_WORKSPACES__<KEY>` | Mapping of project identifiers to workspace directory overrides. A key may be either a project ID or a project file path: it is first matched against loaded project IDs, and if none match, treated as a project file path. When a project is loaded, if it matches a key here, the corresponding value is used as the workspace directory instead of the project-adjacent config or auto-default.                                                                                                                                                                     |
 
 ## Agent
 
 Agent behavior and system prompt
 
-| Setting | Type   | Default         | Environment variable           | Description                                                   |
-| ------- | ------ | --------------- | ------------------------------ | ------------------------------------------------------------- |
-| `agent` | object | (nested object) | n/a (nested; edit config file) | Nested settings; edit the sub-keys directly in a config file. |
+| Setting | Type   | Default         | Environment variable              | Description                                                                                                                      |
+| ------- | ------ | --------------- | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `agent` | object | (nested object) | `GTN_CONFIG_AGENT__SYSTEM_PROMPT` | Nested settings; the listed sub-keys can be set from the environment, and every sub-key can be edited directly in a config file. |
 
 ## Libraries
 
 Settings for library management and dependency installation
 
-| Setting   | Type   | Default         | Environment variable           | Description                                                   |
-| --------- | ------ | --------------- | ------------------------------ | ------------------------------------------------------------- |
-| `library` | object | (nested object) | n/a (nested; edit config file) | Nested settings; edit the sub-keys directly in a config file. |
+| Setting   | Type   | Default         | Environment variable                                                                                                                  | Description                                                                                                                      |
+| --------- | ------ | --------------- | ------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `library` | object | (nested object) | `GTN_CONFIG_LIBRARY__DEPENDENCY_INSTALL_BEHAVIOR`, `GTN_CONFIG_LIBRARY__LAZY_NODE_LOADING`, `GTN_CONFIG_LIBRARY__MINIMUM_RELEASE_AGE` | Nested settings; the listed sub-keys can be set from the environment, and every sub-key can be edited directly in a config file. |

--- a/scripts/generate_settings_reference.py
+++ b/scripts/generate_settings_reference.py
@@ -5,9 +5,13 @@ per-setting reference (type, default, env var, description) cannot drift from th
 code. Run via `make docs/settings-reference`; `make docs` runs it before building.
 
 The page is grouped by the category attached to each Field (see the custom Field
-wrapper in settings.py). Only top-level scalar settings get a GTN_CONFIG_* env var
-column, because env-var parsing is a flat key lookup with no nesting support
-(config_manager._load_config_from_env_vars).
+wrapper in settings.py). A top-level scalar setting gets a `GTN_CONFIG_<NAME>` env var
+column. A nested setting (a model, e.g. worker/agent/library) gets one env var per scalar
+leaf found anywhere beneath it, named with the `__`-separated path
+config_manager._load_config_from_env_vars parses. A mapping-valued setting (`type: object`
+with `additionalProperties`, e.g. artifacts, project_workspaces) gets a `__<KEY>` template,
+since any individual entry can be set that way. Arrays get "n/a": there is no string form
+the Settings model accepts for a list.
 """
 
 import json
@@ -68,8 +72,8 @@ def _build_row(name: str, prop: dict, defs: dict, dumped_defaults: dict) -> Sett
     is_nested = _is_nested(prop, defs)
     type_label = _resolve_type_label(prop, defs)
     default_label = _resolve_default_label(name, dumped_defaults, is_nested=is_nested)
-    env_var_label = _resolve_env_var_label(name, is_nested=is_nested)
-    description = _resolve_description(prop, is_nested=is_nested)
+    env_var_label = _resolve_env_var_label(name, prop, defs, is_nested=is_nested)
+    description = _resolve_description(prop, defs, is_nested=is_nested)
 
     return SettingRow(
         name=name,
@@ -91,6 +95,52 @@ def _is_nested(prop: dict, defs: dict) -> bool:
         target = defs.get(ref, {})
         return "properties" in target
     return False
+
+
+def _is_scalar_leaf(prop: dict, defs: dict) -> bool:
+    """True when a sub-field is a single value rather than a nested model, list, or mapping.
+
+    An enum $ref has no "properties" key, so it counts as scalar. A union is scalar when any
+    non-null member is, since that member's string form is what an env var supplies: `str | None`
+    is settable, `list[str] | dict[str, str]` is not.
+    """
+    if prop.get("type") in {"object", "array"}:
+        return False
+
+    if (options := prop.get("anyOf")) is not None:
+        return any(option.get("type") != "null" and _is_scalar_leaf(option, defs) for option in options)
+
+    ref = _extract_ref(prop)
+    if ref is not None:
+        target = defs.get(ref, {})
+        return "properties" not in target
+    return True
+
+
+def _scalar_leaf_paths(ref: str, defs: dict, seen: frozenset[str] = frozenset()) -> list[str]:
+    """Collect the `__`-joined path to every scalar leaf beneath the model `ref` points at.
+
+    Recurses to full depth, so a scalar buried under an otherwise list-valued model (e.g.
+    app_events.on_app_initialization_complete.requires_engine) is still reported. `seen` guards
+    against a self-referential schema looping the docs build.
+    """
+    if ref in seen:
+        return []
+
+    paths = []
+    sub_properties = defs.get(ref, {}).get("properties", {})
+    for sub_name, sub_prop in sub_properties.items():
+        if _is_scalar_leaf(sub_prop, defs):
+            paths.append(sub_name.upper())
+            continue
+        sub_ref = _extract_ref(sub_prop)
+        if sub_ref is None:
+            continue
+        paths.extend(
+            f"{sub_name.upper()}__{nested_path}" for nested_path in _scalar_leaf_paths(sub_ref, defs, seen | {ref})
+        )
+
+    return paths
 
 
 def _resolve_type_label(prop: dict, defs: dict) -> str:
@@ -147,19 +197,53 @@ def _resolve_default_label(name: str, dumped_defaults: dict, *, is_nested: bool)
     return f"`{json.dumps(default_value)}`"
 
 
-def _resolve_env_var_label(name: str, *, is_nested: bool) -> str:
-    if is_nested:
-        return "n/a (nested; edit config file)"
-    return f"`GTN_CONFIG_{name.upper()}`"
+def _is_mapping(prop: dict) -> bool:
+    """True when a property is a mapping (`type: object` with `additionalProperties`).
+
+    Distinguishes a mapping from a nested model, which comes through a `$ref` to a def with
+    `properties` and never carries `additionalProperties` itself, and from an array
+    (`type: array`). A mapping's individual entries are settable via a `__<KEY>` env var path
+    (config_manager._load_config_from_env_vars splits on `__` and merges into a dict
+    regardless of whether the model declares that key), so it is not "n/a" the way an array is.
+    """
+    return prop.get("type") == "object" and "additionalProperties" in prop
 
 
-def _resolve_description(prop: dict, *, is_nested: bool) -> str:
+def _resolve_env_var_label(name: str, prop: dict, defs: dict, *, is_nested: bool) -> str:
+    if not is_nested:
+        return f"`GTN_CONFIG_{name.upper()}`"
+
+    if _is_mapping(prop):
+        return f"`GTN_CONFIG_{name.upper()}__<KEY>`"
+
+    ref = _extract_ref(prop)
+    if ref is None:
+        return "n/a (list/object; edit config file)"
+
+    leaf_paths = _scalar_leaf_paths(ref, defs)
+    if not leaf_paths:
+        return "n/a (list/object; edit config file)"
+
+    return ", ".join(f"`GTN_CONFIG_{name.upper()}__{leaf_path}`" for leaf_path in leaf_paths)
+
+
+def _resolve_description(prop: dict, defs: dict, *, is_nested: bool) -> str:
     description = _normalize_cell(prop.get("description", ""))
     if description:
         return description
-    if is_nested:
-        return "Nested settings; edit the sub-keys directly in a config file."
-    return ""
+    if not is_nested:
+        return ""
+
+    if _is_mapping(prop):
+        return (
+            "Nested settings; an entry can be set with a `GTN_CONFIG_<NAME>__<KEY>` env var "
+            "(only reaches an entry whose key is already lowercase), or edited directly in a config file."
+        )
+
+    ref = _extract_ref(prop)
+    if ref is not None and _scalar_leaf_paths(ref, defs):
+        return "Nested settings; the listed sub-keys can be set from the environment, and every sub-key can be edited directly in a config file."
+    return "Nested settings; edit the sub-keys directly in a config file."
 
 
 def _normalize_cell(text: str) -> str:
@@ -173,8 +257,11 @@ def _render_markdown(rows: list[SettingRow]) -> str:
     lines.append(
         "Every Griptape Nodes engine setting, grouped by category. Each setting can be placed in any "
         "`griptape_nodes_config.json` file (see [Engine Configuration](../guides/configuration.md) for the load "
-        "order). Settings with a `GTN_CONFIG_*` env var can also be overridden from the environment; "
-        "nested settings must be edited in a config file."
+        "order). Settings with a `GTN_CONFIG_*` env var, including the `GTN_CONFIG_<NAME>__<SUB_KEY>` form for a "
+        "nested setting's scalar sub-keys and the `GTN_CONFIG_<NAME>__<KEY>` form for a mapping-valued setting's "
+        "entries, can also be overridden from the environment; list-valued settings must be edited in a config "
+        "file. A mapping's keys are matched case-sensitively but the whole variable name is lowercased, so only "
+        "an already-lowercase key is reachable from the environment (see the guide for details)."
     )
     lines.append("")
 

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, NamedTuple
 
 from pydantic import ValidationError
 from xdg_base_dirs import xdg_config_home
@@ -79,9 +79,18 @@ DEFAULT_LIBRARIES_ROOT_ENV_VAR = "GTN_DEFAULT_LIBRARIES_ROOT"
 ENV_VAR_PREFIX = "GTN_CONFIG_"
 ENV_VAR_PATH_SEPARATOR = "__"
 
+
+class EnvVarOverride(NamedTuple):
+    """One GTN_CONFIG_ variable, paired with the config key it resolves to."""
+
+    env_var_name: str
+    config_key: str
+    raw_value: str
+
+
 # Outcomes of coercing an environment variable that no real config value can collide with.
-_REJECTED_BY_SCHEMA = object()
-_ABSENT_FROM_SCHEMA = object()
+_REJECTED_BAD_VALUE = object()
+_REJECTED_UNKNOWN_KEY = object()
 
 
 class ConfigManager(EngineScoped):
@@ -128,9 +137,10 @@ class ConfigManager(EngineScoped):
         self._workspace_config_path: Path | None = None
         self._workspace_dir_override: str | None = None
         self._libraries_root_override: str | None = None
-        # (variable name, value) pairs already reported as invalid. The env layer is re-read on every
-        # load_configs() and on each read_env_config() call, so without this a single bad variable
-        # warns repeatedly for the life of the process.
+        # (variable name, value) pairs already reported as ignored. The env layer is re-read on
+        # every load_configs() and on each read_env_config() call, so without this a single bad
+        # variable warns repeatedly for the life of this manager. Other ConfigManagers built
+        # elsewhere in the process keep their own accounting.
         self._reported_invalid_env_vars: set[tuple[str, str]] = set()
         self.load_configs()
 
@@ -400,18 +410,55 @@ class ConfigManager(EngineScoped):
             Dictionary containing config values from environment variables
         """
         env_config: dict[str, Any] = {}
-        for key, value in os.environ.items():
-            if not key.startswith(ENV_VAR_PREFIX):
+        for override in self._collect_env_var_overrides():
+            coerced_value = self._coerce_env_var_value(override.config_key, override.raw_value)
+            if coerced_value is _REJECTED_BAD_VALUE:
+                self._report_ignored_env_var(
+                    override,
+                    f"'{override.raw_value}' is not a valid value for the '{override.config_key}' setting",
+                )
                 continue
-            config_key = key.removeprefix(ENV_VAR_PREFIX).lower().replace(ENV_VAR_PATH_SEPARATOR, ".")
-            coerced_value = self._coerce_env_var_value(config_key, value)
-            if coerced_value is _REJECTED_BY_SCHEMA:
-                self._report_invalid_env_var(key, value, config_key)
+            if coerced_value is _REJECTED_UNKNOWN_KEY:
+                self._report_ignored_env_var(override, f"there is no '{override.config_key}' setting")
                 continue
-            set_dot_value(env_config, config_key, coerced_value)
-            logger.debug("Loaded config from env var: %s -> %s", key, config_key)
+            set_dot_value(env_config, override.config_key, coerced_value)
+            logger.debug("Loaded config from env var: %s -> %s", override.env_var_name, override.config_key)
 
         return env_config
+
+    def _collect_env_var_overrides(self) -> list[EnvVarOverride]:
+        """Gather the GTN_CONFIG_ variables to apply, dropping paths that contradict each other.
+
+        Two variables conflict when one's key is a strict prefix of another's: exporting both
+        GTN_CONFIG_ARTIFACTS__IMAGE and GTN_CONFIG_ARTIFACTS__IMAGE__PREVIEW_FORMAT asks for
+        `artifacts.image` to be a value and a section at once. `set_dot_value` honors whichever
+        `os.environ` yields last, so the winner would depend on iteration order. The deeper path is
+        kept because it carries strictly more of what was asked for; the prefix is dropped.
+
+        Returns:
+            The overrides to apply, in environment order, minus the dropped prefixes.
+        """
+        overrides = []
+        for env_var_name, raw_value in os.environ.items():
+            if not env_var_name.startswith(ENV_VAR_PREFIX):
+                continue
+            config_key = env_var_name.removeprefix(ENV_VAR_PREFIX).lower().replace(ENV_VAR_PATH_SEPARATOR, ".")
+            overrides.append(EnvVarOverride(env_var_name=env_var_name, config_key=config_key, raw_value=raw_value))
+
+        applicable = []
+        for override in overrides:
+            deeper_keys = sorted(
+                other.config_key for other in overrides if other.config_key.startswith(f"{override.config_key}.")
+            )
+            if deeper_keys:
+                self._report_ignored_env_var(
+                    override,
+                    f"'{override.config_key}' is also the start of a longer path ({', '.join(deeper_keys)})",
+                )
+                continue
+            applicable.append(override)
+
+        return applicable
 
     def _coerce_env_var_value(self, config_key: str, raw_value: str) -> Any:
         """Coerce one environment variable's string to the type the Settings model declares for it.
@@ -421,49 +468,45 @@ class ConfigManager(EngineScoped):
         Settings (every field has a default, so a partial dict validates) both converts the value and
         contains the damage from a bad one to that key.
 
+        A key the schema does not declare survives validation but not the dump, because a nested
+        model ignores sub-keys it does not know. Free-form keys never reach that state: an entry in a
+        mapping-valued setting and a path riding Settings' `extra="allow"` are both retained through
+        the dump. So an absent key means the path names nothing, as `worker.heartbeat_timeout` does
+        by dropping the `_s`.
+
         Args:
             config_key: The dot-notation key the variable maps to.
             raw_value: The variable's string value.
 
         Returns:
-            The coerced value, the raw string when the key is outside the Settings schema, or
-            _REJECTED_BY_SCHEMA when the model rejects the value.
+            The coerced value, _REJECTED_BAD_VALUE when the model rejects the value, or
+            _REJECTED_UNKNOWN_KEY when the path names no setting.
         """
         candidate = set_dot_value({}, config_key, raw_value)
 
         try:
             validated = Settings.model_validate(candidate)
         except ValidationError:
-            return _REJECTED_BY_SCHEMA
+            return _REJECTED_BAD_VALUE
 
-        coerced_value = get_dot_value(validated.model_dump(), config_key, _ABSENT_FROM_SCHEMA)
-        if coerced_value is _ABSENT_FROM_SCHEMA:
-            # A sub-key of a nested model that the model does not declare; it validated only because
-            # the model ignores unknown sub-keys. Keep the string so the value still reaches
-            # anything reading the key directly.
-            return raw_value
+        return get_dot_value(validated.model_dump(), config_key, _REJECTED_UNKNOWN_KEY)
 
-        return coerced_value
-
-    def _report_invalid_env_var(self, env_var_name: str, raw_value: str, config_key: str) -> None:
-        """Warn once per variable and value that an environment override was ignored.
+    def _report_ignored_env_var(self, override: EnvVarOverride, reason: str) -> None:
+        """Warn that an environment override was ignored, once per variable and value.
 
         Args:
-            env_var_name: The full environment variable name.
-            raw_value: The value that failed validation.
-            config_key: The dot-notation setting the variable maps to.
+            override: The override being ignored.
+            reason: Why it was ignored, phrased to complete "Ignoring <var>: <reason>.".
         """
-        report_key = (env_var_name, raw_value)
+        report_key = (override.env_var_name, override.raw_value)
         if report_key in self._reported_invalid_env_vars:
             return
 
         self._reported_invalid_env_vars.add(report_key)
         logger.warning(
-            "Ignoring environment variable %s: '%s' is not a valid value for the '%s' setting. "
-            "Falling back to the configured value.",
-            env_var_name,
-            raw_value,
-            config_key,
+            "Ignoring environment variable %s: %s. Falling back to the configured value.",
+            override.env_var_name,
+            reason,
         )
 
     def _load_config_from_file(self, path: Path, label: str) -> dict:

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -81,11 +81,12 @@ ENV_VAR_PATH_SEPARATOR = "__"
 
 
 class EnvVarOverride(NamedTuple):
-    """One GTN_CONFIG_ variable, paired with the config key it resolves to."""
+    """One GTN_CONFIG_ variable, with the config key and coerced value it resolves to."""
 
     env_var_name: str
     config_key: str
     raw_value: str
+    value: Any
 
 
 # Outcomes of coercing an environment variable that no real config value can collide with.
@@ -411,44 +412,55 @@ class ConfigManager(EngineScoped):
         """
         env_config: dict[str, Any] = {}
         for override in self._collect_env_var_overrides():
-            coerced_value = self._coerce_env_var_value(override.config_key, override.raw_value)
-            if coerced_value is _REJECTED_BAD_VALUE:
-                self._report_ignored_env_var(
-                    override,
-                    f"'{override.raw_value}' is not a valid value for the '{override.config_key}' setting",
-                )
-                continue
-            if coerced_value is _REJECTED_UNKNOWN_KEY:
-                self._report_ignored_env_var(override, f"there is no '{override.config_key}' setting")
-                continue
-            set_dot_value(env_config, override.config_key, coerced_value)
+            set_dot_value(env_config, override.config_key, override.value)
             logger.debug("Loaded config from env var: %s -> %s", override.env_var_name, override.config_key)
 
         return env_config
 
     def _collect_env_var_overrides(self) -> list[EnvVarOverride]:
-        """Gather the GTN_CONFIG_ variables to apply, dropping paths that contradict each other.
+        """Resolve the GTN_CONFIG_ variables to apply, reporting each one ignored along the way.
 
-        Two variables conflict when one's key is a strict prefix of another's: exporting both
-        GTN_CONFIG_ARTIFACTS__IMAGE and GTN_CONFIG_ARTIFACTS__IMAGE__PREVIEW_FORMAT asks for
-        `artifacts.image` to be a value and a section at once. `set_dot_value` honors whichever
-        `os.environ` yields last, so the winner would depend on iteration order. The deeper path is
-        kept because it carries strictly more of what was asked for; the prefix is dropped.
+        Three things get a variable ignored: a value the setting's type rejects, a path that names no
+        setting, and a path that is a strict prefix of another surviving path.
+
+        The prefix case is last because it only has to separate overrides that are each valid on
+        their own. Exporting both GTN_CONFIG_ARTIFACTS__IMAGE and
+        GTN_CONFIG_ARTIFACTS__IMAGE__PREVIEW_FORMAT asks for `artifacts.image` to be a value and a
+        section at once, and `dict[str, Any]` accepts either, so something has to break the tie:
+        `set_dot_value` would otherwise honor whichever `os.environ` yielded last. The deeper path
+        wins because it carries strictly more of what was asked for. An override that fails
+        validation is not competing for anything, so it must be dropped before the tie is broken;
+        judging overlap first would let a typo like GTN_CONFIG_AGENT__SYSTEM_PROMPT__OOPS, or a
+        stray trailing separator, take a correct neighbour down with it.
 
         Returns:
-            The overrides to apply, in environment order, minus the dropped prefixes.
+            The overrides to apply, in environment order.
         """
-        overrides = []
+        coerced = []
         for env_var_name, raw_value in os.environ.items():
             if not env_var_name.startswith(ENV_VAR_PREFIX):
                 continue
             config_key = env_var_name.removeprefix(ENV_VAR_PREFIX).lower().replace(ENV_VAR_PATH_SEPARATOR, ".")
-            overrides.append(EnvVarOverride(env_var_name=env_var_name, config_key=config_key, raw_value=raw_value))
+            override = EnvVarOverride(
+                env_var_name=env_var_name,
+                config_key=config_key,
+                raw_value=raw_value,
+                value=self._coerce_env_var_value(config_key, raw_value),
+            )
+            if override.value is _REJECTED_BAD_VALUE:
+                self._report_ignored_env_var(
+                    override, f"'{raw_value}' is not a valid value for the '{config_key}' setting"
+                )
+                continue
+            if override.value is _REJECTED_UNKNOWN_KEY:
+                self._report_ignored_env_var(override, f"there is no '{config_key}' setting")
+                continue
+            coerced.append(override)
 
         applicable = []
-        for override in overrides:
+        for override in coerced:
             deeper_keys = sorted(
-                other.config_key for other in overrides if other.config_key.startswith(f"{override.config_key}.")
+                other.config_key for other in coerced if other.config_key.startswith(f"{override.config_key}.")
             )
             if deeper_keys:
                 self._report_ignored_env_var(

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -420,8 +420,8 @@ class ConfigManager(EngineScoped):
     def _collect_env_var_overrides(self) -> list[EnvVarOverride]:
         """Resolve the GTN_CONFIG_ variables to apply, reporting each one ignored along the way.
 
-        Three things get a variable ignored: a value the setting's type rejects, a path that names no
-        setting, and a path that is a strict prefix of another surviving path.
+        Three things get a variable ignored: a name with an empty path segment, a value the
+        setting's type rejects, and a path that is a strict prefix of another surviving path.
 
         The prefix case is last because it only has to separate overrides that are each valid on
         their own. Exporting both GTN_CONFIG_ARTIFACTS__IMAGE and
@@ -430,8 +430,8 @@ class ConfigManager(EngineScoped):
         `set_dot_value` would otherwise honor whichever `os.environ` yielded last. The deeper path
         wins because it carries strictly more of what was asked for. An override that fails
         validation is not competing for anything, so it must be dropped before the tie is broken;
-        judging overlap first would let a typo like GTN_CONFIG_AGENT__SYSTEM_PROMPT__OOPS, or a
-        stray trailing separator, take a correct neighbour down with it.
+        judging overlap first would let a typo like GTN_CONFIG_AGENT__SYSTEM_PROMPT__OOPS take a
+        correct neighbour down with it.
 
         Returns:
             The overrides to apply, in environment order.
@@ -441,21 +441,25 @@ class ConfigManager(EngineScoped):
             if not env_var_name.startswith(ENV_VAR_PREFIX):
                 continue
             config_key = env_var_name.removeprefix(ENV_VAR_PREFIX).lower().replace(ENV_VAR_PATH_SEPARATOR, ".")
-            override = EnvVarOverride(
-                env_var_name=env_var_name,
-                config_key=config_key,
-                raw_value=raw_value,
-                value=self._coerce_env_var_value(config_key, raw_value),
-            )
-            if override.value is _REJECTED_BAD_VALUE:
+            if "" in config_key.split("."):
+                # A trailing, doubled, or leading separator. Nothing rejects it later: an empty key
+                # is a perfectly good key under a mapping or an undeclared tree, so it would
+                # validate, apply garbage at the highest-priority layer, and count as a longer path
+                # that discards its own correct prefix.
+                self._report_ignored_env_var(env_var_name, raw_value, "its name has an empty path segment")
+                continue
+            value = self._coerce_env_var_value(config_key, raw_value)
+            if value is _REJECTED_BAD_VALUE:
                 self._report_ignored_env_var(
-                    override, f"'{raw_value}' is not a valid value for the '{config_key}' setting"
+                    env_var_name, raw_value, f"'{raw_value}' is not a valid value for the '{config_key}' setting"
                 )
                 continue
-            if override.value is _REJECTED_UNKNOWN_KEY:
-                self._report_ignored_env_var(override, f"there is no '{config_key}' setting")
+            if value is _REJECTED_UNKNOWN_KEY:
+                self._report_ignored_env_var(env_var_name, raw_value, f"there is no '{config_key}' setting")
                 continue
-            coerced.append(override)
+            coerced.append(
+                EnvVarOverride(env_var_name=env_var_name, config_key=config_key, raw_value=raw_value, value=value)
+            )
 
         applicable = []
         for override in coerced:
@@ -464,7 +468,8 @@ class ConfigManager(EngineScoped):
             )
             if deeper_keys:
                 self._report_ignored_env_var(
-                    override,
+                    override.env_var_name,
+                    override.raw_value,
                     f"'{override.config_key}' is also the start of a longer path ({', '.join(deeper_keys)})",
                 )
                 continue
@@ -503,21 +508,22 @@ class ConfigManager(EngineScoped):
 
         return get_dot_value(validated.model_dump(), config_key, _REJECTED_UNKNOWN_KEY)
 
-    def _report_ignored_env_var(self, override: EnvVarOverride, reason: str) -> None:
+    def _report_ignored_env_var(self, env_var_name: str, raw_value: str, reason: str) -> None:
         """Warn that an environment override was ignored, once per variable and value.
 
         Args:
-            override: The override being ignored.
+            env_var_name: The full environment variable name.
+            raw_value: The value it carried.
             reason: Why it was ignored, phrased to complete "Ignoring <var>: <reason>.".
         """
-        report_key = (override.env_var_name, override.raw_value)
+        report_key = (env_var_name, raw_value)
         if report_key in self._reported_invalid_env_vars:
             return
 
         self._reported_invalid_env_vars.add(report_key)
         logger.warning(
             "Ignoring environment variable %s: %s. Falling back to the configured value.",
-            override.env_var_name,
+            env_var_name,
             reason,
         )
 

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -447,16 +447,23 @@ class ConfigManager(EngineScoped):
                 # is a perfectly good key under a mapping or an undeclared tree, so it would
                 # validate, apply garbage at the highest-priority layer, and count as a longer path
                 # that discards its own correct prefix.
-                self._report_ignored_env_var(env_var_name, raw_value, "its name has an empty path segment")
+                self._report_ignored_env_var(
+                    env_var_name, raw_value, "its name has an empty path segment, so the configured value stands"
+                )
                 continue
             value = self._coerce_env_var_value(config_key, raw_value)
             if value is _REJECTED_BAD_VALUE:
                 self._report_ignored_env_var(
-                    env_var_name, raw_value, f"'{raw_value}' is not a valid value for the '{config_key}' setting"
+                    env_var_name,
+                    raw_value,
+                    f"'{raw_value}' is not a valid value for the '{config_key}' setting, "
+                    "so the configured value stands",
                 )
                 continue
             if value is _REJECTED_UNKNOWN_KEY:
-                self._report_ignored_env_var(env_var_name, raw_value, f"there is no '{config_key}' setting")
+                self._report_ignored_env_var(
+                    env_var_name, raw_value, f"there is no '{config_key}' setting, so it sets nothing"
+                )
                 continue
             coerced.append(
                 EnvVarOverride(env_var_name=env_var_name, config_key=config_key, raw_value=raw_value, value=value)
@@ -471,7 +478,8 @@ class ConfigManager(EngineScoped):
                 self._report_ignored_env_var(
                     override.env_var_name,
                     override.raw_value,
-                    f"'{override.config_key}' is also the start of a longer path ({', '.join(deeper_keys)})",
+                    f"'{override.config_key}' is also the start of a longer path "
+                    f"({', '.join(deeper_keys)}), which still applies",
                 )
                 continue
             applicable.append(override)
@@ -515,18 +523,17 @@ class ConfigManager(EngineScoped):
         Args:
             env_var_name: The full environment variable name.
             raw_value: The value it carried.
-            reason: Why it was ignored, phrased to complete "Ignoring <var>: <reason>.".
+            reason: Why it was ignored and what happens instead, phrased to complete
+                "Ignoring <var>: <reason>.". The consequence differs per reason, so it belongs
+                here rather than in a shared closing sentence: a dropped prefix is not falling
+                back to anything, since the longer path that displaced it still writes underneath.
         """
         report_key = (env_var_name, raw_value)
         if report_key in self._reported_invalid_env_vars:
             return
 
         self._reported_invalid_env_vars.add(report_key)
-        logger.warning(
-            "Ignoring environment variable %s: %s. Falling back to the configured value.",
-            env_var_name,
-            reason,
-        )
+        logger.warning("Ignoring environment variable %s: %s.", env_var_name, reason)
 
     def _load_config_from_file(self, path: Path, label: str) -> dict:
         """Read and parse a JSON config file. Returns empty dict if missing or unparsable."""

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -72,6 +72,17 @@ USER_CONFIG_PATH = xdg_config_home() / "griptape_nodes" / "griptape_nodes_config
 # would pin the resolved path above every config file and every project override.
 DEFAULT_LIBRARIES_ROOT_ENV_VAR = "GTN_DEFAULT_LIBRARIES_ROOT"
 
+# Prefix marking an environment variable as a config input, and the separator that splits the
+# remainder into a nested key path. A single underscore cannot serve as the separator because
+# setting names contain underscores themselves (`storage_backend`), so `WORKER_HEARTBEAT_TIMEOUT_S`
+# would be ambiguous.
+ENV_VAR_PREFIX = "GTN_CONFIG_"
+ENV_VAR_PATH_SEPARATOR = "__"
+
+# Outcomes of coercing an environment variable that no real config value can collide with.
+_REJECTED_BY_SCHEMA = object()
+_ABSENT_FROM_SCHEMA = object()
+
 
 class ConfigManager(EngineScoped):
     """A class to manage application configuration and file pathing.
@@ -84,8 +95,10 @@ class ConfigManager(EngineScoped):
     5. Environment variables with GTN_CONFIG_ prefix (highest priority)
 
     Environment variables starting with GTN_CONFIG_ are converted to config keys by removing the prefix
-    and converting to lowercase (e.g., GTN_CONFIG_FOO=bar becomes {"foo": "bar"}). That flow is
-    input-only: nothing here writes a GTN_CONFIG_ variable back out.
+    and converting to lowercase (e.g., GTN_CONFIG_FOO=bar becomes {"foo": "bar"}), with a double
+    underscore separating nested keys (GTN_CONFIG_WORKER__HEARTBEAT_TIMEOUT_S=30 becomes
+    {"worker": {"heartbeat_timeout_s": 30.0}}). That flow is input-only: nothing here writes a
+    GTN_CONFIG_ variable back out.
 
     The one variable this manager PUBLISHES is GTN_DEFAULT_LIBRARIES_ROOT, written once at
     construction so project templates can reference the engine's default libraries root. See
@@ -115,6 +128,10 @@ class ConfigManager(EngineScoped):
         self._workspace_config_path: Path | None = None
         self._workspace_dir_override: str | None = None
         self._libraries_root_override: str | None = None
+        # (variable name, value) pairs already reported as invalid. The env layer is re-read on every
+        # load_configs() and on each read_env_config() call, so without this a single bad variable
+        # warns repeatedly for the life of the process.
+        self._reported_invalid_env_vars: set[tuple[str, str]] = set()
         self.load_configs()
 
         # Once per engine process, before any project YAML is read. See the method docstring for why
@@ -374,18 +391,80 @@ class ConfigManager(EngineScoped):
         GTN_CONFIG_FOO=bar becomes {"foo": "bar"}
         GTN_CONFIG_STORAGE_BACKEND=gtc becomes {"storage_backend": "gtc"}
 
+        A double underscore separates nested keys, so
+        GTN_CONFIG_WORKER__HEARTBEAT_TIMEOUT_S=30 becomes {"worker": {"heartbeat_timeout_s": 30.0}}.
+        Because the whole name is lowercased, this only reaches settings whose keys are lowercase:
+        case-sensitive trees such as `nodes.<Library>.<SECRET>` stay config-file-only.
+
         Returns:
             Dictionary containing config values from environment variables
         """
-        env_config = {}
+        env_config: dict[str, Any] = {}
         for key, value in os.environ.items():
-            if key.startswith("GTN_CONFIG_"):
-                # Remove GTN_CONFIG_ prefix and convert to lowercase
-                config_key = key[11:].lower()  # len("GTN_CONFIG_") = 11
-                env_config[config_key] = value
-                logger.debug("Loaded config from env var: %s -> %s", key, config_key)
+            if not key.startswith(ENV_VAR_PREFIX):
+                continue
+            config_key = key.removeprefix(ENV_VAR_PREFIX).lower().replace(ENV_VAR_PATH_SEPARATOR, ".")
+            coerced_value = self._coerce_env_var_value(config_key, value)
+            if coerced_value is _REJECTED_BY_SCHEMA:
+                self._report_invalid_env_var(key, value, config_key)
+                continue
+            set_dot_value(env_config, config_key, coerced_value)
+            logger.debug("Loaded config from env var: %s -> %s", key, config_key)
 
         return env_config
+
+    def _coerce_env_var_value(self, config_key: str, raw_value: str) -> Any:
+        """Coerce one environment variable's string to the type the Settings model declares for it.
+
+        Environment variables are always strings, so a bool, number, or enum setting would otherwise
+        reach read sites as text -- and "false" is truthy. Validating a single-key delta against
+        Settings (every field has a default, so a partial dict validates) both converts the value and
+        contains the damage from a bad one to that key.
+
+        Args:
+            config_key: The dot-notation key the variable maps to.
+            raw_value: The variable's string value.
+
+        Returns:
+            The coerced value, the raw string when the key is outside the Settings schema, or
+            _REJECTED_BY_SCHEMA when the model rejects the value.
+        """
+        candidate = set_dot_value({}, config_key, raw_value)
+
+        try:
+            validated = Settings.model_validate(candidate)
+        except ValidationError:
+            return _REJECTED_BY_SCHEMA
+
+        coerced_value = get_dot_value(validated.model_dump(), config_key, _ABSENT_FROM_SCHEMA)
+        if coerced_value is _ABSENT_FROM_SCHEMA:
+            # A sub-key of a nested model that the model does not declare; it validated only because
+            # the model ignores unknown sub-keys. Keep the string so the value still reaches
+            # anything reading the key directly.
+            return raw_value
+
+        return coerced_value
+
+    def _report_invalid_env_var(self, env_var_name: str, raw_value: str, config_key: str) -> None:
+        """Warn once per variable and value that an environment override was ignored.
+
+        Args:
+            env_var_name: The full environment variable name.
+            raw_value: The value that failed validation.
+            config_key: The dot-notation setting the variable maps to.
+        """
+        report_key = (env_var_name, raw_value)
+        if report_key in self._reported_invalid_env_vars:
+            return
+
+        self._reported_invalid_env_vars.add(report_key)
+        logger.warning(
+            "Ignoring environment variable %s: '%s' is not a valid value for the '%s' setting. "
+            "Falling back to the configured value.",
+            env_var_name,
+            raw_value,
+            config_key,
+        )
 
     def _load_config_from_file(self, path: Path, label: str) -> dict:
         """Read and parse a JSON config file. Returns empty dict if missing or unparsable."""

--- a/src/griptape_nodes/retained_mode/managers/config_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/config_manager.py
@@ -420,8 +420,9 @@ class ConfigManager(EngineScoped):
     def _collect_env_var_overrides(self) -> list[EnvVarOverride]:
         """Resolve the GTN_CONFIG_ variables to apply, reporting each one ignored along the way.
 
-        Three things get a variable ignored: a name with an empty path segment, a value the
-        setting's type rejects, and a path that is a strict prefix of another surviving path.
+        Four things get a variable ignored: a name with an empty path segment, a value the
+        setting's type rejects, a path that names no setting, and a path that is a strict prefix
+        of another surviving path.
 
         The prefix case is last because it only has to separate overrides that are each valid on
         their own. Exporting both GTN_CONFIG_ARTIFACTS__IMAGE and

--- a/tests/unit/retained_mode/managers/test_config_manager.py
+++ b/tests/unit/retained_mode/managers/test_config_manager.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import platform
 import tempfile
@@ -67,6 +68,220 @@ class TestConfigManager:
             manager = ConfigManager()
             env_config = manager._load_config_from_env_vars()
             assert env_config == {"some_long_key_name": "value1", "api_key": "value2", "123_numeric": "value3"}
+
+    def test_load_config_from_env_vars_nested_path(self) -> None:
+        """A `__` separator maps to a nested dict, and the value is coerced to the field's type."""
+        with patch.dict(os.environ, {"GTN_CONFIG_WORKER__HEARTBEAT_TIMEOUT_S": "30"}, clear=True):
+            manager = ConfigManager()
+            env_config = manager._load_config_from_env_vars()
+            assert env_config == {"worker": {"heartbeat_timeout_s": 30.0}}
+
+    def test_load_config_from_env_vars_three_level_path(self) -> None:
+        """A three-level `__` path (app_events -> on_app_initialization_complete -> requires_engine) works."""
+        with patch.dict(
+            os.environ,
+            {"GTN_CONFIG_APP_EVENTS__ON_APP_INITIALIZATION_COMPLETE__REQUIRES_ENGINE": ">=0.5,<0.6"},
+            clear=True,
+        ):
+            manager = ConfigManager()
+            env_config = manager._load_config_from_env_vars()
+            assert env_config == {"app_events": {"on_app_initialization_complete": {"requires_engine": ">=0.5,<0.6"}}}
+
+    def test_load_config_from_env_vars_sibling_nested_keys_merge(self) -> None:
+        """Two `__` vars under the same parent merge into one dict instead of clobbering."""
+        with patch.dict(
+            os.environ,
+            {
+                "GTN_CONFIG_LIBRARY__LAZY_NODE_LOADING": "false",
+                "GTN_CONFIG_LIBRARY__DEPENDENCY_INSTALL_BEHAVIOR": "never",
+            },
+            clear=True,
+        ):
+            manager = ConfigManager()
+            env_config = manager._load_config_from_env_vars()
+            assert env_config == {
+                "library": {
+                    "lazy_node_loading": False,
+                    "dependency_install_behavior": "never",
+                }
+            }
+
+    def test_load_config_from_env_vars_bool_coercion(self) -> None:
+        """A bool-typed nested setting coerces 'false' to False, not the truthy string 'false'.
+
+        library_manager.py reads `library.lazy_node_loading` with a bare `bool(...)` and no
+        `cast_type`, so an uncoerced string would silently invert the setting.
+        """
+        with patch.dict(os.environ, {"GTN_CONFIG_LIBRARY__LAZY_NODE_LOADING": "false"}, clear=True):
+            manager = ConfigManager()
+            env_config = manager._load_config_from_env_vars()
+            assert env_config["library"]["lazy_node_loading"] is False
+
+    def test_load_config_from_env_vars_enum_coercion(self) -> None:
+        """An enum-typed nested setting resolves to the enum's value."""
+        with patch.dict(os.environ, {"GTN_CONFIG_LIBRARY__DEPENDENCY_INSTALL_BEHAVIOR": "never"}, clear=True):
+            manager = ConfigManager()
+            env_config = manager._load_config_from_env_vars()
+            assert env_config["library"]["dependency_install_behavior"] == "never"
+
+    def test_load_config_from_env_vars_invalid_typed_value_dropped(self) -> None:
+        """A value the Settings model rejects for a typed setting is dropped, not merged."""
+        with patch.dict(os.environ, {"GTN_CONFIG_MAX_NODES_IN_PARALLEL": "not-an-int"}, clear=True):
+            manager = ConfigManager()
+            env_config = manager._load_config_from_env_vars()
+            assert env_config == {}
+
+    def test_invalid_env_var_does_not_reset_the_rest_of_the_config(self, isolate_user_config: Path) -> None:
+        """A single bad env var must not wipe the merged config back to defaults.
+
+        Before per-key validation, an invalid GTN_CONFIG_ value flowed straight into
+        merged_config, and Settings.model_validate(merged_config) in load_configs rejected the
+        whole dict on any single bad field, resetting every other setting -- including the
+        user's own config file -- back to defaults.
+        """
+        isolate_user_config.write_text(json.dumps({"log_level": "ERROR"}), encoding="utf-8")
+
+        with patch.dict(os.environ, {"GTN_CONFIG_MAX_NODES_IN_PARALLEL": "not-an-int"}, clear=True):
+            manager = ConfigManager()
+            manager.load_configs()
+
+            assert manager.merged_config["log_level"] == "ERROR"
+
+    def test_load_config_from_env_vars_unknown_nested_key_keeps_raw_string(self) -> None:
+        """A sub-key the nested model doesn't declare keeps its raw string value.
+
+        It validates only because Settings ignores unknown keys on a nested model, so the
+        loader falls back to the raw string rather than losing the value entirely.
+        """
+        with patch.dict(os.environ, {"GTN_CONFIG_WORKER__BOGUS": "1"}, clear=True):
+            manager = ConfigManager()
+            env_config = manager._load_config_from_env_vars()
+            assert env_config == {"worker": {"bogus": "1"}}
+
+    def test_invalid_env_var_warning_logged_once_per_variable_and_value(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The same (variable, value) pair warns once even when the env layer is re-read.
+
+        Several call sites re-read the env layer over a process's life (load_configs on every
+        project switch, read_env_config for provisioning previews), so without deduping, one
+        bad variable would re-warn every time.
+        """
+        with patch.dict(os.environ, {"GTN_CONFIG_MAX_NODES_IN_PARALLEL": "not-an-int"}, clear=True):
+            manager = ConfigManager()
+            with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+                manager._load_config_from_env_vars()
+                manager.read_env_config()
+
+            warnings = [record for record in caplog.records if "is not a valid value for the" in record.message]
+            assert len(warnings) == 1
+
+    def test_nested_env_var_reaches_merged_config_with_correct_type(self) -> None:
+        """A nested env var survives merge_dicts and whole-config validation with the right type.
+
+        The tests above check `_load_config_from_env_vars()` directly; this exercises the public
+        pipeline (`load_configs()` -> `merged_config` / `get_config_value()`) that value actually
+        has to travel through, proving it lands typed rather than as the raw string.
+        """
+        with patch.dict(os.environ, {"GTN_CONFIG_WORKER__HEARTBEAT_TIMEOUT_S": "30"}, clear=True):
+            manager = ConfigManager()
+            manager.load_configs()
+
+            value = manager.get_config_value("worker.heartbeat_timeout_s")
+            assert value == 30.0  # noqa: PLR2004
+            assert isinstance(value, float)
+
+    def test_nested_env_var_overrides_project_config_layer(self) -> None:
+        """A `__` env var wins over the same nested key set in a project-adjacent config file.
+
+        Mirrors test_workspace_config_overrides_project_config_but_not_env_vars above, but for a
+        nested key, to prove GTN_CONFIG_ precedence holds through the full layer stack and not
+        only for top-level settings.
+        """
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_dir = Path(temp_dir)
+            (project_dir / "griptape_nodes_config.json").write_text(
+                json.dumps({"worker": {"heartbeat_timeout_s": 99.0}})
+            )
+
+            with patch.dict(os.environ, {"GTN_CONFIG_WORKER__HEARTBEAT_TIMEOUT_S": "30"}, clear=True):
+                manager = ConfigManager()
+                manager.load_project_config(project_dir)
+
+                assert manager.get_config_value("worker.heartbeat_timeout_s") == 30.0  # noqa: PLR2004
+
+    def test_nested_env_var_does_not_clobber_sibling_defaults(self) -> None:
+        """Setting one leaf under a parent must not blank out its siblings.
+
+        merge_dicts overlays a nested dict rather than replacing the parent wholesale, but that
+        property was previously unverified: with only heartbeat_timeout_s exported,
+        heartbeat_interval_s must still be WorkerSettings's own default.
+        """
+        with patch.dict(os.environ, {"GTN_CONFIG_WORKER__HEARTBEAT_TIMEOUT_S": "30"}, clear=True):
+            manager = ConfigManager()
+            manager.load_configs()
+
+            assert manager.get_config_value("worker.heartbeat_timeout_s") == 30.0  # noqa: PLR2004
+            assert manager.get_config_value("worker.heartbeat_interval_s") == 5.0  # noqa: PLR2004
+
+    def test_flat_and_nested_worker_env_vars_together_nested_wins(self) -> None:
+        """A flat GTN_CONFIG_WORKER cannot clobber a sibling GTN_CONFIG_WORKER__X, in either order.
+
+        `worker` is a declared WorkerSettings-typed field, so a bare string always fails
+        Settings.model_validate({"worker": "<string>"}) and is dropped via _REJECTED_BY_SCHEMA;
+        the nested key must survive regardless of os.environ iteration order. Safe by
+        construction today, but unverified before this test, and a future `extra="allow"` on
+        WorkerSettings (or a scalar top-level `worker` alias) would break it silently.
+        """
+        for env in (
+            {"GTN_CONFIG_WORKER": "x", "GTN_CONFIG_WORKER__HEARTBEAT_TIMEOUT_S": "30"},
+            {"GTN_CONFIG_WORKER__HEARTBEAT_TIMEOUT_S": "30", "GTN_CONFIG_WORKER": "x"},
+        ):
+            with patch.dict(os.environ, env, clear=True):
+                manager = ConfigManager()
+                env_config = manager._load_config_from_env_vars()
+                assert env_config == {"worker": {"heartbeat_timeout_s": 30.0}}
+
+    def test_mapping_entry_settable_via_env(self) -> None:
+        """An entry in a mapping-valued setting (not a nested model) can be set with `__<KEY>`.
+
+        `artifacts` is `dict[str, Any]`, not a Settings sub-model, so this exercises a different
+        path than the worker/agent/library tests above: the key is not declared anywhere in the
+        schema, and the value survives only because Settings ignores unknown keys within a
+        mapping the way it does within a nested model.
+        """
+        with patch.dict(os.environ, {"GTN_CONFIG_ARTIFACTS__SOME_KEY": "1"}, clear=True):
+            manager = ConfigManager()
+            env_config = manager._load_config_from_env_vars()
+            assert env_config == {"artifacts": {"some_key": "1"}}
+
+    def test_mapping_entry_key_is_lowercased(self) -> None:
+        """A mapping key arrives lowercased, which is why some mappings are unreachable in practice.
+
+        `project_workspaces` is the example the configuration guide uses. Its keys are project IDs
+        or file paths, matched case-sensitively, so a mixed-case key set this way silently never
+        matches the project it names. This pins the lowercasing that makes that true rather than
+        endorsing it as a way to configure project workspaces.
+        """
+        with patch.dict(os.environ, {"GTN_CONFIG_PROJECT_WORKSPACES__MyProject": "/studio/ws"}, clear=True):
+            manager = ConfigManager()
+            env_config = manager._load_config_from_env_vars()
+            assert env_config == {"project_workspaces": {"myproject": "/studio/ws"}}
+
+    def test_invalid_enum_value_silently_becomes_the_built_in_default(self, isolate_user_config: Path) -> None:
+        """Pins a known pre-existing wart, NOT desired behavior: do not read this as an endorsement.
+
+        `log_level` has a `mode="before"` validator that catches its own lookup failure and
+        returns LogLevel.INFO instead of raising, so an invalid GTN_CONFIG_LOG_LEVEL never trips
+        the reject-and-warn path the rest of this test class exercises for other settings. This
+        predates the nested-env-var work in this file and is being tracked, not fixed, here.
+        """
+        isolate_user_config.write_text(json.dumps({"log_level": "DEBUG"}), encoding="utf-8")
+
+        with patch.dict(os.environ, {"GTN_CONFIG_LOG_LEVEL": "NOTALEVEL"}, clear=True):
+            manager = ConfigManager()
+
+            # Silently becomes the schema default (INFO), not the user's file-configured DEBUG,
+            # and with no warning logged -- unlike every other invalid-value case in this class.
+            assert manager.get_config_value("log_level") == "INFO"
 
     def test_config_integration_with_env_vars(self) -> None:
         """Test that environment variables are integrated into merged config with highest priority."""
@@ -988,18 +1203,22 @@ class TestComputeProjectProvisioningConfig:
         assert get_dot_value(merged, LIBRARIES_TO_REGISTER_KEY) == ["workspace-lib"]
 
     def test_env_var_overrides_all_file_layers(self, tmp_path: Path) -> None:
-        """A GTN_CONFIG_ env var sits above every config-file layer, matching load_configs."""
+        """A GTN_CONFIG_ env var sits above every config-file layer, matching load_configs.
+
+        storage_backend is Literal["local", "gtc"], so both layers must use valid values;
+        the point under test is precedence, not the literal strings.
+        """
         from griptape_nodes.utils.dict_utils import get_dot_value
 
         project_dir = tmp_path / "project"
         project_dir.mkdir()
-        self._write_config(project_dir / "griptape_nodes_config.json", "storage_backend", "from-project")
+        self._write_config(project_dir / "griptape_nodes_config.json", "storage_backend", "local")
 
-        with patch.dict(os.environ, {"GTN_CONFIG_STORAGE_BACKEND": "from-env"}, clear=True):
+        with patch.dict(os.environ, {"GTN_CONFIG_STORAGE_BACKEND": "gtc"}, clear=True):
             manager = ConfigManager()
             merged = manager.compute_project_provisioning_config(project_dir, project_dir, apply_override=True)
 
-        assert get_dot_value(merged, "storage_backend") == "from-env"
+        assert get_dot_value(merged, "storage_backend") == "gtc"
 
     def test_self_contained_project_skips_duplicate_workspace_layer(self, tmp_path: Path) -> None:
         """When workspace dir == project dir, the project-adjacent file is the only file layer.

--- a/tests/unit/retained_mode/managers/test_config_manager.py
+++ b/tests/unit/retained_mode/managers/test_config_manager.py
@@ -260,8 +260,9 @@ class TestConfigManager:
 
         Overlap is only a real conflict when both paths are individually valid, so a variable that
         fails validation must be dropped before overlap is judged. `agent.system_prompt` is a `str`
-        with no sub-keys, and a stray trailing separator produces the same shape, so both of these
-        would otherwise silently take a correct neighbour down with them.
+        with no sub-keys, so `…__OOPS` is rejected for its value and must not take its own prefix
+        down with it. The trailing-separator case is rejected earlier still, at the split, and is
+        kept here to pin that neither route reaches the prefix filter.
         """
         cases = [
             (

--- a/tests/unit/retained_mode/managers/test_config_manager.py
+++ b/tests/unit/retained_mode/managers/test_config_manager.py
@@ -134,10 +134,11 @@ class TestConfigManager:
     def test_invalid_env_var_does_not_reset_the_rest_of_the_config(self, isolate_user_config: Path) -> None:
         """A single bad env var must not wipe the merged config back to defaults.
 
-        Before per-key validation, an invalid GTN_CONFIG_ value flowed straight into
-        merged_config, and Settings.model_validate(merged_config) in load_configs rejected the
-        whole dict on any single bad field, resetting every other setting -- including the
-        user's own config file -- back to defaults.
+        `load_configs` calls `Settings.model_validate(merged_config)` on the whole merged dict, so
+        an invalid value anywhere in it would fail validation for the entire config, resetting
+        every setting, including the user's own config file, back to defaults. Validating each
+        `GTN_CONFIG_` variable against its own single-key delta before it is merged keeps one bad
+        variable's damage contained to that key instead.
         """
         isolate_user_config.write_text(json.dumps({"log_level": "ERROR"}), encoding="utf-8")
 
@@ -147,16 +148,23 @@ class TestConfigManager:
 
             assert manager.merged_config["log_level"] == "ERROR"
 
-    def test_load_config_from_env_vars_unknown_nested_key_keeps_raw_string(self) -> None:
-        """A sub-key the nested model doesn't declare keeps its raw string value.
+    def test_load_config_from_env_vars_unknown_nested_key_rejected(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A sub-key a declared nested model doesn't recognize is rejected, not kept as a raw string.
 
-        It validates only because Settings ignores unknown keys on a nested model, so the
-        loader falls back to the raw string rather than losing the value entirely.
+        `WorkerSettings` has no `heartbeat_timeout` field, only `heartbeat_timeout_s`, and being a
+        strict model it drops an unrecognized sub-key from `model_dump()` rather than keeping it.
+        That absence after validation is unambiguous: a free-form path, an entry in a
+        mapping-valued setting, or one riding Settings' own `extra="allow"`, is retained through
+        the dump instead, so an absent key here means the path names no real setting.
         """
         with patch.dict(os.environ, {"GTN_CONFIG_WORKER__BOGUS": "1"}, clear=True):
-            manager = ConfigManager()
-            env_config = manager._load_config_from_env_vars()
-            assert env_config == {"worker": {"bogus": "1"}}
+            with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+                manager = ConfigManager()
+                env_config = manager._load_config_from_env_vars()
+
+            assert env_config == {}
+            warnings = [record for record in caplog.records if "there is no" in record.message]
+            assert len(warnings) == 1
 
     def test_invalid_env_var_warning_logged_once_per_variable_and_value(self, caplog: pytest.LogCaptureFixture) -> None:
         """The same (variable, value) pair warns once even when the env layer is re-read.
@@ -166,8 +174,8 @@ class TestConfigManager:
         bad variable would re-warn every time.
         """
         with patch.dict(os.environ, {"GTN_CONFIG_MAX_NODES_IN_PARALLEL": "not-an-int"}, clear=True):
-            manager = ConfigManager()
             with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+                manager = ConfigManager()
                 manager._load_config_from_env_vars()
                 manager.read_env_config()
 
@@ -211,9 +219,9 @@ class TestConfigManager:
     def test_nested_env_var_does_not_clobber_sibling_defaults(self) -> None:
         """Setting one leaf under a parent must not blank out its siblings.
 
-        merge_dicts overlays a nested dict rather than replacing the parent wholesale, but that
-        property was previously unverified: with only heartbeat_timeout_s exported,
-        heartbeat_interval_s must still be WorkerSettings's own default.
+        `merge_dicts` overlays a nested dict onto the existing one rather than replacing the
+        parent wholesale, so with only `heartbeat_timeout_s` exported, `heartbeat_interval_s`
+        must still resolve to `WorkerSettings`'s own default.
         """
         with patch.dict(os.environ, {"GTN_CONFIG_WORKER__HEARTBEAT_TIMEOUT_S": "30"}, clear=True):
             manager = ConfigManager()
@@ -222,23 +230,29 @@ class TestConfigManager:
             assert manager.get_config_value("worker.heartbeat_timeout_s") == 30.0  # noqa: PLR2004
             assert manager.get_config_value("worker.heartbeat_interval_s") == 5.0  # noqa: PLR2004
 
-    def test_flat_and_nested_worker_env_vars_together_nested_wins(self) -> None:
-        """A flat GTN_CONFIG_WORKER cannot clobber a sibling GTN_CONFIG_WORKER__X, in either order.
+    def test_flat_and_nested_worker_env_vars_together_nested_wins(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A flat GTN_CONFIG_WORKER is dropped as a prefix of GTN_CONFIG_WORKER__X, in either order.
 
-        `worker` is a declared WorkerSettings-typed field, so a bare string always fails
-        Settings.model_validate({"worker": "<string>"}) and is dropped via _REJECTED_BY_SCHEMA;
-        the nested key must survive regardless of os.environ iteration order. Safe by
-        construction today, but unverified before this test, and a future `extra="allow"` on
-        WorkerSettings (or a scalar top-level `worker` alias) would break it silently.
+        `worker` is a strict prefix of `worker.heartbeat_timeout_s`, so exporting both asks for
+        `worker` to be a scalar value and a section at once. The prefix filter drops the shallower
+        key before either reaches validation, independent of `os.environ` iteration order, so the
+        deeper key always survives.
         """
         for env in (
             {"GTN_CONFIG_WORKER": "x", "GTN_CONFIG_WORKER__HEARTBEAT_TIMEOUT_S": "30"},
             {"GTN_CONFIG_WORKER__HEARTBEAT_TIMEOUT_S": "30", "GTN_CONFIG_WORKER": "x"},
         ):
+            caplog.clear()
             with patch.dict(os.environ, env, clear=True):
-                manager = ConfigManager()
-                env_config = manager._load_config_from_env_vars()
+                with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+                    manager = ConfigManager()
+                    env_config = manager._load_config_from_env_vars()
+
                 assert env_config == {"worker": {"heartbeat_timeout_s": 30.0}}
+                warnings = [
+                    record for record in caplog.records if "is also the start of a longer path" in record.message
+                ]
+                assert len(warnings) == 1
 
     def test_mapping_entry_settable_via_env(self) -> None:
         """An entry in a mapping-valued setting (not a nested model) can be set with `__<KEY>`.
@@ -266,13 +280,58 @@ class TestConfigManager:
             env_config = manager._load_config_from_env_vars()
             assert env_config == {"project_workspaces": {"myproject": "/studio/ws"}}
 
+    def test_overlapping_mapping_paths_resolve_identically_regardless_of_order(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Overlap under a mapping-valued parent is order-independent too, unlike a validation-based drop.
+
+        `artifacts` is `dict[str, Any]`, so neither `artifacts.image` nor
+        `artifacts.image.preview_format` is rejected by `Settings.model_validate` on its own: both
+        are free-form entries an `Any`-typed mapping accepts. Without the prefix filter, whichever
+        variable `os.environ` happened to yield last would silently win. The filter removes that
+        dependency by dropping the shallower path outright, with a warning naming the longer one.
+        """
+        for env in (
+            {"GTN_CONFIG_ARTIFACTS__IMAGE": "x", "GTN_CONFIG_ARTIFACTS__IMAGE__PREVIEW_FORMAT": "png"},
+            {"GTN_CONFIG_ARTIFACTS__IMAGE__PREVIEW_FORMAT": "png", "GTN_CONFIG_ARTIFACTS__IMAGE": "x"},
+        ):
+            caplog.clear()
+            with patch.dict(os.environ, env, clear=True):
+                with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+                    manager = ConfigManager()
+                    env_config = manager._load_config_from_env_vars()
+
+                assert env_config == {"artifacts": {"image": {"preview_format": "png"}}}
+                warnings = [
+                    record for record in caplog.records if "is also the start of a longer path" in record.message
+                ]
+                assert len(warnings) == 1
+
+    def test_free_form_path_kept_while_declared_model_typo_rejected(self) -> None:
+        """The same absent-after-validation check tells a mapping entry apart from a model typo.
+
+        `GTN_CONFIG_ARTIFACTS__SOME_KEY` (a `dict[str, Any]` entry) and `GTN_CONFIG_WORKER__BOGUS`
+        (an unrecognized `WorkerSettings` sub-key) both validate against `Settings`, since neither
+        is a fully unknown top-level key. Only the mapping entry survives `model_dump()`:
+        `WorkerSettings` is a strict model and drops `bogus`, while `artifacts` being typed
+        `dict[str, Any]` means Pydantic has nothing to drop.
+        """
+        with patch.dict(
+            os.environ,
+            {"GTN_CONFIG_ARTIFACTS__SOME_KEY": "1", "GTN_CONFIG_WORKER__BOGUS": "1"},
+            clear=True,
+        ):
+            manager = ConfigManager()
+            env_config = manager._load_config_from_env_vars()
+            assert env_config == {"artifacts": {"some_key": "1"}}
+
     def test_invalid_enum_value_silently_becomes_the_built_in_default(self, isolate_user_config: Path) -> None:
-        """Pins a known pre-existing wart, NOT desired behavior: do not read this as an endorsement.
+        """An invalid `log_level` resolves to INFO rather than falling back to the config files.
 
         `log_level` has a `mode="before"` validator that catches its own lookup failure and
-        returns LogLevel.INFO instead of raising, so an invalid GTN_CONFIG_LOG_LEVEL never trips
-        the reject-and-warn path the rest of this test class exercises for other settings. This
-        predates the nested-env-var work in this file and is being tracked, not fixed, here.
+        returns LogLevel.INFO instead of raising, so an invalid GTN_CONFIG_LOG_LEVEL never
+        reaches the reject-and-warn path this class exercises for other settings. Same for
+        workflow_execution_mode, thread_storage_backend, and library.dependency_install_behavior.
         """
         isolate_user_config.write_text(json.dumps({"log_level": "DEBUG"}), encoding="utf-8")
 

--- a/tests/unit/retained_mode/managers/test_config_manager.py
+++ b/tests/unit/retained_mode/managers/test_config_manager.py
@@ -286,13 +286,42 @@ class TestConfigManager:
                 ]
                 assert prefix_warnings == []
 
+    def test_empty_path_segment_is_rejected(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A separator that produces an empty path segment is ignored rather than applied.
+
+        An empty segment is a legitimate key under a mapping or an undeclared tree, so validation
+        accepts it. Left alone it would write garbage at the highest-priority layer, masking the
+        config file underneath, and count as a longer path that discards its own correct prefix.
+        A lone one has no prefix to discard and so would apply silently.
+        """
+        preview_format = "GTN_CONFIG_ARTIFACTS__IMAGE__PREVIEW_GENERATION__PREVIEW_FORMAT"
+        cases = [
+            ({f"{preview_format}__": "jpg"}, {}),
+            (
+                {preview_format: "png", f"{preview_format}__": "jpg"},
+                {"artifacts": {"image": {"preview_generation": {"preview_format": "png"}}}},
+            ),
+            ({"GTN_CONFIG_ARTIFACTS____IMAGE": "y"}, {}),
+            ({"GTN_CONFIG_": "x"}, {}),
+            ({"GTN_CONFIG_NODES__FOO__BAR__": "b"}, {}),
+        ]
+        for env, want in cases:
+            caplog.clear()
+            with patch.dict(os.environ, env, clear=True):
+                with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+                    manager = ConfigManager()
+                    env_config = manager._load_config_from_env_vars()
+
+                assert env_config == want
+                assert any("has an empty path segment" in record.message for record in caplog.records)
+
     def test_mapping_entry_settable_via_env(self) -> None:
         """An entry in a mapping-valued setting (not a nested model) can be set with `__<KEY>`.
 
         `artifacts` is `dict[str, Any]`, not a Settings sub-model, so this exercises a different
-        path than the worker/agent/library tests above: the key is not declared anywhere in the
-        schema, and the value survives only because Settings ignores unknown keys within a
-        mapping the way it does within a nested model.
+        path than the worker/agent/library tests above: `Any` gives Pydantic nothing to drop, so
+        an undeclared key survives `model_dump()` instead of being rejected the way an undeclared
+        sub-key on a nested model is.
         """
         with patch.dict(os.environ, {"GTN_CONFIG_ARTIFACTS__SOME_KEY": "1"}, clear=True):
             manager = ConfigManager()

--- a/tests/unit/retained_mode/managers/test_config_manager.py
+++ b/tests/unit/retained_mode/managers/test_config_manager.py
@@ -231,12 +231,11 @@ class TestConfigManager:
             assert manager.get_config_value("worker.heartbeat_interval_s") == 5.0  # noqa: PLR2004
 
     def test_flat_and_nested_worker_env_vars_together_nested_wins(self, caplog: pytest.LogCaptureFixture) -> None:
-        """A flat GTN_CONFIG_WORKER is dropped as a prefix of GTN_CONFIG_WORKER__X, in either order.
+        """A flat GTN_CONFIG_WORKER cannot clobber GTN_CONFIG_WORKER__X, in either order.
 
-        `worker` is a strict prefix of `worker.heartbeat_timeout_s`, so exporting both asks for
-        `worker` to be a scalar value and a section at once. The prefix filter drops the shallower
-        key before either reaches validation, independent of `os.environ` iteration order, so the
-        deeper key always survives.
+        `worker` is a declared `WorkerSettings` field, so the bare string fails validation and is
+        dropped for that reason rather than for overlapping. The deeper key therefore survives
+        regardless of `os.environ` iteration order, and the prefix filter never has to weigh in.
         """
         for env in (
             {"GTN_CONFIG_WORKER": "x", "GTN_CONFIG_WORKER__HEARTBEAT_TIMEOUT_S": "30"},
@@ -250,9 +249,42 @@ class TestConfigManager:
 
                 assert env_config == {"worker": {"heartbeat_timeout_s": 30.0}}
                 warnings = [
-                    record for record in caplog.records if "is also the start of a longer path" in record.message
+                    record for record in caplog.records if "is not a valid value for the 'worker'" in record.message
                 ]
                 assert len(warnings) == 1
+
+    def test_invalid_deeper_path_does_not_discard_a_valid_shallower_override(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A rejected deeper variable leaves its valid prefix alone.
+
+        Overlap is only a real conflict when both paths are individually valid, so a variable that
+        fails validation must be dropped before overlap is judged. `agent.system_prompt` is a `str`
+        with no sub-keys, and a stray trailing separator produces the same shape, so both of these
+        would otherwise silently take a correct neighbour down with them.
+        """
+        cases = [
+            (
+                {"GTN_CONFIG_AGENT__SYSTEM_PROMPT": "hi", "GTN_CONFIG_AGENT__SYSTEM_PROMPT__OOPS": "x"},
+                {"agent": {"system_prompt": "hi"}},
+            ),
+            (
+                {"GTN_CONFIG_WORKER__HEARTBEAT_TIMEOUT_S": "30", "GTN_CONFIG_WORKER__HEARTBEAT_TIMEOUT_S__": "99"},
+                {"worker": {"heartbeat_timeout_s": 30.0}},
+            ),
+        ]
+        for env, want in cases:
+            caplog.clear()
+            with patch.dict(os.environ, env, clear=True):
+                with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+                    manager = ConfigManager()
+                    env_config = manager._load_config_from_env_vars()
+
+                assert env_config == want
+                prefix_warnings = [
+                    record for record in caplog.records if "is also the start of a longer path" in record.message
+                ]
+                assert prefix_warnings == []
 
     def test_mapping_entry_settable_via_env(self) -> None:
         """An entry in a mapping-valued setting (not a nested model) can be set with `__<KEY>`.

--- a/tests/unit/retained_mode/managers/test_config_project_layer_dropout.py
+++ b/tests/unit/retained_mode/managers/test_config_project_layer_dropout.py
@@ -3,10 +3,12 @@
 This is the mechanism behind the stale-library report. Three facts combine:
 
 1. `libraries_to_register` lives at
-   `app_events.on_app_initialization_complete.libraries_to_register` -- a *nested* key.
-   `_load_config_from_env_vars` only ever produces flat top-level keys
-   (`config_key = key[11:].lower()`, no dot-splitting), so no `GTN_CONFIG_*` variable can
-   set or shadow it.
+   `app_events.on_app_initialization_complete.libraries_to_register` -- a *nested*,
+   *list-valued* key. `_load_config_from_env_vars` can reach a nested key via a `__`
+   path separator (e.g. `GTN_CONFIG_WORKER__HEARTBEAT_TIMEOUT_S`), but a list-valued
+   setting has no string representation the `Settings` model accepts, so any value
+   supplied for `libraries_to_register` is rejected and dropped. No `GTN_CONFIG_*`
+   variable can set or shadow it.
 
 2. `merge_dicts` is called with the default `merge_lists=False`, so a project layer that
    declares `libraries_to_register` *replaces* the user layer's list, hiding a polluted
@@ -31,6 +33,7 @@ config, where it persists after the project is gone.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import tempfile
 from pathlib import Path
@@ -180,8 +183,9 @@ class TestProjectLayerDropoutExposesUserLayer:
     def test_env_vars_cannot_protect_the_register_list(self, isolate_user_config: Path) -> None:
         """The user's GTN_CONFIG_* pins are structurally unable to shadow the nested key.
 
-        Env vars become flat top-level keys, so `libraries_to_register` -- nested two levels
-        deep -- is untouched no matter what is exported.
+        `libraries_to_register` is list-valued, and list values have no string form the
+        `Settings` model accepts, so no `GTN_CONFIG_*` variable -- flat or `__`-nested -- can
+        set or shadow it: any attempt is rejected and dropped.
         """
         isolate_user_config.write_text(
             _register_list_config(PREVIOUS_INSTALL_LIBRARIES, workspace_directory=OLD_WORKSPACE)
@@ -204,24 +208,27 @@ class TestProjectLayerDropoutExposesUserLayer:
 
             # ...but the nested register list is still the previous install's.
             assert manager.get_config_value(LIBRARIES_TO_REGISTER_KEY) == PREVIOUS_INSTALL_LIBRARIES
-
-            # No env-derived key can reach it: the loader never splits on dots.
-            assert all("." not in key for key in manager.env_config)
             assert LIBRARIES_TO_REGISTER_KEY not in manager.env_config
 
-    def test_env_config_only_produces_flat_keys(self) -> None:
-        """Pin the loader behavior the test above depends on."""
+    def test_list_valued_setting_cannot_be_set_from_env(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Pin the loader behavior the test above depends on.
+
+        A `__`-nested path reaches `libraries_to_register`, but the value supplied is a
+        JSON-array string, and the `Settings` model has no string form for a `list[str |
+        LibraryRegistration]` field, so validation rejects it and the env layer ends up empty.
+        """
         with patch.dict(
             os.environ,
             {"GTN_CONFIG_APP_EVENTS__ON_APP_INITIALIZATION_COMPLETE__LIBRARIES_TO_REGISTER": "[]"},
             clear=True,
         ):
             manager = ConfigManager()
-            env_config = manager._load_config_from_env_vars()
+            with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+                env_config = manager._load_config_from_env_vars()
 
-        # Flattened to a single meaningless key rather than a nested path.
-        assert list(env_config) == ["app_events__on_app_initialization_complete__libraries_to_register"]
-        assert "app_events" not in env_config
+        # Rejected by the Settings model, not merged as a nested path or a flat key.
+        assert env_config == {}
+        assert any("is not a valid value for the" in record.message for record in caplog.records)
 
 
 class TestDropoutProducesTheReportedErrors:


### PR DESCRIPTION
`GTN_CONFIG_*` env vars could only reach top-level settings. A double underscore now separates path segments, so nested settings are settable, and each value is coerced to the type the setting declares instead of arriving as a string.

```bash
GTN_CONFIG_WORKER__HEARTBEAT_TIMEOUT_S=30    # worker.heartbeat_timeout_s, as 30.0
GTN_CONFIG_LIBRARY__LAZY_NODE_LOADING=false  # False, not the truthy string "false"
GTN_CONFIG_AGENT__SYSTEM_PROMPT="Be terse."  # agent.system_prompt
GTN_CONFIG_ARTIFACTS__SOME_KEY=png           # an entry in a mapping-valued setting
```

griptape-ai/internal#223: the desktop app writes IPC transport values into the user's `griptape_nodes_config.json` on every boot, silently overwriting whatever they set by hand.

griptape-ai/griptape-nodes-app#222 keyed transport config by transport name instead of by list position, which makes a single transport addressable. Together with this change, that means:

```bash
GTN_CONFIG_TRANSPORTS__WEBSOCKET_DIRECT__ENABLED=false
GTN_CONFIG_TRANSPORTS__LOCAL_SOCKET__ENABLED=true
```
