### PR TITLE
fix(loops): report why each iteration failed, and stop announcing the transient loop flow

### DIFF
--- a/src/griptape_nodes/common/node_executor.py
+++ b/src/griptape_nodes/common/node_executor.py
@@ -84,6 +84,8 @@ from griptape_nodes.retained_mode.events.flow_events import (
     PackageNodesAsSerializedFlowResultSuccess,
 )
 from griptape_nodes.retained_mode.events.node_events import (
+    CreateNodeResultFailure,
+    CreateNodeResultSuccess,
     DeserializeNodeFromCommandsResultFailure,
     DeserializeNodeFromCommandsResultSuccess,
     SetLockNodeStateResultFailure,
@@ -141,7 +143,34 @@ class IterationControlAction(StrEnum):
     BREAK = "break"  # Break out of loop immediately
 
 
+@dataclass(frozen=True)
+class IterationFailure:
+    """One loop iteration that did not finish, with the reason it gave.
+
+    ``iteration_index`` is zero-based to match the executor's internal indexing;
+    everything shown to an artist adds one, because a loop's first pass is
+    iteration 1 to the person who built it.
+    """
+
+    iteration_index: int
+    detail: str
+
+
+# How many distinct failure reasons a loop error message names before deferring to the log.
+MAX_REPORTED_ITERATION_FAILURES = 5
+
+# Results the engine produces while rebuilding a loop body into a transient flow. They describe
+# node copies the artist never placed, in a flow that is deleted before the run ends, so an editor
+# that hears about them asks the engine for a flow that no longer exists and reports an error.
+#
+# CreateNodeResultSuccess/Failure are here because node_manager.on_deserialize_node_from_commands
+# dispatches a nested CreateNodeRequest whose result names the transient flow as the node's parent
+# -- the specific leak behind the "no Flow with that name exists" toast on every loop run.
+# _silence_packaged_node_creation_broadcasts covers the same leak at the source; this set is the
+# backstop for any future creation path that escapes it.
 LOOP_EVENTS_TO_SUPPRESS = {
+    CreateNodeResultSuccess,
+    CreateNodeResultFailure,
     CreateFlowResultSuccess,
     CreateFlowResultFailure,
     ImportWorkflowAsReferencedSubFlowResultSuccess,
@@ -158,6 +187,12 @@ LOOP_EVENTS_TO_SUPPRESS = {
     DeserializeFlowFromCommandsResultFailure,
 }
 
+# NOTE: unlike LOOP_EVENTS_TO_SUPPRESS, this set is inert. Execution events are emitted through
+# put_event/aput_event, which never consult should_suppress_event -- only request results are
+# checked (engine.py). Left in place as the record of intent: the aim is to stop parallel
+# iterations from flooding the websocket with per-node execution traffic. Wiring put_event up to
+# suppression would also silence the node highlighting that EventTranslationContext exists to
+# provide, so it needs its own design rather than a one-line change.
 EXECUTION_EVENTS_TO_SUPPRESS = {
     CurrentControlNodeEvent,
     CurrentDataNodeEvent,
@@ -343,6 +378,78 @@ class NodeExecutor(EngineScoped):
         return (
             f"Node '{node_name}' execution failed: {type_prefix}{getattr(result, 'result_details', result)}{tb_suffix}"
         )
+
+    @staticmethod
+    def _format_loop_failure_message(
+        loop_name: str, total_iterations: int, iteration_failures: list[IterationFailure]
+    ) -> str:
+        """Compose the RuntimeError message for a loop that lost iterations.
+
+        This lands on the artist's node via the execution machine, so it leads with what was
+        attempted and how much was lost, then names the iterations and their reasons.
+        """
+        summary = (
+            f"Attempted to run all {total_iterations} iterations of loop '{loop_name}'. "
+            f"Failed because {len(iteration_failures)} of them did not finish."
+        )
+        detail_lines = NodeExecutor._format_iteration_failure_lines(iteration_failures)
+        if not detail_lines:
+            return summary
+        return "\n".join([summary, *detail_lines])
+
+    @staticmethod
+    def _format_iteration_failure_lines(
+        iteration_failures: list[IterationFailure], *, max_lines: int = MAX_REPORTED_ITERATION_FAILURES
+    ) -> list[str]:
+        """Render one indented line per distinct failure reason.
+
+        Iterations that failed for the same reason share a line: the common case is every
+        iteration failing identically, and repeating one sentence dozens of times buries it.
+        At most ``max_lines`` reasons are rendered so a long loop cannot produce an unreadable
+        wall of text; the engine log has already recorded every iteration individually, so the
+        tail line points there.
+        """
+        if not iteration_failures:
+            return []
+
+        iterations_by_detail: dict[str, list[int]] = {}
+        for iteration_failure in iteration_failures:
+            iterations_by_detail.setdefault(iteration_failure.detail, []).append(iteration_failure.iteration_index + 1)
+
+        lines = []
+        for detail, iteration_numbers in list(iterations_by_detail.items())[:max_lines]:
+            if len(iteration_numbers) == 1:
+                label = f"Iteration {iteration_numbers[0]}"
+            else:
+                label = f"Iterations {', '.join(str(number) for number in iteration_numbers)}"
+            lines.append(f"  {label}: {detail}")
+
+        unreported_count = len(iterations_by_detail) - len(lines)
+        if unreported_count > 0:
+            lines.append(f"  ... and {unreported_count} more reason(s). See the engine log for every iteration.")
+        return lines
+
+    @staticmethod
+    def _silence_packaged_node_creation_broadcasts(
+        package_result: PackageNodesAsSerializedFlowResultSuccess,
+    ) -> None:
+        """Keep editors from ever hearing about the nodes inside a packaged loop body.
+
+        A loop body is rebuilt into a transient child flow on every run and torn down
+        afterwards. Each rebuild dispatches a nested CreateNodeRequest whose success result
+        names that transient flow, and an editor that receives it turns around and asks the
+        engine for the flow's details -- by which time the flow is gone, so the artist gets an
+        error toast naming a flow they never made. Marking the creation commands non-broadcast
+        keeps the rebuild entirely inside the engine: in-process callers still get the full
+        result, only the queued broadcast is skipped.
+
+        Set here rather than in the packaging handler on purpose. That handler also serves
+        workflow publishing, and generated workflow files are emitted by reflecting over each
+        create command's non-default fields (workflow_manager._generate_node_creation_code), so
+        flipping the flag there would bake a transport detail into saved artifacts.
+        """
+        for serialized_node in package_result.serialized_flow_commands.serialized_node_commands:
+            serialized_node.create_node_command.broadcast_result = False
 
     async def _execute_and_apply_workflow(
         self,
@@ -838,6 +945,8 @@ class NodeExecutor(EngineScoped):
             msg = f"Failed to package loop nodes for '{end_node.name}'. Error: {package_result.result_details}"
             raise TypeError(msg)
 
+        self._silence_packaged_node_creation_broadcasts(package_result)
+
         logger.info(
             "Successfully packaged %d nodes for loop execution from '%s' to '%s'",
             len(all_nodes),
@@ -1048,7 +1157,7 @@ class NodeExecutor(EngineScoped):
         total_iterations: int,
         parameter_values_per_iteration: dict[int, dict[str, Any]],
         end_loop_node: BaseIterativeEndNode | BaseIterativeNodeGroup,
-    ) -> tuple[dict[int, Any], list[int], dict[str, Any], int, bool, list[int]]:
+    ) -> tuple[dict[int, Any], list[int], dict[str, Any], int, bool, list[IterationFailure]]:
         """Execute loop iterations sequentially by running one flow instance N times.
 
         Args:
@@ -1064,7 +1173,7 @@ class NodeExecutor(EngineScoped):
             - last_iteration_values: Dict mapping parameter names -> values from last iteration
             - skipped_count: Number of iterations that were skipped via skip control signal
             - break_occurred: True if the loop exited early due to a break signal
-            - failed_iterations: List of iteration indices that raised a subflow error
+            - iteration_failures: One IterationFailure per iteration that raised a subflow error
         """
         # Deserialize the loop body once and reuse it for every iteration.
         # Everything from deserialization onward is inside the try so the finally deletes the
@@ -1103,7 +1212,7 @@ class NodeExecutor(EngineScoped):
 
             iteration_results: dict[int, Any] = {}
             successful_iterations: list[int] = []
-            failed_iterations: list[int] = []
+            iteration_failures: list[IterationFailure] = []
             skipped_count = 0
             break_occurred = False
 
@@ -1168,7 +1277,12 @@ class NodeExecutor(EngineScoped):
                     )
                     # Don't immediately store None - try to extract results first in case there are partial results
                     # (e.g., nested loop that had some failures but still produced output)
-                    failed_iterations.append(iteration_index)
+                    iteration_failures.append(
+                        IterationFailure(
+                            iteration_index=iteration_index,
+                            detail=str(start_subflow_result.result_details),
+                        )
+                    )
                 else:
                     successful_iterations.append(iteration_index)
 
@@ -1236,7 +1350,7 @@ class NodeExecutor(EngineScoped):
                 last_iteration_values,
                 skipped_count,
                 break_occurred,
-                failed_iterations,
+                iteration_failures,
             )
 
         finally:
@@ -1292,7 +1406,7 @@ class NodeExecutor(EngineScoped):
 
         # Execute iterations sequentially based on execution environment
         break_occurred = False
-        failed_iterations: list[int] = []
+        iteration_failures: list[IterationFailure] = []
         if execution_type == LOCAL_EXECUTION:
             (
                 iteration_results,
@@ -1300,7 +1414,7 @@ class NodeExecutor(EngineScoped):
                 last_iteration_values,
                 _skipped_count,
                 break_occurred,
-                failed_iterations,
+                iteration_failures,
             ) = await self._execute_loop_iterations_sequentially(
                 package_result=package_result,
                 total_iterations=total_iterations,
@@ -1339,8 +1453,14 @@ class NodeExecutor(EngineScoped):
                 len(successful_iterations),
                 total_iterations,
             )
-        elif failed_iterations:
-            msg = f"Loop execution failed: {len(failed_iterations)} of {total_iterations} iterations failed"
+        # Only the local sequential path reports per-iteration failures; private and cloud loops
+        # leave this empty and fall through to the short-count branch below.
+        elif iteration_failures:
+            msg = self._format_loop_failure_message(
+                loop_name=end_node.name,
+                total_iterations=total_iterations,
+                iteration_failures=iteration_failures,
+            )
             raise RuntimeError(msg)
         elif len(successful_iterations) < total_iterations:
             logger.info(
@@ -2113,6 +2233,8 @@ class NodeExecutor(EngineScoped):
             msg = f"Failed to package {label} '{node.name}'. Error: {package_result.result_details}"
             raise TypeError(msg)
 
+        self._silence_packaged_node_creation_broadcasts(package_result)
+
         logger.info(
             "Successfully packaged %d nodes for %s '%s'",
             len(node_names),
@@ -2278,7 +2400,7 @@ class NodeExecutor(EngineScoped):
 
         # Execute iterations sequentially based on execution environment
         break_occurred = False
-        failed_iterations: list[int] = []
+        iteration_failures: list[IterationFailure] = []
         match execution_type:
             case node_types.LOCAL_EXECUTION:
                 (
@@ -2287,7 +2409,7 @@ class NodeExecutor(EngineScoped):
                     last_iteration_values,
                     _skipped_count,
                     break_occurred,
-                    failed_iterations,
+                    iteration_failures,
                 ) = await self._execute_loop_iterations_sequentially(
                     package_result=package_result,
                     total_iterations=total_iterations,
@@ -2326,8 +2448,14 @@ class NodeExecutor(EngineScoped):
                 len(successful_iterations),
                 total_iterations,
             )
-        elif failed_iterations:
-            msg = f"Iterative group execution failed: {len(failed_iterations)} of {total_iterations} iterations failed"
+        # Only the local sequential path reports per-iteration failures; private and cloud loops
+        # leave this empty and fall through to the short-count branch below.
+        elif iteration_failures:
+            msg = self._format_loop_failure_message(
+                loop_name=node.name,
+                total_iterations=total_iterations,
+                iteration_failures=iteration_failures,
+            )
             raise RuntimeError(msg)
         elif len(successful_iterations) < total_iterations:
             logger.info(
@@ -3103,13 +3231,13 @@ class NodeExecutor(EngineScoped):
             # Step 5: Collect successful and failed iterations
             successful_iterations = []
             failed_iteration_indices = []
-            failed_iteration_errors = {}  # Map iteration_index -> error
+            iteration_failures: list[IterationFailure] = []
 
             for idx, result in enumerate(iteration_task_results):
                 if isinstance(result, Exception):
                     # Exception doesn't include iteration_index, use enumerate index
                     failed_iteration_indices.append(idx)
-                    failed_iteration_errors[idx] = str(result)
+                    iteration_failures.append(IterationFailure(iteration_index=idx, detail=str(result)))
                     continue
                 if isinstance(result, tuple):
                     iteration_index, success = result
@@ -3117,14 +3245,20 @@ class NodeExecutor(EngineScoped):
                         successful_iterations.append(iteration_index)
                     else:
                         failed_iteration_indices.append(iteration_index)
-                        failed_iteration_errors[iteration_index] = "Iteration failed"
+                        iteration_failures.append(
+                            IterationFailure(
+                                iteration_index=iteration_index,
+                                detail="The iteration reported failure without a reason.",
+                            )
+                        )
 
             if failed_iteration_indices:
                 logger.warning(
-                    "Loop execution: %d of %d parallel iterations failed. Results will contain None for failed iterations. Errors: %s",
+                    "Loop execution: %d of %d parallel iterations failed. Results will contain None for failed "
+                    "iterations.\n%s",
                     len(failed_iteration_indices),
                     total_iterations,
-                    failed_iteration_errors,
+                    "\n".join(self._format_iteration_failure_lines(iteration_failures)),
                 )
 
             # Step 6: Extract parameter values from iterations BEFORE cleanup

--- a/src/griptape_nodes/common/node_executor.py
+++ b/src/griptape_nodes/common/node_executor.py
@@ -205,19 +205,16 @@ LOOP_EVENTS_TO_SUPPRESS = {
     DeserializeFlowFromCommandsResultFailure,
 }
 
-# NOTE: unlike LOOP_EVENTS_TO_SUPPRESS, every member of this set is inert, and that is checked by
-# test_execution_events_to_suppress_is_entirely_inert. Execution events are emitted through
-# put_event/aput_event, which never consult should_suppress_event -- only request results are
-# checked (engine.py). Left in place as the record of intent: the aim is to stop parallel
-# iterations from flooding the websocket with per-node execution traffic. Wiring put_event up to
-# suppression would also silence the node highlighting that EventTranslationContext exists to
-# provide, so it needs its own design rather than a one-line change.
+# NOTE: every member of this set is inert, and test_execution_events_to_suppress_is_entirely_inert
+# checks that it stays that way. Execution events are emitted through put_event/aput_event, which
+# never consult should_suppress_event -- only request results are checked (engine.py). The set is
+# kept as the record of intent: the aim is to stop parallel iterations from flooding the websocket
+# with per-node execution traffic. Wiring put_event up to suppression would also silence the node
+# highlighting that EventTranslationContext exists to provide, so it needs its own design rather
+# than a one-line change.
 #
-# Keep it that way. StartLocalSubflowResultSuccess/Failure used to be listed here, and they are
-# ResultPayload subclasses, so once should_suppress_event started matching properly they were the
-# one pair that actually took effect -- silently dropping a parallel loop's per-iteration results
-# on the way to the editor. Adding a request result to this set is a live transport change wearing
-# the costume of a no-op; put it in LOOP_EVENTS_TO_SUPPRESS deliberately or leave it out.
+# Only ExecutionPayload members belong here. A ResultPayload in this set is a live transport change
+# wearing the costume of a no-op: put it in LOOP_EVENTS_TO_SUPPRESS deliberately, or leave it out.
 EXECUTION_EVENTS_TO_SUPPRESS = {
     CurrentControlNodeEvent,
     CurrentDataNodeEvent,
@@ -447,14 +444,23 @@ class NodeExecutor(EngineScoped):
         for iteration_failure in iteration_failures:
             iterations_by_detail.setdefault(iteration_failure.detail, []).append(iteration_failure.iteration_index + 1)
 
+        reported = list(iterations_by_detail.items())[:max_lines]
+        unreported = list(iterations_by_detail.items())[max_lines:]
+
         lines = []
-        for detail, iteration_numbers in list(iterations_by_detail.items())[:max_lines]:
+        for detail, iteration_numbers in reported:
             label = NodeExecutor._describe_failed_iterations(iteration_numbers, total_iterations)
             lines.append(f"  {label}: {detail}")
 
-        unreported_count = len(iterations_by_detail) - len(lines)
-        if unreported_count > 0:
-            lines.append(f"  ... and {unreported_count} more reason(s). See the engine log for every iteration.")
+        if unreported:
+            # Count the iterations behind the omitted reasons, not just the reasons: the lines above
+            # are phrased in iterations, so a bare reason count reads as one and can undersell the
+            # tail by two orders of magnitude.
+            unreported_iterations = sum(len(iteration_numbers) for _, iteration_numbers in unreported)
+            lines.append(
+                f"  ... and {len(unreported)} more reason(s) affecting {unreported_iterations} iteration(s). "
+                f"See the engine log for every iteration."
+            )
         return lines
 
     @staticmethod
@@ -468,10 +474,12 @@ class NodeExecutor(EngineScoped):
         sorted_numbers = sorted(iteration_numbers)
         count = len(sorted_numbers)
 
-        if total_iterations is not None and count >= total_iterations:
-            return "Every iteration"
+        # Naming the single iteration comes first: "Every iteration" is only more informative than
+        # a number when there is more than one, and a one-item loop satisfies both tests.
         if count == 1:
             return f"Iteration {sorted_numbers[0]}"
+        if total_iterations is not None and count >= total_iterations:
+            return "Every iteration"
 
         spans_a_contiguous_run = sorted_numbers[-1] - sorted_numbers[0] == count - 1
         if spans_a_contiguous_run:
@@ -3219,8 +3227,8 @@ class NodeExecutor(EngineScoped):
                     start_subflow_result = await self.engine.ahandle_request(start_subflow_request)
                     if isinstance(start_subflow_result, StartLocalSubflowResultSuccess):
                         return IterationOutcome(iteration_index=iteration_index, succeeded=True, detail="")
-                    # Carry the reason out with the verdict. Narrowing this to a bool is what used to
-                    # leave the parallel path reporting a failure "without a reason" it had in hand.
+                    # The reason travels out with the verdict: this closure is the only place that
+                    # holds it, so anything narrower than IterationOutcome loses it for good.
                     return IterationOutcome(
                         iteration_index=iteration_index,
                         succeeded=False,

--- a/src/griptape_nodes/common/node_executor.py
+++ b/src/griptape_nodes/common/node_executor.py
@@ -156,8 +156,26 @@ class IterationFailure:
     detail: str
 
 
+@dataclass(frozen=True)
+class IterationOutcome:
+    """What one parallel loop iteration did, as reported back by its task.
+
+    A bool would be enough to route the iteration, but not enough to explain it: the reason a
+    parallel iteration failed is only available inside the task that ran it, so the verdict and
+    the reason have to travel together or the reason is lost.
+    """
+
+    iteration_index: int
+    succeeded: bool
+    detail: str
+
+
 # How many distinct failure reasons a loop error message names before deferring to the log.
 MAX_REPORTED_ITERATION_FAILURES = 5
+
+# How many individual iteration numbers to name before switching to "(+N more)". Only reached when
+# the failed iterations are not a contiguous run, which is already summarised as "first-last".
+MAX_ENUMERATED_ITERATION_NUMBERS = 6
 
 # Results the engine produces while rebuilding a loop body into a transient flow. They describe
 # node copies the artist never placed, in a flow that is deleted before the run ends, so an editor
@@ -187,12 +205,19 @@ LOOP_EVENTS_TO_SUPPRESS = {
     DeserializeFlowFromCommandsResultFailure,
 }
 
-# NOTE: unlike LOOP_EVENTS_TO_SUPPRESS, this set is inert. Execution events are emitted through
+# NOTE: unlike LOOP_EVENTS_TO_SUPPRESS, every member of this set is inert, and that is checked by
+# test_execution_events_to_suppress_is_entirely_inert. Execution events are emitted through
 # put_event/aput_event, which never consult should_suppress_event -- only request results are
 # checked (engine.py). Left in place as the record of intent: the aim is to stop parallel
 # iterations from flooding the websocket with per-node execution traffic. Wiring put_event up to
 # suppression would also silence the node highlighting that EventTranslationContext exists to
 # provide, so it needs its own design rather than a one-line change.
+#
+# Keep it that way. StartLocalSubflowResultSuccess/Failure used to be listed here, and they are
+# ResultPayload subclasses, so once should_suppress_event started matching properly they were the
+# one pair that actually took effect -- silently dropping a parallel loop's per-iteration results
+# on the way to the editor. Adding a request result to this set is a live transport change wearing
+# the costume of a no-op; put it in LOOP_EVENTS_TO_SUPPRESS deliberately or leave it out.
 EXECUTION_EVENTS_TO_SUPPRESS = {
     CurrentControlNodeEvent,
     CurrentDataNodeEvent,
@@ -211,8 +236,6 @@ EXECUTION_EVENTS_TO_SUPPRESS = {
     AgentStreamEvent,
     AlterElementEvent,
     RemoveElementEvent,
-    StartLocalSubflowResultSuccess,
-    StartLocalSubflowResultFailure,
     ProgressEvent,
 }
 
@@ -392,14 +415,19 @@ class NodeExecutor(EngineScoped):
             f"Attempted to run all {total_iterations} iterations of loop '{loop_name}'. "
             f"Failed because {len(iteration_failures)} of them did not finish."
         )
-        detail_lines = NodeExecutor._format_iteration_failure_lines(iteration_failures)
+        detail_lines = NodeExecutor._format_iteration_failure_lines(
+            iteration_failures, total_iterations=total_iterations
+        )
         if not detail_lines:
             return summary
         return "\n".join([summary, *detail_lines])
 
     @staticmethod
     def _format_iteration_failure_lines(
-        iteration_failures: list[IterationFailure], *, max_lines: int = MAX_REPORTED_ITERATION_FAILURES
+        iteration_failures: list[IterationFailure],
+        *,
+        total_iterations: int | None = None,
+        max_lines: int = MAX_REPORTED_ITERATION_FAILURES,
     ) -> list[str]:
         """Render one indented line per distinct failure reason.
 
@@ -408,6 +436,9 @@ class NodeExecutor(EngineScoped):
         At most ``max_lines`` reasons are rendered so a long loop cannot produce an unreadable
         wall of text; the engine log has already recorded every iteration individually, so the
         tail line points there.
+
+        ``total_iterations`` is optional only because the parallel path logs these lines without a
+        summary above them; pass it whenever it is known so a wholly-failed loop can say so.
         """
         if not iteration_failures:
             return []
@@ -418,16 +449,38 @@ class NodeExecutor(EngineScoped):
 
         lines = []
         for detail, iteration_numbers in list(iterations_by_detail.items())[:max_lines]:
-            if len(iteration_numbers) == 1:
-                label = f"Iteration {iteration_numbers[0]}"
-            else:
-                label = f"Iterations {', '.join(str(number) for number in iteration_numbers)}"
+            label = NodeExecutor._describe_failed_iterations(iteration_numbers, total_iterations)
             lines.append(f"  {label}: {detail}")
 
         unreported_count = len(iterations_by_detail) - len(lines)
         if unreported_count > 0:
             lines.append(f"  ... and {unreported_count} more reason(s). See the engine log for every iteration.")
         return lines
+
+    @staticmethod
+    def _describe_failed_iterations(iteration_numbers: list[int], total_iterations: int | None) -> str:
+        """Name a group of failed iterations in a handful of characters, however many there are.
+
+        Capping the number of *reasons* is not enough on its own: a 500-iteration loop that fails
+        identically every time collapses to a single line, and enumerating all 500 numbers pushes
+        the reason -- the part worth reading -- kilobytes to the right.
+        """
+        sorted_numbers = sorted(iteration_numbers)
+        count = len(sorted_numbers)
+
+        if total_iterations is not None and count >= total_iterations:
+            return "Every iteration"
+        if count == 1:
+            return f"Iteration {sorted_numbers[0]}"
+
+        spans_a_contiguous_run = sorted_numbers[-1] - sorted_numbers[0] == count - 1
+        if spans_a_contiguous_run:
+            return f"Iterations {sorted_numbers[0]}-{sorted_numbers[-1]}"
+        if count <= MAX_ENUMERATED_ITERATION_NUMBERS:
+            return f"Iterations {', '.join(str(number) for number in sorted_numbers)}"
+
+        shown = ", ".join(str(number) for number in sorted_numbers[:MAX_ENUMERATED_ITERATION_NUMBERS])
+        return f"Iterations {shown} (+{count - MAX_ENUMERATED_ITERATION_NUMBERS} more)"
 
     @staticmethod
     def _silence_packaged_node_creation_broadcasts(
@@ -443,10 +496,19 @@ class NodeExecutor(EngineScoped):
         keeps the rebuild entirely inside the engine: in-process callers still get the full
         result, only the queued broadcast is skipped.
 
-        Set here rather than in the packaging handler on purpose. That handler also serves
-        workflow publishing, and generated workflow files are emitted by reflecting over each
-        create command's non-default fields (workflow_manager._generate_node_creation_code), so
-        flipping the flag there would bake a transport detail into saved artifacts.
+        Call this at the boundary that deserializes in-process, not at the one that packages.
+        Generated workflow files are emitted by reflecting over each create command's non-default
+        fields (workflow_manager._generate_node_creation_code), so a command carrying
+        broadcast_result=False writes that transport detail into the saved artifact. Packaging runs
+        before the execution-environment branch, and the private and cloud-publisher branches hand
+        the very same serialized_flow_commands to SaveWorkflowFileFromSerializedFlowRequest -- so
+        silencing at packaging time reaches a file on disk, and on the publisher branch a file in a
+        library. The local deserialization sites are the only ones that both need the flag and never
+        save; they also already own the EventSuppressionContext window that backs this up, which
+        puts the two halves of the fix in one place.
+
+        The mutation is in place and permanent for the lifetime of the package_result, which is safe
+        here only because these callers do not save it.
         """
         for serialized_node in package_result.serialized_flow_commands.serialized_node_commands:
             serialized_node.create_node_command.broadcast_result = False
@@ -945,8 +1007,6 @@ class NodeExecutor(EngineScoped):
             msg = f"Failed to package loop nodes for '{end_node.name}'. Error: {package_result.result_details}"
             raise TypeError(msg)
 
-        self._silence_packaged_node_creation_broadcasts(package_result)
-
         logger.info(
             "Successfully packaged %d nodes for loop execution from '%s' to '%s'",
             len(all_nodes),
@@ -1184,6 +1244,7 @@ class NodeExecutor(EngineScoped):
         context_manager = self.engine.context_manager
         event_manager = self.engine.event_manager
         deserialized_flows: list[tuple[int, str, dict[str, str]]] = []
+        self._silence_packaged_node_creation_broadcasts(package_result)
         try:
             with EventSuppressionContext(event_manager, LOOP_EVENTS_TO_SUPPRESS):
                 deserialize_request = DeserializeFlowFromCommandsRequest(
@@ -1776,6 +1837,7 @@ class NodeExecutor(EngineScoped):
         """
         context_manager = self.engine.context_manager
         event_manager = self.engine.event_manager
+        self._silence_packaged_node_creation_broadcasts(package_result)
         with EventSuppressionContext(event_manager, LOOP_EVENTS_TO_SUPPRESS):
             deserialize_request = DeserializeFlowFromCommandsRequest(
                 serialized_flow_commands=package_result.serialized_flow_commands
@@ -2232,8 +2294,6 @@ class NodeExecutor(EngineScoped):
         if not isinstance(package_result, PackageNodesAsSerializedFlowResultSuccess):
             msg = f"Failed to package {label} '{node.name}'. Error: {package_result.result_details}"
             raise TypeError(msg)
-
-        self._silence_packaged_node_creation_broadcasts(package_result)
 
         logger.info(
             "Successfully packaged %d nodes for %s '%s'",
@@ -3104,6 +3164,7 @@ class NodeExecutor(EngineScoped):
         deserialized_flows = []
         context_manager = self.engine.context_manager
         saved_context_flow = context_manager.get_current_flow() if context_manager.has_current_flow() else None
+        self._silence_packaged_node_creation_broadcasts(package_result)
 
         # Suppress events during deserialization to prevent sending them to websockets
         event_manager = self.engine.event_manager
@@ -3146,8 +3207,8 @@ class NodeExecutor(EngineScoped):
 
             async def run_single_iteration(
                 flow_name: str, iteration_index: int, start_node_name: str
-            ) -> tuple[int, bool]:
-                """Run a single iteration flow and return success status."""
+            ) -> IterationOutcome:
+                """Run a single iteration flow and report whether it finished, and why not."""
                 # Suppress execution events during parallel iteration to prevent flooding websockets
                 with EventSuppressionContext(event_manager, EXECUTION_EVENTS_TO_SUPPRESS):
                     start_subflow_request = StartLocalSubflowRequest(
@@ -3156,8 +3217,15 @@ class NodeExecutor(EngineScoped):
                         pickle_control_flow_result=False,
                     )
                     start_subflow_result = await self.engine.ahandle_request(start_subflow_request)
-                    success = isinstance(start_subflow_result, StartLocalSubflowResultSuccess)
-                    return iteration_index, success
+                    if isinstance(start_subflow_result, StartLocalSubflowResultSuccess):
+                        return IterationOutcome(iteration_index=iteration_index, succeeded=True, detail="")
+                    # Carry the reason out with the verdict. Narrowing this to a bool is what used to
+                    # leave the parallel path reporting a failure "without a reason" it had in hand.
+                    return IterationOutcome(
+                        iteration_index=iteration_index,
+                        succeeded=False,
+                        detail=str(start_subflow_result.result_details),
+                    )
 
             # Step 3: Set input values on start nodes for each iteration
             for iteration_index, _, node_name_mappings in deserialized_flows:
@@ -3239,16 +3307,15 @@ class NodeExecutor(EngineScoped):
                     failed_iteration_indices.append(idx)
                     iteration_failures.append(IterationFailure(iteration_index=idx, detail=str(result)))
                     continue
-                if isinstance(result, tuple):
-                    iteration_index, success = result
-                    if success:
-                        successful_iterations.append(iteration_index)
+                if isinstance(result, IterationOutcome):
+                    if result.succeeded:
+                        successful_iterations.append(result.iteration_index)
                     else:
-                        failed_iteration_indices.append(iteration_index)
+                        failed_iteration_indices.append(result.iteration_index)
                         iteration_failures.append(
                             IterationFailure(
-                                iteration_index=iteration_index,
-                                detail="The iteration reported failure without a reason.",
+                                iteration_index=result.iteration_index,
+                                detail=result.detail or "The iteration reported failure without a reason.",
                             )
                         )
 
@@ -3258,7 +3325,9 @@ class NodeExecutor(EngineScoped):
                     "iterations.\n%s",
                     len(failed_iteration_indices),
                     total_iterations,
-                    "\n".join(self._format_iteration_failure_lines(iteration_failures)),
+                    "\n".join(
+                        self._format_iteration_failure_lines(iteration_failures, total_iterations=total_iterations)
+                    ),
                 )
 
             # Step 6: Extract parameter values from iterations BEFORE cleanup

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -78,10 +78,57 @@ _active_post_dispatch_hooks: ContextVar[tuple[tuple[type[RequestPayload], Any], 
     "_event_manager_active_post_dispatch_hooks", default=()
 )
 
+# Result/payload types whose broadcast is suppressed for the *current logical chain* only.
+# EventSuppressionContext writes this; should_suppress_event reads it.
+#
+# Scoped to the context rather than to the manager on purpose. Suppression exists to hide
+# engine-internal bookkeeping -- rebuilding and tearing down the short-lived flows a loop runs
+# its body in -- and the types it hides (SetParameterValueResultSuccess,
+# CreateConnectionResultSuccess, CreateNodeResultSuccess) are ones an editor also asks for on
+# its own behalf. handle_request runs on arbitrary threads and asyncio can interleave another
+# task at every await inside a suppression window, so a manager-wide refcount keyed only by type
+# would silently swallow a client's own confirmations mid-loop, leaving the editor showing state
+# the engine does not have. A ContextVar is inherited by the nested requests a suppressed handler
+# dispatches -- which is exactly the lineage meant to be hidden -- and is invisible to any task
+# or thread the engine did not spawn from inside the window.
+#
+# It fails open: work handed to a thread the engine does not control (a library-internal
+# ThreadPoolExecutor) starts from a fresh context and loses the flag, so its results are
+# broadcast as they are today. Over-broadcasting is a cosmetic event; over-suppressing desyncs
+# the editor. Frozensets are replaced, never mutated, because the value object itself is shared
+# with every context that copied it.
+_suppressed_event_types: ContextVar[frozenset[type]] = ContextVar(
+    "_event_manager_suppressed_event_types", default=frozenset()
+)
+
 # Post-dispatch hooks are deliberately unbounded -- every result gets its own task so a
 # notification hook never misses a request. This is purely a "something is wrong" signal
 # for a hook that runs slower than requests arrive.
 POST_DISPATCH_HOOK_INFLIGHT_WARNING_THRESHOLD = 100
+
+
+def _suppression_candidates(event: Any) -> list[Any]:
+    """The event itself plus anything it wraps, for matching against a suppression set.
+
+    Kept a plain function so both the wrapper and the payload naming conventions live in one
+    place: ``EventResultSuccess``/``EventResultFailure`` carry the result payload as ``result``,
+    ``ExecutionEvent`` carries it as ``payload``, and ``GriptapeNodeEvent`` /
+    ``ExecutionGriptapeNodeEvent`` nest one of those under ``wrapped_event``. Suppression sets are
+    written in terms of payload types, so missing one of these attributes means the whole set
+    silently matches nothing.
+    """
+    candidates = [event]
+    wrapped_event = getattr(event, "wrapped_event", None)
+    if wrapped_event is not None:
+        candidates.append(wrapped_event)
+
+    for candidate in list(candidates):
+        for attribute_name in ("result", "payload"):
+            payload = getattr(candidate, attribute_name, None)
+            if payload is not None:
+                candidates.append(payload)
+
+    return candidates
 
 
 def _is_async_callable(callback: Any) -> bool:
@@ -182,8 +229,6 @@ class EventManager(EngineScoped):
         self._loop_thread_id: int | None = None
         # Keep a reference to the event loop for thread-safe operations
         self._event_loop: asyncio.AbstractEventLoop | None = None
-        # Per-event reference counting for event suppression
-        self._event_suppression_counts: dict[type, int] = {}
         # Worker-to-orchestrator forwarding state. Inert until
         # configure_worker_forwarding() is called at worker startup.
         self._worker_forwarding_enabled: bool = False
@@ -248,32 +293,30 @@ class EventManager(EngineScoped):
         return self._event_loop
 
     def should_suppress_event(self, event: BaseEvent | ProgressEvent) -> bool:
-        """Check if events should be suppressed from being sent to websockets.
+        """Whether this event must not reach websocket clients.
 
-        This method checks both the wrapper event type and the payload type for wrapped events.
-        For example, if InvolvedNodesEvent is in the suppression set, an ExecutionGriptapeNodeEvent
-        that wraps an InvolvedNodesEvent will be suppressed.
+        Matches the event's own type and the payload it carries, so a suppression set can name
+        either a wrapper (``ExecutionGriptapeNodeEvent``) or the thing inside it
+        (``InvolvedNodesEvent``, ``CreateNodeResultSuccess``). The payload lives under a different
+        attribute depending on the wrapper: request results expose it as ``result``, execution
+        events as ``payload``, and both may arrive already wrapped in a ``GriptapeNodeEvent``.
+
+        Suppression is scoped to the current context; see ``_suppressed_event_types``.
         """
-        event_type = type(event)
+        suppressed_types = _suppressed_event_types.get()
+        if not suppressed_types:
+            return False
 
-        # Check wrapper type first
-        if self._event_suppression_counts.get(event_type, 0) > 0:
-            return True
-
-        # For wrapped events (like ExecutionGriptapeNodeEvent), also check the payload type
-        wrapped_event = getattr(event, "wrapped_event", None)
-        if wrapped_event is not None:
-            payload = getattr(wrapped_event, "payload", None)
-            if payload is not None:
-                payload_type = type(payload)
-                if self._event_suppression_counts.get(payload_type, 0) > 0:
-                    return True
-
-        return False
+        return any(type(candidate) in suppressed_types for candidate in _suppression_candidates(event))
 
     def clear_event_suppression(self) -> None:
-        """Clear all event suppression counts."""
-        self._event_suppression_counts.clear()
+        """Drop any suppression the current context has in effect.
+
+        A safety valve for a full state reset. Suppression cannot leak past the ``with`` block
+        that opened it (``EventSuppressionContext`` restores the previous value on exit) and is
+        invisible to other contexts, so this is a no-op in the normal case.
+        """
+        _suppressed_event_types.set(frozenset())
 
     def initialize_queue(self, queue: asyncio.Queue | None = None) -> None:
         """Set the event queue for this manager.
@@ -1436,14 +1479,17 @@ class EventManager(EngineScoped):
 
 
 class EventSuppressionContext:
-    """Context manager to suppress events from being sent to websockets.
+    """Keep engine-internal bookkeeping off the websocket while it happens.
 
-    Use this to prevent internal operations (like deserialization/deletion of iteration flows)
-    from sending events to the GUI while still allowing the operations to complete normally.
+    Wrap work the GUI must not see -- deserializing and deleting the short-lived flows a loop
+    runs its body in -- and the listed result/payload types are not broadcast for the duration.
+    The operations themselves complete normally: suppression only skips queueing the broadcast,
+    and in-process callers still receive every result in full.
 
-    Uses per-event reference counting to track nested suppression contexts.
-    Each event type maintains its own reference count, and is only unsuppressed
-    when its count reaches zero.
+    Suppression applies to the current context and to any nested request dispatched from inside
+    the block, not to the manager as a whole -- see ``_suppressed_event_types`` for why that
+    distinction is load-bearing. Nesting composes: the previous value is restored on exit, so an
+    inner block adding a type does not unsuppress what an outer block was already hiding.
     """
 
     events_to_suppress: set[type]
@@ -1451,11 +1497,11 @@ class EventSuppressionContext:
     def __init__(self, manager: EventManager, events_to_suppress: set[type]):
         self.manager = manager
         self.events_to_suppress = events_to_suppress
+        self._token: contextvars.Token[frozenset[type]] | None = None
 
     def __enter__(self) -> None:
-        for event_type in self.events_to_suppress:
-            current_count = self.manager._event_suppression_counts.get(event_type, 0)
-            self.manager._event_suppression_counts[event_type] = current_count + 1
+        currently_suppressed = _suppressed_event_types.get()
+        self._token = _suppressed_event_types.set(currently_suppressed | frozenset(self.events_to_suppress))
 
     def __exit__(
         self,
@@ -1463,12 +1509,11 @@ class EventSuppressionContext:
         exc_value: BaseException | None,
         exc_traceback: types.TracebackType | None,
     ) -> None:
-        for event_type in self.events_to_suppress:
-            current_count = self.manager._event_suppression_counts.get(event_type, 0)
-            if current_count <= 1:
-                self.manager._event_suppression_counts.pop(event_type, None)
-            else:
-                self.manager._event_suppression_counts[event_type] = current_count - 1
+        if self._token is None:
+            return
+
+        _suppressed_event_types.reset(self._token)
+        self._token = None
 
 
 class EventTranslationContext:

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -1490,6 +1490,13 @@ class EventSuppressionContext:
     the block, not to the manager as a whole -- see ``_suppressed_event_types`` for why that
     distinction is load-bearing. Nesting composes: the previous value is restored on exit, so an
     inner block adding a type does not unsuppress what an outer block was already hiding.
+
+    One instance may be entered more than once, whether nested in itself or reused for a later
+    block. Tokens are therefore kept on a stack rather than in a single field: with one field, a
+    second ``__enter__`` overwrites the outer block's token, and the outer ``__exit__`` has nothing
+    left to restore -- so the suppressed set stays in place for the rest of the context. Nothing
+    would report it, and it fails in the harmful direction: over-broadcasting is cosmetic, a
+    permanently dark event stream desyncs the editor.
     """
 
     events_to_suppress: set[type]
@@ -1497,11 +1504,11 @@ class EventSuppressionContext:
     def __init__(self, manager: EventManager, events_to_suppress: set[type]):
         self.manager = manager
         self.events_to_suppress = events_to_suppress
-        self._token: contextvars.Token[frozenset[type]] | None = None
+        self._tokens: list[contextvars.Token[frozenset[type]]] = []
 
     def __enter__(self) -> None:
         currently_suppressed = _suppressed_event_types.get()
-        self._token = _suppressed_event_types.set(currently_suppressed | frozenset(self.events_to_suppress))
+        self._tokens.append(_suppressed_event_types.set(currently_suppressed | frozenset(self.events_to_suppress)))
 
     def __exit__(
         self,
@@ -1509,11 +1516,10 @@ class EventSuppressionContext:
         exc_value: BaseException | None,
         exc_traceback: types.TracebackType | None,
     ) -> None:
-        if self._token is None:
+        if not self._tokens:
             return
 
-        _suppressed_event_types.reset(self._token)
-        self._token = None
+        _suppressed_event_types.reset(self._tokens.pop())
 
 
 class EventTranslationContext:

--- a/tests/e2e/fixtures/loop_library/griptape_nodes_library.json
+++ b/tests/e2e/fixtures/loop_library/griptape_nodes_library.json
@@ -1,0 +1,71 @@
+{
+  "name": "Griptape Nodes Library",
+  "library_schema_version": "0.7.0",
+  "metadata": {
+    "author": "Test Fixture",
+    "description": "Minimal library used by loop-body packaging tests",
+    "library_version": "0.1.0",
+    "engine_version": "0.0.0",
+    "tags": ["test"],
+    "dependencies": {
+      "pip_dependencies": []
+    }
+  },
+  "categories": [
+    {
+      "test": {
+        "title": "test",
+        "description": "Test nodes",
+        "color": "border-gray-500",
+        "icon": "Folder"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "class_name": "StartFlow",
+      "file_path": "loop_nodes.py",
+      "metadata": {
+        "category": "test",
+        "description": "Entry node for a packaged flow",
+        "display_name": "Start Flow"
+      }
+    },
+    {
+      "class_name": "EndFlow",
+      "file_path": "loop_nodes.py",
+      "metadata": {
+        "category": "test",
+        "description": "Exit node for a packaged flow",
+        "display_name": "End Flow"
+      }
+    },
+    {
+      "class_name": "LoopBodyNode",
+      "file_path": "loop_nodes.py",
+      "metadata": {
+        "category": "test",
+        "description": "Copies its `text` input to its `result` output",
+        "display_name": "Loop Body"
+      }
+    },
+    {
+      "class_name": "LoopStartNode",
+      "file_path": "loop_nodes.py",
+      "metadata": {
+        "category": "test",
+        "description": "Iterative start node over a fixed list",
+        "display_name": "Loop Start"
+      }
+    },
+    {
+      "class_name": "LoopEndNode",
+      "file_path": "loop_nodes.py",
+      "metadata": {
+        "category": "test",
+        "description": "Iterative end node",
+        "display_name": "Loop End"
+      }
+    }
+  ]
+}

--- a/tests/e2e/fixtures/loop_library/loop_nodes.py
+++ b/tests/e2e/fixtures/loop_library/loop_nodes.py
@@ -1,0 +1,109 @@
+"""Nodes for exercising loop-body packaging end to end.
+
+``NodeExecutor._package_loop_body`` needs three things from a library: a ``StartFlow``/``EndFlow``
+pair (the packager wraps every packaged body in one), an iterative Start/End pair to delimit the
+loop, and something to put in the body. All three live here so the fixture can be registered from
+one node file.
+
+The library is registered under the name ``Griptape Nodes Library`` because that is the name the
+packager asks for its flow endpoints by.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from griptape_nodes.exe_types.base_iterative_nodes import BaseIterativeEndNode, BaseIterativeStartNode
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import DataNode, EndNode, StartNode
+
+
+class StartFlow(StartNode):
+    """The packaged body's entry node."""
+
+
+class EndFlow(EndNode):
+    """The packaged body's exit node."""
+
+
+class LoopBodyNode(DataNode):
+    """One node's worth of loop body: copies ``text`` to ``result``."""
+
+    def __init__(self, name: str, metadata: dict | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="text",
+                tooltip="Text to echo",
+                type="str",
+                default_value="",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="result",
+                tooltip="Echoed text",
+                type="str",
+                default_value="",
+                allowed_modes={ParameterMode.OUTPUT, ParameterMode.PROPERTY},
+            )
+        )
+
+    def process(self) -> None:
+        self.parameter_output_values["result"] = self.get_parameter_value("text") or ""
+
+
+class LoopEndNode(BaseIterativeEndNode):
+    """Closes the loop. Declared before the Start node so it can name it as compatible."""
+
+    @classmethod
+    def _get_compatible_start_classes(cls) -> set[type]:
+        return {LoopStartNode}
+
+    def process(self) -> None:
+        return None
+
+
+class LoopStartNode(BaseIterativeStartNode):
+    """Iterates a fixed three-item list, so no input wiring is needed to have a total."""
+
+    ITEMS = ("first", "second", "third")
+
+    @classmethod
+    def _get_compatible_end_classes(cls) -> set[type]:
+        return {LoopEndNode}
+
+    def _get_parameter_group_name(self) -> str:
+        return "Iteration Data"
+
+    def _get_exec_out_display_name(self) -> str:
+        return "On Each Item"
+
+    def _get_exec_out_tooltip(self) -> str:
+        return "Execute for each item"
+
+    def _get_iteration_items(self) -> list[Any]:
+        return list(self.ITEMS)
+
+    def _initialize_iteration_data(self) -> None:
+        self._current_iteration_count = 0
+        self._total_iterations = len(self.ITEMS)
+
+    def _get_current_item_value(self) -> Any:
+        return self.ITEMS[self._current_iteration_count]
+
+    def is_loop_finished(self) -> bool:
+        return self._current_iteration_count >= len(self.ITEMS)
+
+    def _get_total_iterations(self) -> int:
+        return len(self.ITEMS)
+
+    def _get_current_iteration_count(self) -> int:
+        return self._current_iteration_count
+
+    def get_current_index(self) -> int:
+        return self._current_iteration_count
+
+    def _advance_to_next_iteration(self) -> None:
+        self._current_iteration_count += 1

--- a/tests/e2e/test_loop_body_packaging_broadcast_flag.py
+++ b/tests/e2e/test_loop_body_packaging_broadcast_flag.py
@@ -1,0 +1,167 @@
+"""Where a loop body's node creations get silenced is load-bearing, so pin it.
+
+``NodeExecutor._silence_packaged_node_creation_broadcasts`` clears ``broadcast_result`` on a
+packaged body's create commands. Packaging is the obvious place to call it and the wrong one:
+packaging runs *before* the execution-environment branch, and the private and cloud-publisher
+branches hand the very same ``serialized_flow_commands`` to
+``SaveWorkflowFileFromSerializedFlowRequest``. Workflow codegen writes out every create-command
+field whose value differs from its default, so silencing at packaging time puts a transport flag
+into a generated ``.py`` file -- on the publish path, into a library.
+
+Nothing about the three local call sites is visible from a unit test of the helper, and reinstating
+the packaging-time call keeps every other test in this change green. This test is the one that goes
+red: it packages a real loop body and asserts the commands come out of the packager unsilenced.
+
+See ``tests/unit/retained_mode/managers/test_workflow_manager_broadcast_flag_codegen.py`` for the
+other half -- that codegen really is that literal about non-default fields.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.common.node_executor import NodeExecutor
+from griptape_nodes.exe_types.base_iterative_nodes import BaseIterativeStartNode
+from griptape_nodes.retained_mode.events.connection_events import (
+    CreateConnectionRequest,
+    CreateConnectionResultSuccess,
+)
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    CreateFlowResultSuccess,
+    PackageNodesAsSerializedFlowResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from griptape_nodes.retained_mode.engine import Engine
+
+# Timeout with thread dump.
+pytestmark = pytest.mark.timeout(300, method="thread")
+
+FIXTURE_LIBRARY_DIR = Path(__file__).parent / "fixtures" / "loop_library"
+FIXTURE_LIBRARY_JSON_TEMPLATE = FIXTURE_LIBRARY_DIR / "griptape_nodes_library.json"
+FIXTURE_NODE_FILE = FIXTURE_LIBRARY_DIR / "loop_nodes.py"
+# The packager asks for its StartFlow/EndFlow endpoints from this library by name.
+LIBRARY_NAME = "Griptape Nodes Library"
+
+
+def _create_node(engine: Engine, node_type: str, node_name: str) -> str:
+    # An iterative start node auto-creates its paired end node beside it, which needs a position
+    # to offset from, so every node here carries one.
+    result = engine.handle_request(
+        CreateNodeRequest(
+            node_type=node_type,
+            specific_library_name=LIBRARY_NAME,
+            node_name=node_name,
+            metadata={"position": {"x": 0, "y": 0}},
+        )
+    )
+    assert isinstance(result, CreateNodeResultSuccess), result
+    return result.node_name
+
+
+def _connect(engine: Engine, source: str, source_param: str, target: str, target_param: str) -> None:
+    result = engine.handle_request(
+        CreateConnectionRequest(
+            source_node_name=source,
+            source_parameter_name=source_param,
+            target_node_name=target,
+            target_parameter_name=target_param,
+        )
+    )
+    assert isinstance(result, CreateConnectionResultSuccess), result
+
+
+async def _package_a_real_loop_body(
+    engine: Engine, materialize_library: Callable[..., Path], tmp_path: Path
+) -> PackageNodesAsSerializedFlowResultSuccess:
+    """Build start -> body -> end in a real flow and run the packager over it."""
+    library_json = materialize_library(
+        tmp_path / "loop_library",
+        template=FIXTURE_LIBRARY_JSON_TEMPLATE,
+        node_file=FIXTURE_NODE_FILE,
+        name=LIBRARY_NAME,
+    )
+    register_result = engine.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
+
+    engine.context_manager.push_workflow(workflow_name="loop_packaging_e2e_workflow")
+    flow_result = engine.handle_request(
+        CreateFlowRequest(parent_flow_name=None, flow_name="LoopFlow", set_as_new_context=False)
+    )
+    assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
+
+    # Serializing a node pushes a node context, which requires an active flow, so the whole build
+    # and the packaging call happen inside the flow context.
+    with engine.context_manager.flow(flow_result.flow_name):
+        # Creating the start node auto-creates and tethers its paired end node, exactly as the
+        # editor path does, so the pair does not need wiring up by hand here.
+        start_name = _create_node(engine, "LoopStartNode", "Loop Start")
+        body_name = _create_node(engine, "LoopBodyNode", "Body Node")
+
+        start_node = engine.node_manager.get_node_by_name(start_name)
+        assert isinstance(start_node, BaseIterativeStartNode), start_node
+        end_node = start_node.end_node
+        assert end_node is not None, "The start node did not tether an end node."
+
+        _connect(engine, start_name, "exec_out", body_name, "exec_in")
+        _connect(engine, body_name, "exec_out", end_node.name, "add_item")
+
+        packaged = await NodeExecutor(engine=engine)._package_loop_body(start_node, end_node)
+
+    assert packaged is not None, "The loop body came back empty, so this test asserted nothing."
+    package_result, _execution_type = packaged
+    assert package_result.serialized_flow_commands.serialized_node_commands, (
+        "No node commands were packaged, so this test asserted nothing."
+    )
+    return package_result
+
+
+def _broadcast_flags(package_result: PackageNodesAsSerializedFlowResultSuccess) -> dict[str, bool]:
+    flags: dict[str, bool] = {}
+    for serialized_node in package_result.serialized_flow_commands.serialized_node_commands:
+        create_command = serialized_node.create_node_command
+        flags[create_command.node_name or "<unnamed>"] = create_command.broadcast_result
+    return flags
+
+
+@pytest.mark.asyncio
+async def test_packaging_a_loop_body_leaves_its_create_commands_unsilenced(
+    engine: Engine, materialize_library: Callable[..., Path], tmp_path: Path
+) -> None:
+    """The packager's output is save-safe: whatever silences it must do so further downstream."""
+    package_result = await _package_a_real_loop_body(engine, materialize_library, tmp_path)
+
+    silenced = sorted(name for name, broadcasts in _broadcast_flags(package_result).items() if broadcasts is False)
+
+    assert silenced == [], (
+        f"Packaging silenced the create commands for {silenced}. The private and cloud-publisher "
+        "branches save these very commands to a workflow file, and codegen writes non-default "
+        "fields out -- so broadcast_result=False would land in the artist's .py file. Silence at "
+        "the local deserialization boundary instead."
+    )
+
+
+@pytest.mark.asyncio
+async def test_silencing_the_packaged_body_is_what_clears_the_flag(
+    engine: Engine, materialize_library: Callable[..., Path], tmp_path: Path
+) -> None:
+    """The paired positive case: the flag is still reachable on a real package result.
+
+    Without this, the assertion above would keep passing if the helper stopped working entirely.
+    """
+    package_result = await _package_a_real_loop_body(engine, materialize_library, tmp_path)
+
+    NodeExecutor._silence_packaged_node_creation_broadcasts(package_result)
+
+    assert all(broadcasts is False for broadcasts in _broadcast_flags(package_result).values())

--- a/tests/e2e/test_transient_flow_node_broadcast.py
+++ b/tests/e2e/test_transient_flow_node_broadcast.py
@@ -1,0 +1,188 @@
+"""A loop body rebuilt inside the engine must not announce its nodes to editors.
+
+When a loop runs, ``NodeExecutor`` packages the body into a short-lived child flow and
+deserializes it once per run (or once per iteration, in parallel). Each rebuild dispatches a
+nested ``CreateNodeRequest``, and its success result reports the transient flow as the node's
+parent. An editor that receives it asks the engine for that flow's details -- by which time
+the flow has been torn down -- so the artist gets an error toast naming a flow they never
+made. ``NodeExecutor._silence_packaged_node_creation_broadcasts`` clears
+``broadcast_result`` on the packaged create commands to keep the rebuild inside the engine.
+
+These tests pin the transport half of that contract end-to-end: that a deserialized flow's
+``broadcast_result=False`` create command genuinely stays off the event queue while an
+unflagged one reaches it. The paired positive case is what makes the negative case
+meaningful -- without it the assertion would also pass if nothing were ever queued.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.common.node_executor import LOOP_EVENTS_TO_SUPPRESS
+from griptape_nodes.retained_mode.events.base_events import GriptapeNodeEvent
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    DeserializeFlowFromCommandsRequest,
+    DeserializeFlowFromCommandsResultSuccess,
+    SerializedFlowCommands,
+)
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.events.node_events import (
+    CreateNodeRequest,
+    CreateNodeResultSuccess,
+    NodeDependencies,
+    SerializedNodeCommands,
+)
+from griptape_nodes.retained_mode.managers.event_manager import EventSuppressionContext
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from griptape_nodes.retained_mode.engine import Engine
+
+# Timeout with thread dump.
+pytestmark = pytest.mark.timeout(300, method="thread")
+
+FIXTURE_LIBRARY_DIR = Path(__file__).parent / "fixtures" / "echo_library"
+FIXTURE_LIBRARY_JSON_TEMPLATE = FIXTURE_LIBRARY_DIR / "griptape_nodes_library.json"
+FIXTURE_NODE_FILE = FIXTURE_LIBRARY_DIR / "echo_node.py"
+LIBRARY_NAME = "Echo Library"
+
+
+def _register_echo_library(engine: Engine, materialize_library: Callable[..., Path], tmp_path: Path) -> None:
+    library_json = materialize_library(
+        tmp_path / "echo_library",
+        template=FIXTURE_LIBRARY_JSON_TEMPLATE,
+        node_file=FIXTURE_NODE_FILE,
+    )
+    register_result = engine.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    assert isinstance(register_result, RegisterLibraryFromFileResultSuccess), register_result
+    # Creating a flow requires an active workflow in the Current Context.
+    engine.context_manager.push_workflow(workflow_name="transient_broadcast_e2e_workflow")
+
+
+def _build_body_flow_commands(*, broadcast_result: bool) -> SerializedFlowCommands:
+    """One-node flow standing in for a packaged loop body, mirroring what the packager emits."""
+    create_node_command = CreateNodeRequest(
+        node_type="EchoNode",
+        specific_library_name=LIBRARY_NAME,
+        node_name="Body Node",
+    )
+    create_node_command.broadcast_result = broadcast_result
+    return SerializedFlowCommands(
+        flow_initialization_command=CreateFlowRequest(parent_flow_name=None, set_as_new_context=False),
+        serialized_node_commands=[
+            SerializedNodeCommands(
+                create_node_command=create_node_command,
+                element_modification_commands=[],
+                node_dependencies=NodeDependencies(),
+            )
+        ],
+        serialized_connections=[],
+        unique_parameter_uuid_to_values={},
+        set_parameter_value_commands={},
+        set_lock_commands_per_node={},
+        sub_flows_commands=[],
+        node_dependencies=NodeDependencies(),
+        node_types_used=set(),
+    )
+
+
+def _drain_created_node_results(queue: asyncio.Queue) -> list[CreateNodeResultSuccess]:
+    """Every CreateNodeResultSuccess an editor would have received."""
+    created_node_results = []
+    while not queue.empty():
+        event = queue.get_nowait()
+        if not isinstance(event, GriptapeNodeEvent):
+            continue
+        result = getattr(event.wrapped_event, "result", None)
+        if isinstance(result, CreateNodeResultSuccess):
+            created_node_results.append(result)
+    return created_node_results
+
+
+def _deserialize_body_flow(
+    engine: Engine, *, broadcast_result: bool, suppress_events: bool = False
+) -> DeserializeFlowFromCommandsResultSuccess:
+    """Deserialize the stand-in body flow with the event queue live, then return the result.
+
+    ``put_event`` no-ops while ``_event_queue`` is None, so the queue must be initialized or
+    the negative assertion would pass vacuously.
+    """
+    engine.event_manager.initialize_queue(asyncio.Queue())
+    request = DeserializeFlowFromCommandsRequest(
+        serialized_flow_commands=_build_body_flow_commands(broadcast_result=broadcast_result)
+    )
+    if suppress_events:
+        with EventSuppressionContext(engine.event_manager, LOOP_EVENTS_TO_SUPPRESS):
+            deserialize_result = engine.handle_request(request)
+    else:
+        deserialize_result = engine.handle_request(request)
+
+    assert isinstance(deserialize_result, DeserializeFlowFromCommandsResultSuccess), deserialize_result
+    return deserialize_result
+
+
+def test_flagged_create_command_is_not_broadcast(
+    engine: Engine, materialize_library: Callable[..., Path], tmp_path: Path
+) -> None:
+    """The node is really built, but no editor is told -- so none can ask about its flow."""
+    _register_echo_library(engine, materialize_library, tmp_path)
+
+    deserialize_result = _deserialize_body_flow(engine, broadcast_result=False)
+
+    # The rebuild succeeded: the node exists under the transient flow.
+    assert deserialize_result.node_name_mappings, deserialize_result
+    created_node_name = next(iter(deserialize_result.node_name_mappings.values()))
+    assert engine.object_manager.attempt_get_object_by_name(created_node_name) is not None
+
+    queue = engine.event_manager._event_queue
+    assert queue is not None
+    created_node_results = _drain_created_node_results(queue)
+    parent_flow_names = [result.parent_flow_name for result in created_node_results]
+    assert created_node_results == [], (
+        f"A packaged body node was announced to editors, naming parent flow(s) {parent_flow_names}. "
+        "An editor will ask the engine for those flows and toast an error once they are torn down."
+    )
+
+
+def test_unflagged_create_command_is_broadcast(
+    engine: Engine, materialize_library: Callable[..., Path], tmp_path: Path
+) -> None:
+    """Control case: without the flag the result does reach the queue.
+
+    Proves the negative assertion above is detecting the flag rather than an inert queue.
+    """
+    _register_echo_library(engine, materialize_library, tmp_path)
+
+    _deserialize_body_flow(engine, broadcast_result=True)
+
+    queue = engine.event_manager._event_queue
+    assert queue is not None
+    created_node_results = _drain_created_node_results(queue)
+    assert len(created_node_results) == 1, created_node_results
+
+
+def test_suppression_window_catches_an_unflagged_create_command(
+    engine: Engine, materialize_library: Callable[..., Path], tmp_path: Path
+) -> None:
+    """The backstop: a creation that escaped the flag is still hidden inside a loop's window.
+
+    ``LOOP_EVENTS_TO_SUPPRESS`` is what covers any future path that rebuilds a loop body without
+    going through ``_silence_packaged_node_creation_broadcasts``. Same input as the control case
+    above -- ``broadcast_result=True`` -- so the only difference is the suppression window.
+    """
+    _register_echo_library(engine, materialize_library, tmp_path)
+
+    _deserialize_body_flow(engine, broadcast_result=True, suppress_events=True)
+
+    queue = engine.event_manager._event_queue
+    assert queue is not None
+    assert _drain_created_node_results(queue) == []

--- a/tests/unit/common/test_node_executor_loop_helpers.py
+++ b/tests/unit/common/test_node_executor_loop_helpers.py
@@ -431,7 +431,38 @@ class TestFormatIterationFailureLines:
         """The common case is every iteration failing identically; say the reason once."""
         failures = [IterationFailure(iteration_index=index, detail="same reason") for index in range(3)]
         lines = NodeExecutor._format_iteration_failure_lines(failures)
-        assert lines == ["  Iterations 1, 2, 3: same reason"]
+        assert lines == ["  Iterations 1-3: same reason"]
+
+    def test_names_a_wholly_failed_loop_as_such(self) -> None:
+        """When nothing survived, saying so beats naming every iteration."""
+        failures = [IterationFailure(iteration_index=index, detail="same reason") for index in range(50)]
+        lines = NodeExecutor._format_iteration_failure_lines(failures, total_iterations=50)
+        assert lines == ["  Every iteration: same reason"]
+
+    def test_keeps_the_line_short_for_a_long_collapsed_run(self) -> None:
+        """Capping reasons is not enough: the iteration list inside one reason must be bounded too.
+
+        Without this, 500 iterations failing identically push the reason -- the part worth reading --
+        kilobytes to the right of where the artist starts reading.
+        """
+        iteration_count = 500
+        failures = [IterationFailure(iteration_index=index, detail="boom") for index in range(iteration_count)]
+        # No total_iterations, so the "every iteration" shortcut cannot apply and the run must
+        # still be summarised rather than enumerated.
+        lines = NodeExecutor._format_iteration_failure_lines(failures)
+        assert lines == ["  Iterations 1-500: boom"]
+
+    def test_truncates_a_scattered_iteration_list(self) -> None:
+        """A non-contiguous set has no range to collapse to, so the enumeration itself is capped."""
+        scattered = [1, 3, 5, 7, 9, 11, 13, 15, 17]
+        failures = [IterationFailure(iteration_index=index, detail="boom") for index in scattered]
+        lines = NodeExecutor._format_iteration_failure_lines(failures)
+        assert lines == ["  Iterations 2, 4, 6, 8, 10, 12 (+3 more): boom"]
+
+    def test_names_a_two_iteration_gap_without_a_range(self) -> None:
+        failures = [IterationFailure(iteration_index=index, detail="boom") for index in (0, 4)]
+        lines = NodeExecutor._format_iteration_failure_lines(failures)
+        assert lines == ["  Iterations 1, 5: boom"]
 
     def test_keeps_distinct_details_on_separate_lines(self) -> None:
         lines = NodeExecutor._format_iteration_failure_lines(_make_iteration_failures(["first", "second"]))

--- a/tests/unit/common/test_node_executor_loop_helpers.py
+++ b/tests/unit/common/test_node_executor_loop_helpers.py
@@ -10,17 +10,28 @@ These tests cover small, near-pure helpers that decide loop control flow:
   pair has fired its control output.
 * ``_find_source_for_control_param`` - return the first source for a given
   control parameter name, or None.
+* ``_format_loop_failure_message`` / ``_format_iteration_failure_lines`` - compose
+  the artist-facing error naming which iterations failed and why.
+* ``_silence_packaged_node_creation_broadcasts`` - keep a packaged loop body's node
+  creations from reaching editors.
 """
 
+import logging
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from griptape_nodes.common.node_executor import IterationControlAction, NodeExecutor
+from griptape_nodes.common.node_executor import IterationControlAction, IterationFailure, NodeExecutor
 from griptape_nodes.exe_types.base_iterative_nodes import BaseIterativeEndNode
 from griptape_nodes.exe_types.node_groups.base_iterative_node_group import BaseIterativeNodeGroup
-from griptape_nodes.retained_mode.events.node_events import ListConnectionsForNodeResultSuccess
+from griptape_nodes.retained_mode.events.base_events import ResultDetail, ResultDetails
+from griptape_nodes.retained_mode.events.node_events import (
+    CreateNodeRequest,
+    ListConnectionsForNodeResultSuccess,
+    NodeDependencies,
+    SerializedNodeCommands,
+)
 
 
 def _make_executor() -> NodeExecutor:
@@ -398,3 +409,160 @@ class TestGetIterationControlActionEndToEnd:
         # CondNode_orig is NOT in node_name_mappings
         result = self._run_real(end_node, connections, {}, {})
         assert result == IterationControlAction.ADD
+
+
+def _make_iteration_failures(details: list[str]) -> list[IterationFailure]:
+    """One IterationFailure per detail, indexed 0..n-1."""
+    return [IterationFailure(iteration_index=index, detail=detail) for index, detail in enumerate(details)]
+
+
+class TestFormatIterationFailureLines:
+    """Renders one indented line per distinct reason, collapsing iterations that agree."""
+
+    def test_returns_no_lines_for_no_failures(self) -> None:
+        assert NodeExecutor._format_iteration_failure_lines([]) == []
+
+    def test_renders_one_based_iteration_number(self) -> None:
+        """Iteration 0 internally is iteration 1 to the artist who built the loop."""
+        lines = NodeExecutor._format_iteration_failure_lines([IterationFailure(iteration_index=0, detail="boom")])
+        assert lines == ["  Iteration 1: boom"]
+
+    def test_collapses_iterations_sharing_a_detail(self) -> None:
+        """The common case is every iteration failing identically; say the reason once."""
+        failures = [IterationFailure(iteration_index=index, detail="same reason") for index in range(3)]
+        lines = NodeExecutor._format_iteration_failure_lines(failures)
+        assert lines == ["  Iterations 1, 2, 3: same reason"]
+
+    def test_keeps_distinct_details_on_separate_lines(self) -> None:
+        lines = NodeExecutor._format_iteration_failure_lines(_make_iteration_failures(["first", "second"]))
+        assert lines == ["  Iteration 1: first", "  Iteration 2: second"]
+
+    def test_caps_lines_and_reports_the_remainder(self) -> None:
+        reason_count = 8
+        max_lines = 3
+        failures = _make_iteration_failures([f"reason {index}" for index in range(reason_count)])
+        lines = NodeExecutor._format_iteration_failure_lines(failures, max_lines=max_lines)
+        assert len(lines) == max_lines + 1  # the capped reasons, plus the tail line
+        assert f"... and {reason_count - max_lines} more reason(s)" in lines[-1]
+        assert "engine log" in lines[-1]
+
+    def test_does_not_add_a_tail_line_when_everything_fits(self) -> None:
+        failures = _make_iteration_failures(["a", "b", "c"])
+        lines = NodeExecutor._format_iteration_failure_lines(failures, max_lines=len(failures) + 2)
+        assert len(lines) == len(failures)
+        assert not any("more reason" in line for line in lines)
+
+    def test_preserves_multiline_detail_text(self) -> None:
+        """ResultDetails.__str__ joins several messages with newlines; keep them verbatim."""
+        detail = "Attempted to run node 'Blur'.\nFailed because the input image was empty."
+        lines = NodeExecutor._format_iteration_failure_lines([IterationFailure(iteration_index=4, detail=detail)])
+        assert lines == [f"  Iteration 5: {detail}"]
+
+
+class TestFormatLoopFailureMessage:
+    """Leads with what was attempted and how much was lost, then names the reasons."""
+
+    def test_includes_loop_name_and_counts(self) -> None:
+        msg = NodeExecutor._format_loop_failure_message(
+            loop_name="Trim Frames End",
+            total_iterations=4,
+            iteration_failures=_make_iteration_failures(["first", "second"]),
+        )
+        assert "'Trim Frames End'" in msg
+        assert "all 4 iterations" in msg
+        assert "2 of them did not finish" in msg
+
+    def test_follows_the_attempted_failed_because_form(self) -> None:
+        msg = NodeExecutor._format_loop_failure_message(
+            loop_name="Trim Frames End",
+            total_iterations=1,
+            iteration_failures=_make_iteration_failures(["boom"]),
+        )
+        assert msg.startswith("Attempted to run all")
+        assert ". Failed because " in msg
+
+    def test_appends_one_detail_line_per_reason(self) -> None:
+        failures = _make_iteration_failures(["first", "second"])
+        msg = NodeExecutor._format_loop_failure_message(
+            loop_name="Trim Frames End",
+            total_iterations=len(failures),
+            iteration_failures=failures,
+        )
+        # One newline joining the summary to the detail block, then one per extra reason.
+        assert msg.count("\n") == len(failures)
+
+    def test_returns_summary_only_when_failures_empty(self) -> None:
+        """Guards the branch even though production only calls this with failures."""
+        msg = NodeExecutor._format_loop_failure_message(
+            loop_name="Trim Frames End", total_iterations=3, iteration_failures=[]
+        )
+        assert "\n" not in msg
+
+    def test_message_survives_str_of_result_details(self) -> None:
+        """The collector stores str(result_details); both messages must reach the artist."""
+        details = ResultDetails(
+            ResultDetail(message="Attempted to run node 'Blur'.", level=logging.ERROR),
+            ResultDetail(message="Failed because the input image was empty.", level=logging.ERROR),
+        )
+        msg = NodeExecutor._format_loop_failure_message(
+            loop_name="Trim Frames End",
+            total_iterations=1,
+            iteration_failures=[IterationFailure(iteration_index=0, detail=str(details))],
+        )
+        assert "Attempted to run node 'Blur'." in msg
+        assert "Failed because the input image was empty." in msg
+
+
+def _make_package_result_with_nodes(node_count: int) -> MagicMock:
+    """Package result whose serialized_node_commands are real, so flag flips are observable."""
+    serialized_nodes = [
+        SerializedNodeCommands(
+            create_node_command=CreateNodeRequest(node_type="Note", node_name=f"Body Node {index}"),
+            element_modification_commands=[],
+            node_dependencies=NodeDependencies(),
+        )
+        for index in range(node_count)
+    ]
+    package_result = MagicMock()
+    package_result.serialized_flow_commands.serialized_node_commands = serialized_nodes
+    return package_result
+
+
+class TestSilencePackagedNodeCreationBroadcasts:
+    """A packaged loop body is engine-internal; its node creations must not reach editors."""
+
+    def test_clears_broadcast_on_every_create_command(self) -> None:
+        package_result = _make_package_result_with_nodes(3)
+        serialized_nodes = package_result.serialized_flow_commands.serialized_node_commands
+        assert all(node.create_node_command.broadcast_result for node in serialized_nodes)
+
+        NodeExecutor._silence_packaged_node_creation_broadcasts(package_result)
+
+        assert all(node.create_node_command.broadcast_result is False for node in serialized_nodes)
+
+    def test_is_idempotent(self) -> None:
+        """The parallel path deserializes the same commands once per iteration."""
+        node_count = 3
+        package_result = _make_package_result_with_nodes(node_count)
+        NodeExecutor._silence_packaged_node_creation_broadcasts(package_result)
+        NodeExecutor._silence_packaged_node_creation_broadcasts(package_result)
+
+        serialized_nodes = package_result.serialized_flow_commands.serialized_node_commands
+        assert len(serialized_nodes) == node_count
+        assert all(node.create_node_command.broadcast_result is False for node in serialized_nodes)
+
+    def test_does_not_touch_other_create_command_fields(self) -> None:
+        """Guards against a future rewrite reaching for replace() and dropping fields."""
+        package_result = _make_package_result_with_nodes(2)
+        serialized_nodes = package_result.serialized_flow_commands.serialized_node_commands
+        before = [(node.create_node_command.node_type, node.create_node_command.node_name) for node in serialized_nodes]
+
+        NodeExecutor._silence_packaged_node_creation_broadcasts(package_result)
+
+        after = [(node.create_node_command.node_type, node.create_node_command.node_name) for node in serialized_nodes]
+        assert after == before
+
+    def test_handles_a_flow_with_no_nodes(self) -> None:
+        package_result = _make_package_result_with_nodes(0)
+        NodeExecutor._silence_packaged_node_creation_broadcasts(package_result)
+        assert package_result.serialized_flow_commands.serialized_node_commands == []

--- a/tests/unit/common/test_node_executor_loop_helpers.py
+++ b/tests/unit/common/test_node_executor_loop_helpers.py
@@ -439,6 +439,13 @@ class TestFormatIterationFailureLines:
         lines = NodeExecutor._format_iteration_failure_lines(failures, total_iterations=50)
         assert lines == ["  Every iteration: same reason"]
 
+    def test_names_the_iteration_when_the_loop_had_only_one(self) -> None:
+        """A one-item loop satisfies both "every iteration" and "one iteration"; the number wins."""
+        lines = NodeExecutor._format_iteration_failure_lines(
+            [IterationFailure(iteration_index=0, detail="boom")], total_iterations=1
+        )
+        assert lines == ["  Iteration 1: boom"]
+
     def test_keeps_the_line_short_for_a_long_collapsed_run(self) -> None:
         """Capping reasons is not enough: the iteration list inside one reason must be bounded too.
 
@@ -476,6 +483,24 @@ class TestFormatIterationFailureLines:
         assert len(lines) == max_lines + 1  # the capped reasons, plus the tail line
         assert f"... and {reason_count - max_lines} more reason(s)" in lines[-1]
         assert "engine log" in lines[-1]
+
+    def test_tail_line_counts_the_iterations_behind_the_omitted_reasons(self) -> None:
+        """The lines above the tail are phrased in iterations, so the tail has to be too.
+
+        A reason count alone reads as an iteration count: here one omitted reason covers 95 of the
+        100 iterations, and "and 1 more reason(s)" undersells the loop's failure by two orders of
+        magnitude.
+        """
+        max_lines = 5
+        failures = [IterationFailure(iteration_index=index, detail=f"reason {index}") for index in range(max_lines)]
+        failures += [
+            IterationFailure(iteration_index=max_lines + index, detail="the reason that got cut") for index in range(95)
+        ]
+
+        lines = NodeExecutor._format_iteration_failure_lines(failures, total_iterations=100, max_lines=max_lines)
+
+        assert len(lines) == max_lines + 1
+        assert "1 more reason(s) affecting 95 iteration(s)" in lines[-1]
 
     def test_does_not_add_a_tail_line_when_everything_fits(self) -> None:
         failures = _make_iteration_failures(["a", "b", "c"])

--- a/tests/unit/retained_mode/managers/test_event_suppression.py
+++ b/tests/unit/retained_mode/managers/test_event_suppression.py
@@ -1,0 +1,258 @@
+"""Event suppression: what it matches, and how far it reaches.
+
+``EventSuppressionContext`` hides engine-internal bookkeeping from editors -- the node copies and
+short-lived flows a loop rebuilds its body into. Two things have to hold for that to be safe, and
+neither was covered before: the suppression set has to actually *match* the events the engine
+emits, and it must not reach a request the engine did not dispatch from inside the window.
+
+The matching half went untested for long enough to stop working entirely. Suppression sets are
+written in terms of result payload classes, but request results arrive as an
+``EventResultSuccess`` that carries its payload under ``result`` -- an attribute the matcher never
+looked at -- so every entry silently matched nothing. The existing tests in
+``test_griptape_nodes.py`` patch ``should_suppress_event`` wholesale, which is why nothing noticed.
+
+The reach half matters because the suppressed types (``SetParameterValueResultSuccess``,
+``CreateConnectionResultSuccess``, ``CreateNodeResultSuccess``) are ones an editor also requests
+on its own behalf. Suppression keyed only by type and stored on the manager would drop a client's
+own confirmations whenever a loop happened to be mid-rebuild, leaving the editor displaying state
+the engine does not have.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+from griptape_nodes.retained_mode.events.base_events import (
+    EventResultFailure,
+    EventResultSuccess,
+    ExecutionEvent,
+    ExecutionGriptapeNodeEvent,
+    GriptapeNodeEvent,
+)
+from griptape_nodes.retained_mode.events.execution_events import (
+    CurrentControlNodeEvent,
+    NodeResolvedEvent,
+)
+from griptape_nodes.retained_mode.events.node_events import (
+    CreateNodeRequest,
+    CreateNodeResultFailure,
+    CreateNodeResultSuccess,
+)
+from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueResultSuccess
+from griptape_nodes.retained_mode.managers.event_manager import EventManager, EventSuppressionContext
+
+
+def _create_node_result_event() -> EventResultSuccess:
+    """A request result shaped exactly as the engine hands it to should_suppress_event.
+
+    ``engine.handle_request`` passes the ``EventResultSuccess`` itself, not the
+    ``GriptapeNodeEvent`` it later wraps it in, so this is the shape that has to match.
+    """
+    return EventResultSuccess(
+        request=CreateNodeRequest(node_type="Note", node_name="Body Node"),
+        result=CreateNodeResultSuccess(
+            node_name="Body Node",
+            node_type="Note",
+            parent_flow_name="ControlFlow_2",
+            result_details="Created node 'Body Node'.",
+        ),
+    )
+
+
+def _create_node_failure_event() -> EventResultFailure:
+    return EventResultFailure(
+        request=CreateNodeRequest(node_type="Note", node_name="Body Node"),
+        result=CreateNodeResultFailure(result_details="Could not create node 'Body Node'."),
+    )
+
+
+class TestShouldSuppressEventMatching:
+    """Which shapes a suppression set matches."""
+
+    def test_nothing_is_suppressed_by_default(self) -> None:
+        event_manager = EventManager()
+        assert event_manager.should_suppress_event(_create_node_result_event()) is False
+
+    def test_matches_the_result_payload_of_a_request_result(self) -> None:
+        """The shape the engine actually checks. This is the branch that was missing."""
+        event_manager = EventManager()
+        with EventSuppressionContext(event_manager, {CreateNodeResultSuccess}):
+            assert event_manager.should_suppress_event(_create_node_result_event()) is True
+
+    def test_does_not_match_an_unlisted_result_payload(self) -> None:
+        """Suppressing one result type must not suppress its neighbours."""
+        event_manager = EventManager()
+        with EventSuppressionContext(event_manager, {SetParameterValueResultSuccess}):
+            assert event_manager.should_suppress_event(_create_node_result_event()) is False
+
+    def test_matches_a_failure_result_payload_independently(self) -> None:
+        event_manager = EventManager()
+        with EventSuppressionContext(event_manager, {CreateNodeResultFailure}):
+            assert event_manager.should_suppress_event(_create_node_failure_event()) is True
+            assert event_manager.should_suppress_event(_create_node_result_event()) is False
+
+    def test_matches_a_result_payload_already_wrapped_for_broadcast(self) -> None:
+        """Callers that pass the outer GriptapeNodeEvent must get the same answer."""
+        event_manager = EventManager()
+        wrapped = GriptapeNodeEvent(wrapped_event=_create_node_result_event())
+        with EventSuppressionContext(event_manager, {CreateNodeResultSuccess}):
+            assert event_manager.should_suppress_event(wrapped) is True
+
+    def test_matches_an_execution_payload_under_wrapped_event(self) -> None:
+        """The pre-existing branch: ExecutionEvent names its payload `payload`, not `result`."""
+        event_manager = EventManager()
+        event = ExecutionGriptapeNodeEvent(
+            wrapped_event=ExecutionEvent(payload=CurrentControlNodeEvent(node_name="Blur"))
+        )
+        with EventSuppressionContext(event_manager, {CurrentControlNodeEvent}):
+            assert event_manager.should_suppress_event(event) is True
+
+    def test_does_not_match_an_unlisted_execution_payload(self) -> None:
+        event_manager = EventManager()
+        event = ExecutionGriptapeNodeEvent(
+            wrapped_event=ExecutionEvent(payload=CurrentControlNodeEvent(node_name="Blur"))
+        )
+        with EventSuppressionContext(event_manager, {NodeResolvedEvent}):
+            assert event_manager.should_suppress_event(event) is False
+
+    def test_matches_the_wrapper_type_itself(self) -> None:
+        """A set may name the wrapper rather than the payload."""
+        event_manager = EventManager()
+        wrapped = GriptapeNodeEvent(wrapped_event=_create_node_result_event())
+        with EventSuppressionContext(event_manager, {GriptapeNodeEvent}):
+            assert event_manager.should_suppress_event(wrapped) is True
+
+
+class TestSuppressionWindowLifetime:
+    """A window must close exactly when its block does, however the block ends."""
+
+    def test_suppression_ends_with_the_block(self) -> None:
+        event_manager = EventManager()
+        with EventSuppressionContext(event_manager, {CreateNodeResultSuccess}):
+            pass
+        assert event_manager.should_suppress_event(_create_node_result_event()) is False
+
+    def test_suppression_ends_when_the_block_raises(self) -> None:
+        """Loop teardown runs in `finally` blocks; a failed iteration must not leave events dark."""
+        event_manager = EventManager()
+
+        def fail_inside_the_window() -> None:
+            with EventSuppressionContext(event_manager, {CreateNodeResultSuccess}):
+                msg = "iteration failed"
+                raise RuntimeError(msg)
+
+        with pytest.raises(RuntimeError, match="iteration failed"):
+            fail_inside_the_window()
+
+        assert event_manager.should_suppress_event(_create_node_result_event()) is False
+
+    def test_nested_windows_compose(self) -> None:
+        """An inner window adds to the outer one and restores it, rather than replacing it."""
+        event_manager = EventManager()
+        parameter_event = EventResultSuccess(
+            request=CreateNodeRequest(node_type="Note"),
+            result=SetParameterValueResultSuccess(
+                finalized_value=1,
+                data_type="int",
+                result_details="Set parameter value.",
+            ),
+        )
+
+        with EventSuppressionContext(event_manager, {CreateNodeResultSuccess}):
+            with EventSuppressionContext(event_manager, {SetParameterValueResultSuccess}):
+                assert event_manager.should_suppress_event(_create_node_result_event()) is True
+                assert event_manager.should_suppress_event(parameter_event) is True
+
+            # Leaving the inner window releases only what the inner window added.
+            assert event_manager.should_suppress_event(_create_node_result_event()) is True
+            assert event_manager.should_suppress_event(parameter_event) is False
+
+    def test_clear_event_suppression_releases_everything(self) -> None:
+        event_manager = EventManager()
+        with EventSuppressionContext(event_manager, {CreateNodeResultSuccess}):
+            event_manager.clear_event_suppression()
+            assert event_manager.should_suppress_event(_create_node_result_event()) is False
+
+
+class TestSuppressionIsScopedToItsCaller:
+    """The regression this design exists to prevent: suppression reaching a client's own request.
+
+    Loop windows span awaits (``_delete_iteration_flows``) and whole parallel runs, so "nothing
+    else can be in flight" is not a property the engine has. These tests pin that a window is
+    invisible outside the context that opened it.
+    """
+
+    def test_a_concurrent_task_is_unaffected(self) -> None:
+        """An editor's request handled while a loop rebuilds its body still gets broadcast."""
+        event_manager = EventManager()
+        window_open = asyncio.Event()
+        observed_by_editor: list[bool] = []
+
+        async def loop_rebuilding_its_body() -> None:
+            with EventSuppressionContext(event_manager, {CreateNodeResultSuccess}):
+                window_open.set()
+                # An await inside the window: this is where another task gets to run.
+                await asyncio.sleep(0)
+                assert event_manager.should_suppress_event(_create_node_result_event()) is True
+
+        async def editor_creating_a_node() -> None:
+            await window_open.wait()
+            observed_by_editor.append(event_manager.should_suppress_event(_create_node_result_event()))
+
+        async def run_both() -> None:
+            await asyncio.gather(loop_rebuilding_its_body(), editor_creating_a_node())
+
+        asyncio.run(run_both())
+
+        assert observed_by_editor == [False], (
+            "A suppression window opened by the engine reached a concurrently-handled request. "
+            "The editor would never be told about a node it just created."
+        )
+
+    def test_another_thread_is_unaffected(self) -> None:
+        """handle_request runs on arbitrary threads, so thread reach matters as much as task reach."""
+        event_manager = EventManager()
+        window_open = threading.Event()
+        observed_on_other_thread: list[bool] = []
+
+        def observe() -> None:
+            window_open.wait(timeout=5)
+            observed_on_other_thread.append(event_manager.should_suppress_event(_create_node_result_event()))
+
+        observer = threading.Thread(target=observe)
+        with EventSuppressionContext(event_manager, {CreateNodeResultSuccess}):
+            observer.start()
+            window_open.set()
+            observer.join(timeout=5)
+
+        assert observed_on_other_thread == [False]
+
+    def test_a_nested_request_inherits_suppression(self) -> None:
+        """The other half of the contract: the lineage meant to be hidden stays hidden.
+
+        Suppression has to survive into the requests a suppressed handler dispatches -- the
+        transient node creations come from inside ``on_deserialize_node_from_commands``, not from
+        the call the executor makes directly.
+        """
+        event_manager = EventManager()
+
+        def nested_handler() -> bool:
+            return event_manager.should_suppress_event(_create_node_result_event())
+
+        with EventSuppressionContext(event_manager, {CreateNodeResultSuccess}):
+            assert nested_handler() is True
+
+    @pytest.mark.asyncio
+    async def test_a_nested_await_inherits_suppression(self) -> None:
+        """Same, for the async dispatch path."""
+        event_manager = EventManager()
+
+        async def nested_handler() -> bool:
+            await asyncio.sleep(0)
+            return event_manager.should_suppress_event(_create_node_result_event())
+
+        with EventSuppressionContext(event_manager, {CreateNodeResultSuccess}):
+            assert await nested_handler() is True

--- a/tests/unit/retained_mode/managers/test_event_suppression.py
+++ b/tests/unit/retained_mode/managers/test_event_suppression.py
@@ -172,6 +172,50 @@ class TestSuppressionWindowLifetime:
             assert event_manager.should_suppress_event(_create_node_result_event()) is True
             assert event_manager.should_suppress_event(parameter_event) is False
 
+    def test_one_context_can_be_reused_for_a_later_block(self) -> None:
+        """Nothing stops a caller from holding a context and entering it twice in sequence."""
+        event_manager = EventManager()
+        suppression = EventSuppressionContext(event_manager, {CreateNodeResultSuccess})
+
+        with suppression:
+            assert event_manager.should_suppress_event(_create_node_result_event()) is True
+        assert event_manager.should_suppress_event(_create_node_result_event()) is False
+
+        with suppression:
+            assert event_manager.should_suppress_event(_create_node_result_event()) is True
+        assert event_manager.should_suppress_event(_create_node_result_event()) is False
+
+    def test_one_context_nested_in_itself_releases_on_the_outermost_exit(self) -> None:
+        """The failure mode a single token field has: the outer block loses its restore point.
+
+        With one token, the inner ``__enter__`` overwrites it and the outer ``__exit__`` has
+        nothing to reset -- so the type stays suppressed for the rest of the context, with nothing
+        to report it.
+        """
+        event_manager = EventManager()
+        suppression = EventSuppressionContext(event_manager, {CreateNodeResultSuccess})
+
+        with suppression:
+            with suppression:
+                assert event_manager.should_suppress_event(_create_node_result_event()) is True
+            assert event_manager.should_suppress_event(_create_node_result_event()) is True
+
+        assert event_manager.should_suppress_event(_create_node_result_event()) is False
+
+    def test_one_context_nested_in_itself_releases_when_the_inner_block_raises(self) -> None:
+        event_manager = EventManager()
+        suppression = EventSuppressionContext(event_manager, {CreateNodeResultSuccess})
+
+        def fail_inside_the_inner_window() -> None:
+            with suppression, suppression:
+                msg = "iteration failed"
+                raise RuntimeError(msg)
+
+        with pytest.raises(RuntimeError, match="iteration failed"):
+            fail_inside_the_inner_window()
+
+        assert event_manager.should_suppress_event(_create_node_result_event()) is False
+
     def test_clear_event_suppression_releases_everything(self) -> None:
         event_manager = EventManager()
         with EventSuppressionContext(event_manager, {CreateNodeResultSuccess}):
@@ -268,11 +312,10 @@ class TestSuppressionSetReachability:
     listing one has a real effect. ``ExecutionPayload`` members are emitted through
     ``put_event``/``aput_event``, which never consult it -- so listing one does nothing.
 
-    ``EXECUTION_EVENTS_TO_SUPPRESS`` documents itself as inert, and its own comment says to keep it
-    that way. It was not: two ``StartLocalSubflowResult`` types sat in it, and once the matcher was
-    repaired they became the one pair that took effect, dropping a parallel loop's per-iteration
-    results on the way to the editor. That is the class of mistake these tests catch -- a live
-    transport change added to a set everybody reads as a no-op.
+    So the mistake these tests catch is a request result added to ``EXECUTION_EVENTS_TO_SUPPRESS``:
+    a live transport change in a set everybody reads as a no-op, which would silently drop a
+    parallel loop's per-iteration results on the way to the editor. The mirror mistake -- an
+    execution payload in ``LOOP_EVENTS_TO_SUPPRESS`` -- is documentation posing as behaviour.
     """
 
     def test_execution_events_to_suppress_is_entirely_inert(self) -> None:

--- a/tests/unit/retained_mode/managers/test_event_suppression.py
+++ b/tests/unit/retained_mode/managers/test_event_suppression.py
@@ -25,12 +25,14 @@ import threading
 
 import pytest
 
+from griptape_nodes.common.node_executor import EXECUTION_EVENTS_TO_SUPPRESS, LOOP_EVENTS_TO_SUPPRESS
 from griptape_nodes.retained_mode.events.base_events import (
     EventResultFailure,
     EventResultSuccess,
     ExecutionEvent,
     ExecutionGriptapeNodeEvent,
     GriptapeNodeEvent,
+    ResultPayload,
 )
 from griptape_nodes.retained_mode.events.execution_events import (
     CurrentControlNodeEvent,
@@ -256,3 +258,65 @@ class TestSuppressionIsScopedToItsCaller:
 
         with EventSuppressionContext(event_manager, {CreateNodeResultSuccess}):
             assert await nested_handler() is True
+
+
+class TestSuppressionSetReachability:
+    """Which of the executor's two suppression sets the matcher can actually reach.
+
+    The distinction is transport, not naming. ``ResultPayload`` subclasses are broadcast from
+    ``engine.ahandle_request``, which consults ``should_suppress_event`` before queueing -- so
+    listing one has a real effect. ``ExecutionPayload`` members are emitted through
+    ``put_event``/``aput_event``, which never consult it -- so listing one does nothing.
+
+    ``EXECUTION_EVENTS_TO_SUPPRESS`` documents itself as inert, and its own comment says to keep it
+    that way. It was not: two ``StartLocalSubflowResult`` types sat in it, and once the matcher was
+    repaired they became the one pair that took effect, dropping a parallel loop's per-iteration
+    results on the way to the editor. That is the class of mistake these tests catch -- a live
+    transport change added to a set everybody reads as a no-op.
+    """
+
+    def test_execution_events_to_suppress_is_entirely_inert(self) -> None:
+        live = sorted(
+            event_type.__name__ for event_type in EXECUTION_EVENTS_TO_SUPPRESS if issubclass(event_type, ResultPayload)
+        )
+        assert live == [], (
+            "EXECUTION_EVENTS_TO_SUPPRESS documents itself as having no effect, but these are "
+            f"request results, which suppression does reach: {live}. Either put them in "
+            "LOOP_EVENTS_TO_SUPPRESS deliberately, or leave them out."
+        )
+
+    def test_loop_events_to_suppress_is_entirely_live(self) -> None:
+        """The mirror assertion: a member that cannot be reached is documentation, not behaviour."""
+        inert = sorted(
+            event_type.__name__ for event_type in LOOP_EVENTS_TO_SUPPRESS if not issubclass(event_type, ResultPayload)
+        )
+        assert inert == [], (
+            "LOOP_EVENTS_TO_SUPPRESS is the set that is supposed to work, but these are not "
+            f"request results, so suppression never sees them: {inert}."
+        )
+
+    def test_a_loop_suppressed_type_is_matched_in_its_real_shape(self) -> None:
+        """Type membership is necessary but not sufficient -- match the shape the engine passes."""
+        event_manager = EventManager()
+        with EventSuppressionContext(event_manager, LOOP_EVENTS_TO_SUPPRESS):
+            assert event_manager.should_suppress_event(_create_node_result_event()) is True
+            assert event_manager.should_suppress_event(_create_node_failure_event()) is True
+
+    @pytest.mark.asyncio
+    async def test_an_execution_event_is_queued_even_inside_its_own_suppression_window(self) -> None:
+        """Why the set is inert, demonstrated on the real transport rather than by type inspection.
+
+        ``put_event`` enqueues unconditionally. If that ever changes, this test fails and whoever
+        changed it has to decide what happens to the node highlighting the editor relies on.
+        """
+        event_manager = EventManager()
+        queue: asyncio.Queue = asyncio.Queue()
+        event_manager.initialize_queue(queue)
+
+        execution_event = ExecutionGriptapeNodeEvent(
+            wrapped_event=ExecutionEvent(payload=CurrentControlNodeEvent(node_name="Blur"))
+        )
+        with EventSuppressionContext(event_manager, EXECUTION_EVENTS_TO_SUPPRESS):
+            event_manager.put_event(execution_event)
+
+        assert queue.get_nowait() is execution_event

--- a/tests/unit/retained_mode/managers/test_workflow_manager_broadcast_flag_codegen.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager_broadcast_flag_codegen.py
@@ -1,0 +1,119 @@
+"""A transport flag set for the sake of a loop must not end up in a saved workflow file.
+
+``NodeExecutor._silence_packaged_node_creation_broadcasts`` clears ``broadcast_result`` on a
+packaged loop body's create commands so rebuilding the body stays invisible to editors. Workflow
+codegen, though, writes out every create-command field whose value differs from its default
+(``WorkflowManager._generate_node_creation_code``) -- so the same mutation applied anywhere upstream
+of a save writes ``broadcast_result=False`` into the artist's ``.py`` file, and on the publish path
+into a library. That is why the silencing lives at the local deserialization boundaries, which never
+save, rather than at packaging time, which several branches do save from.
+
+These tests pin both halves: that codegen really is that literal about non-default fields (so the
+constraint is real and not folklore), and that a silenced package result would carry the flag
+through if it were ever handed to the writer.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from griptape_nodes.common.node_executor import NodeExecutor
+from griptape_nodes.exe_types.node_types import NodeDependencies
+from griptape_nodes.node_library.workflow_registry import (
+    LibraryNameAndNodeType,
+    WorkflowMetadata,
+    WorkflowShape,
+)
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    PackageNodesAsSerializedFlowResultSuccess,
+    SerializedFlowCommands,
+)
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, SerializedNodeCommands
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
+
+
+def _package_result(*node_names: str) -> PackageNodesAsSerializedFlowResultSuccess:
+    """A packaging result shaped the way the loop executor receives one."""
+    serialized_nodes = [
+        SerializedNodeCommands(
+            create_node_command=CreateNodeRequest(node_type="EchoNode", node_name=node_name),
+            element_modification_commands=[],
+            node_dependencies=NodeDependencies(),
+        )
+        for node_name in node_names
+    ]
+    serialized_flow_commands = SerializedFlowCommands(
+        flow_initialization_command=CreateFlowRequest(flow_name="packaged_body", parent_flow_name=None),
+        serialized_node_commands=serialized_nodes,
+        serialized_connections=[],
+        unique_parameter_uuid_to_values={},
+        set_parameter_value_commands={},
+        set_lock_commands_per_node={},
+        sub_flows_commands=[],
+        node_dependencies=NodeDependencies(),
+        node_types_used={LibraryNameAndNodeType(library_name="Echo Library", node_type="EchoNode")},
+        flow_name="packaged_body",
+    )
+    return PackageNodesAsSerializedFlowResultSuccess(
+        serialized_flow_commands=serialized_flow_commands,
+        workflow_shape=WorkflowShape(),
+        packaged_node_names=list(node_names),
+        parameter_name_mappings=[],
+        result_details="Packaged the loop body.",
+    )
+
+
+def _generate(engine: Engine, serialized_flow_commands: SerializedFlowCommands) -> str:
+    metadata = WorkflowMetadata(
+        name="broadcast_flag_workflow",
+        schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+        engine_version_created_with="1.0.0",
+        node_libraries_referenced=[],
+        workflow_shape=None,
+    )
+    return engine.workflow_manager._generate_workflow_file_content(
+        serialized_flow_commands=serialized_flow_commands, workflow_metadata=metadata
+    )
+
+
+class TestBroadcastFlagAndCodegen:
+    def test_an_untouched_package_result_writes_no_transport_flag(self) -> None:
+        """The baseline: nothing about packaging mentions broadcasting."""
+        package_result = _package_result("Body Node")
+        assert package_result.serialized_flow_commands.serialized_node_commands[0].create_node_command.broadcast_result
+
+    def test_silencing_makes_broadcast_result_a_non_default_field(self) -> None:
+        """The coupling in one line: codegen emits non-default fields, and this makes it non-default."""
+        package_result = _package_result("Body Node", "Other Body Node")
+        NodeExecutor._silence_packaged_node_creation_broadcasts(package_result)
+
+        create_commands = [
+            serialized_node.create_node_command
+            for serialized_node in package_result.serialized_flow_commands.serialized_node_commands
+        ]
+        assert [command.broadcast_result for command in create_commands] == [False, False]
+
+    def test_codegen_writes_the_flag_out_when_it_is_silenced(self, engine: Engine) -> None:
+        """The consequence, on the real writer: a silenced command reaches the file as source.
+
+        This is the test that says *why* the silencing call may not move upstream of a save. If
+        codegen ever stops writing the flag, this failure is the place to record that the
+        constraint has been lifted -- do not simply delete the assertion.
+        """
+        package_result = _package_result("Body Node")
+        NodeExecutor._silence_packaged_node_creation_broadcasts(package_result)
+
+        generated = _generate(engine, package_result.serialized_flow_commands)
+
+        assert "broadcast_result=False" in generated
+
+    def test_codegen_is_clean_for_a_package_result_that_was_not_silenced(self, engine: Engine) -> None:
+        """The paired positive case: the flag appears only because of the mutation, not always."""
+        package_result = _package_result("Body Node")
+
+        generated = _generate(engine, package_result.serialized_flow_commands)
+
+        assert "broadcast_result" not in generated


### PR DESCRIPTION
## What

Two defects that make a failing loop hard to debug, found while investigating a report of a ForEach loop where every iteration failed.

### 1. Per-iteration failure detail was thrown away

When an iteration failed, `_execute_loop_iterations_sequentially` logged the subflow's `result_details` at WARNING and appended only the *index* to `failed_iterations: list[int]`. The user saw nothing but:

```
Loop execution failed: 3 of 4 iterations failed
```

The actual reason sat in the engine log and never reached the person who needed it. Now:

```
Attempted to run all 4 iterations of loop 'ForEach End'. Failed because 3 of them did not finish.
  Iteration 2: Node 'Load Image_1' execution failed: Failed to load image from: /opt/frames/missing_01.png
  Iteration 3: Node 'Load Image_1' execution failed: Failed to load image from: /opt/frames/missing_02.png
  Iteration 4: Node 'Load Image_1' execution failed: Failed to load image from: /opt/frames/missing_03.png
```

`failed_iterations` is now `list[IterationFailure]` (frozen dataclass: index + reason), and `_format_loop_failure_message` composes the artist-facing text. Iterations sharing a reason collapse onto one line — the common case is every iteration failing identically, which would otherwise be a wall of duplicated text — capped at `MAX_REPORTED_ITERATION_FAILURES` distinct reasons plus a pointer to the log.

Scoped to the local execution paths. The private/cloud subprocess helpers never populated a failure list, and making them raise would change success/failure semantics for environments this bug never touched. The while-group path is also untouched: there a failed iteration is a legitimate retry signal.

### 2. The engine announced nodes in a flow it never announced

A loop body is packaged into a short-lived `ControlFlow`. `on_deserialize_node_from_commands` dispatches a nested `CreateNodeRequest` whose `CreateNodeResultSuccess` reports that transient flow as `parent_flow_name`. The GUI then quite reasonably asks for details about a flow it has never heard of, the lookup fails, and the artist gets an error toast on every loop run:

```
Attempted to get Flow details for 'ControlFlow_2'. Failed because no Flow with that name exists.
```

**No GUI change is needed** — the GUI's question is correct; the engine should not be making the claim. `_silence_packaged_node_creation_broadcasts` sets `broadcast_result = False` on every packaged node's create command, from both `_package_loop_body` and `_package_subflow_group_body`.

It deliberately does *not* live in `flow_manager.on_package_nodes_as_serialized_flow_request`, even though that is where the packaged flow is tagged transient: that handler also serves workflow publishing, and `_generate_node_creation_code` emits every create-command field whose value differs from its default — so setting the flag there would bake a transport detail into saved workflow `.py` files.

### 3. The suppression mechanism meant to prevent (2) had never worked

`LOOP_EVENTS_TO_SUPPRESS` names result-payload classes, but `should_suppress_event` was only ever handed an `EventResult`, which exposes its payload as `.result` — not the `.payload` the predicate looked for. **Nothing in any suppression set had ever matched.** Every existing test patched the predicate out wholesale, which is why the coverage gap hid it.

Repairing the match alone would have introduced a real regression: the refcount lived on the manager as a process-wide `dict[type, int]`, so a loop running in one task would have silenced another task's parameter and connection confirmations. Suppression is now a module-level `ContextVar[frozenset[type]]` with token-based set/reset, scoped to the task that opened the window.

It fails **open** — losing the flag broadcasts as before, the harmless direction. That is deliberately the opposite of `_node_execution_depth`, which must fail closed and stays a lock-guarded int.

`EXECUTION_EVENTS_TO_SUPPRESS` stays inert and is now commented as such: its members travel via `put_event`/`aput_event`, which never consult the predicate, and reviving them would go dark on the node highlighting that `EventTranslationContext` exists to provide.

## Note on the originating report

The reported "every iteration failed" was **not** a loop regression — the workflow's topology and body run correctly on HEAD, and every iteration failed because the image paths baked into it no longer resolved on that machine. These are the two engine defects that made the report undiagnosable: the reason was in the engine log the whole time, and the flow-details toast pointed the investigation at a red herring.

## Verification

Ran one loop workflow on this branch's base commit and on the branch, hooking `EventManager.put_event` / `aput_event` (the websocket path) and diffing every event:

| | base | branch |
|---|---|---|
| events broadcast | 2194 | 2045 |
| **events naming a flow the GUI doesn't know** | **8** | **0** |
| `CreateNodeResultSuccess` | 23 | 15 |
| `CreateConnectionResultSuccess` | 66 | 25 |
| `SetParameterValueResultSuccess` | 393 | 306 |
| `CreateFlowResultSuccess` | 2 | 1 |
| `DeleteFlowResultSuccess`, `DeserializeFlowFromCommands*`, `DeserializeNodeFromCommands*` | present | gone |

That last row is the repaired suppression doing the job it was written for. The succeeding iteration still broadcasts normally, so nothing on the success path is being swallowed.

Also: `make check` clean, `4726 passed, 13 skipped` unit, 59 passed across the new/changed test files.

## Tests

- `tests/unit/retained_mode/managers/test_event_suppression.py` — 16 new tests covering the matching that nothing exercised. **7 of them fail against the previous implementation**, including a concurrent-task case that pins the regression the `ContextVar` rewrite avoids.
- `tests/unit/common/test_node_executor_loop_helpers.py` — message formatting: single/multiple failures, reason collapsing, the cap and its tail, 1-based numbering, multi-line details.
- `tests/e2e/test_transient_flow_node_broadcast.py` — builds a minimal ForEach loop, records broadcasts, asserts no event names a flow absent from `ObjectManager`.

## Known, not addressed here

One `PackageNodesAsSerializedFlowResultSuccess` (~120KB of engine-internal bookkeeping) is still broadcast per loop run. Fixable with `broadcast_result=False` at the two loop-body request sites — but not the publishing site — and kept out of this PR to hold the scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
