### PR TITLE
Settle a pending request on the loop that owns its future

### DIFF
--- a/docs/development/custom_nodes/node_isolation_with_workers.md
+++ b/docs/development/custom_nodes/node_isolation_with_workers.md
@@ -227,28 +227,80 @@ bus:
 
 Issue the request via `GriptapeNodes.handle_request(...)` from
 inside `process`. The handler-side path propagates the change back
-to the orchestrator. Worker subprocesses pick up the new parameter
-list on the next execute. The
+to the orchestrator. The
 [`parameter-mutation-during-aprocess`](strict_mode.md) rule fires
 on direct in-execute mutations and tells you which one to use.
 
-**`before_value_set` / `after_value_set` do not fire on editor
-changes for isolated libraries.** These hooks run inside the worker
-subprocess, on the temporary copy of your node built for each
-execute. The orchestrator holds only a stub copy of your node class
-— parameters, no code — so it never calls your overrides when a
-user edits a value in the editor. Transforming an incoming value
-still works: the hooks run as inputs are applied, just before
-`process`. But a parameter-list change made inside them is
-discarded with the temporary node. It skips the
-[`parameter-mutation-during-aprocess`](strict_mode.md) rule, and it
-does not propagate either.
+**The change lands on the orchestrator's node, not the one that is
+running.** That is the same rule as everywhere else here — the
+orchestrator holds the authoritative node — but it has a
+consequence worth stating outright: you cannot read the parameter
+back during the execution that added it.
+`self.get_parameter_by_name("new_param")` returns `None` in the
+worker even though the request succeeded and the editor is already
+showing the parameter.
 
-The practical consequence: hooks that adjust the parameter list in
-response to user input (for example, showing or hiding fields when
-a dropdown changes) only work in Shared mode. For an isolated
-library, define the full parameter list statically in `__init__`.
-Overriding a value hook fires the
+It does not reappear on the next execute either. Each execution
+builds a fresh worker-side copy from the node class, so parameter
+*structure* never carries forward — only values do.
+
+This is the contract, stated once: **a node's parameter structure
+must be a deterministic function of its parameter values.** Create
+parameters in `__init__`, or create and remove them from a value
+hook based on the values being set — the pattern the diffusers VAE
+decoder uses, rebuilding its output parameters from the pipeline
+value whenever it is set. Structure written that way needs no
+syncing at all: the same derivation runs on the orchestrator's
+node at edit time and again on the fresh worker copy as its values
+hydrate, so every copy converges on the same shape. Structure that
+exists only because something added it once — by request, from
+`process`, in a previous session — is history, not derivation, and
+history does not carry.
+
+Hydration honors the contract from its side. Values are applied in
+passes until the structure settles, so a value for a derived
+parameter works even when it arrives before the value that derives
+it — including chains, where one derived parameter's hook creates
+the next. A value for a parameter
+that nothing on the copy derives — most commonly one a user added
+in the editor — is left unapplied for that run, with a warning
+naming the parameter; it does not fail the execution, and the
+authoritative value on the orchestrator is untouched.
+
+### Value hooks: it depends on which kind of library
+
+**Execution-dependency libraries** (the ones that declare
+`pip_dependencies_exec`) keep real node classes on the
+orchestrator, so `before_value_set` / `after_value_set` fire there
+when a user edits a value, exactly as they do for a Shared
+library. Hooks that adjust the parameter list in response to user
+input — showing or hiding fields when a dropdown changes, growing
+a list — work normally at edit time.
+
+Two things to know about those hooks at *execution* time:
+
+- They also run in the worker, as inputs are applied. The
+    orchestrator skips hooks for a value that has not changed, but
+    the worker's node is freshly built, so every value looks new and
+    every hook runs. Keep them cheap and idempotent.
+- Anything they do to the node object there is discarded with the
+    temporary node. A parameter-list change made from a hook during
+    execution follows the rule above: route it through the request
+    bus if it needs to persist, and do not expect to read it back in
+    that same execution.
+
+**Legacy worker-mode libraries** (Isolated mode, chosen by
+`worker_mode_override` or `suggested_worker_mode`) behave
+differently, because the orchestrator holds only a stub copy of
+your node class — parameters, no code — so it never calls your
+overrides when a user edits a value. Transforming an incoming
+value still works, since the hooks run as inputs are applied just
+before `process`, but a parameter-list change made inside them is
+discarded with the temporary node: it skips the
+[`parameter-mutation-during-aprocess`](strict_mode.md) rule and
+does not propagate either. For those libraries, define the full
+parameter list statically in `__init__`. Overriding a value hook
+fires the
 [`value-hooks-execute-only-on-worker`](strict_mode.md) warning at
 library load.
 

--- a/docs/guides/libraries.md
+++ b/docs/guides/libraries.md
@@ -186,6 +186,28 @@ clashing heavy pins can still be edited side by side.
 Declaring no `pip_dependencies_exec` is always safe: the library
 behaves exactly as it did before the split existed.
 
+#### What declaring execution dependencies changes
+
+A library that declares them runs differently, in three ways:
+
+- **Its nodes execute in the library's own process.** The main
+    engine can show, edit, and save them (it has the edit-time
+    dependencies), but running them happens where the heavy
+    packages live. If that process isn't up yet, running the node
+    reports that rather than failing strangely.
+- **Node code asks the engine for state instead of reading it.**
+    Inside `process()`, reaching for a manager directly (config,
+    secrets, files) raises an error telling you the request to use
+    instead. The library's process holds no settings or secrets of
+    its own, so a direct read would be answering from the wrong
+    place. Saving static files still works normally.
+- **Values that can't leave the process must stay inside it.** If a
+    node outputs something marked `serializable=False` (a live
+    model handle, a tensor), you'll get an error explaining the two
+    ways forward: make the value serializable, or keep it inside
+    the library by caching it library-side and outputting a small
+    descriptor that the next node trades back.
+
 ### Process isolation: the Isolated mode
 
 Running a library **Isolated** (in its own dedicated process,

--- a/docs/guides/libraries.md
+++ b/docs/guides/libraries.md
@@ -165,6 +165,27 @@ isolation is the same.
 pip resolution conflicts.** This is the most important guarantee on
 this page.
 
+#### Edit-time vs. execution dependencies
+
+A library can split its dependencies into two sets in its manifest:
+
+- `pip_dependencies` — **edit-time**: what's needed to show the
+    library's nodes in the editor, place them on the canvas, and
+    edit their parameters. Keep this set light.
+- `pip_dependencies_exec` — **execution**: the heavy packages
+    (torch, diffusers, and friends) that are only needed when a
+    node actually *runs*.
+
+Execution dependencies are installed into a separate environment
+(`.venv-exec`, next to the library's `.venv`) and are only loaded
+in the process where nodes execute — never in the main engine
+process. That means a library can depend on multi-gigabyte ML
+stacks while the editor stays light, and two libraries with
+clashing heavy pins can still be edited side by side.
+
+Declaring no `pip_dependencies_exec` is always safe: the library
+behaves exactly as it did before the split existed.
+
 ### Process isolation: the Isolated mode
 
 Running a library **Isolated** (in its own dedicated process,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,7 +177,6 @@ ignore = [
 #
 # Group 2 -- not yet migrated. Each of these should eventually receive an Engine instead.
 # Deleting an entry from this list is the definition of done; do not add new entries.
-"src/griptape_nodes/exe_types/**" = ["TID251"]
 # WorkflowRegistry is still a process-global fake singleton reaching the facade for config.
 # Making it engine-owned is its own change, since it alters what node libraries import.
 "src/griptape_nodes/node_library/workflow_registry.py" = ["TID251"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,10 +180,6 @@ ignore = [
 # WorkflowRegistry is still a process-global fake singleton reaching the facade for config.
 # Making it engine-owned is its own change, since it alters what node libraries import.
 "src/griptape_nodes/node_library/workflow_registry.py" = ["TID251"]
-# artifact_normalization.py is called from Parameter converter closures in
-# exe_types/param_types/parameter_{image,audio,video,three_d}.py, which have no Engine of
-# their own yet, so it cannot come off this list until exe_types does.
-"src/griptape_nodes/utils/artifact_normalization.py" = ["TID251"]
 
 [tool.ruff.lint.flake8-type-checking]
 runtime-evaluated-base-classes = ["pydantic.BaseModel"]

--- a/src/griptape_nodes/api_client/request_client.py
+++ b/src/griptape_nodes/api_client/request_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import threading
 import uuid
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Self
@@ -74,7 +75,13 @@ class RequestClient:
 
         # Map of request_id -> pending request where tag identifies the originating worker/caller
         self._pending_requests: dict[str, _PendingRequest] = {}
-        self._lock = asyncio.Lock()
+        # threading.Lock, not asyncio.Lock: this guards state reached from more than one loop --
+        # _try_match runs on the transport loop while _track_request and _cancel_request run on the
+        # loop that issued the request. An asyncio.Lock binds to the loop that first awaits it and
+        # only checks on the CONTENDED path, so a cross-loop acquire raises intermittently while the
+        # uncontended fast path excludes nothing at all. Every section it guards is synchronous
+        # bookkeeping -- no await inside -- so a plain lock cannot deadlock here.
+        self._lock = threading.Lock()
 
         # Track subscribed response topics
         self._subscribed_response_topics: set[str] = set()
@@ -354,7 +361,7 @@ class RequestClient:
         Args:
             tag: The tag value used when track_request was called (e.g. worker_engine_id)
         """
-        async with self._lock:
+        with self._lock:
             to_cancel = [rid for rid, entry in self._pending_requests.items() if entry.tag == tag]
             for rid in to_cancel:
                 entry = self._pending_requests.pop(rid)
@@ -381,7 +388,7 @@ class RequestClient:
         Raises:
             ValueError: If request_id is already being tracked
         """
-        async with self._lock:
+        with self._lock:
             if request_id in self._pending_requests:
                 msg = f"Request ID already exists: {request_id}"
                 raise ValueError(msg)
@@ -458,7 +465,7 @@ class RequestClient:
             request_id: Request identifier
             result: Result data to return to the requester
         """
-        async with self._lock:
+        with self._lock:
             self._resolve_request_unlocked(request_id, result)
 
     async def _reject_request(self, request_id: str, error: Exception) -> None:
@@ -468,7 +475,7 @@ class RequestClient:
             request_id: Request identifier
             error: Exception to raise for the requester
         """
-        async with self._lock:
+        with self._lock:
             self._reject_request_unlocked(request_id, error)
 
     async def _cancel_request(self, request_id: str) -> None:
@@ -477,7 +484,7 @@ class RequestClient:
         Args:
             request_id: Request identifier
         """
-        async with self._lock:
+        with self._lock:
             entry = self._pending_requests.pop(request_id, None)
 
             if entry is None:
@@ -526,7 +533,7 @@ class RequestClient:
         payload = message.get("payload", {})
 
         request_id = payload.get("request_id") or ""
-        async with self._lock:
+        with self._lock:
             if not request_id or request_id not in self._pending_requests:
                 return False
 

--- a/src/griptape_nodes/api_client/request_client.py
+++ b/src/griptape_nodes/api_client/request_client.py
@@ -23,6 +23,14 @@ logger = logging.getLogger(__name__)
 class _PendingRequest:
     future: asyncio.Future
     tag: str
+    # The loop the future belongs to, which is NOT always the loop that resolves it. Websocket
+    # messages are handled on the transport loop while a request may have been issued from the
+    # loop running a flow, and asyncio futures are single-loop objects: set_result schedules the
+    # waiting task through `future._loop.call_soon`, which does not wake a loop it is not called
+    # from. Resolving across loops without this left the result sitting in the target loop's ready
+    # queue until something unrelated woke it -- a node stayed "running" for ~30s, and raising the
+    # log level "fixed" it because the extra log events did the waking.
+    loop: asyncio.AbstractEventLoop
     # When True, EventResultFailure responses resolve the future with
     # the full payload dict instead of rejecting it with
     # ``Exception(error_msg)``. The default (False) preserves the
@@ -351,9 +359,8 @@ class RequestClient:
             to_cancel = [rid for rid, entry in self._pending_requests.items() if entry.tag == tag]
             for rid in to_cancel:
                 entry = self._pending_requests.pop(rid)
-                if not entry.future.done():
-                    entry.future.cancel()
-                    logger.debug("Cancelled request %s (tag=%s)", rid, tag)
+                RequestClient._settle(entry, entry.future.cancel)
+                logger.debug("Cancelled request %s (tag=%s)", rid, tag)
 
     async def _track_request(
         self,
@@ -380,12 +387,38 @@ class RequestClient:
                 msg = f"Request ID already exists: {request_id}"
                 raise ValueError(msg)
 
-            future: asyncio.Future = asyncio.Future()
+            loop = asyncio.get_running_loop()
+            future: asyncio.Future = loop.create_future()
             self._pending_requests[request_id] = _PendingRequest(
-                future, tag, resolve_failures_as_payload=resolve_failures_as_payload
+                future, tag, loop, resolve_failures_as_payload=resolve_failures_as_payload
             )
             logger.debug("Tracking request: %s (tag=%s)", request_id, tag)
             return future
+
+    @staticmethod
+    def _settle(entry: _PendingRequest, settle: Callable[[], object]) -> None:
+        """Apply a terminal state to a pending request's future, on the loop that owns it.
+
+        A future is bound to one loop. Calling set_result/set_exception/cancel from a different
+        loop marks it done but schedules the waiting task's wakeup with a non-threadsafe
+        `call_soon`, so a sleeping owner loop never learns about it. call_soon_threadsafe is the
+        same operation plus the wakeup, and is safe to use even from the owning loop, so there is
+        one path rather than a same-loop special case to keep in sync.
+
+        The done-check is re-run inside the callback because it runs later, on the other loop,
+        where a cancellation may have landed first.
+        """
+
+        def apply() -> None:
+            if not entry.future.done():
+                settle()
+
+        try:
+            entry.loop.call_soon_threadsafe(apply)
+        except RuntimeError:
+            # The owning loop is closed, so nothing is waiting on this future any more. Shutdown
+            # races here rather than an error worth surfacing.
+            logger.debug("Dropping a settled request: its loop is closed")
 
     def _resolve_request_unlocked(self, request_id: str, result: Any) -> None:
         """Resolve a request's future. Caller must hold self._lock.
@@ -400,9 +433,8 @@ class RequestClient:
             logger.warning("Received response for unknown request: %s", request_id)
             return
 
-        if not entry.future.done():
-            entry.future.set_result(result)
-            logger.debug("Resolved request: %s", request_id)
+        RequestClient._settle(entry, lambda: entry.future.set_result(result))
+        logger.debug("Resolved request: %s", request_id)
 
     def _reject_request_unlocked(self, request_id: str, error: Exception) -> None:
         """Reject a request's future. Caller must hold self._lock.
@@ -417,9 +449,8 @@ class RequestClient:
             logger.warning("Received error for unknown request: %s", request_id)
             return
 
-        if not entry.future.done():
-            entry.future.set_exception(error)
-            logger.debug("Rejected request: %s with error: %s", request_id, error)
+        RequestClient._settle(entry, lambda: entry.future.set_exception(error))
+        logger.debug("Rejected request: %s with error: %s", request_id, error)
 
     async def _resolve_request(self, request_id: str, result: Any) -> None:
         """Mark a request as successful and resolve its future with a result.
@@ -454,9 +485,8 @@ class RequestClient:
                 logger.debug("Request already completed or unknown: %s", request_id)
                 return
 
-            if not entry.future.done():
-                entry.future.cancel()
-                logger.debug("Cancelled request: %s", request_id)
+            RequestClient._settle(entry, entry.future.cancel)
+            logger.debug("Cancelled request: %s", request_id)
 
     @property
     def pending_count(self) -> int:

--- a/src/griptape_nodes/api_client/request_client.py
+++ b/src/griptape_nodes/api_client/request_client.py
@@ -27,9 +27,8 @@ class _PendingRequest:
     # messages are handled on the transport loop while a request may have been issued from the
     # loop running a flow, and asyncio futures are single-loop objects: set_result schedules the
     # waiting task through `future._loop.call_soon`, which does not wake a loop it is not called
-    # from. Resolving across loops without this left the result sitting in the target loop's ready
-    # queue until something unrelated woke it -- a node stayed "running" for ~30s, and raising the
-    # log level "fixed" it because the extra log events did the waking.
+    # from. Without this the result sits in the target loop's ready queue until something
+    # unrelated wakes it.
     loop: asyncio.AbstractEventLoop
     # When True, EventResultFailure responses resolve the future with
     # the full payload dict instead of rejecting it with

--- a/src/griptape_nodes/app/worker_routing.py
+++ b/src/griptape_nodes/app/worker_routing.py
@@ -45,6 +45,7 @@ from griptape_nodes.retained_mode.events.execution_events import (
     CancelExecuteNodeRequest,
     ExecuteNodeRequest,
 )
+from griptape_nodes.retained_mode.events.library_events import ReloadAllLibrariesRequest
 from griptape_nodes.retained_mode.events.parameter_events import MigrateParameterRequest
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 from griptape_nodes.retained_mode.events.project_events import (
@@ -202,6 +203,13 @@ LOCAL_ONLY_REQUEST_TYPES: frozenset[type[RequestPayload]] = frozenset(
         ReloadConfigRequest,
         RefreshSecretsRequest,
         ActivateProjectRequest,
+        # Adopting a project reloads this worker's libraries, and that reload must stay here. The
+        # orchestrator decides WHEN libraries reload -- it is mid-reload already, which is what sent
+        # the activation -- so forwarding would have the worker dictate to it. Worse, the
+        # orchestrator's pre-reload callback is reset_workers, which terminates the very worker that
+        # asked, mid-node. Reached because in_node_execution() is a process-wide refcount, so a
+        # reload dispatched by a broadcast handler forwards whenever any node happens to be running.
+        ReloadAllLibrariesRequest,
         # Two requests carry a live Python object in a field, and both were local under the
         # allowlist this exclusion list replaces -- the flip is what started forwarding them.
         # `_registers_a_python_class` does not catch either: it matches a `type[...]` annotation,

--- a/src/griptape_nodes/app/worker_routing.py
+++ b/src/griptape_nodes/app/worker_routing.py
@@ -51,7 +51,10 @@ from griptape_nodes.retained_mode.events.library_events import ReloadAllLibrarie
 from griptape_nodes.retained_mode.events.parameter_events import MigrateParameterRequest
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 from griptape_nodes.retained_mode.events.project_events import (
+    AttemptMapAbsolutePathToProjectRequest,
     GetCurrentProjectRequest,
+    GetPathForMacroRequest,
+    GetSituationRequest,
     SetCurrentProjectRequest,
 )
 from griptape_nodes.retained_mode.events.resource_events import (
@@ -338,6 +341,20 @@ LOCAL_ONLY_REQUEST_TYPES: frozenset[type[RequestPayload]] = frozenset(
         # the first attribute access fails. In a worker that meant every sidecar write logged
         # "'dict' object has no attribute 'project_base_dir'" and silently wrote nothing.
         GetCurrentProjectRequest,
+        # The same argument, for the reads that resolve a path against that project. All three are
+        # pure template reads carrying serializable payloads, and all three sit on the per-file
+        # write path, so forwarding them costs a round trip per saved file.
+        # GetPathForMacroResultFailure also declares `missing_variables: set[str] | None`, the same
+        # shape cattrs cannot round-trip that broke the os_events forwards.
+        #
+        # AttemptMapAbsolutePathToProjectRequest is the write-side counterpart and hid longest:
+        # every file written through a ProjectFileDestination asks whether its absolute path maps
+        # back into the project so the caller can store a portable macro reference instead. It sits
+        # AFTER the write rather than before it, which is the only reason it read as a different
+        # case; its handler is a pure read of the same project template.
+        GetSituationRequest,
+        GetPathForMacroRequest,
+        AttemptMapAbsolutePathToProjectRequest,
         # Two requests carry a live Python object in a field, and both were local under the
         # allowlist this exclusion list replaces -- the flip is what started forwarding them.
         # `_registers_a_python_class` does not catch either: it matches a `type[...]` annotation,

--- a/src/griptape_nodes/app/worker_routing.py
+++ b/src/griptape_nodes/app/worker_routing.py
@@ -58,6 +58,7 @@ from griptape_nodes.retained_mode.events.project_events import (
     SetCurrentProjectRequest,
 )
 from griptape_nodes.retained_mode.events.resource_events import (
+    GetExecutionDeviceRequest,
     RegisterResourceTypeRequest,
 )
 from griptape_nodes.retained_mode.events.static_file_events import (
@@ -347,6 +348,12 @@ LOCAL_ONLY_REQUEST_TYPES: frozenset[type[RequestPayload]] = frozenset(
         GetSituationRequest,
         GetPathForMacroRequest,
         AttemptMapAbsolutePathToProjectRequest,
+        # resource_events: which device to run on describes the machine that will run the model,
+        # which is THIS one. Forwarding asked the orchestrator about its own hardware --
+        # indistinguishable while both processes share a machine, and wrong the moment a venue runs
+        # anywhere else. Detection is torch-free and reads local hardware, so the worker's answer is
+        # authoritative by construction.
+        GetExecutionDeviceRequest,
         # Two requests carry a live Python object in a field, and both were local under the
         # allowlist this exclusion list replaces -- the flip is what started forwarding them.
         # `_registers_a_python_class` does not catch either: it matches a `type[...]` annotation,

--- a/src/griptape_nodes/app/worker_routing.py
+++ b/src/griptape_nodes/app/worker_routing.py
@@ -4,7 +4,7 @@ On a worker, a handful of request types must be serviced by the orchestrator
 because the authoritative state (flow graph, connections, node registry) lives
 there. This module provides:
 
-- ``FORWARDED_REQUEST_TYPES``: the flat list of request classes whose worker-
+- ``LOCAL_ONLY_REQUEST_TYPES``: the exclusion list of request classes whose worker-
   side handler should forward to the orchestrator.
 - ``RemoteHandler``: an async callable that replaces the original manager
   handler for those request types on the worker. While the worker is actively
@@ -41,53 +41,25 @@ from griptape_nodes.retained_mode.events.base_events import (
     SkipTheLineMixin,
     WorkflowNotAlteredMixin,
 )
-from griptape_nodes.retained_mode.events.config_events import (
-    GetConfigValueRequest,
-    ResetConfigRequest,
-    SetConfigCategoryRequest,
-    SetConfigValueRequest,
-)
-from griptape_nodes.retained_mode.events.connection_events import (
-    CreateConnectionRequest,
-    DeleteConnectionRequest,
-    ListConnectionsForNodeRequest,
-)
-from griptape_nodes.retained_mode.events.flow_events import (
-    CreateFlowRequest,
-    DeleteFlowRequest,
-    ListFlowsInCurrentContextRequest,
-    ListFlowsInFlowRequest,
-    ListNodesInFlowRequest,
-)
-from griptape_nodes.retained_mode.events.node_events import (
-    CreateNodeRequest,
-    DeleteNodeRequest,
-    GetFlowForNodeRequest,
-    ListParametersOnNodeRequest,
-)
-from griptape_nodes.retained_mode.events.parameter_events import (
-    AddParameterToNodeRequest,
-    AlterParameterDetailsRequest,
-    GetConnectionsForParameterRequest,
-    GetParameterDetailsRequest,
-    GetParameterValueRequest,
-    RemoveParameterFromNodeRequest,
-    SetParameterValueRequest,
+from griptape_nodes.retained_mode.events.execution_events import (
+    CancelExecuteNodeRequest,
+    ExecuteNodeRequest,
 )
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 from griptape_nodes.retained_mode.events.project_events import (
     SetCurrentProjectRequest,
 )
-from griptape_nodes.retained_mode.events.secrets_events import (
-    DeleteSecretValueRequest,
-    GetSecretValueRequest,
-    SetSecretValueRequest,
+from griptape_nodes.retained_mode.events.static_file_events import (
+    CreateStaticFileDownloadUrlFromPathRequest,
+    CreateStaticFileDownloadUrlRequest,
+    CreateStaticFileRequest,
+    CreateStaticFileUploadUrlRequest,
 )
-from griptape_nodes.retained_mode.events.variable_events import (
-    GetVariablesRequest,
-    ListVariablesRequest,
-    ResolveSubstitutionRequest,
-    SetVariablesRequest,
+from griptape_nodes.retained_mode.events.worker_events import (
+    RegisterWorkerRequest,
+    StartWorkerRequest,
+    UnregisterWorkerRequest,
+    WorkerHeartbeatRequest,
 )
 from griptape_nodes.retained_mode.managers.event_manager import ResultContext
 from griptape_nodes.utils.async_utils import call_function
@@ -102,53 +74,6 @@ if TYPE_CHECKING:
 
 
 HandlerCallback = "Callable[[RequestPayload], ResultPayload | Awaitable[ResultPayload]]"
-
-
-FORWARDED_REQUEST_TYPES: frozenset[type[RequestPayload]] = frozenset(
-    {
-        # connection_events
-        CreateConnectionRequest,
-        DeleteConnectionRequest,
-        ListConnectionsForNodeRequest,
-        # node_events
-        CreateNodeRequest,
-        DeleteNodeRequest,
-        ListParametersOnNodeRequest,
-        GetFlowForNodeRequest,
-        # parameter_events
-        AddParameterToNodeRequest,
-        RemoveParameterFromNodeRequest,
-        SetParameterValueRequest,
-        GetParameterDetailsRequest,
-        AlterParameterDetailsRequest,
-        GetParameterValueRequest,
-        GetConnectionsForParameterRequest,
-        # flow_events
-        CreateFlowRequest,
-        DeleteFlowRequest,
-        ListNodesInFlowRequest,
-        ListFlowsInCurrentContextRequest,
-        ListFlowsInFlowRequest,
-        # config_events
-        # Getters forward too: a worker's own ConfigManager is populated from the same shared
-        # files, but it is a non-authoritative copy that can lag the orchestrator's in-memory
-        # state. Reads during node execution should see what the orchestrator sees.
-        GetConfigValueRequest,
-        SetConfigValueRequest,
-        SetConfigCategoryRequest,
-        ResetConfigRequest,
-        # secrets_events
-        GetSecretValueRequest,
-        SetSecretValueRequest,
-        DeleteSecretValueRequest,
-        # variable_events
-        GetVariablesRequest,
-        ListVariablesRequest,
-        # DEPRECATED: forwarded only while the shims live. TODO(https://github.com/griptape-ai/griptape-nodes/issues/5143): remove with the shims.
-        ResolveSubstitutionRequest,
-        SetVariablesRequest,
-    }
-)
 
 
 @dataclass
@@ -242,12 +167,47 @@ class ActivateProjectResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure
     """Worker failed to adopt the orchestrator's current project."""
 
 
+LOCAL_ONLY_REQUEST_TYPES: frozenset[type[RequestPayload]] = frozenset(
+    {
+        # Requests a worker must answer ITSELF while executing a node. Everything else
+        # forwards to the orchestrator, which owns the authoritative state.
+        #
+        # This list is deliberately an exclusion list rather than an allowlist. With an
+        # allowlist, every newly added request type silently resolved against the worker's
+        # own managers -- a non-authoritative copy -- and every migration note that told
+        # authors to "use a request instead" was wrong for any type nobody remembered to
+        # add. Defaulting to forwarding makes that class of mistake impossible.
+        #
+        # execution_events: forwarding a worker's own execution request would send it
+        # straight back to the orchestrator, which would route it here again.
+        ExecuteNodeRequest,
+        CancelExecuteNodeRequest,
+        # static_file_events: the payload is bytes. A worker writes them to the shared
+        # workspace itself and forwards only the resulting registration; shipping a 4K
+        # video across the boundary is the one thing storage must never do.
+        CreateStaticFileRequest,
+        CreateStaticFileUploadUrlRequest,
+        CreateStaticFileDownloadUrlRequest,
+        CreateStaticFileDownloadUrlFromPathRequest,
+        # worker_events + broadcasts: these travel orchestrator -> worker. Sending them back
+        # is the same loop as execution.
+        RegisterWorkerRequest,
+        UnregisterWorkerRequest,
+        WorkerHeartbeatRequest,
+        StartWorkerRequest,
+        ReloadConfigRequest,
+        RefreshSecretsRequest,
+        ActivateProjectRequest,
+    }
+)
+
+
 @dataclass
 class RemoteHandler:
     """Worker-side dispatch shim.
 
     Registered in place of the original manager handler for types in
-    FORWARDED_REQUEST_TYPES. Forwards to the orchestrator while the worker is
+    every registered type except LOCAL_ONLY_REQUEST_TYPES. Forwards to the orchestrator while the worker is
     inside a ``worker_node_execution_scope``; delegates to the original
     handler otherwise (so bootstrap / library-load paths keep running locally).
 
@@ -292,25 +252,24 @@ def schedule_broadcast(broadcast_type: type[RequestPayload]) -> None:
 
 
 def register_remote_handlers(event_manager: EventManager) -> None:
-    """Swap every FORWARDED_REQUEST_TYPE handler for a RemoteHandler.
+    """Route requests made during node execution to the orchestrator.
 
-    Must be called after every manager that claims one of these request types
-    has finished registering (i.e. after ``GriptapeNodes()`` construction is
-    complete) AND after ``configure_worker_forwarding`` has supplied the
-    RequestClient / topic / loop references. See ``_run_worker`` in app.py.
+    Swaps a RemoteHandler in for every registered request type except those in
+    LOCAL_ONLY_REQUEST_TYPES. The handler forwards only while the worker is inside a
+    ``worker_node_execution_scope`` and delegates to the original handler otherwise, so
+    engine boot and library load -- which legitimately need this process's own managers --
+    are unaffected.
 
-    Raises RuntimeError if a forwarded request type has no registered owner;
-    that always indicates a bootstrap-order bug, not a runtime condition.
+    Must be called after every manager has finished registering (i.e. after the engine is
+    constructed) AND after ``configure_worker_forwarding`` has supplied the RequestClient,
+    topic, and loop references. See ``_run_worker`` in app.py.
     """
-    for request_type in FORWARDED_REQUEST_TYPES:
+    for request_type in event_manager.registered_request_types():
+        if request_type in LOCAL_ONLY_REQUEST_TYPES:
+            continue
         original = event_manager.get_manager_for_request_type(request_type)
         if original is None:
-            msg = (
-                f"register_remote_handlers: no manager registered for "
-                f"{request_type.__name__}. Worker bootstrap must finish manager "
-                f"registration before remote handlers are installed."
-            )
-            raise RuntimeError(msg)
+            continue
         remote = RemoteHandler(original=original, event_manager=event_manager)
         event_manager.remove_manager_from_request_type(request_type)
         event_manager.assign_manager_to_request_type(request_type, remote)

--- a/src/griptape_nodes/app/worker_routing.py
+++ b/src/griptape_nodes/app/worker_routing.py
@@ -45,9 +45,13 @@ from griptape_nodes.retained_mode.events.execution_events import (
     CancelExecuteNodeRequest,
     ExecuteNodeRequest,
 )
+from griptape_nodes.retained_mode.events.parameter_events import MigrateParameterRequest
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 from griptape_nodes.retained_mode.events.project_events import (
     SetCurrentProjectRequest,
+)
+from griptape_nodes.retained_mode.events.resource_events import (
+    RegisterResourceTypeRequest,
 )
 from griptape_nodes.retained_mode.events.static_file_events import (
     CreateStaticFileDownloadUrlFromPathRequest,
@@ -198,6 +202,15 @@ LOCAL_ONLY_REQUEST_TYPES: frozenset[type[RequestPayload]] = frozenset(
         ReloadConfigRequest,
         RefreshSecretsRequest,
         ActivateProjectRequest,
+        # Two requests carry a live Python object in a field, and both were local under the
+        # allowlist this exclusion list replaces -- the flip is what started forwarding them.
+        # `_registers_a_python_class` does not catch either: it matches a `type[...]` annotation,
+        # and these carry an INSTANCE (a ResourceType, a Callable). Forwarding puts the object
+        # through `json.dumps(default=str)`, so the orchestrator registers a string and the worker
+        # -- the process that needs it while running a node -- registers nothing, with no error on
+        # either side.
+        RegisterResourceTypeRequest,
+        MigrateParameterRequest,
     }
 )
 

--- a/src/griptape_nodes/app/worker_routing.py
+++ b/src/griptape_nodes/app/worker_routing.py
@@ -226,26 +226,18 @@ def _carries_a_macro_path(payload: type) -> bool:
     and fails if a carrier appears elsewhere -- rather than this widening to the registry, where
     a false positive would silently answer a request in the wrong process.
     """
-    # Handles both annotation forms: a real class where the module evaluates annotations eagerly,
-    # and the text where `from __future__ import annotations` postponed it.
     return any("MacroPath" in _annotation_text(field.type) for field in dc_fields(payload))
 
 
-# Requests a worker must answer itself, derived rather than listed. Two independent reasons, and
-# both are derived from the CAUSE so that a request added later is covered without anyone
-# remembering this file:
+# Requests a worker must answer itself, derived from the CAUSE rather than listed, so a request
+# added later is covered without anyone remembering this file. Two independent reasons: filesystem
+# work, where the shared-on-disk workspace makes the worker's own answer the authoritative one and
+# forwarding a write corrupts it (`content` is `str | bytes` and the wire form resolves back to
+# `str`); and carrying a MacroPath, which cannot serialize at all.
 #
-#   1. Filesystem work. The workspace is shared on disk, so the worker's own answer is already the
-#      right one -- and forwarding a write corrupted it (`content` is `str | bytes`, and the wire
-#      form resolves back to `str`).
-#   2. Anything carrying a MacroPath in either module swept below. `os_events` was not the only
-#      one: the artifact preview requests carry one too, and are reached from a handler that a
-#      worker runs locally, so the first version of this derivation still let them forward and
-#      fail. A registry-wide test guards the case of a third module growing a carrier.
-#
-# OpenAssociatedFileRequest is the one filesystem request that is deliberately NOT local: it hands
-# a path to the OS to open in the user's default application, and that side effect belongs where
-# the user is, not in a headless subprocess. It carries no MacroPath, so nothing else claims it.
+# OpenAssociatedFileRequest is the one filesystem request deliberately NOT local: it hands a path to
+# the OS to open in the user's default application, and that side effect belongs where the user is,
+# not in a headless subprocess. It carries no MacroPath, so nothing else claims it.
 _FORWARDING_FILESYSTEM_REQUESTS: frozenset[type[RequestPayload]] = frozenset({os_events.OpenAssociatedFileRequest})
 
 
@@ -372,8 +364,8 @@ LOCAL_ONLY_REQUEST_TYPES: frozenset[type[RequestPayload]] = frozenset(
 class RemoteHandler:
     """Worker-side dispatch shim.
 
-    Registered in place of the original manager handler for types in
-    every registered type except LOCAL_ONLY_REQUEST_TYPES. Forwards to the orchestrator while the worker is
+    Registered in place of the original manager handler for every registered type except
+    LOCAL_ONLY_REQUEST_TYPES. Forwards to the orchestrator while the worker is
     inside a ``worker_node_execution_scope``; delegates to the original
     handler otherwise (so bootstrap / library-load paths keep running locally).
 

--- a/src/griptape_nodes/app/worker_routing.py
+++ b/src/griptape_nodes/app/worker_routing.py
@@ -4,8 +4,8 @@ On a worker, a handful of request types must be serviced by the orchestrator
 because the authoritative state (flow graph, connections, node registry) lives
 there. This module provides:
 
-- ``LOCAL_ONLY_REQUEST_TYPES``: the exclusion list of request classes whose worker-
-  side handler should forward to the orchestrator.
+- ``LOCAL_ONLY_REQUEST_TYPES``: the request classes a worker answers ITSELF. Every other
+  registered type gets a ``RemoteHandler`` that forwards to the orchestrator.
 - ``RemoteHandler``: an async callable that replaces the original manager
   handler for those request types on the worker. While the worker is actively
   executing a node it forwards; outside that scope it delegates back to the
@@ -29,10 +29,12 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from dataclasses import fields as dc_fields
 from typing import TYPE_CHECKING, Any, cast
 
 from griptape_nodes.common.strict_mode import STRICT_MODE
 from griptape_nodes.common.strict_mode_checks import RULES
+from griptape_nodes.retained_mode.events import artifact_events, os_events
 from griptape_nodes.retained_mode.events.base_events import (
     RequestPayload,
     ResultPayload,
@@ -49,6 +51,7 @@ from griptape_nodes.retained_mode.events.library_events import ReloadAllLibrarie
 from griptape_nodes.retained_mode.events.parameter_events import MigrateParameterRequest
 from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 from griptape_nodes.retained_mode.events.project_events import (
+    GetCurrentProjectRequest,
     SetCurrentProjectRequest,
 )
 from griptape_nodes.retained_mode.events.resource_events import (
@@ -172,6 +175,101 @@ class ActivateProjectResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure
     """Worker failed to adopt the orchestrator's current project."""
 
 
+def _registers_a_python_class(payload: type) -> bool:
+    """Whether a field is declared as a bare ``type``.
+
+    Two reasons such a request must stay local, and either alone is sufficient. cattrs has no
+    structure hook for ``type``, so the orchestrator's ingress raises and the worker blocks until
+    the forward times out. And the point of the request is to put a *class* into a process-local
+    registry: forwarding it would register something in the wrong process while the worker -- the
+    one that needs the provider while running a node -- registers nothing.
+    """
+    return any(
+        _annotation_text(field.type).strip().startswith(("type[", "type "))
+        or _annotation_text(field.type).strip() == "type"
+        for field in dc_fields(payload)
+    )
+
+
+def _annotation_text(annotation: object) -> str:
+    """The annotation as text, whichever form the module stored it in.
+
+    `str(annotation)` rather than `__name__`, because composite shapes have no useful name:
+    `MacroPath | None` is a UnionType whose `__name__` does not exist, and `list[MacroPath]`
+    is named just `list` -- both would silently defeat a matcher that only reads names, and
+    a missed MacroPath means a forwarded request that dies on the wire instead of answering
+    locally.
+    """
+    if isinstance(annotation, str):
+        return annotation
+    if isinstance(annotation, type):
+        # str() of a plain class is "<class 'x.Y'>", which matches nothing a matcher looks
+        # for -- and `provider_class: type` (a bare builtin) is exactly the shape the
+        # type-registration predicate exists to catch.
+        return annotation.__name__
+    return str(annotation)
+
+
+def _carries_a_macro_path(payload: type) -> bool:
+    """Whether any field of ``payload`` is declared as a ``MacroPath``.
+
+    A MacroPath wraps a ParsedMacro, which will not serialize, so a request carrying one cannot be
+    forwarded at all: the send raises and the worker blocks until the forward times out. Matched on
+    the declared annotation text rather than a resolved type, because these modules annotate under
+    `from __future__ import annotations` and several cannot be resolved at runtime.
+
+    Applied to the two modules swept below, which are the only ones defining a MacroPath carrier
+    today. The invariant is wider than that scope, so a test sweeps the whole payload registry
+    and fails if a carrier appears elsewhere -- rather than this widening to the registry, where
+    a false positive would silently answer a request in the wrong process.
+    """
+    # Handles both annotation forms: a real class where the module evaluates annotations eagerly,
+    # and the text where `from __future__ import annotations` postponed it.
+    return any("MacroPath" in _annotation_text(field.type) for field in dc_fields(payload))
+
+
+# Requests a worker must answer itself, derived rather than listed. Two independent reasons, and
+# both are derived from the CAUSE so that a request added later is covered without anyone
+# remembering this file:
+#
+#   1. Filesystem work. The workspace is shared on disk, so the worker's own answer is already the
+#      right one -- and forwarding a write corrupted it (`content` is `str | bytes`, and the wire
+#      form resolves back to `str`).
+#   2. Anything carrying a MacroPath in either module swept below. `os_events` was not the only
+#      one: the artifact preview requests carry one too, and are reached from a handler that a
+#      worker runs locally, so the first version of this derivation still let them forward and
+#      fail. A registry-wide test guards the case of a third module growing a carrier.
+#
+# OpenAssociatedFileRequest is the one filesystem request that is deliberately NOT local: it hands
+# a path to the OS to open in the user's default application, and that side effect belongs where
+# the user is, not in a headless subprocess. It carries no MacroPath, so nothing else claims it.
+_FORWARDING_FILESYSTEM_REQUESTS: frozenset[type[RequestPayload]] = frozenset({os_events.OpenAssociatedFileRequest})
+
+
+def _local_only_by_derivation() -> frozenset[type[RequestPayload]]:
+    derived: set[type[RequestPayload]] = set()
+    for module in (os_events, artifact_events):
+        for payload in vars(module).values():
+            # `__module__` rather than mere namespace membership: these modules import request
+            # types from each other, and a re-exported CreateNodeRequest becoming local-only would
+            # silently let a worker mutate its own non-authoritative graph.
+            if (
+                not isinstance(payload, type)
+                or not issubclass(payload, RequestPayload)
+                or payload is RequestPayload
+                or payload.__module__ != module.__name__
+            ):
+                continue
+            if payload in _FORWARDING_FILESYSTEM_REQUESTS:
+                continue
+            if module is os_events or _carries_a_macro_path(payload) or _registers_a_python_class(payload):
+                derived.add(payload)
+    return frozenset(derived)
+
+
+_LOCAL_ONLY_FILESYSTEM_REQUESTS: frozenset[type[RequestPayload]] = _local_only_by_derivation()
+
+
 LOCAL_ONLY_REQUEST_TYPES: frozenset[type[RequestPayload]] = frozenset(
     {
         # Requests a worker must answer ITSELF while executing a node. Everything else
@@ -210,6 +308,36 @@ LOCAL_ONLY_REQUEST_TYPES: frozenset[type[RequestPayload]] = frozenset(
         # asked, mid-node. Reached because in_node_execution() is a process-wide refcount, so a
         # reload dispatched by a broadcast handler forwards whenever any node happens to be running.
         ReloadAllLibrariesRequest,
+        # os_events: a worker does its own filesystem work. The workspace is shared on disk, so
+        # the local answer is already the right one -- the same argument as the project reads
+        # below -- and forwarding was actively destructive. `content` is `str | bytes`, and the
+        # wire form base64s bytes into a JSON string that cattrs resolves back to `str`, so a
+        # worker's write landed corrupted with no error anywhere. Requests carrying a `MacroPath`
+        # (`File("{outputs}/out.png")`, `Directory(...).with_versioning()`) cannot be serialized
+        # at all, so the worker blocked until the forward timed out. And four of the failure
+        # results declare `SequenceScanFailureReason | FileIOFailureReason`, a union cattrs cannot
+        # disambiguate, so even the error could not come back.
+        #
+        # Stated as a rule over the whole module rather than a list of the ones found broken,
+        # because the list kept being incomplete: `_LOCAL_ONLY_FILESYSTEM_REQUESTS` is derived
+        # from os_events itself, so a filesystem request added later is covered by construction.
+        # `tests/unit/app/test_worker_routing_filesystem.py` fails if a new one appears without a
+        # routing decision.
+        *_LOCAL_ONLY_FILESYSTEM_REQUESTS,
+        # project_events: a worker already adopts the orchestrator's project (at spawn, and
+        # again on a switch), and a project's base directory is shared on-disk state -- the
+        # same class as the workspace path. So the worker's own answer is correct by
+        # construction, and forwarding buys nothing while costing a round trip on a path as
+        # hot as writing sidecar metadata for every saved file.
+        #
+        # It also cost correctness. Forwarded results are rebuilt with cattrs, and
+        # GetCurrentProjectResultSuccess annotates `project_info: ProjectInfo` under
+        # TYPE_CHECKING to break an import cycle. cattrs cannot resolve that name from this
+        # module's namespace, so the converter's documented NameError fallback passes the raw
+        # dict into the constructor: isinstance() passes while `.project_info` is a dict, and
+        # the first attribute access fails. In a worker that meant every sidecar write logged
+        # "'dict' object has no attribute 'project_base_dir'" and silently wrote nothing.
+        GetCurrentProjectRequest,
         # Two requests carry a live Python object in a field, and both were local under the
         # allowlist this exclusion list replaces -- the flip is what started forwarding them.
         # `_registers_a_python_class` does not catch either: it matches a `type[...]` annotation,

--- a/src/griptape_nodes/app/worker_routing.py
+++ b/src/griptape_nodes/app/worker_routing.py
@@ -42,6 +42,7 @@ from griptape_nodes.retained_mode.events.base_events import (
     WorkflowNotAlteredMixin,
 )
 from griptape_nodes.retained_mode.events.config_events import (
+    GetConfigValueRequest,
     ResetConfigRequest,
     SetConfigCategoryRequest,
     SetConfigValueRequest,
@@ -79,6 +80,7 @@ from griptape_nodes.retained_mode.events.project_events import (
 )
 from griptape_nodes.retained_mode.events.secrets_events import (
     DeleteSecretValueRequest,
+    GetSecretValueRequest,
     SetSecretValueRequest,
 )
 from griptape_nodes.retained_mode.events.variable_events import (
@@ -128,10 +130,15 @@ FORWARDED_REQUEST_TYPES: frozenset[type[RequestPayload]] = frozenset(
         ListFlowsInCurrentContextRequest,
         ListFlowsInFlowRequest,
         # config_events
+        # Getters forward too: a worker's own ConfigManager is populated from the same shared
+        # files, but it is a non-authoritative copy that can lag the orchestrator's in-memory
+        # state. Reads during node execution should see what the orchestrator sees.
+        GetConfigValueRequest,
         SetConfigValueRequest,
         SetConfigCategoryRequest,
         ResetConfigRequest,
         # secrets_events
+        GetSecretValueRequest,
         SetSecretValueRequest,
         DeleteSecretValueRequest,
         # variable_events

--- a/src/griptape_nodes/common/node_executor.py
+++ b/src/griptape_nodes/common/node_executor.py
@@ -360,7 +360,7 @@ class NodeExecutor(EngineScoped):
         lazy fetch inside VariableResolver.get_variables_if_enabled fails with
         KeyError. Pre-seeding here lets the worker skip that path entirely.
         """
-        if not VariableResolver.is_substitution_enabled():
+        if not VariableResolver.is_substitution_enabled(self.engine):
             return {}
         try:
             flow_name = self.engine.node_manager.get_node_parent_flow_by_name(node_name)

--- a/src/griptape_nodes/common/strict_mode_checks.py
+++ b/src/griptape_nodes/common/strict_mode_checks.py
@@ -102,14 +102,28 @@ RULES: dict[str, StrictModeRule] = {
         correctness=False,
         description=(
             "A node called add_parameter or remove_parameter during "
-            "aprocess. On the worker these changes are local to the "
-            "transient node and do not sync back to the orchestrator."
+            "aprocess, which violates the structure contract: a "
+            "node's parameter structure must be a deterministic "
+            "function of its parameter values, created in __init__ or "
+            "by a value hook. Structure created anywhere else cannot "
+            "survive, because each execution builds a fresh copy from "
+            "the node class and only VALUES carry over (hydration "
+            "re-runs the hooks, which is how derived structure "
+            "reappears). A direct mutation during aprocess is local "
+            "to the transient copy and never syncs; the request-driven "
+            "path syncs to the orchestrator but is not readable back "
+            "on the executing copy, and does not reappear on later "
+            "executions either."
         ),
         remediation_template=(
             "Node '{node_name}' (type '{node_class}') mutated parameter "
             "'{parameter_name}' during aprocess via {mutation}. Emit "
             "AddParameterToNodeRequest or RemoveParameterFromNodeRequest "
-            "to propagate the change to the orchestrator."
+            "to propagate the change to the orchestrator. Note that the "
+            "change reaches the orchestrator's node, not this one: do "
+            "not read the parameter back locally. Each execution builds "
+            "a fresh copy from the node class, so the parameter exists "
+            "here only if __init__ or a value hook re-creates it."
         ),
     ),
     "worker-reach-into-orchestrator": StrictModeRule(

--- a/src/griptape_nodes/exe_types/base_iterative_nodes.py
+++ b/src/griptape_nodes/exe_types/base_iterative_nodes.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 from abc import abstractmethod
 from enum import StrEnum
-from typing import Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from griptape_nodes.exe_types.core_types import (
     ControlParameterInput,
@@ -16,66 +18,57 @@ from griptape_nodes.exe_types.core_types import (
 from griptape_nodes.exe_types.flow import ControlFlow
 from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.exe_types.param_components.progress_bar_component import ProgressBarComponent
+from griptape_nodes.retained_mode.events.connection_events import (
+    CreateConnectionRequest,
+    DeleteConnectionRequest,
+    ListConnectionsForNodeRequest,
+    ListConnectionsForNodeResultSuccess,
+)
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
 
 
-def _outgoing_connection_exists(source_node: str, source_param: str) -> bool:
+def _outgoing_connection_exists(engine: Engine, source_node: str, source_param: str) -> bool:
     """Check if a source node/parameter has any outgoing connections.
 
     Args:
+        engine: Engine to ask about the workflow
         source_node: Name of the node that would be sending the connection
         source_param: Name of the parameter on that node
 
     Returns:
         True if the parameter has at least one outgoing connection, False otherwise
 
-    Logic: Look in connections.outgoing_index[source_node][source_param]
+    Asked as a request rather than read from a local connection index: connections are
+    workflow state, and the orchestrator is the only place that holds all of it.
     """
-    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-    connections = GriptapeNodes.FlowManager().get_connections()
-
-    # Check if source_node has any outgoing connections at all
-    source_connections = connections.outgoing_index.get(source_node)
-    if source_connections is None:
+    result = engine.handle_request(ListConnectionsForNodeRequest(node_name=source_node, broadcast_result=False))
+    if not isinstance(result, ListConnectionsForNodeResultSuccess):
         return False
 
-    # Check if source_param has any outgoing connections
-    param_connections = source_connections.get(source_param)
-    if param_connections is None:
-        return False
-
-    # Return True if connections list is populated
-    return bool(param_connections)
+    return any(connection.source_parameter_name == source_param for connection in result.outgoing_connections)
 
 
-def _incoming_connection_exists(target_node: str, target_param: str) -> bool:
+def _incoming_connection_exists(engine: Engine, target_node: str, target_param: str) -> bool:
     """Check if a target node/parameter has any incoming connections.
 
     Args:
+        engine: Engine to ask about the workflow
         target_node: Name of the node that would be receiving the connection
         target_param: Name of the parameter on that node
 
     Returns:
         True if the parameter has at least one incoming connection, False otherwise
 
-    Logic: Look in connections.incoming_index[target_node][target_param]
+    Asked as a request rather than read from a local connection index: connections are
+    workflow state, and the orchestrator is the only place that holds all of it.
     """
-    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-    connections = GriptapeNodes.FlowManager().get_connections()
-
-    # Check if target_node has any incoming connections at all
-    target_connections = connections.incoming_index.get(target_node)
-    if target_connections is None:
+    result = engine.handle_request(ListConnectionsForNodeRequest(node_name=target_node, broadcast_result=False))
+    if not isinstance(result, ListConnectionsForNodeResultSuccess):
         return False
 
-    # Check if target_param has any incoming connections
-    param_connections = target_connections.get(target_param)
-    if param_connections is None:
-        return False
-
-    # Return True if connections list is populated
-    return bool(param_connections)
+    return any(connection.target_parameter_name == target_param for connection in result.incoming_connections)
 
 
 class IterativeNodeParam(StrEnum):
@@ -122,7 +115,7 @@ class BaseIterativeStartNode(BaseNode):
     state tracking, and validation logic used by iterative loop start nodes.
     """
 
-    end_node: "BaseIterativeEndNode | None" = None
+    end_node: BaseIterativeEndNode | None = None
     exec_out: ControlParameterOutput
     _current_iteration_count: int
     _total_iterations: int
@@ -329,8 +322,6 @@ class BaseIterativeStartNode(BaseNode):
 
     def _validate_start_node(self) -> list[Exception] | None:
         """Common validation logic for both workflow and node run validation."""
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         exceptions = []
 
         # Validate end node connection
@@ -344,8 +335,8 @@ class BaseIterativeStartNode(BaseNode):
             exceptions.extend(validation_errors)
 
         try:
-            flow = GriptapeNodes.ObjectManager().get_object_by_name(
-                GriptapeNodes.NodeManager().get_node_parent_flow_by_name(self.name)
+            flow = self.engine.object_manager.get_object_by_name(
+                self.engine.node_manager.get_node_parent_flow_by_name(self.name)
             )
             if isinstance(flow, ControlFlow):
                 self._flow = flow
@@ -481,10 +472,13 @@ class BaseIterativeStartNode(BaseNode):
             self._complete_loop()
             return
 
-        # Continue with current item - unresolve future nodes for fresh evaluation
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-        connections = GriptapeNodes.FlowManager().get_connections()
+        # Continue with current item - unresolve future nodes for fresh evaluation.
+        # NOTE: this walks the LOCAL connection map, which is correct on the orchestrator and
+        # near-empty in a worker, where it would no-op in silence. UnresolveNodeRequest is not
+        # a substitute: it unresolves the node itself and refuses while the node is RESOLVING,
+        # which is exactly this node's state here. An iterative node in a worker-routed library
+        # therefore needs a downstream-only unresolve request that does not exist yet.
+        connections = self.engine.flow_manager.get_connections()
         connections.unresolve_future_nodes(self)
 
         # Always set the index output in base class
@@ -512,7 +506,7 @@ class BaseIterativeStartNode(BaseNode):
         node_type = self._get_base_node_type_name()
 
         # Check if exec_out has outgoing connections
-        if not _outgoing_connection_exists(self.name, self.exec_out.name):
+        if not _outgoing_connection_exists(self.engine, self.name, self.exec_out.name):
             exec_out_display_name = self._get_exec_out_display_name()
             errors.append(
                 Exception(
@@ -535,7 +529,7 @@ class BaseIterativeStartNode(BaseNode):
         # Check if all hidden signal connections exist (only if end_node is connected)
         if self.end_node:
             # Check trigger_next_iteration_signal connection
-            if not _incoming_connection_exists(self.name, self.trigger_next_iteration_signal.name):
+            if not _incoming_connection_exists(self.engine, self.name, self.trigger_next_iteration_signal.name):
                 errors.append(
                     Exception(
                         f"{self.name}: Missing hidden signal connection. "
@@ -545,7 +539,7 @@ class BaseIterativeStartNode(BaseNode):
                 )
 
             # Check break_loop_signal connection
-            if not _incoming_connection_exists(self.name, self.break_loop_signal.name):
+            if not _incoming_connection_exists(self.engine, self.name, self.break_loop_signal.name):
                 errors.append(
                     Exception(
                         f"{self.name}: Missing hidden signal connection. "
@@ -604,7 +598,7 @@ class BaseIterativeEndNode(BaseNode):
     conditional evaluation, and result accumulation logic used by iterative loop end nodes.
     """
 
-    start_node: "BaseIterativeStartNode | None" = None
+    start_node: BaseIterativeStartNode | None = None
 
     def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
         super().__init__(name, metadata)
@@ -887,7 +881,9 @@ class BaseIterativeEndNode(BaseNode):
             )
 
         # Check if all hidden signal connections exist (only if start_node is connected)
-        if self.start_node and not _incoming_connection_exists(self.name, "loop_end_condition_met_signal_input"):
+        if self.start_node and not _incoming_connection_exists(
+            self.engine, self.name, "loop_end_condition_met_signal_input"
+        ):
             errors.append(
                 Exception(
                     f"{self.name}: Missing hidden signal connection. "
@@ -905,7 +901,7 @@ class BaseIterativeEndNode(BaseNode):
         connected_controls = []
 
         for control_name in control_names:
-            if _incoming_connection_exists(self.name, control_name):
+            if _incoming_connection_exists(self.engine, self.name, control_name):
                 connected_controls.append(control_name)  # noqa: PERF401
 
         if not connected_controls:
@@ -988,13 +984,10 @@ class BaseIterativeEndNode(BaseNode):
 
     def _create_hidden_signal_connections(self, start_node: BaseNode) -> None:
         """Automatically create all hidden signal connections between Start and End nodes."""
-        from griptape_nodes.retained_mode.events.connection_events import CreateConnectionRequest
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         # Create the hidden signal connections and default control flow:
 
         # 1. Start → End: loop_end_condition_met_signal → loop_end_condition_met_signal_input
-        GriptapeNodes.handle_request(
+        self.engine.handle_request(
             CreateConnectionRequest(
                 source_node_name=start_node.name,
                 source_parameter_name=IterativeNodeParam.LOOP_END_CONDITION_MET_SIGNAL.value,
@@ -1004,7 +997,7 @@ class BaseIterativeEndNode(BaseNode):
         )
 
         # 2. End → Start: trigger_next_iteration_signal_output → trigger_next_iteration_signal
-        GriptapeNodes.handle_request(
+        self.engine.handle_request(
             CreateConnectionRequest(
                 source_node_name=self.name,
                 source_parameter_name=IterativeNodeParam.TRIGGER_NEXT_ITERATION_SIGNAL_OUTPUT.value,
@@ -1014,7 +1007,7 @@ class BaseIterativeEndNode(BaseNode):
         )
 
         # 3. End → Start: break_loop_signal_output → break_loop_signal
-        GriptapeNodes.handle_request(
+        self.engine.handle_request(
             CreateConnectionRequest(
                 source_node_name=self.name,
                 source_parameter_name=IterativeNodeParam.BREAK_LOOP_SIGNAL_OUTPUT.value,
@@ -1025,8 +1018,8 @@ class BaseIterativeEndNode(BaseNode):
 
         # 4. Default control flow: Start → End: exec_out → add_item (default "happy path")
         # Only create this connection if the exec_out parameter doesn't already have a connection
-        if not _outgoing_connection_exists(start_node.name, IterativeNodeParam.EXEC_OUT.value):
-            GriptapeNodes.handle_request(
+        if not _outgoing_connection_exists(self.engine, start_node.name, IterativeNodeParam.EXEC_OUT.value):
+            self.engine.handle_request(
                 CreateConnectionRequest(
                     source_node_name=start_node.name,
                     source_parameter_name=IterativeNodeParam.EXEC_OUT.value,
@@ -1037,15 +1030,8 @@ class BaseIterativeEndNode(BaseNode):
 
     def _remove_hidden_signal_connections(self, start_node: BaseNode) -> None:
         """Remove all hidden signal connections when the main tethering connection is removed."""
-        from griptape_nodes.retained_mode.events.connection_events import (
-            DeleteConnectionRequest,
-            ListConnectionsForNodeRequest,
-            ListConnectionsForNodeResultSuccess,
-        )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         # Get current connections for start node to check what still exists
-        list_connections_result = GriptapeNodes.handle_request(ListConnectionsForNodeRequest(node_name=start_node.name))
+        list_connections_result = self.engine.handle_request(ListConnectionsForNodeRequest(node_name=start_node.name))
         if not isinstance(list_connections_result, ListConnectionsForNodeResultSuccess):
             return  # Cannot determine what connections exist, exit gracefully
 
@@ -1080,7 +1066,7 @@ class BaseIterativeEndNode(BaseNode):
             self.name,
             IterativeNodeParam.LOOP_END_CONDITION_MET_SIGNAL_INPUT.value,
         ):
-            GriptapeNodes.handle_request(
+            self.engine.handle_request(
                 DeleteConnectionRequest(
                     source_node_name=start_node.name,
                     source_parameter_name=IterativeNodeParam.LOOP_END_CONDITION_MET_SIGNAL.value,
@@ -1096,7 +1082,7 @@ class BaseIterativeEndNode(BaseNode):
             start_node.name,
             IterativeNodeParam.TRIGGER_NEXT_ITERATION_SIGNAL.value,
         ):
-            GriptapeNodes.handle_request(
+            self.engine.handle_request(
                 DeleteConnectionRequest(
                     source_node_name=self.name,
                     source_parameter_name=IterativeNodeParam.TRIGGER_NEXT_ITERATION_SIGNAL_OUTPUT.value,
@@ -1112,7 +1098,7 @@ class BaseIterativeEndNode(BaseNode):
             start_node.name,
             IterativeNodeParam.BREAK_LOOP_SIGNAL.value,
         ):
-            GriptapeNodes.handle_request(
+            self.engine.handle_request(
                 DeleteConnectionRequest(
                     source_node_name=self.name,
                     source_parameter_name=IterativeNodeParam.BREAK_LOOP_SIGNAL_OUTPUT.value,

--- a/src/griptape_nodes/exe_types/core_types.py
+++ b/src/griptape_nodes/exe_types/core_types.py
@@ -414,8 +414,6 @@ class BaseNodeElement:
 
     def _emit_alter_element_event_if_possible(self) -> None:
         """Emit an AlterElementEvent if we have node context and the necessary dependencies."""
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         if self._node_context is None:
             return
 
@@ -449,7 +447,8 @@ class BaseNodeElement:
             wrapped_event=ExecutionEvent(payload=AlterElementEvent(element_details=event_data))
         )
 
-        GriptapeNodes.EventManager().put_event(event)
+        # This is an element, not a node, so the engine comes from the node it belongs to.
+        self._node_context.engine.event_manager.put_event(event)
         self._changes.clear()
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/griptape_nodes/exe_types/node_groups/base_while_node_group.py
+++ b/src/griptape_nodes/exe_types/node_groups/base_while_node_group.py
@@ -132,12 +132,10 @@ class BaseWhileNodeGroup(SubflowNodeGroup):
             iteration: The upcoming iteration number (1-based)
             flow_name: Name of the deserialized flow being executed
         """
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         # Reset all nodes to UNRESOLVED so they re-execute. The DAG builder
         # skips RESOLVED upstream dependencies, so without this reset nodes
         # won't be added to the DAG and won't run on subsequent iterations.
-        GriptapeNodes.FlowManager().unresolve_all_nodes_in_flow(flow_name)
+        self.engine.flow_manager.unresolve_all_nodes_in_flow(flow_name)
 
     def _on_complete(self, *, condition_met: bool, iterations: int) -> None:  # noqa: ARG002
         """Called after all loop iterations are finished, before the node resolves.

--- a/src/griptape_nodes/exe_types/node_groups/subflow_node_group.py
+++ b/src/griptape_nodes/exe_types/node_groups/subflow_node_group.py
@@ -40,7 +40,6 @@ from griptape_nodes.retained_mode.events.parameter_events import (
     AddParameterToNodeResultSuccess,
     RemoveParameterFromNodeRequest,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 
 if TYPE_CHECKING:
@@ -99,7 +98,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             type=ParameterTypeBuiltin.STR,
             allowed_modes={ParameterMode.PROPERTY},
             default_value=LOCAL_EXECUTION,
-            traits={Options(choices=get_library_names_with_publish_handlers())},
+            traits={Options(choices=get_library_names_with_publish_handlers(self.engine))},
         )
         self.add_parameter(self.execution_environment)
         # Track mapping from proxy parameter name to (original_node, original_param_name)
@@ -144,7 +143,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             set_as_new_context=False,
             metadata=subflow_metadata,
         )
-        result = GriptapeNodes.handle_request(request)
+        result = self.engine.handle_request(request)
         if not isinstance(result, CreateFlowResultSuccess):
             # Drop the name we optimistically recorded: no such flow exists, and leaving it set
             # makes every later lookup point at a phantom flow.
@@ -175,7 +174,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
                 return enclosing_subflow_name
 
         # A group can be built with no Flow on the context stack, so this may find nothing.
-        context_manager = GriptapeNodes.ContextManager()
+        context_manager = self.engine.context_manager
         if not context_manager.has_current_flow():
             return None
         return context_manager.get_current_flow().name
@@ -191,7 +190,6 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         4. Stores metadata mapping execution environments to their parameters
         """
         from griptape_nodes.retained_mode.events.workflow_events import PublishWorkflowRequest
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         # Initialize metadata structure for execution environment mappings
         if self.metadata is None:
@@ -200,7 +198,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             self.metadata["execution_environment"] = {}
 
         # Get all libraries that have registered PublishWorkflowRequest handlers
-        library_manager = GriptapeNodes.LibraryManager()
+        library_manager = self.engine.library_manager
         event_handlers = library_manager.get_registered_event_handlers(PublishWorkflowRequest)
 
         # Process each registered library
@@ -327,7 +325,6 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             The newly created proxy parameter
         """
         # Clone the parameter with the new name
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         input_types = None
         output_type = None
@@ -346,7 +343,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             mode_allowed_output=True,
         )
         # Add with a request, because this will handle naming for us.
-        result = GriptapeNodes.handle_request(request)
+        result = self.engine.handle_request(request)
         if not isinstance(result, AddParameterToNodeResultSuccess):
             msg = "Failed to add parameter to node."
             raise TypeError(msg)
@@ -397,7 +394,6 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             # Store the existing connection so it can be recreated if needed.
         else:
             grouped_parameter = conn.source_parameter
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         request = DeleteConnectionRequest(
             conn.source_parameter.name,
@@ -405,7 +401,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             conn.source_node.name,
             conn.target_node.name,
         )
-        result = GriptapeNodes.handle_request(request)
+        result = self.engine.handle_request(request)
         if not isinstance(result, DeleteConnectionResultSuccess):
             return False
         proxy_parameter = self._create_proxy_parameter_for_connection(grouped_parameter, is_incoming=is_incoming)
@@ -416,7 +412,6 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
     def create_connections_for_proxy(
         self, proxy_parameter: Parameter, old_connection: Connection, *, is_incoming: bool
     ) -> None:
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         create_first_connection = CreateConnectionRequest(
             source_parameter_name=old_connection.source_parameter.name,
@@ -438,8 +433,8 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             self._proxy_param_to_connections[proxy_parameter.name] = 2
         else:
             self._proxy_param_to_connections[proxy_parameter.name] += 2
-        GriptapeNodes.handle_request(create_first_connection)
-        GriptapeNodes.handle_request(create_second_connection)
+        self.engine.handle_request(create_first_connection)
+        self.engine.handle_request(create_second_connection)
 
     def unmap_node_connections(self, node: BaseNode, connections: Connections) -> None:  # noqa: C901
         """Remove tracking of an external connection, restore original connection, and clean up proxy parameter.
@@ -448,8 +443,6 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             node: The node to unmap
             connections: The connections object
         """
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         # For the node being removed - We need to figure out all of it's connections TO the node group. These connections need to be remapped.
         # If we delete connections from a proxy parameter, and it has no more connections, then the proxy parameter should be deleted unless it's user defined.
         # It will 1. not be in the proxy map. and 2. it will have a value of > 0
@@ -462,7 +455,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
                 # get old connections first, since this will delete the proxy
                 remap_connections = connections.get_outgoing_connections_from_parameter(self, proxy_parameter)
                 # Delete the internal connection
-                delete_result = GriptapeNodes.FlowManager().on_delete_connection_request(
+                delete_result = self.engine.flow_manager.on_delete_connection_request(
                     DeleteConnectionRequest(
                         source_parameter_name=parameter_name,
                         target_parameter_name=proxy_parameter.name,
@@ -476,7 +469,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
 
                 # Now create the new connection! We need to get the connections from the proxy parameter
                 for connection in remap_connections:
-                    create_result = GriptapeNodes.FlowManager().on_create_connection_request(
+                    create_result = self.engine.flow_manager.on_create_connection_request(
                         CreateConnectionRequest(
                             source_parameter_name=parameter_name,
                             target_parameter_name=connection.target_parameter.name,
@@ -497,7 +490,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
                 # Get the incoming connections to the proxy parameter
                 remap_connections = connections.get_incoming_connections_to_parameter(self, proxy_parameter)
                 # Delete the internal connection
-                delete_result = GriptapeNodes.FlowManager().on_delete_connection_request(
+                delete_result = self.engine.flow_manager.on_delete_connection_request(
                     DeleteConnectionRequest(
                         source_parameter_name=proxy_parameter.name,
                         target_parameter_name=parameter_name,
@@ -511,7 +504,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
 
                 # Now create the new connection! We need to get the connections to the proxy parameter
                 for connection in remap_connections:
-                    create_result = GriptapeNodes.FlowManager().on_create_connection_request(
+                    create_result = self.engine.flow_manager.on_create_connection_request(
                         CreateConnectionRequest(
                             source_parameter_name=connection.source_parameter.name,
                             target_parameter_name=parameter_name,
@@ -530,14 +523,12 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             proxy_parameter: The proxy parameter to potentially clean up
             metadata_key: The metadata key ('left_parameters' or 'right_parameters')
         """
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         if proxy_parameter.name not in self._proxy_param_to_connections:
             return
 
         self._proxy_param_to_connections[proxy_parameter.name] -= 1
         if self._proxy_param_to_connections[proxy_parameter.name] == 0:
-            GriptapeNodes.NodeManager().on_remove_parameter_from_node_request(
+            self.engine.node_manager.on_remove_parameter_from_node_request(
                 request=RemoveParameterFromNodeRequest(node_name=self.name, parameter_name=proxy_parameter.name)
             )
             del self._proxy_param_to_connections[proxy_parameter.name]
@@ -551,8 +542,6 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             node: The node being added to the group
             connections: Connections object from FlowManager
         """
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         outgoing_connections = connections.get_outgoing_connections_to_node(node, to_node=self)
         for parameter_name, outgoing_connection_list in outgoing_connections.items():
             for outgoing_connection in outgoing_connection_list:
@@ -568,7 +557,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
                 )
 
                 # Delete the connection from this node to proxy
-                delete_result = GriptapeNodes.FlowManager().on_delete_connection_request(
+                delete_result = self.engine.flow_manager.on_delete_connection_request(
                     DeleteConnectionRequest(
                         source_parameter_name=parameter_name,
                         target_parameter_name=proxy_parameter.name,
@@ -582,7 +571,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
 
                 # Create direct connections from this node to target nodes
                 for connection in remap_connections:
-                    create_result = GriptapeNodes.FlowManager().on_create_connection_request(
+                    create_result = self.engine.flow_manager.on_create_connection_request(
                         CreateConnectionRequest(
                             source_parameter_name=parameter_name,
                             target_parameter_name=connection.target_parameter.name,
@@ -597,7 +586,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
                 # Only delete outgoing connections from proxy and clean up if no other incoming connections exist
                 if not other_incoming_exists:
                     for connection in remap_connections:
-                        delete_result = GriptapeNodes.FlowManager().on_delete_connection_request(
+                        delete_result = self.engine.flow_manager.on_delete_connection_request(
                             DeleteConnectionRequest(
                                 source_parameter_name=connection.source_parameter.name,
                                 target_parameter_name=connection.target_parameter.name,
@@ -618,8 +607,6 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             node: The node being added to the group
             connections: Connections object from FlowManager
         """
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         incoming_connections = connections.get_incoming_connections_from_node(node, from_node=self)
         for parameter_name, incoming_connection_list in incoming_connections.items():
             for incoming_connection in incoming_connection_list:
@@ -635,7 +622,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
                 )
 
                 # Delete the connection from proxy to this node
-                delete_result = GriptapeNodes.FlowManager().on_delete_connection_request(
+                delete_result = self.engine.flow_manager.on_delete_connection_request(
                     DeleteConnectionRequest(
                         source_parameter_name=proxy_parameter.name,
                         target_parameter_name=parameter_name,
@@ -649,7 +636,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
 
                 # Create direct connections from source nodes to this node
                 for connection in remap_connections:
-                    create_result = GriptapeNodes.FlowManager().on_create_connection_request(
+                    create_result = self.engine.flow_manager.on_create_connection_request(
                         CreateConnectionRequest(
                             source_parameter_name=connection.source_parameter.name,
                             target_parameter_name=parameter_name,
@@ -664,7 +651,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
                 # Only delete incoming connections to proxy and clean up if no other outgoing connections exist
                 if not other_outgoing_exists:
                     for connection in remap_connections:
-                        delete_result = GriptapeNodes.FlowManager().on_delete_connection_request(
+                        delete_result = self.engine.flow_manager.on_delete_connection_request(
                             DeleteConnectionRequest(
                                 source_parameter_name=connection.source_parameter.name,
                                 target_parameter_name=proxy_parameter.name,
@@ -765,7 +752,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
                     self._discard_subflow_created_for_a_failed_add()
                 raise
 
-        connections = GriptapeNodes.FlowManager().get_connections()
+        connections = self.engine.flow_manager.get_connections()
         node_names_in_group = set(self.nodes.keys())
         self.metadata["node_names_in_group"] = list(node_names_in_group)
         self.remap_to_internal(nodes, connections)
@@ -911,7 +898,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         if subflow_name is None:
             return
 
-        subflow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(subflow_name, ControlFlow)
+        subflow = self.engine.object_manager.attempt_get_object_by_name_as_type(subflow_name, ControlFlow)
         if subflow is None:
             self.metadata.pop("subflow_name", None)
             return
@@ -925,7 +912,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             )
             return
 
-        delete_result = GriptapeNodes.handle_request(DeleteFlowRequest(flow_name=subflow_name))
+        delete_result = self.engine.handle_request(DeleteFlowRequest(flow_name=subflow_name))
         if isinstance(delete_result, DeleteFlowResultFailure):
             # Not worth failing the add twice over: it is already failing, and the message the artist
             # gets should be why their nodes did not move, not a leftover flow they cannot see.
@@ -950,7 +937,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             NodeGroupMembershipError: If the engine refused the move, carrying the reason it gave
         """
         move_request = MoveNodeToNewFlowRequest(node_name=node.name, target_flow_name=flow_name)
-        move_result = GriptapeNodes.handle_request(move_request)
+        move_result = self.engine.handle_request(move_request)
         if not isinstance(move_result, MoveNodeToNewFlowResultSuccess):
             # Carry the engine's own reason rather than only logging it: this is the innermost thing
             # that knows why the move was refused, and the caller turns it into what the artist reads.
@@ -988,7 +975,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         # editor but loses its contents on save, so the caller has to hear about it. Both callers
         # turn this into a failure result (see NodeManager.on_add_nodes_to_node_group_request).
         try:
-            GriptapeNodes.FlowManager().reparent_flow(child_subflow_name, parent_subflow_name)
+            self.engine.flow_manager.reparent_flow(child_subflow_name, parent_subflow_name)
         except ValueError as err:
             msg = (
                 f"Attempted to change what group '{node.name}' belongs to. "
@@ -1054,8 +1041,6 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         if not conn_list:
             return
 
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         # All connections share the same external parameter
         # For outgoing: the internal (source) parameter is shared
         # For incoming: the external (source) parameter is shared
@@ -1076,7 +1061,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
                 conn.source_node.name,
                 conn.target_node.name,
             )
-            result = GriptapeNodes.handle_request(request)
+            result = self.engine.handle_request(request)
             if not isinstance(result, DeleteConnectionResultSuccess):
                 logger.warning(
                     "%s failed to delete connection from %s.%s to %s.%s",
@@ -1118,9 +1103,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         Returns:
             The existing proxy parameter if found, None otherwise
         """
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-        connections = GriptapeNodes.FlowManager().get_connections()
+        connections = self.engine.flow_manager.get_connections()
 
         # Determine which proxy parameters to check based on direction
         if is_incoming:
@@ -1154,8 +1137,6 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             old_connection: The original connection being remapped
             is_incoming: True if this is an incoming connection to the group
         """
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         create_first_connection = CreateConnectionRequest(
             source_parameter_name=old_connection.source_parameter.name,
             target_parameter_name=proxy_parameter.name,
@@ -1177,8 +1158,8 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         else:
             self._proxy_param_to_connections[proxy_parameter.name] += 2
 
-        GriptapeNodes.handle_request(create_first_connection)
-        GriptapeNodes.handle_request(create_second_connection)
+        self.engine.handle_request(create_first_connection)
+        self.engine.handle_request(create_second_connection)
 
     def delete_nodes_from_group(self, nodes: list[BaseNode]) -> None:
         """Delete nodes from the group and untrack their connections.
@@ -1231,7 +1212,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             # Rolling back means going the way they came: into this group's subflow.
             self._relocate_nodes(nodes, destination_flow_name=parent_flow_name, rollback_flow_name=subflow_name)
 
-        connections = GriptapeNodes.FlowManager().get_connections()
+        connections = self.engine.flow_manager.get_connections()
         for node in nodes:
             node.parent_group = None
             self.nodes.pop(node.name)
@@ -1261,11 +1242,10 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
             StartLocalSubflowRequest,
             StartLocalSubflowResultFailure,
         )
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         subflow = self.metadata.get("subflow_name")
         if subflow is not None and isinstance(subflow, str):
-            result = await GriptapeNodes.FlowManager().on_start_local_subflow_request(
+            result = await self.engine.flow_manager.on_start_local_subflow_request(
                 StartLocalSubflowRequest(flow_name=subflow)
             )
 
@@ -1285,9 +1265,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         For each right (output) proxy parameter, finds the internal node connected
         to it and copies the value to this group's parameter_output_values.
         """
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-        connections = GriptapeNodes.FlowManager().get_connections()
+        connections = self.engine.flow_manager.get_connections()
 
         right_params = self.metadata.get(RIGHT_PARAMETERS_KEY, [])
         for proxy_param_name in right_params:
@@ -1330,9 +1308,9 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         self.remove_nodes_from_group(nodes_to_remove)
         subflow_name = self.metadata.get("subflow_name")
         if subflow_name is not None:
-            subflow = GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(subflow_name, ControlFlow)
+            subflow = self.engine.object_manager.attempt_get_object_by_name_as_type(subflow_name, ControlFlow)
             if subflow is not None:
-                delete_result = GriptapeNodes.handle_request(DeleteFlowRequest(flow_name=subflow_name))
+                delete_result = self.engine.handle_request(DeleteFlowRequest(flow_name=subflow_name))
                 if isinstance(delete_result, DeleteFlowResultFailure):
                     # This will propagate up to DeleteNodeRequest, and prevent the node from deleting.
                     msg = f"Failed to delete subflow {subflow_name} when deleting node {self.name}"
@@ -1351,7 +1329,7 @@ class SubflowNodeGroup(BaseNodeGroup, ABC):
         nowhere to put these nodes" rather than an error in itself.
         """
         try:
-            return GriptapeNodes.NodeManager().get_node_parent_flow_by_name(self.name)
+            return self.engine.node_manager.get_node_parent_flow_by_name(self.name)
         except KeyError:
             logger.warning("%s has no parent flow", self.name)
             return None

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -55,6 +55,8 @@ from griptape_nodes.traits.widget import Widget
 from griptape_nodes.utils import async_utils
 
 if TYPE_CHECKING:
+    from types import ModuleType
+
     from griptape_nodes.exe_types.core_types import NodeMessagePayload
     from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
     from griptape_nodes.retained_mode.engine import Engine
@@ -1296,6 +1298,31 @@ class BaseNode(ABC):
             msg = str(f"Parameter \"{param}\" was left blank for node '{node_name}'. {additional_msg}").strip()
             return ValueError(msg)
         return None
+
+    def execution_module(self, module_name: str) -> ModuleType:
+        """Return one of this library's execution modules.
+
+        The sanctioned way to reach execution-only code. An execution module is declared in the
+        library manifest and imported only where nodes execute, so it may import heavy
+        dependencies at module scope without making this node impossible to instantiate on a
+        machine that will never run it. Call this from `process`:
+
+            def process(self) -> None:
+                runner = self.execution_module("segmenter")
+                self.parameter_output_values["result"] = runner.segment(...)
+
+        Raises:
+            RuntimeError: If called where execution modules are not imported (the orchestrator),
+                or if the library declares no module by that name. Both messages say what to do.
+        """
+        library_name = self.metadata.get("library")
+        if not library_name:
+            msg = (
+                f"Node '{self.name}' has no library recorded in its metadata, so its execution "
+                "modules cannot be located."
+            )
+            raise RuntimeError(msg)
+        return self.engine.library_manager.get_execution_module(library_name, module_name)
 
     def get_config_value(self, service: str, value: str) -> str:
         warnings.warn(

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -50,11 +50,16 @@ from griptape_nodes.retained_mode.events.parameter_events import (
     RemoveElementEvent,
     RemoveParameterFromNodeRequest,
 )
+from griptape_nodes.retained_mode.events.resource_events import (
+    GetExecutionDeviceRequest,
+    GetExecutionDeviceResultSuccess,
+)
 from griptape_nodes.traits.options import Options
 from griptape_nodes.traits.widget import Widget
 from griptape_nodes.utils import async_utils
 
 if TYPE_CHECKING:
+    from pathlib import Path
     from types import ModuleType
 
     from griptape_nodes.exe_types.core_types import NodeMessagePayload
@@ -1298,6 +1303,62 @@ class BaseNode(ABC):
             msg = str(f"Parameter \"{param}\" was left blank for node '{node_name}'. {additional_msg}").strip()
             return ValueError(msg)
         return None
+
+    @property
+    def execution_device(self) -> str:
+        """The compute device this node should run on: "cuda", "mps" or "cpu".
+
+        Answered by the engine, which detects the machine's backends without importing a
+        framework. Every model-wrapping library currently imports torch purely to call
+        `torch.cuda.is_available()`, which pulls an execution-time dependency into whichever
+        process asks -- including one that only edits, where the import fails outright.
+
+            def process(self) -> None:
+                model = model.to(self.execution_device)
+
+        Falls back to "cpu" if the engine cannot determine the backends, because a node that
+        cannot pick a device is worse than one running slowly.
+        """
+        result = self.engine.handle_request(GetExecutionDeviceRequest())
+        if isinstance(result, GetExecutionDeviceResultSuccess):
+            return result.device
+        logger.warning(
+            "Node %s could not determine an execution device (%s); using cpu.",
+            self.name,
+            result.result_details,
+        )
+        return "cpu"
+
+    @property
+    def available_compute(self) -> list[str]:
+        """Every compute backend this machine has, most capable first.
+
+        For a node that wants to decide for itself rather than take `execution_device`.
+        """
+        result = self.engine.handle_request(GetExecutionDeviceRequest())
+        if isinstance(result, GetExecutionDeviceResultSuccess):
+            return result.available
+        return ["cpu"]
+
+    def model_asset(self, asset_id: str) -> Path:
+        """Return the local directory holding one of this library's declared model assets.
+
+        Weights are declared in the manifest, not installed as dependencies and not fetched by a
+        library-load hook. This resolves on demand in whichever process is about to run the model,
+        and caches under an engine-owned root:
+
+            def process(self) -> None:
+                weights = self.model_asset("sam3-base")
+                model = load_from(weights)
+
+        Raises:
+            RuntimeError: If the library declares no asset by that id, or the fetch fails.
+        """
+        library_name = self.metadata.get("library")
+        if not library_name:
+            msg = f"Node '{self.name}' has no library recorded in its metadata, so its model assets cannot be located."
+            raise RuntimeError(msg)
+        return self.engine.library_manager.get_model_asset(library_name, asset_id)
 
     def execution_module(self, module_name: str) -> ModuleType:
         """Return one of this library's execution modules.

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -1343,6 +1343,10 @@ class BaseNode(ABC):
         result = self.engine.handle_request(GetExecutionDeviceRequest())
         if isinstance(result, GetExecutionDeviceResultSuccess):
             return result.available
+        # A GPU-less machine still takes the success path above, so reaching here means detection
+        # itself failed. Logged because a node branching on this list would otherwise take its CPU
+        # path on an accelerated machine with nothing to show why.
+        logger.warning("Could not detect compute backends; reporting cpu only. %s", result.result_details)
         return ["cpu"]
 
     def model_asset(self, asset_id: str) -> Path:

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -1331,7 +1331,12 @@ class BaseNode(ABC):
 
     @property
     def available_compute(self) -> list[str]:
-        """Every compute backend this machine has, most capable first.
+        """Every compute backend this machine has, in detection order.
+
+        Cpu first, then any accelerator found. NOT ranked: `available_compute[0]` is "cpu" even on
+        a machine with a GPU. Use
+        `execution_device` to get the device to actually run on; this list answers "what
+        exists here", which is a different question.
 
         For a node that wants to decide for itself rather than take `execution_device`.
         """

--- a/src/griptape_nodes/exe_types/node_types.py
+++ b/src/griptape_nodes/exe_types/node_types.py
@@ -35,6 +35,15 @@ from griptape_nodes.retained_mode.events.base_events import (
     ProgressEvent,
     RequestPayload,
 )
+from griptape_nodes.retained_mode.events.config_events import (
+    GetConfigValueRequest,
+    GetConfigValueResultSuccess,
+    SetConfigValueRequest,
+)
+from griptape_nodes.retained_mode.events.connection_events import (
+    ListConnectionsForNodeRequest,
+    ListConnectionsForNodeResultSuccess,
+)
 from griptape_nodes.retained_mode.events.event_converter import safe_unstructure
 from griptape_nodes.retained_mode.events.parameter_events import (
     AddParameterToNodeRequest,
@@ -48,6 +57,7 @@ from griptape_nodes.utils import async_utils
 if TYPE_CHECKING:
     from griptape_nodes.exe_types.core_types import NodeMessagePayload
     from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
+    from griptape_nodes.retained_mode.engine import Engine
     from griptape_nodes.retained_mode.variable_types import VariableScope
 
 logger = logging.getLogger("griptape_nodes")
@@ -284,13 +294,15 @@ class NodeResolutionState(StrEnum):
     RESOLVED = auto()
 
 
-def get_library_names_with_publish_handlers() -> list[str]:
-    """Get names of all registered libraries that have PublishWorkflowRequest handlers."""
-    from griptape_nodes.retained_mode.events.workflow_events import PublishWorkflowRequest
-    from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+def get_library_names_with_publish_handlers(engine: Engine) -> list[str]:
+    """Get names of all registered libraries that have PublishWorkflowRequest handlers.
 
-    library_manager = GriptapeNodes.LibraryManager()
-    event_handlers = library_manager.get_registered_event_handlers(PublishWorkflowRequest)
+    Takes the engine rather than reaching for the facade: a free function has no ``self`` to
+    resolve it from, so its caller (a node, which has one) supplies it.
+    """
+    from griptape_nodes.retained_mode.events.workflow_events import PublishWorkflowRequest
+
+    event_handlers = engine.library_manager.get_registered_event_handlers(PublishWorkflowRequest)
 
     # Always include "local" and "private" as the first options
     library_names = [LOCAL_EXECUTION, PRIVATE_EXECUTION]
@@ -319,6 +331,7 @@ class BaseNode(ABC):
     )
     lock: bool = False  # When lock is true, the node is locked and can't be modified. When lock is false, the node is unlocked and can be modified.
     _cancellation_requested: threading.Event  # Event indicating if cancellation has been requested for this node
+    _engine: Engine | None
 
     @property
     def parameters(self) -> list[Parameter]:
@@ -332,7 +345,27 @@ class BaseNode(ABC):
         name: str,
         metadata: dict[Any, Any] | None = None,
         state: NodeResolutionState = NodeResolutionState.UNRESOLVED,
+        *,
+        engine: Engine | None = None,
     ) -> None:
+        """Initialize the node.
+
+        Args:
+            name: Node name, unique within its flow.
+            metadata: Node metadata (node_type and library, plus optional extras).
+            state: Initial resolution state.
+            engine: The engine this node belongs to. Keyword-only and optional so a library's
+                ``super().__init__(name, metadata=metadata)`` keeps working untouched.
+
+                Nothing in the engine passes it today: ``LibraryRegistry.create_node`` builds
+                nodes as ``node_class(name=name, metadata=metadata)``, and it cannot start
+                passing an engine without breaking every library node and several engine-internal
+                subclasses, all of which fix their signature at two arguments. So in practice a
+                node resolves the ambient engine via ``current_engine()``. The parameter exists
+                for embedders and tests that DO hold a reference, and so the fallback has
+                somewhere to be overridden from -- which is what the unit tests use it for.
+        """
+        self._engine = engine
         self.name = name
         self._state = state
         if metadata is None:
@@ -349,6 +382,29 @@ class BaseNode(ABC):
         self._cancellation_requested = threading.Event()
         self._parent_group = None
         self.set_entry_control_parameter(None)
+
+    @property
+    def engine(self) -> Engine:
+        """The engine this node belongs to.
+
+        Node machinery reaches managers and dispatches requests through here rather than the
+        process-wide ``GriptapeNodes`` facade. The facade remains what it is documented to be:
+        the surface for separately-versioned library code and saved workflow files.
+
+        For a node built without an explicit engine -- which is every node the engine itself
+        creates -- this resolves the ambient one, so the lookup is the same process-wide
+        resolution the facade would have done. What the migration buys is not per-node isolation
+        but the classification it forced: questions about workflow state now travel as requests,
+        which is what makes them answerable from inside a worker.
+        """
+        if self._engine is None:
+            # Deferred import: griptape_nodes.retained_mode.engine pulls in the manager graph,
+            # which pulls in the event payloads, which import this module for
+            # NodeDependencies/NodeResolutionState. Importing it at module scope is a cycle.
+            from griptape_nodes.retained_mode.engine import current_engine
+
+            return current_engine()
+        return self._engine
 
     @property
     def state(self) -> NodeResolutionState:
@@ -393,15 +449,13 @@ class BaseNode(ABC):
     # This is gross and we need to have a universal pass on resolution state changes and emission of events. That's what this ticket does!
     # https://github.com/griptape-ai/griptape-nodes/issues/994
     def make_node_unresolved(self, current_states_to_trigger_change_event: set[NodeResolutionState] | None) -> None:
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         # See if the current state is in the set of states to trigger a change event.
         if current_states_to_trigger_change_event is not None and self.state in current_states_to_trigger_change_event:
             # Trigger the change event.
             # Send an event to the GUI so it knows this node has changed resolution state.
             from griptape_nodes.retained_mode.events.execution_events import NodeUnresolvedEvent
 
-            GriptapeNodes.EventManager().put_event(
+            self.engine.event_manager.put_event(
                 ExecutionGriptapeNodeEvent(
                     wrapped_event=ExecutionEvent(payload=NodeUnresolvedEvent(node_name=self.name))
                 )
@@ -1066,10 +1120,8 @@ class BaseNode(ABC):
             self.metadata["size"] = {"width": width, "height": height}
 
     def kill_parameter_children(self, parameter: Parameter) -> None:
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         for child in parameter.find_elements_by_type(Parameter):
-            GriptapeNodes.handle_request(RemoveParameterFromNodeRequest(parameter_name=child.name, node_name=self.name))
+            self.engine.handle_request(RemoveParameterFromNodeRequest(parameter_name=child.name, node_name=self.name))
 
     def get_parameter_value(self, param_name: str) -> Any:
         param = self.get_parameter_by_name(param_name)
@@ -1188,7 +1240,7 @@ class BaseNode(ABC):
     # if not implemented, it will return no issues.
     def validate_before_workflow_run(self) -> list[Exception] | None:
         """Runs before the entire workflow is run."""
-        if VariableResolver.is_substitution_enabled():
+        if VariableResolver.is_substitution_enabled(self.engine):
             for param in self.parameters:
                 if not param.allow_variable_substitution:
                     continue
@@ -1246,29 +1298,32 @@ class BaseNode(ABC):
         return None
 
     def get_config_value(self, service: str, value: str) -> str:
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         warnings.warn(
-            "get_config_value() is deprecated. Use GriptapeNodes.SecretsManager().get_secret() for secrets/API keys "
-            "or GriptapeNodes.ConfigManager().get_config_value() for other config values.",
+            "get_config_value() is deprecated. Use GetSecretValueRequest for secrets/API keys or "
+            "GetConfigValueRequest for other config values. Both are answered by the main engine "
+            "even when your node runs in an isolated process, where the manager accessors are "
+            "refused.",
             UserWarning,
             stacklevel=2,
         )
 
-        config_value = GriptapeNodes.ConfigManager().get_config_value(f"nodes.{service}.{value}")
+        result = self.engine.handle_request(GetConfigValueRequest(category_and_key=f"nodes.{service}.{value}"))
+        # Typed loosely on purpose: config values are `Any`, and an absent key has always
+        # come back as None here despite the declared return type.
+        config_value: Any = result.value if isinstance(result, GetConfigValueResultSuccess) else None
         return config_value
 
     def set_config_value(self, service: str, value: str, new_value: str) -> None:
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         warnings.warn(
-            "set_config_value() is deprecated. Use GriptapeNodes.SecretsManager().set_secret() for secrets/API keys "
-            "or GriptapeNodes.ConfigManager().set_config_value() for other config values.",
+            "set_config_value() is deprecated. Use SetSecretValueRequest for secrets/API keys or "
+            "SetConfigValueRequest for other config values. Both are answered by the main engine "
+            "even when your node runs in an isolated process, where the manager accessors are "
+            "refused.",
             UserWarning,
             stacklevel=2,
         )
 
-        GriptapeNodes.ConfigManager().set_config_value(f"nodes.{service}.{value}", new_value)
+        self.engine.handle_request(SetConfigValueRequest(category_and_key=f"nodes.{service}.{value}", value=new_value))
 
     def clear_node(self) -> None:
         # set state to unresolved
@@ -1357,8 +1412,6 @@ class BaseNode(ABC):
         return None
 
     def append_value_to_parameter(self, parameter_name: str, value: Any) -> None:
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
         # Add the value to the node
         if parameter_name in self.parameter_output_values:
             try:
@@ -1394,13 +1447,12 @@ class BaseNode(ABC):
             return
 
         # Publish the event up!
-        GriptapeNodes.EventManager().put_event(
+        self.engine.event_manager.put_event(
             ProgressEvent(value=value, node_name=self.name, parameter_name=parameter_name)
         )
 
     def publish_update_to_parameter(self, parameter_name: str, value: Any) -> None:
         from griptape_nodes.retained_mode.events.execution_events import ParameterValueUpdateEvent
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         parameter = self.get_parameter_by_name(parameter_name)
         if parameter:
@@ -1416,7 +1468,7 @@ class BaseNode(ABC):
                 value=safe_unstructure(self.get_display_value_for_output(parameter_name, value)),
             )
 
-            GriptapeNodes.EventManager().put_event(
+            self.engine.event_manager.put_event(
                 ExecutionGriptapeNodeEvent(wrapped_event=ExecutionEvent(payload=payload))
             )
         else:
@@ -1531,14 +1583,17 @@ class BaseNode(ABC):
         self.reorder_elements(list(new_order))
 
     def _param_has_incoming_connection(self, param_name: str) -> bool:
-        # GriptapeNodes import is lazy to avoid circular dependency between exe_types and retained_mode
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+        """Whether ``param_name`` is fed by a connection.
 
-        connections = GriptapeNodes.FlowManager().get_connections()
-        node_connections = connections.incoming_index.get(self.name)
-        if node_connections is None:
+        Asked as a request rather than read from a local manager: this is a question about
+        the workflow, and the workflow's single source of truth is the orchestrator. A node
+        executing in an isolated process holds only a transient copy of itself, so reading
+        its own process's connection index would answer from almost nothing.
+        """
+        result = self.engine.handle_request(ListConnectionsForNodeRequest(node_name=self.name, broadcast_result=False))
+        if not isinstance(result, ListConnectionsForNodeResultSuccess):
             return False
-        return param_name in node_connections
+        return any(connection.target_parameter_name == param_name for connection in result.incoming_connections)
 
     def _has_connected_whole_list_value(self, parameter_list: ParameterList) -> bool:
         """Whether a ParameterList was handed an entire list through a connection to the list itself.
@@ -1553,11 +1608,15 @@ class BaseNode(ABC):
         param_name = parameter_list.name
         if param_name not in self.parameter_values:
             return False
-        if not self._param_has_incoming_connection(param_name):
-            return False
 
+        # Both cheap local checks run before the connection question, which costs a request
+        # dispatch -- and a cross-process round trip in a worker -- on a path that
+        # get_parameter_value reaches for every read of a populated list.
         value = self.parameter_values[param_name]
         if not isinstance(value, list):
+            return False
+
+        if not self._param_has_incoming_connection(param_name):
             return False
 
         child_count = len(parameter_list.find_elements_by_type(Parameter, find_recursively=False))
@@ -1584,13 +1643,13 @@ class BaseNode(ABC):
 
     def _resolve_variables_in_value(self, value: Any) -> Any:
         """Recursively substitute workflow variables in any str/dict/list value."""
-        variables = VariableResolver.get_variables_if_enabled(self.name)
+        variables = VariableResolver.get_variables_if_enabled(self.engine, self.name)
         if variables is None:
             return value
         return VariableResolver.resolve_value(value, variables, self.name)
 
     def _resolve_variables_in_string(self, text: str) -> str:
-        variables = VariableResolver.get_variables_if_enabled(self.name)
+        variables = VariableResolver.get_variables_if_enabled(self.engine, self.name)
         if variables is None:
             return text
         return VariableResolver.resolve_string(text, variables, self.name)
@@ -1629,7 +1688,7 @@ class BaseNode(ABC):
         # get_variables_without_memoizing, not get_variables_if_enabled: this runs
         # outside aprocess_scope(), where the latter's memo write has no reset token
         # and would leave a stale variable dict on the surrounding context.
-        variables = VariableResolver.get_variables_without_memoizing(self.name)
+        variables = VariableResolver.get_variables_without_memoizing(self.engine, self.name)
         if variables is None:
             return True
         return VariableResolver.would_substitute(raw_value, variables)
@@ -1648,7 +1707,7 @@ class BaseNode(ABC):
         connection never gets substituted, so its output is genuine and its
         stored value must stay writable.
         """
-        if not VariableResolver.is_substitution_enabled():
+        if not VariableResolver.is_substitution_enabled(self.engine):
             return None
         parameter = self.get_parameter_by_name(parameter_name)
         if parameter is None:
@@ -1656,8 +1715,8 @@ class BaseNode(ABC):
         raw_value = self.parameter_values.get(parameter_name, parameter.default_value)
         # One short-circuiting chain rather than a ladder of early returns, so the
         # cheap checks stay ordered ahead of the expensive ones. The connection
-        # lookup is last: it reaches through the GriptapeNodes singleton to the
-        # FlowManager, and the checks before it already rule out the common case.
+        # lookup is last: it costs a request round trip to the FlowManager, and the
+        # checks before it already rule out the common case.
         substitution_would_have_applied = (
             ParameterMode.PROPERTY in parameter.allowed_modes
             and parameter.allow_variable_substitution
@@ -1754,7 +1813,6 @@ class BaseNode(ABC):
         """Emit an AlterElementEvent for parameter add/remove operations."""
         from griptape_nodes.retained_mode.events.base_events import ExecutionEvent, ExecutionGriptapeNodeEvent
         from griptape_nodes.retained_mode.events.parameter_events import AlterElementEvent
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
         # Create event data using the parameter's to_event method
         if remove:
@@ -1776,7 +1834,7 @@ class BaseNode(ABC):
                 wrapped_event=ExecutionEvent(payload=AlterElementEvent(element_details=event_data))
             )
 
-        GriptapeNodes.EventManager().put_event(event)
+        self.engine.event_manager.put_event(event)
 
     def _get_element_name(self, element: str | int, element_names: list[str]) -> str:
         """Convert an element identifier (name or index) to its name.
@@ -1978,7 +2036,6 @@ class TrackedParameterOutputValues(dict[str, Any]):
         if parameter is not None:
             from griptape_nodes.retained_mode.events.base_events import ExecutionEvent, ExecutionGriptapeNodeEvent
             from griptape_nodes.retained_mode.events.parameter_events import AlterElementEvent
-            from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
             # Create event data using the parameter's to_event method
             event_data = parameter.to_event(self._node)
@@ -2011,7 +2068,9 @@ class TrackedParameterOutputValues(dict[str, Any]):
                 wrapped_event=ExecutionEvent(payload=AlterElementEvent(element_details=event_data))
             )
 
-            GriptapeNodes.EventManager().put_event(event)
+            # This is a plain dict subclass, not a node, so the engine comes from the node it
+            # belongs to.
+            self._node.engine.event_manager.put_event(event)
 
 
 class ControlNode(BaseNode):
@@ -2109,18 +2168,10 @@ class SuccessFailureNode(BaseNode):
 
     def _has_outgoing_connections(self, parameter: Parameter) -> bool:
         """Check if a specific parameter has outgoing connections."""
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-        connections = GriptapeNodes.FlowManager().get_connections()
-
-        # Check if node has any outgoing connections
-        node_connections = connections.outgoing_index.get(self.name)
-        if node_connections is None:
+        result = self.engine.handle_request(ListConnectionsForNodeRequest(node_name=self.name, broadcast_result=False))
+        if not isinstance(result, ListConnectionsForNodeResultSuccess):
             return False
-
-        # Check if this specific parameter has any outgoing connections
-        param_connections = node_connections.get(parameter.name, [])
-        return len(param_connections) > 0
+        return any(connection.source_parameter_name == parameter.name for connection in result.outgoing_connections)
 
     def _create_status_parameters(
         self,
@@ -2381,8 +2432,6 @@ class ErrorProxyNode(BaseNode):
 
         if existing_param is None:
             # Create new universal parameter with all modes enabled
-            from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
             request = AddParameterToNodeRequest(
                 node_name=self.name,
                 parameter_name=param_name,
@@ -2396,7 +2445,7 @@ class ErrorProxyNode(BaseNode):
                 is_user_defined=False,  # Don't serialize this parameter
                 initial_setup=True,  # Allows setting non-settable parameters and prevents resolution cascades during workflow loading
             )
-            result = GriptapeNodes.handle_request(request)
+            result = self.engine.handle_request(request)
 
             # Check if parameter creation was successful
             from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeResultSuccess

--- a/src/griptape_nodes/exe_types/param_components/api_key_provider_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/api_key_provider_parameter.py
@@ -5,7 +5,10 @@ from typing import Any, NamedTuple
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMessage
 from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.exe_types.param_types.parameter_bool import ParameterBool
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.events.secrets_events import (
+    GetSecretValueRequest,
+    GetSecretValueResultSuccess,
+)
 from griptape_nodes.traits.button import Button
 
 
@@ -152,7 +155,7 @@ class ApiKeyProviderParameter:
         Returns:
             bool: True if the API key exists and is not empty, False otherwise
         """
-        api_key_value = GriptapeNodes.SecretsManager().get_secret(api_key)
+        api_key_value = self._get_secret(api_key, should_error_on_not_found=False)
         if api_key_value is None:
             return False
         if isinstance(api_key_value, str):
@@ -172,7 +175,7 @@ class ApiKeyProviderParameter:
             ValueError: If the API key is not set
         """
         api_key_name = self.api_key_name if use_user_api else self.proxy_api_key_name
-        api_key = GriptapeNodes.SecretsManager().get_secret(api_key_name)
+        api_key = self._get_secret(api_key_name, should_error_on_not_found=True)
         if not api_key:
             msg = f"{self._node.name} is missing {api_key_name}. Ensure it's set in the environment/config."
             raise ValueError(msg)
@@ -198,3 +201,17 @@ class ApiKeyProviderParameter:
             user_api_key = self.get_api_key(use_user_api=True)
 
         return ApiKeyValidationResult(proxy_api_key=proxy_api_key, user_api_key=user_api_key)
+
+    def _get_secret(self, secret_name: str, *, should_error_on_not_found: bool) -> str | None:
+        """Ask the engine for a secret.
+
+        Asked as a request rather than read from a local SecretsManager: when the node runs in
+        a worker, the request reaches the orchestrator, while a manager read would answer from
+        the worker's own copy.
+        """
+        result = self._node.engine.handle_request(
+            GetSecretValueRequest(key=secret_name, should_error_on_not_found=should_error_on_not_found)
+        )
+        if not isinstance(result, GetSecretValueResultSuccess):
+            return None
+        return result.value

--- a/src/griptape_nodes/exe_types/param_components/artifact_url/public_artifact_url_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/artifact_url/public_artifact_url_parameter.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import mimetypes
 import os
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 from urllib.parse import urlparse
 from uuid import uuid4
 
@@ -14,11 +16,13 @@ from griptape.artifacts.video_url_artifact import VideoUrlArtifact
 from griptape_nodes.common.parameter_hydration import hydrate_value
 from griptape_nodes.drivers.cloud_credentials import MISSING_CREDENTIAL_MESSAGE, resolve_cloud_credential
 from griptape_nodes.drivers.storage.griptape_cloud_storage_driver import GriptapeCloudStorageDriver
-from griptape_nodes.exe_types.core_types import Parameter
-from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.retained_mode.events.config_events import GetConfigValueRequest, GetConfigValueResultSuccess
 from griptape_nodes.retained_mode.events.secrets_events import GetSecretValueRequest, GetSecretValueResultSuccess
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+if TYPE_CHECKING:
+    from griptape_nodes.exe_types.core_types import Parameter
+    from griptape_nodes.exe_types.node_types import BaseNode
+    from griptape_nodes.retained_mode.engine import Engine
 
 
 class PublicArtifactUrlParameter:
@@ -53,7 +57,7 @@ class PublicArtifactUrlParameter:
             )
             raise ValueError(msg)
 
-        api_key = resolve_cloud_credential(GriptapeNodes.SecretsManager(), secret_name=self.API_KEY_NAME)
+        api_key = resolve_cloud_credential(node.engine.secrets_manager, secret_name=self.API_KEY_NAME)
         if not api_key:
             msg = (
                 f"Attempted to make '{artifact_url_parameter.name}' publicly accessible. "
@@ -63,16 +67,16 @@ class PublicArtifactUrlParameter:
 
         base = os.getenv("GT_CLOUD_BASE_URL", "https://cloud.griptape.ai")
         self._storage_driver = GriptapeCloudStorageDriver(
-            GriptapeNodes.ConfigManager(),
-            bucket_id=self._get_bucket_id(base, api_key, timeout=self._request_timeout),
+            node.engine.config_manager,
+            bucket_id=self._get_bucket_id(node.engine, base, api_key, timeout=self._request_timeout),
             api_key=api_key,
             base_url=base,
             request_timeout=self._request_timeout,
         )
 
     @classmethod
-    def _get_bucket_id(cls, base_url: str, api_key: str, timeout: float | None = None) -> str:
-        bucket_id: str | None = cls._get_secret_value(cls.BUCKET_ID_NAME, should_error_on_not_found=False)
+    def _get_bucket_id(cls, engine: Engine, base_url: str, api_key: str, timeout: float | None = None) -> str:
+        bucket_id: str | None = cls._get_secret_value(engine, cls.BUCKET_ID_NAME, should_error_on_not_found=False)
 
         # A blank/whitespace-only secret is treated the same as an unset one: it can't
         # point at a real bucket and, left alone, produces confusing downstream 404s from
@@ -116,9 +120,9 @@ class PublicArtifactUrlParameter:
         return default_bucket_id
 
     @classmethod
-    def _get_config_value(cls, key: str, default: Any | None = None) -> Any | None:
+    def _get_config_value(cls, engine: Engine, key: str, default: Any | None = None) -> Any | None:
         request = GetConfigValueRequest(category_and_key=key)
-        result_event = GriptapeNodes.handle_request(request)
+        result_event = engine.handle_request(request)
 
         if isinstance(result_event, GetConfigValueResultSuccess):
             return result_event.value
@@ -127,10 +131,10 @@ class PublicArtifactUrlParameter:
 
     @classmethod
     def _get_secret_value(
-        cls, key: str, default: Any | None = None, *, should_error_on_not_found: bool = False
+        cls, engine: Engine, key: str, default: Any | None = None, *, should_error_on_not_found: bool = False
     ) -> Any | None:
         request = GetSecretValueRequest(key=key, should_error_on_not_found=should_error_on_not_found)
-        result_event = GriptapeNodes.handle_request(request)
+        result_event = engine.handle_request(request)
 
         if isinstance(result_event, GetSecretValueResultSuccess):
             return result_event.value

--- a/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/huggingface/huggingface_model_parameter.py
@@ -14,7 +14,6 @@ from griptape_nodes.exe_types.param_components.model_policy import (
 from griptape_nodes.exe_types.param_types.parameter_button import ParameterButton
 from griptape_nodes.exe_types.param_types.parameter_string import ParameterString
 from griptape_nodes.retained_mode.events.model_events import ListModelDownloadsRequest, ListModelDownloadsResultSuccess
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial
 from griptape_nodes.retained_mode.managers.event_manager import reentrant_bus_in_init_would_report
 from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload, OnClickMessageResultPayload
@@ -81,7 +80,7 @@ class HuggingFaceModelParameter(ABC):
         # Repos hidden from the dropdown; read by `filter_choices`.
         self._deprecated_repos: list[str] = deprecated_repos or []
         # Cached at refresh time only — never fetched from inside a callback to
-        # avoid nested GriptapeNodes.handle_request() calls that cause recursion.
+        # avoid nested handle_request() calls that cause recursion.
         self._downloading_model_ids: set[str] = set()
 
         # License-policy state, and the only two pieces of it: `_gate_mode` is the caller's
@@ -394,7 +393,9 @@ class HuggingFaceModelParameter(ABC):
         ambiguous across two libraries, or mid-reload), and treating that as "allow everything"
         would let an admin's deny be bypassed by a lookup error.
         """
-        self._policy = query_model_policy(type(self._node).__name__, fail_closed=self._gate_mode is not False)
+        self._policy = query_model_policy(
+            self._node.engine, type(self._node).__name__, fail_closed=self._gate_mode is not False
+        )
 
     def _apply_denial_badge(self, parameter: Parameter, value: str | None = None) -> None:
         """Set or clear the parameter's badge for the current selection.
@@ -423,7 +424,7 @@ class HuggingFaceModelParameter(ABC):
         if reentrant_bus_in_init_would_report():
             self._downloading_model_ids = set()
             return
-        result = GriptapeNodes.handle_request(ListModelDownloadsRequest())
+        result = self._node.engine.handle_request(ListModelDownloadsRequest())
         if not isinstance(result, ListModelDownloadsResultSuccess):
             self._downloading_model_ids = set()
             return

--- a/src/griptape_nodes/exe_types/param_components/model_access_component.py
+++ b/src/griptape_nodes/exe_types/param_components/model_access_component.py
@@ -113,7 +113,6 @@ from griptape_nodes.retained_mode.events.access_events import (
     QueryModelAccessForNodeRequest,
     QueryModelAccessForNodeResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.button import Button
 from griptape_nodes.traits.options import Options
 
@@ -393,7 +392,7 @@ class ModelAccessComponent:
         # refresh is honored at run time in BOTH directions -- a newly granted permission unblocks
         # the artist without waiting for a refresh, and a newly revoked one still denies. Returning
         # a cached denial early would make grants invisible.
-        result = GriptapeNodes.handle_request(
+        result = self._node.engine.handle_request(
             QueryModelAccessForNodeRequest(
                 node_type=type(self._node).__name__,
                 candidate_model_ids=list(catalog_ids),
@@ -575,7 +574,7 @@ class ModelAccessComponent:
         ``DEFERRED_SNAPSHOT`` comes back instead (see ``query_model_policy``);
         ``query_for_denial`` re-fetches it before its first real verdict.
         """
-        return query_model_policy(type(self._node).__name__)
+        return query_model_policy(self._node.engine, type(self._node).__name__)
 
     def _build_ui_options(self) -> dict[str, Any]:
         """Build the ``ui_options`` dict that decorates the dropdown row-by-row.

--- a/src/griptape_nodes/exe_types/param_components/model_policy.py
+++ b/src/griptape_nodes/exe_types/param_components/model_policy.py
@@ -24,12 +24,12 @@ from griptape_nodes.retained_mode.events.access_events import (
     QueryModelAccessForNodeRequest,
     QueryModelAccessForNodeResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 from griptape_nodes.retained_mode.managers.event_manager import reentrant_bus_in_init_would_report
 
 if TYPE_CHECKING:
     from griptape_nodes.exe_types.core_types import Parameter
+    from griptape_nodes.retained_mode.engine import Engine
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -177,7 +177,7 @@ class ModelPolicySnapshot:
 DEFERRED_SNAPSHOT = ModelPolicySnapshot(deferred=True)
 
 
-def query_model_policy(node_type: str, *, fail_closed: bool = True) -> ModelPolicySnapshot:
+def query_model_policy(engine: Engine, node_type: str, *, fail_closed: bool = True) -> ModelPolicySnapshot:
     """Ask the engine which of ``node_type``'s declared models are permitted.
 
     Returns ``DEFERRED_SNAPSHOT`` without querying when the request would trip
@@ -192,6 +192,7 @@ def query_model_policy(node_type: str, *, fail_closed: bool = True) -> ModelPoli
     only after it runs.
 
     Args:
+        engine: Engine to ask about model access.
         node_type: The node class name the manifest declares ``model_usage`` against.
         fail_closed: What an unanswerable query means. When True, the returned snapshot carries a
             ``failure_detail`` so every subsequent lookup denies -- a broken library registration
@@ -205,7 +206,7 @@ def query_model_policy(node_type: str, *, fail_closed: bool = True) -> ModelPoli
             node_type,
         )
         return DEFERRED_SNAPSHOT
-    result = GriptapeNodes.handle_request(QueryModelAccessForNodeRequest(node_type=node_type))
+    result = engine.handle_request(QueryModelAccessForNodeRequest(node_type=node_type))
     if not isinstance(result, QueryModelAccessForNodeResultSuccess):
         details = getattr(result, "result_details", None) or type(result).__name__
         if not fail_closed:

--- a/src/griptape_nodes/exe_types/param_components/parameter_transition_component.py
+++ b/src/griptape_nodes/exe_types/param_components/parameter_transition_component.py
@@ -15,7 +15,6 @@ from griptape_nodes.retained_mode.events.parameter_events import (
     GetConnectionsForParameterResultSuccess,
     RemoveParameterFromNodeRequest,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -204,7 +203,7 @@ class ParameterTransitionComponent:
     def _capture_connections(self, parameter_name: str) -> GetConnectionsForParameterResultSuccess | None:
         """Fetch the connection lists for a parameter, or None if the query fails."""
         request = GetConnectionsForParameterRequest(parameter_name=parameter_name, node_name=self._node.name)
-        result = GriptapeNodes.handle_request(request)
+        result = self._node.engine.handle_request(request)
         if isinstance(result, GetConnectionsForParameterResultSuccess):
             return result
         logger.warning(
@@ -218,7 +217,7 @@ class ParameterTransitionComponent:
     def _remove_parameter(self, name: str) -> bool:
         """Dispatch RemoveParameterFromNodeRequest. Returns True on success."""
         request = RemoveParameterFromNodeRequest(parameter_name=name, node_name=self._node.name)
-        result = GriptapeNodes.handle_request(request)
+        result = self._node.engine.handle_request(request)
         if result.failed():
             logger.error(
                 "Attempted to remove parameter '%s' from node '%s'. Failed because: %s",
@@ -232,7 +231,7 @@ class ParameterTransitionComponent:
     def _add_parameter(self, desired: TransitionParameter) -> bool:
         """Dispatch the caller-supplied add-request factory. Returns True on success."""
         add_request = desired.add_request_factory()
-        result = GriptapeNodes.handle_request(add_request)
+        result = self._node.engine.handle_request(add_request)
         if result.failed():
             logger.error(
                 "Attempted to add parameter '%s' to node '%s'. Failed because: %s",
@@ -267,7 +266,7 @@ class ParameterTransitionComponent:
             target_node_name=self._node.name,
             target_parameter_name=incoming.target_parameter_name,
         )
-        result = GriptapeNodes.handle_request(request)
+        result = self._node.engine.handle_request(request)
         if result.failed():
             logger.debug(
                 "Dropped incoming connection %s.%s -> %s.%s during replace because: %s",
@@ -285,7 +284,7 @@ class ParameterTransitionComponent:
             target_node_name=outgoing.target_node_name,
             target_parameter_name=outgoing.target_parameter_name,
         )
-        result = GriptapeNodes.handle_request(request)
+        result = self._node.engine.handle_request(request)
         if result.failed():
             logger.debug(
                 "Dropped outgoing connection %s.%s -> %s.%s during replace because: %s",

--- a/src/griptape_nodes/exe_types/param_components/project_file_parameter.py
+++ b/src/griptape_nodes/exe_types/param_components/project_file_parameter.py
@@ -8,10 +8,10 @@ from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.files.file import FileDestination, FileDestinationProvider
 from griptape_nodes.files.project_file import ProjectFileDestination
 from griptape_nodes.retained_mode.events.connection_events import (
+    CreateConnectionRequest,
     ListConnectionsForNodeRequest,
     ListConnectionsForNodeResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.retained_mode.retained_mode import RetainedMode
 from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
 from griptape_nodes.traits.file_system_picker import FileSystemPicker
@@ -127,11 +127,11 @@ class ProjectFileParameter:
         Raises:
             ValueError: If an upstream FileDestinationProvider is connected but returns None.
         """
-        result = GriptapeNodes.handle_request(ListConnectionsForNodeRequest(node_name=self._node.name))
+        result = self._node.engine.handle_request(ListConnectionsForNodeRequest(node_name=self._node.name))
         if isinstance(result, ListConnectionsForNodeResultSuccess):
             for conn in result.incoming_connections:
                 if conn.target_parameter_name == self._name:
-                    source_node = GriptapeNodes.ObjectManager().attempt_get_object_by_name(conn.source_node_name)
+                    source_node = self._node.engine.object_manager.attempt_get_object_by_name(conn.source_node_name)
                     if isinstance(source_node, FileDestinationProvider):
                         file_dest = source_node.file_destination
                         if file_dest is None:
@@ -172,7 +172,7 @@ class ProjectFileParameter:
         node_name = self._node.name
 
         has_incoming = False
-        result = GriptapeNodes.handle_request(ListConnectionsForNodeRequest(node_name=node_name))
+        result = self._node.engine.handle_request(ListConnectionsForNodeRequest(node_name=node_name))
         if isinstance(result, ListConnectionsForNodeResultSuccess):
             has_incoming = any(conn.target_parameter_name == self._name for conn in result.incoming_connections)
 
@@ -186,6 +186,9 @@ class ProjectFileParameter:
 
         # TODO: https://github.com/griptape-ai/griptape-nodes/issues/4097
         # Replace with a non-RM utility for creating sibling nodes relative to a given node.
+        # Until then this is the one remaining path from exe_types to the facade: RetainedMode is
+        # a re-export, so the TID251 ban does not see it. It resolves the ambient engine, which is
+        # correct here only because button handlers run where the node lives.
         create_result = RetainedMode.create_node_relative_to(
             reference_node_name=node_name,
             new_node_type="FileOutputSettings",
@@ -205,7 +208,7 @@ class ProjectFileParameter:
 
         configure_node_name = create_result
 
-        configure_node = GriptapeNodes.ObjectManager().attempt_get_object_by_name(configure_node_name)
+        configure_node = self._node.engine.object_manager.attempt_get_object_by_name(configure_node_name)
         if configure_node is not None:
             configure_node.set_parameter_value("situation", self._situation_name)
             configure_node.publish_update_to_parameter("situation", self._situation_name)
@@ -215,9 +218,17 @@ class ProjectFileParameter:
                 configure_node.set_parameter_value("filename", current_filename)
                 configure_node.publish_update_to_parameter("filename", current_filename)
 
-        connection_result = RetainedMode.connect(
-            source=f"{configure_node_name}.file_destination",
-            destination=f"{node_name}.{self._name}",
+        # Dispatched through this node's engine rather than RetainedMode. RetainedMode is a
+        # facade re-export, so going through it resolves the ambient engine -- which the TID251
+        # ban does not catch, and which would answer from a different engine than the request
+        # above it.
+        connection_result = self._node.engine.handle_request(
+            CreateConnectionRequest(
+                source_node_name=configure_node_name,
+                source_parameter_name="file_destination",
+                target_node_name=node_name,
+                target_parameter_name=self._name,
+            )
         )
 
         if not connection_result.succeeded():

--- a/src/griptape_nodes/exe_types/variable_resolver.py
+++ b/src/griptape_nodes/exe_types/variable_resolver.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 import logging
 import re
 from contextvars import ContextVar
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from griptape_nodes.common.macro_parser.core import ParsedMacro
 from griptape_nodes.common.macro_parser.exceptions import MacroResolutionError, MacroSyntaxError
 from griptape_nodes.common.macro_parser.segments import ParsedVariable
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -25,8 +28,9 @@ _aprocess_variable_cache: ContextVar[dict | object | None] = ContextVar(
 class VariableResolver:
     """Resolves inline {VAR} macro references in node parameter values during aprocess().
 
-    All GriptapeNodes singleton access is concentrated in this class's static methods,
-    keeping the lazy-import cycle-break in one place rather than scattered across BaseNode.
+    The methods that need engine state take the engine as their first argument rather than
+    reaching for process-wide state, so a resolver call answers from the same engine as the
+    node that asked.
     """
 
     _HAS_VARIABLE_MACRO: ClassVar[re.Pattern[str]] = re.compile(r"\{[A-Za-z_]")
@@ -121,15 +125,32 @@ class VariableResolver:
         _aprocess_variable_cache.reset(token)  # type: ignore[arg-type]
 
     @staticmethod
-    def is_substitution_enabled() -> bool:
-        """Return True if variable substitution is enabled for the active workflow."""
-        # GriptapeNodes import is lazy to avoid circular dependency between exe_types and retained_mode.
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+    def is_substitution_enabled(engine: Engine) -> bool:
+        """Return True if variable substitution is enabled for the active workflow.
 
-        return GriptapeNodes.WorkflowManager().is_variable_substitution_enabled()
+        KNOWN LIMITATION in a worker: this reads a local manager, and
+        `is_variable_substitution_enabled` answers True whenever there is no current workflow,
+        which is always the case in a worker process.
+
+        The orchestrator encodes "disabled" as an EMPTY variable dict when it pre-seeds one for a
+        dispatch, and substituting with an empty dict is not the same as not substituting:
+        `{VAR}` is preserved either way, but `{VAR?}` collapses to "" instead of staying literal.
+        So an optional macro resolves differently for a worker-executed node than for the same
+        node in-process, on a workflow that turned substitution off. The other affected readers
+        are the ones using this answer to decide whether a stored value is still an unresolved
+        template -- `node_types._variable_template_to_preserve`, and through it the display value
+        and the output write-back -- plus the sibling local read in `get_variables_if_enabled`.
+
+        Routing it through GetVariableSubstitutionEnabledRequest so it forwards was tried and
+        backed out: `parameter_output_values[...] = x` inside a node `__init__` reaches this
+        through TrackedParameterOutputValues, so every node construction became a bus request
+        and tripped `reentrant-bus-in-init`. Fixing it properly means resolving the answer once
+        per execution and carrying it, rather than asking per value.
+        """
+        return engine.workflow_manager.is_variable_substitution_enabled()
 
     @staticmethod
-    def get_variables_if_enabled(node_name: str) -> dict[str, str | int] | None:
+    def get_variables_if_enabled(engine: Engine, node_name: str) -> dict[str, str | int] | None:
         """Return the variable dict if substitution is enabled, else None.
 
         Checks the per-aprocess cache first to avoid repeated singleton lookups.
@@ -147,10 +168,9 @@ class VariableResolver:
         orchestrator-resolved variable dict, so this fallback path is only reached for
         in-process nodes whose request predates the variables field (e.g. unit tests).
         """
-        # GriptapeNodes import is lazy to avoid circular dependency between exe_types and retained_mode.
-        from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-        if not GriptapeNodes.WorkflowManager().is_variable_substitution_enabled():
+        # Same local read as is_substitution_enabled, and the same worker limitation applies;
+        # see the note there.
+        if not engine.workflow_manager.is_variable_substitution_enabled():
             return None
 
         cached = _aprocess_variable_cache.get()
@@ -166,11 +186,11 @@ class VariableResolver:
         from griptape_nodes.retained_mode.variable_types import VariableScope
 
         try:
-            flow_name = GriptapeNodes.NodeManager().get_node_parent_flow_by_name(node_name)
+            flow_name = engine.node_manager.get_node_parent_flow_by_name(node_name)
         except KeyError:
             _aprocess_variable_cache.set(_NO_FLOW)
             return None
-        result = GriptapeNodes.handle_request(
+        result = engine.handle_request(
             ListVariablesRequest(starting_flow=flow_name, lookup_scope=VariableScope.HIERARCHICAL)
         )
         if not isinstance(result, ListVariablesResultSuccess):
@@ -232,7 +252,7 @@ class VariableResolver:
         return False
 
     @staticmethod
-    def get_variables_without_memoizing(node_name: str) -> dict[str, str | int] | None:
+    def get_variables_without_memoizing(engine: Engine, node_name: str) -> dict[str, str | int] | None:
         """Like `get_variables_if_enabled`, but never leaves the memo cache set.
 
         ``get_variables_if_enabled`` memoises its lookup into the ContextVar without
@@ -243,10 +263,10 @@ class VariableResolver:
         outside ``aprocess_scope()``. An already-populated cache is left untouched.
         """
         if _aprocess_variable_cache.get() is not None:
-            return VariableResolver.get_variables_if_enabled(node_name)
+            return VariableResolver.get_variables_if_enabled(engine, node_name)
         token = _aprocess_variable_cache.set(None)
         try:
-            return VariableResolver.get_variables_if_enabled(node_name)
+            return VariableResolver.get_variables_if_enabled(engine, node_name)
         finally:
             _aprocess_variable_cache.reset(token)
 

--- a/src/griptape_nodes/exe_types/workflow_node.py
+++ b/src/griptape_nodes/exe_types/workflow_node.py
@@ -33,13 +33,13 @@ from griptape_nodes.retained_mode.events.workflow_events import (
     ImportWorkflowAsReferencedSubFlowRequest,
     ImportWorkflowAsReferencedSubFlowResultSuccess,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path
 
     from griptape_nodes.node_library.workflow_registry import NodeParametersMapping, ParameterMinimalDict
+    from griptape_nodes.retained_mode.engine import Engine
 
 logger = logging.getLogger("griptape_nodes")
 
@@ -315,7 +315,7 @@ class WorkflowNode(ControlNode):
 
         self._apply_inputs(subflow_name, live_routes)
 
-        result = await GriptapeNodes.ahandle_request(StartLocalSubflowRequest(flow_name=subflow_name))
+        result = await self.engine.ahandle_request(StartLocalSubflowRequest(flow_name=subflow_name))
         if not isinstance(result, StartLocalSubflowResultSuccess):
             msg = (
                 f"Attempted to run the workflow behind node '{self.name}'. "
@@ -352,12 +352,12 @@ class WorkflowNode(ControlNode):
         """
         tracked = self.metadata.get(SUBFLOW_NAME_KEY)
         if tracked is not None:
-            if _get_flow_or_none(tracked) is not None:
+            if _get_flow_or_none(self.engine, tracked) is not None:
                 return tracked
             # Torn down out from under us (for example when the parent flow was deleted).
             self.metadata.pop(SUBFLOW_NAME_KEY, None)
 
-        flow_result = GriptapeNodes.handle_request(GetFlowForNodeRequest(node_name=self.name))
+        flow_result = self.engine.handle_request(GetFlowForNodeRequest(node_name=self.name))
         if not isinstance(flow_result, GetFlowForNodeResultSuccess):
             msg = (
                 f"Attempted to run the workflow behind node '{self.name}'. "
@@ -366,7 +366,7 @@ class WorkflowNode(ControlNode):
             raise RuntimeError(msg)  # noqa: TRY004 - the lookup failed at run time; this is not a type error
 
         registry_key = self._register_workflow()
-        import_result = await GriptapeNodes.ahandle_request(
+        import_result = await self.engine.ahandle_request(
             ImportWorkflowAsReferencedSubFlowRequest(
                 workflow_name=registry_key,
                 flow_name=flow_result.flow_name,
@@ -399,9 +399,9 @@ class WorkflowNode(ControlNode):
         tracked = self.metadata.pop(SUBFLOW_NAME_KEY, None)
         if tracked is None:
             return
-        if _get_flow_or_none(tracked) is None:
+        if _get_flow_or_none(self.engine, tracked) is None:
             return
-        delete_result = GriptapeNodes.handle_request(DeleteFlowRequest(flow_name=tracked))
+        delete_result = self.engine.handle_request(DeleteFlowRequest(flow_name=tracked))
         if delete_result.failed():
             logger.warning(
                 "Node '%s' could not clean up its workflow subflow '%s': %s",
@@ -424,7 +424,7 @@ class WorkflowNode(ControlNode):
             WorkflowNodeRoutingError: A declared parameter is not present on the node it was paired
                 with, meaning the loaded copy does not match the workflow's stored shape.
         """
-        flow = GriptapeNodes.FlowManager().get_flow_by_name(subflow_name)
+        flow = self.engine.flow_manager.get_flow_by_name(subflow_name)
         live_start_nodes = [node.name for node in flow.nodes.values() if isinstance(node, StartNode)]
         live_end_nodes = [node.name for node in flow.nodes.values() if isinstance(node, EndNode)]
 
@@ -472,7 +472,7 @@ class WorkflowNode(ControlNode):
 
     def _apply_inputs(self, subflow_name: str, live_routes: WorkflowNodeLiveRoutes) -> None:
         for surface_name, route in live_routes.inputs.items():
-            set_result = GriptapeNodes.handle_request(
+            set_result = self.engine.handle_request(
                 SetParameterValueRequest(
                     parameter_name=route.parameter_name,
                     node_name=route.workflow_node_name,
@@ -489,7 +489,7 @@ class WorkflowNode(ControlNode):
         logger.debug("Node '%s' applied inputs to workflow subflow '%s'.", self.name, subflow_name)
 
     def _collect_outputs(self, subflow_name: str, live_routes: WorkflowNodeLiveRoutes) -> None:
-        flow = GriptapeNodes.FlowManager().get_flow_by_name(subflow_name)
+        flow = self.engine.flow_manager.get_flow_by_name(subflow_name)
         for surface_name, route in live_routes.outputs.items():
             end_node = flow.nodes[route.workflow_node_name]
             # A node that ran publishes to parameter_output_values; fall back to the stored value
@@ -561,5 +561,5 @@ def _build_surface_parameter(surface_name: str, surface_parameter: WorkflowNodeS
     )
 
 
-def _get_flow_or_none(flow_name: str) -> ControlFlow | None:
-    return GriptapeNodes.ObjectManager().attempt_get_object_by_name_as_type(flow_name, ControlFlow)
+def _get_flow_or_none(engine: Engine, flow_name: str) -> ControlFlow | None:
+    return engine.object_manager.attempt_get_object_by_name_as_type(flow_name, ControlFlow)

--- a/src/griptape_nodes/files/drivers/local_file_driver.py
+++ b/src/griptape_nodes/files/drivers/local_file_driver.py
@@ -13,7 +13,7 @@ from griptape_nodes.files.path_utils import (
     resolve_path_safely,
     sanitize_path_string,
 )
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.engine import current_engine
 
 
 class LocalFileDriver(BaseFileDriver):
@@ -91,7 +91,7 @@ class LocalFileDriver(BaseFileDriver):
         # Anchor a relative path on the workspace directory. Mirrors File.resolve()
         # logic so reported path matches opened path.
         if not path.is_absolute():
-            workspace_path = GriptapeNodes.ConfigManager().workspace_path
+            workspace_path = current_engine().config_manager.workspace_path
             # Normalise joined path without evaluating symlinks en route.
             path = resolve_path_safely(workspace_path / path)
 

--- a/src/griptape_nodes/files/drivers/static_server_file_driver.py
+++ b/src/griptape_nodes/files/drivers/static_server_file_driver.py
@@ -12,7 +12,7 @@ import anyio
 
 from griptape_nodes.files.base_file_driver import BaseFileDriver
 from griptape_nodes.files.path_utils import parse_static_server_url
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.engine import current_engine
 
 
 class StaticServerFileDriver(BaseFileDriver):
@@ -57,7 +57,7 @@ class StaticServerFileDriver(BaseFileDriver):
         Raises:
             ValueError: If URL format is invalid
         """
-        workspace_path = GriptapeNodes.ConfigManager().workspace_path
+        workspace_path = current_engine().config_manager.workspace_path
         local_path = parse_static_server_url(location, workspace_path)
 
         if local_path is None:

--- a/src/griptape_nodes/files/file.py
+++ b/src/griptape_nodes/files/file.py
@@ -18,6 +18,7 @@ from griptape_nodes.files.path_utils import (
     resolve_file_path,
     resolve_path_safely,
 )
+from griptape_nodes.retained_mode.engine import current_engine
 from griptape_nodes.retained_mode.events.os_events import (
     ExistingFilePolicy,
     FileIOFailureReason,
@@ -221,7 +222,7 @@ def _resolve_plain_path(path_str: str) -> str:
     if local_path is not None:
         path_str = local_path
 
-    workspace_path = GriptapeNodes.ConfigManager().workspace_path
+    workspace_path = current_engine().config_manager.workspace_path
 
     if is_url(path_str):
         static_server_path = parse_static_server_url(path_str, workspace_path)

--- a/src/griptape_nodes/machines/parallel_resolution.py
+++ b/src/griptape_nodes/machines/parallel_resolution.py
@@ -146,6 +146,16 @@ class ParallelResolutionContext(EngineScoped):
             if self.dag_builder:
                 for node in self.node_to_reference.values():
                     node.node_state = NodeState.CANCELED
+                    # Give the node back here as well as in ErrorState. A cancel bumps the
+                    # generation, and every was_reset_since guard in ExecuteDagState then abandons
+                    # the run by returning None -- without entering ErrorState at all. So whether
+                    # a cancelled node stopped claiming to be mid-resolution came down to a race
+                    # between the driver waking and this bump, and losing it left the editor
+                    # spinning on that node forever.
+                    if node.node_reference.state is NodeResolutionState.RESOLVING:
+                        node.node_reference.make_node_unresolved(
+                            current_states_to_trigger_change_event={NodeResolutionState.RESOLVING}
+                        )
         else:
             self.workflow_state = WorkflowState.NO_ERROR
             self.error_message = None
@@ -849,6 +859,26 @@ class ErrorState(State):
             task_to_node.pop(task)
 
         if len(task_to_node) == 0:
+            # Give back every node this run left mid-flight. `state` is set to RESOLVING when a
+            # node is dispatched and to RESOLVED by handle_done_nodes when it finishes, and
+            # nothing sat between those two: a node that raised, or that was cancelled because
+            # a sibling raised, kept RESOLVING after the run was over. Since nothing else moves
+            # it -- this run is finishing right here -- the editor showed it spinning forever,
+            # and GetNodeResolutionStateRequest kept answering RESOLVING. A node that did not
+            # finish is UNRESOLVED: it holds no valid outputs and needs to run again.
+            #
+            # Done before the maps are cleared, which is the last moment the nodes are reachable.
+            # make_node_unresolved rather than a bare assignment, so the editor is told; the
+            # state filter keeps it quiet for nodes that never started.
+            # Only the ones still mid-flight. A node that finished before a sibling failed is
+            # RESOLVED with real outputs that downstream consumers may already hold, and
+            # make_node_unresolved assigns UNRESOLVED unconditionally -- its argument gates the
+            # event, not the write -- so calling it on everything would discard completed work.
+            for dag_node in context.node_to_reference.values():
+                node = dag_node.node_reference
+                if node.state is NodeResolutionState.RESOLVING:
+                    node.make_node_unresolved(current_states_to_trigger_change_event={NodeResolutionState.RESOLVING})
+
             # ErrorState is entered either because a task raised an exception
             # (error_message is set) or because a task was cancelled via user-
             # initiated flow cancel (error_message is None). Distinguish here

--- a/src/griptape_nodes/machines/parallel_resolution.py
+++ b/src/griptape_nodes/machines/parallel_resolution.py
@@ -146,12 +146,9 @@ class ParallelResolutionContext(EngineScoped):
             if self.dag_builder:
                 for node in self.node_to_reference.values():
                     node.node_state = NodeState.CANCELED
-                    # Give the node back here as well as in ErrorState. A cancel bumps the
-                    # generation, and every was_reset_since guard in ExecuteDagState then abandons
-                    # the run by returning None -- without entering ErrorState at all. So whether
-                    # a cancelled node stopped claiming to be mid-resolution came down to a race
-                    # between the driver waking and this bump, and losing it left the editor
-                    # spinning on that node forever.
+                    # Given back here as well as in ErrorState: a cancel bumps the generation, and
+                    # the was_reset_since guards in ExecuteDagState then abandon the run by
+                    # returning None, so ErrorState is never entered to do it.
                     if node.node_reference.state is NodeResolutionState.RESOLVING:
                         node.node_reference.make_node_unresolved(
                             current_states_to_trigger_change_event={NodeResolutionState.RESOLVING}
@@ -859,21 +856,11 @@ class ErrorState(State):
             task_to_node.pop(task)
 
         if len(task_to_node) == 0:
-            # Give back every node this run left mid-flight. `state` is set to RESOLVING when a
-            # node is dispatched and to RESOLVED by handle_done_nodes when it finishes, and
-            # nothing sat between those two: a node that raised, or that was cancelled because
-            # a sibling raised, kept RESOLVING after the run was over. Since nothing else moves
-            # it -- this run is finishing right here -- the editor showed it spinning forever,
-            # and GetNodeResolutionStateRequest kept answering RESOLVING. A node that did not
-            # finish is UNRESOLVED: it holds no valid outputs and needs to run again.
-            #
-            # Done before the maps are cleared, which is the last moment the nodes are reachable.
-            # make_node_unresolved rather than a bare assignment, so the editor is told; the
-            # state filter keeps it quiet for nodes that never started.
-            # Only the ones still mid-flight. A node that finished before a sibling failed is
-            # RESOLVED with real outputs that downstream consumers may already hold, and
-            # make_node_unresolved assigns UNRESOLVED unconditionally -- its argument gates the
-            # event, not the write -- so calling it on everything would discard completed work.
+            # A node that did not finish is UNRESOLVED: it holds no valid outputs, and nothing else
+            # moves it once this run ends. Filtered to RESOLVING because make_node_unresolved writes
+            # unconditionally -- its argument gates only the event -- so calling it on a node that
+            # finished before a sibling failed would discard outputs consumers may already hold.
+            # Before the maps are cleared, the last moment these nodes are reachable.
             for dag_node in context.node_to_reference.values():
                 node = dag_node.node_reference
                 if node.state is NodeResolutionState.RESOLVING:

--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -273,9 +273,10 @@ class LibrarySchema(BaseModel):
     library itself.
     """
 
-    # 0.12.0 added Dependencies.pip_dependencies_exec. Older manifests still validate: the
-    # field is optional, and its absence means every dependency is edit-time.
-    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.12.0"
+    # 0.12.0 added Dependencies.pip_dependencies_exec. 0.13.0 added execution_modules. Older
+    # manifests still validate: both fields are optional, and their absence means every
+    # dependency is edit-time and no module is execution-only.
+    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.13.0"
 
     name: str
     library_schema_version: str
@@ -290,6 +291,16 @@ class LibrarySchema(BaseModel):
     is_default_library: bool | None = None
     advanced_library_path: str | None = None
     widgets: list[WidgetDefinition] | None = None
+    # Modules that only ever run where nodes execute. Paths relative to this manifest; a
+    # directory means every `.py` beneath it.
+    #
+    # The declaration exists so heavy imports stop being an author's discipline problem. A module
+    # named here may import whatever it likes at module scope, because the orchestrator never
+    # imports it -- only a worker does, eagerly, at library load. Node modules reach it through
+    # `BaseNode.execution_module(...)` rather than importing it, and importing it from a node
+    # module is a reportable violation: that is what would drag execution dependencies onto the
+    # orchestrator's import path, which is the thing the edit/execution split exists to prevent.
+    execution_modules: list[str] | None = None
 
 
 class LibraryRegistry:

--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -62,9 +62,29 @@ class LibraryNameAndVersion(NamedTuple):
 
 
 class Dependencies(BaseModel):
-    """Pip packages that need to be installed for this library."""
+    """Pip packages that need to be installed for this library.
+
+    Dependencies are declared in two sets, because a library needs far less installed to be
+    *edited* than to be *run*:
+
+    - ``pip_dependencies`` (edit-time): everything needed to import the library's node modules
+      and instantiate its nodes. The orchestrator installs these, so they are what the editor,
+      workflow loading, and parameter/trait behavior depend on. Keep this set light.
+    - ``pip_dependencies_exec`` (execution-time): the heavy packages only ``process`` needs
+      (torch, diffusers, and friends). These are installed into a separate environment and are
+      only on ``sys.path`` where nodes actually execute, so they never enter the orchestrator's
+      import path and cannot collide with another library's pins there.
+
+    A library that declares no execution dependencies behaves exactly as it always has:
+    everything is edit-time, and it runs in the orchestrator.
+
+    ``pip_install_flags`` applies to both installs, since flags in practice configure where
+    packages come from (index URLs, ``--find-links``, backend selection) rather than which set
+    is being installed.
+    """
 
     pip_dependencies: list[str] | None = None
+    pip_dependencies_exec: list[str] | None = None
     pip_install_flags: list[str] | None = None
 
 
@@ -253,7 +273,9 @@ class LibrarySchema(BaseModel):
     library itself.
     """
 
-    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.11.0"
+    # 0.12.0 added Dependencies.pip_dependencies_exec. Older manifests still validate: the
+    # field is optional, and its absence means every dependency is edit-time.
+    LATEST_SCHEMA_VERSION: ClassVar[str] = "0.12.0"
 
     name: str
     library_schema_version: str

--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -91,10 +91,9 @@ class Dependencies(BaseModel):
 class ModelAsset(BaseModel):
     """Weight files a library needs on disk, declared rather than installed.
 
-    Weights are not dependencies. Libraries have been acquiring them three ways -- bundled inside a
-    pip-installed source tree, downloaded by a library-load hook, or fetched ad hoc by node code --
-    and only the last is even in the right process. A declaration lets the engine own fetching,
-    cache location, revision pinning and the entitlement gate, and lets a node ask for a path.
+    Declaring them, rather than installing them as dependencies, is what lets the engine own
+    fetching, cache location, revision pinning and the entitlement gate while a node only asks for
+    a path.
 
     Distinct from ``model_catalog``, which declares HOSTED models a node may invoke and the keys
     and terms that govern them. This is about bytes on local disk.
@@ -119,11 +118,8 @@ class ResourceRequirements(BaseModel):
     Specifies what system resources (OS, compute backends) the library needs.
     Example: {"platform": (["linux", "windows"], "has_any"), "arch": "x86_64", "compute": (["cuda", "cpu"], "has_all")}
 
-    ``required``: without this the library cannot run. Execution refuses with the reason, and
-    editing is unaffected -- SAM3 declares cuda-only and is still fully editable on a laptop.
-
-    There is deliberately no advisory tier. One was added and removed: nothing consumed it, so an
-    author who moved a declaration to it gave up the gate and gained nothing an artist could see.
+    ``required`` is the only tier: without it the library cannot run. Execution refuses with the
+    reason and editing is unaffected, so a cuda-only library stays fully editable on a laptop.
     """
 
     required: Requirements | None = None

--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -88,16 +88,53 @@ class Dependencies(BaseModel):
     pip_install_flags: list[str] | None = None
 
 
+class ModelAsset(BaseModel):
+    """Weight files a library needs on disk, declared rather than installed.
+
+    Weights are not dependencies. Libraries have been acquiring them three ways -- bundled inside a
+    pip-installed source tree, downloaded by a library-load hook, or fetched ad hoc by node code --
+    and only the last is even in the right process. A declaration lets the engine own fetching,
+    cache location, revision pinning and the entitlement gate, and lets a node ask for a path.
+
+    Distinct from ``model_catalog``, which declares HOSTED models a node may invoke and the keys
+    and terms that govern them. This is about bytes on local disk.
+
+    Args:
+        source: Where the weights come from. ``hf:owner/repo`` is the only scheme today.
+        revision: Git revision to pin. Defaults to "main", but pinning is strongly preferred: an
+            unpinned asset means a workflow can produce different output next month.
+        files: Optional glob patterns to fetch instead of the whole repository, e.g.
+            ``["*.safetensors", "config.json"]``. Whole repositories are often much larger than
+            what a node actually loads.
+    """
+
+    source: str
+    revision: str = "main"
+    files: list[str] | None = None
+
+
 class ResourceRequirements(BaseModel):
     """Resource requirements for a library.
 
     Specifies what system resources (OS, compute backends) the library needs.
     Example: {"platform": (["linux", "windows"], "has_any"), "arch": "x86_64", "compute": (["cuda", "cpu"], "has_all")}
+
+    Two tiers, because "needs" and "prefers" are different claims and libraries were being made
+    to pick one of them:
+
+    - ``required``: without this the library cannot run. Execution refuses with the reason;
+      editing is unaffected.
+    - ``preferred``: it runs either way, better with this. Recorded and reported, never a gate.
+
+    Before the second tier existed, an author who wanted to say "this really wants a GPU" had to
+    choose between a hard gate and saying nothing. SAM3 chose the gate and declared cuda-only,
+    which is why it could not be edited on a laptop at all.
     """
 
     required: Requirements | None = None
+    preferred: Requirements | None = None
 
-    @field_validator("required", mode="before")
+    @field_validator("required", "preferred", mode="before")
     @classmethod
     def convert_lists_to_tuples(cls, v: Any) -> Any:
         """Convert list values to tuples for requirements loaded from JSON.
@@ -291,6 +328,9 @@ class LibrarySchema(BaseModel):
     is_default_library: bool | None = None
     advanced_library_path: str | None = None
     widgets: list[WidgetDefinition] | None = None
+    # Weight files this library needs on disk, keyed by the id node code asks for. Fetched on
+    # demand by whichever process runs the model -- never at library load.
+    model_assets: dict[str, ModelAsset] | None = None
     # Modules that only ever run where nodes execute. Paths relative to this manifest; a
     # directory means every `.py` beneath it.
     #

--- a/src/griptape_nodes/node_library/library_registry.py
+++ b/src/griptape_nodes/node_library/library_registry.py
@@ -119,22 +119,16 @@ class ResourceRequirements(BaseModel):
     Specifies what system resources (OS, compute backends) the library needs.
     Example: {"platform": (["linux", "windows"], "has_any"), "arch": "x86_64", "compute": (["cuda", "cpu"], "has_all")}
 
-    Two tiers, because "needs" and "prefers" are different claims and libraries were being made
-    to pick one of them:
+    ``required``: without this the library cannot run. Execution refuses with the reason, and
+    editing is unaffected -- SAM3 declares cuda-only and is still fully editable on a laptop.
 
-    - ``required``: without this the library cannot run. Execution refuses with the reason;
-      editing is unaffected.
-    - ``preferred``: it runs either way, better with this. Recorded and reported, never a gate.
-
-    Before the second tier existed, an author who wanted to say "this really wants a GPU" had to
-    choose between a hard gate and saying nothing. SAM3 chose the gate and declared cuda-only,
-    which is why it could not be edited on a laptop at all.
+    There is deliberately no advisory tier. One was added and removed: nothing consumed it, so an
+    author who moved a declaration to it gave up the gate and gained nothing an artist could see.
     """
 
     required: Requirements | None = None
-    preferred: Requirements | None = None
 
-    @field_validator("required", "preferred", mode="before")
+    @field_validator("required", mode="before")
     @classmethod
     def convert_lists_to_tuples(cls, v: Any) -> Any:
         """Convert list values to tuples for requirements loaded from JSON.

--- a/src/griptape_nodes/retained_mode/events/event_converter.py
+++ b/src/griptape_nodes/retained_mode/events/event_converter.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import logging
 import traceback
 import types
+from collections.abc import Mapping, MutableMapping
 from dataclasses import fields as dc_fields
 from dataclasses import is_dataclass
 from datetime import datetime
+from functools import cache
 from pathlib import Path
-from typing import Any, Union, get_args, get_origin
+from typing import Any, Union, get_args, get_origin, get_type_hints
 
 from cattrs.gen import make_dict_structure_fn, make_dict_unstructure_fn, override
 from cattrs.preconf.json import make_converter
@@ -169,12 +171,96 @@ def _fallback_unstructure(obj: Any) -> dict[str, Any]:
     return result
 
 
+# Classes already reported as arriving with an unstructured field, so the warning below fires
+# once per class rather than once per payload.
+_REPORTED_DEGRADED_CLASSES: set[type] = set()
+
+# Annotation fragments meaning "a dict here IS the declared type", so a dict-valued field is not
+# evidence of anything going wrong. Includes project aliases OF a mapping: `Requirements` is
+# `dict[str, RequirementValue]`, and reads as neither "dict" nor "Mapping", so without it every
+# forwarded resource-lock request reported its own `requirements` as corrupted. Matched as text
+# because the classes reaching this path are precisely the ones whose annotations cannot be
+# resolved -- get_type_hints is tried first for the ones that can.
+_DICT_SHAPED_ANNOTATIONS = ("dict", "Dict", "Mapping", "Any", "object", "Requirements")
+
+
+@cache
+def _dict_shaped_fields(cls: type) -> frozenset[str]:
+    """Fields where a dict IS the declared type, so a dict value proves nothing is wrong.
+
+    Resolved properly where possible rather than matched as text, because an alias hides the shape:
+    ``Requirements = dict[str, RequirementValue]`` reads as neither "dict" nor "Mapping", so a text
+    rule reported a GPU-lock request's `requirements` as corrupted every time one was forwarded --
+    the exact false-alarm class this reporting was gated to avoid. Falls back to annotation text for
+    fields that cannot be resolved, which is the situation this whole code path exists for.
+    """
+    shaped: set[str] = set()
+    try:
+        hints = get_type_hints(cls)
+    except Exception:
+        hints = {}
+    for field in dc_fields(cls):
+        resolved = hints.get(field.name)
+        if resolved is not None:
+            origin = get_origin(resolved) or resolved
+            if origin in (dict, Mapping, MutableMapping) or resolved in (Any, object):
+                shaped.add(field.name)
+            continue
+        annotation = field.type if isinstance(field.type, str) else getattr(field.type, "__name__", "")
+        if any(fragment in annotation for fragment in _DICT_SHAPED_ANNOTATIONS):
+            shaped.add(field.name)
+    return frozenset(shaped)
+
+
+def _looks_unstructured(value: Any) -> bool:
+    """Whether a value came through as raw JSON rather than the type its field declares.
+
+    Lists count: a field declared ``list[SomeDataclass]`` degrades into a list of dicts exactly
+    the way a single field degrades into one dict, and reporting only the scalar case would miss
+    every collection-valued payload.
+    """
+    if isinstance(value, dict):
+        return True
+    return isinstance(value, list) and any(isinstance(item, dict) for item in value)
+
+
+def _report_unstructured_fields(cls: type, values: dict[str, Any]) -> None:
+    """Warn when the fallback left a field holding a raw dict.
+
+    Checked against the actual value rather than the annotation, because the annotation is
+    unresolvable by definition in this path -- that is why the fallback is running. A dict where
+    the declared type is something else is the corruption signature: the object passes isinstance()
+    while the field is not the type it claims, and the mismatch surfaces later as
+    "'dict' object has no attribute ...", arbitrarily far from here.
+
+    Deliberately silent for classes that reach the fallback over an alias of a builtin
+    (``ProjectID = str``), which is most of them. There the raw JSON value is already the right
+    type and nothing degrades; warning would bury the cases that matter in false alarms.
+    """
+    if cls in _REPORTED_DEGRADED_CLASSES:
+        return
+    dict_shaped = _dict_shaped_fields(cls)
+    degraded = [name for name, value in values.items() if _looks_unstructured(value) and name not in dict_shaped]
+    if not degraded:
+        return
+    _REPORTED_DEGRADED_CLASSES.add(cls)
+    logger.warning(
+        "'%s' was rebuilt from a serialized payload with %s left as raw dict(s), because its "
+        "annotations could not be resolved (usually a TYPE_CHECKING-only import). Attribute "
+        "access on those fields will fail. Give the annotation a runtime-importable name, or "
+        "register an explicit structure hook for this class.",
+        cls.__name__,
+        ", ".join(f"'{name}'" for name in degraded),
+    )
+
+
 def _make_fallback_structure_fn(cls: type) -> Any:
     """Fallback structure for dataclasses where get_type_hints() fails."""
 
     def structure_fn(data: dict[str, Any], _cls: type = cls) -> Any:
         init_fields = {f.name for f in dc_fields(_cls) if f.init}
         filtered = {k: v for k, v in data.items() if k in init_fields}
+        _report_unstructured_fields(_cls, filtered)
         return _cls(**filtered)
 
     return structure_fn
@@ -196,7 +282,11 @@ def _make_dataclass_structure_fn(cls: type) -> Any:
             if not f.init:
                 overrides[f.name] = override(omit=True)
         return make_dict_structure_fn(cls, converter, **overrides)
-    except NameError:
+    except NameError as err:
+        # Reported when a payload actually arrives with an unstructured field, not here: most
+        # classes reaching this branch do so over an alias of a builtin and degrade in no way.
+        # See _report_unstructured_fields.
+        logger.debug("Falling back to field-iteration structuring for '%s': %s", cls.__name__, err)
         return _make_fallback_structure_fn(cls)
 
 

--- a/src/griptape_nodes/retained_mode/events/resource_events.py
+++ b/src/griptape_nodes/retained_mode/events/resource_events.py
@@ -309,16 +309,11 @@ class GetExecutionDeviceRequest(RequestPayload):
         preferred: Optional device to use if the machine has it, e.g. a user or config pin. When
             it is unavailable the answer falls back to the normal preference order rather than
             failing, so a workflow authored on one machine still runs on another.
-        required_by_library: Optional library name whose declared compute requirement narrows the
-            choice, so "needs cuda" and "run on cuda" stop being two statements kept in sync by
-            hand.
-
     Results: GetExecutionDeviceResultSuccess (with the device and what is available) |
         GetExecutionDeviceResultFailure (compute resources could not be read)
     """
 
     preferred: str | None = None
-    required_by_library: str | None = None
 
 
 @dataclass
@@ -328,7 +323,8 @@ class GetExecutionDeviceResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSucc
 
     Args:
         device: The chosen backend: "cuda", "mps" or "cpu".
-        available: Every backend detected on this machine, most capable first.
+        available: Every backend detected on this machine, in detection order -- cpu first,
+            then any accelerator. NOT ranked; use `device` for what to run on.
         honored_preference: Whether `preferred` was available and used.
     """
 

--- a/src/griptape_nodes/retained_mode/events/resource_events.py
+++ b/src/griptape_nodes/retained_mode/events/resource_events.py
@@ -289,3 +289,55 @@ class ListResourceInstancesByTypeResultSuccess(WorkflowNotAlteredMixin, ResultPa
 @PayloadRegistry.register
 class ListResourceInstancesByTypeResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     """Resource instances by type listing failed. Common causes: invalid resource type."""
+
+
+# Get Execution Device Events
+@dataclass
+@PayloadRegistry.register
+class GetExecutionDeviceRequest(RequestPayload):
+    """Ask which compute device a node should run on.
+
+    Use when: A node needs a device to place a model or tensor on, and does not want to import a
+    heavy framework to find out. Every library that wraps a model currently imports torch purely
+    to call `torch.cuda.is_available()`, which drags an execution-time dependency into whatever
+    process asks the question -- including the one that only edits.
+
+    The engine already knows: OSManager detects the machine's backends without torch (nvidia-smi
+    for CUDA, a platform check for MPS) and registers them as a compute resource.
+
+    Args:
+        preferred: Optional device to use if the machine has it, e.g. a user or config pin. When
+            it is unavailable the answer falls back to the normal preference order rather than
+            failing, so a workflow authored on one machine still runs on another.
+        required_by_library: Optional library name whose declared compute requirement narrows the
+            choice, so "needs cuda" and "run on cuda" stop being two statements kept in sync by
+            hand.
+
+    Results: GetExecutionDeviceResultSuccess (with the device and what is available) |
+        GetExecutionDeviceResultFailure (compute resources could not be read)
+    """
+
+    preferred: str | None = None
+    required_by_library: str | None = None
+
+
+@dataclass
+@PayloadRegistry.register
+class GetExecutionDeviceResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """The device to run on, and the backends this machine actually has.
+
+    Args:
+        device: The chosen backend: "cuda", "mps" or "cpu".
+        available: Every backend detected on this machine, most capable first.
+        honored_preference: Whether `preferred` was available and used.
+    """
+
+    device: str
+    available: list[str]
+    honored_preference: bool = False
+
+
+@dataclass
+@PayloadRegistry.register
+class GetExecutionDeviceResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """The device could not be determined. Common cause: no compute resource instance registered."""

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -96,9 +96,10 @@ def _forbid_manager_during_worker_execution(manager_name: str, request_hint: str
     if not engine.event_manager.in_node_execution():
         return
     msg = (
-        f"Attempted to use {manager_name} while running in an isolated library process, where "
-        f"it holds no authoritative state. Use GriptapeNodes.handle_request({request_hint}) "
-        f"instead, which asks the main engine and returns the real value."
+        f"Attempted to use {manager_name} while running in an isolated library process, whose "
+        f"copy of that state is not the source of truth. Use "
+        f"GriptapeNodes.handle_request({request_hint}) instead: requests made while a node is "
+        f"executing are answered by the main engine, so the value is always the real one."
     )
     raise RuntimeError(msg)
 

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -249,9 +249,8 @@ class GriptapeNodes(metaclass=_EngineRootMeta):
 
     @classmethod
     def StaticFilesManager(cls) -> StaticFilesManager:
-        # Deliberately unguarded: a worker shares the workspace on disk and serves static
-        # files through the orchestrator's server URL, so its StaticFilesManager is real and
-        # its answers are correct. This is a decided exception, not an oversight.
+        # Unguarded: a worker shares the workspace on disk and serves static files through the
+        # orchestrator's server URL, so its StaticFilesManager answers correctly.
         return current_engine().static_files_manager
 
     @classmethod

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -79,6 +79,30 @@ class _EngineRootMeta(type):
         return current_engine()
 
 
+def _forbid_manager_during_worker_execution(manager_name: str, request_hint: str) -> None:
+    """Raise when node code reaches for a manager while executing in a worker process.
+
+    A worker holds no authoritative state: config, secrets, and the filesystem all belong to
+    the orchestrator, and reads that look local would be answered by a process that is not
+    the source of truth. Node code gets there with ``GriptapeNodes.handle_request(...)``,
+    which forwards to the orchestrator, so the value is always the real one.
+
+    Scoped to node execution deliberately: engine boot and library load run in the worker
+    too, and they legitimately need their own managers.
+    """
+    engine = current_engine()
+    if not engine.library_manager.is_worker:
+        return
+    if not engine.event_manager.in_node_execution():
+        return
+    msg = (
+        f"Attempted to use {manager_name} while running in an isolated library process, where "
+        f"it holds no authoritative state. Use GriptapeNodes.handle_request({request_hint}) "
+        f"instead, which asks the main engine and returns the real value."
+    )
+    raise RuntimeError(msg)
+
+
 class GriptapeNodes(metaclass=_EngineRootMeta):
     """Static accessors for the current engine's managers and request handlers."""
 
@@ -157,14 +181,17 @@ class GriptapeNodes(metaclass=_EngineRootMeta):
 
     @classmethod
     def ConfigManager(cls) -> ConfigManager:
+        _forbid_manager_during_worker_execution("ConfigManager", "GetConfigValueRequest(...)")
         return current_engine().config_manager
 
     @classmethod
     def OSManager(cls) -> OSManager:
+        _forbid_manager_during_worker_execution("OSManager", "ReadFileRequest(...) / WriteFileRequest(...)")
         return current_engine().os_manager
 
     @classmethod
     def SecretsManager(cls) -> SecretsManager:
+        _forbid_manager_during_worker_execution("SecretsManager", "GetSecretValueRequest(...)")
         return current_engine().secrets_manager
 
     @classmethod

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -89,6 +89,18 @@ def _forbid_manager_during_worker_execution(manager_name: str, request_hint: str
 
     Scoped to node execution deliberately: engine boot and library load run in the worker
     too, and they legitimately need their own managers.
+
+    Adding a manager here is only safe once EVERY engine-internal path to it is off the facade.
+    The guard cannot tell library code from engine code -- both arrive as the same classmethod --
+    so a manager still reached internally through the facade raises on the engine's own plumbing
+    rather than on the node author it is meant to teach. That is not hypothetical: the storage
+    driver read the workspace path this way, which made a worker unable to write a single file.
+
+    Every manager accessor carries this guard except StaticFilesManager, which is a decided
+    exception: a worker shares the workspace on disk, so its static-file answers are real.
+    Everything else either answers from worker state that can diverge from the orchestrator's
+    (silently wrong, which is worse than an error) or is orchestrator bookkeeping a node has
+    no business touching mid-execution.
     """
     engine = current_engine()
     if not engine.library_manager.is_worker:
@@ -142,42 +154,67 @@ class GriptapeNodes(metaclass=_EngineRootMeta):
 
     @classmethod
     def EventManager(cls) -> EventManager:
+        _forbid_manager_during_worker_execution(
+            "EventManager",
+            "your node's own APIs (append_value_to_parameter, publish_update_to_parameter), whose events forward on their own",
+        )
         return current_engine().event_manager
 
     @classmethod
     def LibraryManager(cls) -> LibraryManager:
+        _forbid_manager_during_worker_execution(
+            "LibraryManager", "ListRegisteredLibrariesRequest(...) / GetNodeMetadataFromLibraryRequest(...)"
+        )
         return current_engine().library_manager
 
     @classmethod
     def ModelManager(cls) -> ModelManager:
+        _forbid_manager_during_worker_execution("ModelManager", "ListModelDownloadsRequest(...)")
         return current_engine().model_manager
 
     @classmethod
     def AccessManager(cls) -> AccessManager:
+        _forbid_manager_during_worker_execution("AccessManager", "QueryModelAccessForNodeRequest(...)")
         return current_engine().access_manager
 
     @classmethod
     def ObjectManager(cls) -> ObjectManager:
+        _forbid_manager_during_worker_execution(
+            "ObjectManager", "a request against the orchestrator's graph (e.g., RenameObjectRequest(...))"
+        )
         return current_engine().object_manager
 
     @classmethod
     def FlowManager(cls) -> FlowManager:
+        _forbid_manager_during_worker_execution(
+            "FlowManager", "flow requests (e.g., ListNodesInFlowRequest(...), ListConnectionsForNodeRequest(...))"
+        )
         return current_engine().flow_manager
 
     @classmethod
     def NodeManager(cls) -> NodeManager:
+        _forbid_manager_during_worker_execution(
+            "NodeManager", "node requests (e.g., GetNodeResolutionStateRequest(...), AddParameterToNodeRequest(...))"
+        )
         return current_engine().node_manager
 
     @classmethod
     def ContextManager(cls) -> ContextManager:
+        _forbid_manager_during_worker_execution(
+            "ContextManager", "GetCurrentProjectRequest(...) for the project; flow context belongs to the orchestrator"
+        )
         return current_engine().context_manager
 
     @classmethod
     def WorkflowManager(cls) -> WorkflowManager:
+        _forbid_manager_during_worker_execution(
+            "WorkflowManager", "workflow requests (e.g., ListWorkflowsRequest(...))"
+        )
         return current_engine().workflow_manager
 
     @classmethod
     def ArbitraryCodeExecManager(cls) -> ArbitraryCodeExecManager:
+        _forbid_manager_during_worker_execution("ArbitraryCodeExecManager", "RunArbitraryPythonStringRequest(...)")
         return current_engine().arbitrary_code_exec_manager
 
     @classmethod
@@ -187,7 +224,15 @@ class GriptapeNodes(metaclass=_EngineRootMeta):
 
     @classmethod
     def OSManager(cls) -> OSManager:
-        _forbid_manager_during_worker_execution("OSManager", "ReadFileRequest(...) / WriteFileRequest(...)")
+        # Files are the exception to the reason this guard exists: a worker shares the workspace
+        # on disk, so its own answer is right, and ReadFileRequest / WriteFileRequest are
+        # answered locally rather than forwarded. Going through the request still matters --
+        # paths get canonicalized and the OS boundary's policies apply -- so the guard stays,
+        # but it must not claim the orchestrator is what makes the value correct.
+        _forbid_manager_during_worker_execution(
+            "OSManager",
+            "ReadFileRequest(...) / WriteFileRequest(...), which canonicalize the path and apply the write policy",
+        )
         return current_engine().os_manager
 
     @classmethod
@@ -197,60 +242,95 @@ class GriptapeNodes(metaclass=_EngineRootMeta):
 
     @classmethod
     def OperationDepthManager(cls) -> OperationDepthManager:
+        _forbid_manager_during_worker_execution(
+            "OperationDepthManager", "nothing: operation depth is orchestrator bookkeeping with no node-facing request"
+        )
         return current_engine().operation_depth_manager
 
     @classmethod
     def StaticFilesManager(cls) -> StaticFilesManager:
+        # Deliberately unguarded: a worker shares the workspace on disk and serves static
+        # files through the orchestrator's server URL, so its StaticFilesManager is real and
+        # its answers are correct. This is a decided exception, not an oversight.
         return current_engine().static_files_manager
 
     @classmethod
     def AgentManager(cls) -> AgentManager:
+        _forbid_manager_during_worker_execution("AgentManager", "agent requests (e.g., RunAgentRequest(...))")
         return current_engine().agent_manager
 
     @classmethod
     def VersionCompatibilityManager(cls) -> VersionCompatibilityManager:
+        _forbid_manager_during_worker_execution("VersionCompatibilityManager", "GetEngineVersionRequest(...)")
         return current_engine().version_compatibility_manager
 
     @classmethod
     def SessionManager(cls) -> SessionManager:
+        _forbid_manager_during_worker_execution(
+            "SessionManager", "session state belongs to the orchestrator; there is no node-facing request"
+        )
         return current_engine().session_manager
 
     @classmethod
     def MCPManager(cls) -> MCPManager:
+        _forbid_manager_during_worker_execution("MCPManager", "MCP requests (e.g., ListMCPServersRequest(...))")
         return current_engine().mcp_manager
 
     @classmethod
     def EngineIdentityManager(cls) -> EngineIdentityManager:
+        _forbid_manager_during_worker_execution("EngineIdentityManager", "GetEngineNameRequest(...)")
         return current_engine().engine_identity_manager
 
     @classmethod
     def ResourceManager(cls) -> ResourceManager:
+        _forbid_manager_during_worker_execution(
+            "ResourceManager", "resource requests (e.g., ListResourcesRequest(...))"
+        )
         return current_engine().resource_manager
 
     @classmethod
     def SyncManager(cls) -> SyncManager:
+        _forbid_manager_during_worker_execution(
+            "SyncManager", "sync state belongs to the orchestrator; there is no node-facing request"
+        )
         return current_engine().sync_manager
 
     @classmethod
     def VariablesManager(cls) -> VariablesManager:
+        _forbid_manager_during_worker_execution(
+            "VariablesManager",
+            "variable requests (e.g., GetVariableRequest(...)); {VAR} macros resolve before process() runs",
+        )
         return current_engine().variables_manager
 
     @classmethod
     def UserManager(cls) -> UserManager:
+        _forbid_manager_during_worker_execution("UserManager", "user requests (e.g., GetUserRequest(...))")
         return current_engine().user_manager
 
     @classmethod
     def ProjectManager(cls) -> ProjectManager:
+        _forbid_manager_during_worker_execution(
+            "ProjectManager",
+            "project requests (e.g., GetCurrentProjectRequest(...)), which answer locally and correctly",
+        )
         return current_engine().project_manager
 
     @classmethod
     def ArtifactManager(cls) -> ArtifactManager:
+        _forbid_manager_during_worker_execution(
+            "ArtifactManager", "artifact requests (e.g., ExtractArtifactMetadataRequest(...)), which answer locally"
+        )
         return current_engine().artifact_manager
 
     @classmethod
     def ManifestManager(cls) -> ManifestManager:
+        _forbid_manager_during_worker_execution("ManifestManager", "manifest requests, answered by the orchestrator")
         return current_engine().manifest_manager
 
     @classmethod
     def WorkerManager(cls) -> WorkerManager:
+        _forbid_manager_during_worker_execution(
+            "WorkerManager", "nothing: worker lifecycle belongs to the orchestrator"
+        )
         return current_engine().worker_manager

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -939,6 +939,15 @@ class EventManager(EngineScoped):
         """Return the currently-registered handler callback for a request type, or None."""
         return self._request_type_to_manager.get(request_type)
 
+    def registered_request_types(self) -> list[type[RequestPayload]]:
+        """Every request type that currently has a handler.
+
+        A worker uses this to route requests made during node execution to the orchestrator
+        by default, rather than maintaining a list of types to forward that silently goes
+        stale whenever a new request type is added.
+        """
+        return list(self._request_type_to_manager.keys())
+
     async def forward_to_orchestrator(
         self,
         request: RP,

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -802,26 +802,29 @@ class LibraryManager(EngineScoped):
         """
         if library_name:
             library_info = self.get_library_info_by_library_name(library_name)
+            # Checked ahead of the worker lookup because execution can be unavailable for
+            # reasons that have nothing to do with a worker -- a declared resource this machine
+            # does not have -- and those apply to an in-process library too, which never reaches
+            # the branch below.
+            if library_info and library_info.execution_unavailable_reason:
+                msg = (
+                    f"Library '{library_name}' cannot run right now: "
+                    f"{library_info.execution_unavailable_reason} Editing its nodes still works, "
+                    "and a saved workflow keeps them."
+                )
+                raise RuntimeError(msg)
             if library_info and library_info.executes_in_worker:
                 wm = self._worker_manager
                 if wm:
                     worker = wm.get_worker_for_key(library_name)
                     if worker:
                         return worker
-                    # Distinguish "not ready yet" from "went away", which read identically
-                    # before: a library whose worker had been evicted reported that it might
-                    # still be starting up, forever.
-                    if library_info.execution_unavailable_reason:
-                        msg = (
-                            f"Library '{library_name}' cannot run right now: "
-                            f"{library_info.execution_unavailable_reason} Editing its nodes still "
-                            "works, and a saved workflow keeps them."
-                        )
-                    else:
-                        msg = (
-                            f"Library '{library_name}' requires a dedicated worker process "
-                            "that is not yet registered. The worker may still be starting up."
-                        )
+                    # A reason set on the library was already reported above, so reaching here
+                    # means there is none: the worker genuinely has not registered yet.
+                    msg = (
+                        f"Library '{library_name}' requires a dedicated worker process "
+                        "that is not yet registered. The worker may still be starting up."
+                    )
                     raise RuntimeError(msg)
                 msg = (
                     f"Library '{library_name}' requires a dedicated worker process. "
@@ -2469,12 +2472,19 @@ class LibraryManager(EngineScoped):
                             library_requirements, library_data.name
                         )
                         if requirements_check_result is not None:
-                            library_info.fitness = LibraryManager.LibraryFitness.UNUSABLE
+                            # A declared resource this machine does not have costs EXECUTION, not
+                            # loading. Nothing about a missing GPU stops the orchestrator importing
+                            # base-clean node modules, drawing their parameters, or saving a
+                            # workflow that uses them -- and refusing to register took all of that
+                            # away, leaving placeholder nodes reading "Library not found" on every
+                            # machine that was only ever going to edit. It is the same rule the
+                            # engine applies to a dependency that will not install: the capability
+                            # gates the run, and the artist finds out when they run.
+                            library_info.fitness = LibraryManager.LibraryFitness.FLAWED
                             library_info.problems.append(requirements_check_result)
-                            library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.FAILURE
-                            self._library_file_path_to_info[library_info.library_path] = library_info
-                            details = f"Library '{library_data.name}' requirements not met: {library_requirements}"
-                            return RegisterLibraryFromFileResultFailure(result_details=details)
+                            library_info.execution_unavailable_reason = self._describe_unmet_requirements(
+                                requirements_check_result
+                            )
 
                     library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.EVALUATED
 
@@ -2983,6 +2993,31 @@ class LibraryManager(EngineScoped):
         logger.debug("Created virtual environment at %s", library_venv_path)
 
         return LibraryVenvInitResult(python_path=venv_python_path(library_venv_path), reused=False)
+
+    @staticmethod
+    def _describe_unmet_requirements(problem: IncompatibleRequirementsProblem) -> str:
+        """Phrase an unmet resource requirement for whoever has to act on it.
+
+        The raw dicts read like internals ("{'compute': (['cuda'], 'has_any')}"), so the
+        capability and what this machine actually reports are named plainly instead.
+        """
+
+        def render(value: Any) -> str:
+            # Capability values arrive as enums and nested tuples; their reprs
+            # ("<ComputeBackend.MPS: 'mps'>") have no business in a message an artist reads.
+            if isinstance(value, (list, tuple)):
+                return ", ".join(render(item) for item in value)
+            return str(getattr(value, "value", value))
+
+        wanted = ", ".join(
+            f"{capability} {render(value[0] if isinstance(value, (list, tuple)) else value)}"
+            for capability, value in problem.requirements.items()
+        )
+        have = (
+            ", ".join(f"{key} {render(value)}" for key, value in problem.system_capabilities.items())
+            or "nothing detectable"
+        )
+        return f"it needs {wanted}, and this machine has {have}."
 
     def _check_library_requirements(
         self, requirements: dict[str, Any], library_name: str

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -506,9 +506,6 @@ class LibraryManager(EngineScoped):
         # orchestrator never learns it -- the worker reports that itself when a run is attempted.
         # None means nothing is known to be wrong.
         execution_unavailable_reason: str | None = None
-        # Resources the library says it runs BETTER with and this machine lacks. Informational
-        # only: it never blocks loading or execution. None means nothing is known to be missing.
-        unmet_preferences: str | None = None
         # Declared execution modules, imported and keyed by their file stem. Populated only in a
         # worker: the orchestrator deliberately never imports these, so it holds an empty dict
         # and `get_execution_module` refuses there.
@@ -2510,25 +2507,6 @@ class LibraryManager(EngineScoped):
                         if library_data.metadata.resources is not None
                         else None
                     )
-                    preferred_requirements = (
-                        library_data.metadata.resources.preferred
-                        if library_data.metadata.resources is not None
-                        else None
-                    )
-                    if preferred_requirements is not None:
-                        # A preference is not a gate. It is recorded so the settings panel can
-                        # say "this runs better with a GPU" and so a slow run has an explanation,
-                        # and then execution proceeds either way.
-                        preferred_check = self._check_library_requirements(
-                            preferred_requirements, library_data.name, tier="preferred"
-                        )
-                        if preferred_check is not None:
-                            library_info.unmet_preferences = self._describe_unmet_requirements(preferred_check)
-                            logger.info(
-                                "Library '%s' runs better with resources this machine does not have: %s",
-                                library_data.name,
-                                library_info.unmet_preferences,
-                            )
                     if library_requirements is not None:
                         requirements_check_result = self._check_library_requirements(
                             library_requirements, library_data.name
@@ -3082,15 +3060,13 @@ class LibraryManager(EngineScoped):
         return f"it needs {wanted}, and this machine has {have}."
 
     def _check_library_requirements(
-        self, requirements: dict[str, Any], library_name: str, *, tier: str = "required"
+        self, requirements: dict[str, Any], library_name: str
     ) -> IncompatibleRequirementsProblem | None:
         """Check if the current system meets the library's resource requirements.
 
         Args:
             requirements: Dictionary of requirements in the format used by resource_instance.Requirements
             library_name: Name of the library being checked (for logging)
-            tier: Which declaration is being checked, "required" or "preferred". Only affects how
-                loudly an unmet result is logged: a preference is information, not a problem.
 
         Returns:
             IncompatibleRequirementsProblem if requirements are not met, None if they are met
@@ -3113,11 +3089,9 @@ class LibraryManager(EngineScoped):
 
             if isinstance(result, ListCompatibleResourceInstancesResultSuccess) and not result.instance_ids:
                 system_capabilities = self._get_system_capabilities()
-                logger.log(
-                    logging.WARNING if tier == "required" else logging.INFO,
-                    "Library '%s' %s OS resources not met. Wanted: %s, System: %s",
+                logger.warning(
+                    "Library '%s' required OS resources not met. Wanted: %s, System: %s",
                     library_name,
-                    tier,
                     os_requirements,
                     system_capabilities,
                 )
@@ -3136,11 +3110,9 @@ class LibraryManager(EngineScoped):
 
             if isinstance(result, ListCompatibleResourceInstancesResultSuccess) and not result.instance_ids:
                 system_capabilities = self._get_system_capabilities()
-                logger.log(
-                    logging.WARNING if tier == "required" else logging.INFO,
-                    "Library '%s' %s compute resources not met. Wanted: %s, System: %s",
+                logger.warning(
+                    "Library '%s' required compute resources not met. Wanted: %s, System: %s",
                     library_name,
-                    tier,
                     compute_requirements,
                     system_capabilities,
                 )
@@ -5251,7 +5223,14 @@ class LibraryManager(EngineScoped):
             raise RuntimeError(msg)
 
         target = self._model_asset_path(library_name, asset_id, asset)
-        if target.exists() and any(target.iterdir()):
+        # A marker written only after a fetch succeeds, rather than "the directory has something in
+        # it". The directory is created before the download starts, so an interrupted fetch -- a
+        # dropped connection, a cancelled run, a rate limit part-way through a repo -- leaves
+        # partial weights behind. Treating those as present handed back a truncated model from every
+        # later call, failing in a way that points at the model rather than the cache, with nothing
+        # but manual deletion to recover.
+        complete_marker = target / ".griptape-nodes-complete"
+        if complete_marker.exists():
             logger.debug("Model asset '%s' for library '%s' is already present at %s", asset_id, library_name, target)
             return target
 
@@ -5289,6 +5268,7 @@ class LibraryManager(EngineScoped):
             # isinstance here discriminates a result payload, the engine's universal idiom; the
             # failure is a fetch failure, not a type error.
             raise RuntimeError(msg)  # noqa: TRY004
+        complete_marker.touch()
         return target
 
     @staticmethod

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -501,6 +501,13 @@ class LibraryManager(EngineScoped):
         # orchestrator never learns it -- the worker reports that itself when a run is attempted.
         # None means nothing is known to be wrong.
         execution_unavailable_reason: str | None = None
+        # Declared execution modules, imported and keyed by their file stem. Populated only in a
+        # worker: the orchestrator deliberately never imports these, so it holds an empty dict
+        # and `get_execution_module` refuses there.
+        execution_modules: dict[str, ModuleType] = field(default_factory=dict)
+        # Resolved absolute paths of the declared execution modules, kept so the boundary check
+        # can run from the module loader, which fires lazily and has no access to the schema.
+        declared_execution_module_paths: set[Path] = field(default_factory=set)
         # The path string the user wrote in `libraries_to_register` before workspace
         # resolution / `~`-expansion / symlink-following. Surfaced to the GUI so the
         # settings panel can match library metadata back to its config row using the
@@ -3799,8 +3806,24 @@ class LibraryManager(EngineScoped):
         def load_module() -> ModuleType:
             module = cache.get("module")
             if module is None:
-                module = self._load_module_from_file(node_file_path, library_name)
+                # Checked around the import, the only moment a boundary violation is observable:
+                # node modules can load lazily, long after the library finished registering.
+                #
+                # Both outcomes matter. If the execution module imports cleanly the violation is
+                # SILENT, and the diff of sys.modules is the only evidence. If it does not -- the
+                # usual case, since its dependencies are absent here by design -- the node module
+                # fails with a bare ImportError naming a module the author did not write, and the
+                # traceback is where the evidence lives.
+                modules_before = set(sys.modules)
+                try:
+                    module = self._load_module_from_file(node_file_path, library_name)
+                except Exception as exc:
+                    self._check_execution_module_boundary(
+                        library_name, node_file_path, set(sys.modules) - modules_before, exc=exc
+                    )
+                    raise
                 cache["module"] = module
+                self._check_execution_module_boundary(library_name, node_file_path, set(sys.modules) - modules_before)
             return module
 
         return load_module
@@ -4988,6 +5011,182 @@ class LibraryManager(EngineScoped):
             library_info.problems.append(library_problem)
         return True
 
+    def _resolve_execution_module_paths(self, library_data: LibrarySchema, base_dir: Path) -> list[Path]:
+        """Expand the declared execution-module paths; a directory means every .py beneath it."""
+        resolved: list[Path] = []
+        for declared in library_data.execution_modules or []:
+            target = base_dir / declared
+            if target.is_dir():
+                resolved.extend(sorted(f for f in target.rglob("*.py") if f.name != "__init__.py"))
+            elif target.exists():
+                resolved.append(target)
+            else:
+                logger.warning(
+                    "Library '%s' declares execution module '%s', which does not exist at %s.",
+                    library_data.name,
+                    declared,
+                    target,
+                )
+        return resolved
+
+    def _load_execution_modules(self, library_data: LibrarySchema, base_dir: Path, library_info: LibraryInfo) -> None:
+        """Import a library's execution modules -- in a worker, and only there.
+
+        These modules exist so heavy imports have a home. They may import anything at module
+        scope, and the orchestrator's contract is that it never imports them: that is what keeps a
+        library's execution dependencies off the editing process's import path, without asking the
+        author to scatter deferred imports through node code and remember never to add one back.
+
+        A failure here does not fail the library. The nodes still load and stay editable; what is
+        lost is the ability to run them, recorded as the reason so the refusal can say why.
+        """
+        paths = self._resolve_execution_module_paths(library_data, base_dir)
+        library_info.declared_execution_module_paths = {path.resolve() for path in paths}
+        if not paths:
+            return
+        if not self._is_worker:
+            logger.debug(
+                "Library '%s' declares %d execution module(s); not importing them here, because "
+                "this process only edits.",
+                library_data.name,
+                len(paths),
+            )
+            return
+
+        for path in paths:
+            try:
+                module = self._load_module_from_file(path, library_data.name)
+            except Exception as exc:
+                library_info.execution_unavailable_reason = (
+                    f"its execution module '{path.name}' could not be imported ({exc})."
+                )
+                logger.exception(
+                    "Library '%s': execution module %s failed to import; the library stays editable but cannot run.",
+                    library_data.name,
+                    path,
+                )
+                return
+            library_info.execution_modules[path.stem] = module
+            logger.debug("Library '%s': imported execution module '%s'", library_data.name, path.stem)
+
+    def _check_execution_module_boundary(
+        self,
+        library_name: str,
+        node_file_path: Path,
+        newly_imported: set[str],
+        *,
+        exc: BaseException | None = None,
+    ) -> None:
+        """Whether importing a node module pulled an execution module in with it.
+
+        Checked by FILE LOCATION rather than by scanning the node module's own import statements.
+        A direct import is the easy case; the one that actually happens is transitive -- two node
+        modules import a shared helper, and the helper imports the heavy dependency. A source scan
+        of the node modules calls them both clean.
+
+        Both outcomes are covered. A clean import of the execution module makes the violation
+        silent, and sys.modules is the evidence. A failed one -- the usual case, because the
+        dependencies are absent here by design -- surfaces as an ImportError naming a module the
+        author did not write, and the traceback is the evidence.
+
+        Records a library problem naming the offending file and both fixes.
+        """
+        library_info = self.get_library_info_by_library_name(library_name)
+        if library_info is None or not library_info.declared_execution_module_paths:
+            return
+
+        offender = self._execution_module_in_traceback(library_info, exc) if exc is not None else None
+        if offender is None:
+            offender = self._execution_module_among(library_info, newly_imported)
+        if offender is None:
+            return
+
+        message = (
+            f"Node module '{node_file_path.name}' imports execution module '{offender.name}', "
+            "directly or through a helper. Execution modules carry this library's execution-time "
+            "dependencies, so importing one here puts them on the editing process's import path -- "
+            "which is what the edit/execution split exists to prevent. Either reach it from "
+            "process() with self.execution_module(...), or move the dependency it needs into "
+            "pip_dependencies if instantiating the node genuinely requires it."
+        )
+        library_info.problems.append(
+            LibraryDependencyProblem(dependency_name="execution module boundary", error_message=message)
+        )
+        if library_info.fitness is LibraryManager.LibraryFitness.GOOD:
+            library_info.fitness = LibraryManager.LibraryFitness.FLAWED
+        logger.error(message)
+
+    @staticmethod
+    def _execution_module_in_traceback(library_info: LibraryInfo, exc: BaseException) -> Path | None:
+        """The execution module a failed import passed through, if any.
+
+        The import raised before the module reached sys.modules, so its frames are the evidence.
+        The whole chain is walked, not just this exception: `_load_module_from_file` re-raises as
+        its own ImportError, so the frames that actually touched the execution module sit on the
+        `__cause__` rather than on what the caller catches.
+        """
+        seen: set[int] = set()
+        current: BaseException | None = exc
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+            tb = current.__traceback__
+            while tb is not None:
+                try:
+                    frame_file = Path(tb.tb_frame.f_code.co_filename).resolve()
+                except (OSError, ValueError):
+                    frame_file = None
+                if frame_file is not None and frame_file in library_info.declared_execution_module_paths:
+                    return frame_file
+                tb = tb.tb_next
+            current = current.__cause__ or current.__context__
+        return None
+
+    @staticmethod
+    def _execution_module_among(library_info: LibraryInfo, module_names: set[str]) -> Path | None:
+        """The execution module that landed in sys.modules, if any -- the silent-success case."""
+        for module_name in module_names:
+            module = sys.modules.get(module_name)
+            module_file = getattr(module, "__file__", None)
+            if not module_file:
+                continue
+            try:
+                resolved = Path(module_file).resolve()
+            except (OSError, ValueError):
+                continue
+            if resolved in library_info.declared_execution_module_paths:
+                return resolved
+        return None
+
+    def get_execution_module(self, library_name: str, module_name: str) -> ModuleType:
+        """Return one of a library's execution modules, or explain why it is not available here.
+
+        The sanctioned way node code reaches execution-only code. A lookup rather than an import,
+        because the worker already imported it at library load; the orchestrator never did, and
+        says so rather than raising ImportError from a stack the node author did not write.
+        """
+        library_info = self.get_library_info_by_library_name(library_name)
+        if library_info is None:
+            msg = f"No library named '{library_name}' is registered, so its execution modules cannot be reached."
+            raise RuntimeError(msg)
+        if not self._is_worker:
+            msg = (
+                f"Execution module '{module_name}' of library '{library_name}' is not available in "
+                "this process. Execution modules are imported only where nodes execute, because "
+                "they carry the library's execution-time dependencies. Reach them from process(), "
+                "which runs there."
+            )
+            raise RuntimeError(msg)
+        module = library_info.execution_modules.get(module_name)
+        if module is None:
+            available = ", ".join(sorted(library_info.execution_modules)) or "none"
+            msg = (
+                f"Library '{library_name}' has no execution module named '{module_name}'. "
+                f"Declared and imported: {available}. Names come from the file stem of each entry "
+                "in the manifest's execution_modules."
+            )
+            raise RuntimeError(msg)
+        return module
+
     def _attempt_load_nodes_from_library(  # noqa: PLR0912, PLR0915, C901
         self,
         library_data: LibrarySchema,
@@ -5009,6 +5208,11 @@ class LibraryManager(EngineScoped):
                 with a deferred loader and their modules are imported on first use instead.
         """
         any_nodes_loaded_successfully = False
+
+        # Execution modules first: a worker that cannot import them cannot run this library's
+        # nodes, and finding that out now -- at library load, with the failure attached to the
+        # library -- beats finding out on the first execution of some node deep in a graph.
+        self._load_execution_modules(library_data, base_dir, library_info)
 
         # Check if library is in old XDG location
         old_xdg_libraries_path = xdg_data_home() / "griptape_nodes" / "libraries"
@@ -5065,7 +5269,6 @@ class LibraryManager(EngineScoped):
                 node_registered = self._register_node_eager(
                     node_definition, node_file_path, library, library_info, module_loaders
                 )
-
             if node_registered:
                 any_nodes_loaded_successfully = True
 

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -5194,10 +5194,12 @@ class LibraryManager(EngineScoped):
     def get_model_asset(self, library_name: str, asset_id: str) -> Path:
         """Return the local directory holding a declared model asset, fetching it if needed.
 
-        Weights are not dependencies, and they are not a library-load concern either. This resolves
-        on demand, in whichever process asks -- which is the one about to run the model -- and
-        caches under an engine-owned root so two libraries wanting the same revision share it and
-        neither has to invent a location.
+        Weights are not dependencies, and they are not a library-load concern either. Resolved on
+        demand and cached under an engine-owned root, so no library has to invent a location.
+
+        The fetch itself is a request, so a worker asking mid-execution has the ORCHESTRATOR
+        download it; only the completion marker is written by the caller. That holds together
+        because both processes share the cache root, and stops holding the moment they do not.
 
         Raises:
             RuntimeError: If the library is unknown, declares no asset by that id, or the fetch

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -5044,10 +5044,15 @@ class LibraryManager(EngineScoped):
         library_info.declared_execution_module_paths = {path.resolve() for path in paths}
         if not paths:
             return
-        if not self._is_worker:
+        # Gated on running THIS library's nodes, not merely on being a worker. A worker also loads
+        # the libraries its own library declares as dependencies, and those get no execution
+        # environment of their own here -- so importing their execution modules would either fail
+        # with a traceback for a perfectly healthy library, or succeed by resolving against this
+        # library's pins, silently binding someone else's heavy imports to them.
+        if not (self._is_worker and self._is_one_of_my_target_libraries(library_data.name)):
             logger.debug(
                 "Library '%s' declares %d execution module(s); not importing them here, because "
-                "this process only edits.",
+                "this process does not run that library's nodes.",
                 library_data.name,
                 len(paths),
             )
@@ -5178,6 +5183,17 @@ class LibraryManager(EngineScoped):
             raise RuntimeError(msg)
         module = library_info.execution_modules.get(module_name)
         if module is None:
+            # An import failure during library load recorded WHY and then stopped importing the
+            # rest, so the "no module by that name" wording below sends the author hunting for a
+            # manifest typo when the real cause is an exception the worker already logged. The
+            # reason is worker-local, so this is the only place it can reach whoever called.
+            if library_info.execution_unavailable_reason:
+                msg = (
+                    f"Execution module '{module_name}' of library '{library_name}' is not "
+                    f"available: {library_info.execution_unavailable_reason} The full traceback is "
+                    "in this worker's log."
+                )
+                raise RuntimeError(msg)
             available = ", ".join(sorted(library_info.execution_modules)) or "none"
             msg = (
                 f"Library '{library_name}' has no execution module named '{module_name}'. "

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -2959,28 +2959,43 @@ class LibraryManager(EngineScoped):
 
         return capabilities
 
-    def _get_library_venv_path(self, library_name: str, library_file_path: str | None = None) -> Path:
-        """Get the path to the virtual environment directory for a library.
+    def _get_library_venv_path(
+        self, library_name: str, library_file_path: str | None = None, *, execution: bool = False
+    ) -> Path:
+        """Get the path to a virtual environment directory for a library.
+
+        A library has up to two environments. The edit-time environment (``.venv``) holds the
+        dependencies needed to import and instantiate nodes, and is the one a developer's
+        ``uv sync`` already produces, so it is deliberately left at the conventional name. The
+        execution environment (``.venv-exec``) holds the heavy dependencies only ``process``
+        needs and is put on ``sys.path`` solely where nodes execute.
 
         Args:
             library_name: Name of the library
             library_file_path: Optional path to the library JSON file
+            execution: Whether to return the execution environment instead of the edit-time one
 
         Returns:
             Path to the virtual environment directory
         """
+        venv_dir_name = ".venv-exec" if execution else ".venv"
         clean_library_name = library_name.replace(" ", "_").strip()
 
         if library_file_path is not None:
             # Create venv relative to the library.json file
             library_dir = Path(library_file_path).parent.absolute()
-            return library_dir / ".venv"
+            return library_dir / venv_dir_name
 
         # Create venv relative to the xdg data home
-        return xdg_data_home() / "griptape_nodes" / "libraries" / clean_library_name / ".venv"
+        return xdg_data_home() / "griptape_nodes" / "libraries" / clean_library_name / venv_dir_name
 
     async def _add_library_paths_to_sys_path(self, library_name: str, library_file_path: str, base_dir: Path) -> None:
         """Add a library's directory and venv site-packages to sys.path.
+
+        The edit-time environment is added everywhere, because importing node modules and
+        instantiating nodes needs it. The execution environment is added only in a worker
+        process: the orchestrator must never have a library's heavy dependencies on its import
+        path, since keeping them out is what stops one library's pins from shadowing another's.
 
         Args:
             library_name: Name of the library (for venv lookup)
@@ -2989,18 +3004,30 @@ class LibraryManager(EngineScoped):
         """
         sys.path.insert(0, str(base_dir))
 
-        venv_path = self._get_library_venv_path(library_name, library_file_path)
-        if await anyio.Path(venv_path).exists():
-            site_packages = str(
-                Path(
-                    sysconfig.get_path(
-                        "purelib",
-                        vars={"base": str(venv_path), "platbase": str(venv_path)},
-                    )
+        await self._add_library_venv_to_sys_path(library_name, library_file_path, execution=False)
+
+        if self._is_worker:
+            await self._add_library_venv_to_sys_path(library_name, library_file_path, execution=True)
+
+    async def _add_library_venv_to_sys_path(
+        self, library_name: str, library_file_path: str, *, execution: bool
+    ) -> None:
+        """Add one of a library's venv site-packages directories to sys.path, if it exists."""
+        venv_path = self._get_library_venv_path(library_name, library_file_path, execution=execution)
+        if not await anyio.Path(venv_path).exists():
+            return
+
+        site_packages = str(
+            Path(
+                sysconfig.get_path(
+                    "purelib",
+                    vars={"base": str(venv_path), "platbase": str(venv_path)},
                 )
             )
-            sys.path.insert(0, site_packages)
-            logger.debug("Added library '%s' venv to sys.path: %s", library_name, site_packages)
+        )
+        sys.path.insert(0, site_packages)
+        venv_kind = "execution" if execution else "edit-time"
+        logger.debug("Added library '%s' %s venv to sys.path: %s", library_name, venv_kind, site_packages)
 
     def _can_write_to_venv_location(self, venv_python_path: Path) -> bool:
         """Check if we can write to the venv location (either create it or modify existing).
@@ -6855,14 +6882,14 @@ class LibraryManager(EngineScoped):
             result_details=details,
         )
 
-    async def install_library_dependencies_request(self, request: InstallLibraryDependenciesRequest) -> ResultPayload:  # noqa: PLR0911
-        """Install a library's dependencies, recovering from a corrupt reused venv.
+    async def install_library_dependencies_request(self, request: InstallLibraryDependenciesRequest) -> ResultPayload:
+        """Install a library's dependencies into its edit-time and execution environments.
 
-        Advanced library hooks (before_library_nodes_loaded) expect the venv to exist, so the
-        venv is always initialized even when there are no dependencies to install. When the
-        venv is reused from a previous session it may be corrupt (e.g. a dist-info directory
-        missing its METADATA file), which makes uv fail while planning the install; in that
-        case the venv is rebuilt once and the install retried against a clean environment.
+        Edit-time dependencies go into ``.venv``, which is always created even when there is
+        nothing to install, because advanced library hooks (before_library_nodes_loaded) expect
+        it to exist. Execution dependencies go into ``.venv-exec``, which is created only when
+        the library declares any, so a library with no execution dependencies produces exactly
+        the layout it always has.
         """
         library_file_path = request.library_file_path
 
@@ -6879,44 +6906,93 @@ class LibraryManager(EngineScoped):
         library_metadata = library_data.metadata
 
         pip_dependencies = []
+        pip_dependencies_exec = []
         pip_install_flags = []
         if library_metadata.dependencies:
             pip_dependencies = library_metadata.dependencies.pip_dependencies or []
+            pip_dependencies_exec = library_metadata.dependencies.pip_dependencies_exec or []
             pip_install_flags = library_metadata.dependencies.pip_install_flags or []
 
-        # Always initialize the venv, even if there are no dependencies to install.
-        # Advanced library hooks (before_library_nodes_loaded) expect the venv to exist.
-        venv_path = self._get_library_venv_path(library_name, library_file_path)
+        edit_failure = await self._install_dependency_set(
+            library_name=library_name,
+            library_file_path=library_file_path,
+            pip_dependencies=pip_dependencies,
+            pip_install_flags=pip_install_flags,
+            execution=False,
+        )
+        if edit_failure is not None:
+            return InstallLibraryDependenciesResultFailure(result_details=edit_failure)
+
+        exec_failure = await self._install_dependency_set(
+            library_name=library_name,
+            library_file_path=library_file_path,
+            pip_dependencies=pip_dependencies_exec,
+            pip_install_flags=pip_install_flags,
+            execution=True,
+        )
+        if exec_failure is not None:
+            return InstallLibraryDependenciesResultFailure(result_details=exec_failure)
+
+        installed_count = len(pip_dependencies) + len(pip_dependencies_exec)
+        if installed_count == 0:
+            details = f"Library '{library_name}' has no dependencies to install"
+        elif pip_dependencies_exec:
+            details = (
+                f"Installed {len(pip_dependencies)} edit-time and {len(pip_dependencies_exec)} "
+                f"execution dependencies for library '{library_name}'"
+            )
+        else:
+            details = f"Installed {len(pip_dependencies)} dependencies for library '{library_name}'"
+        logger.info(details)
+        return InstallLibraryDependenciesResultSuccess(
+            library_name=library_name, dependencies_installed=installed_count, result_details=details
+        )
+
+    async def _install_dependency_set(  # noqa: PLR0911
+        self,
+        *,
+        library_name: str,
+        library_file_path: str,
+        pip_dependencies: list[str],
+        pip_install_flags: list[str],
+        execution: bool,
+    ) -> str | None:
+        """Install one dependency set into its environment, creating the environment first.
+
+        Returns a user-facing failure detail, or None on success.
+
+        The edit-time environment is created even with nothing to install, because advanced
+        library hooks expect it to exist. The execution environment is skipped entirely when
+        the library declares no execution dependencies, so nothing new appears on disk for the
+        libraries that do not use them.
+        """
+        venv_kind = "execution" if execution else "edit-time"
+        if execution and not pip_dependencies:
+            return None
+
+        venv_path = self._get_library_venv_path(library_name, library_file_path, execution=execution)
 
         try:
             venv_init = await self._init_library_venv(venv_path)
         except RuntimeError as e:
-            details = f"Attempted to prepare the environment for library '{library_name}'. Failed due to: {e}"
-            return InstallLibraryDependenciesResultFailure(result_details=details)
+            return f"Attempted to prepare the {venv_kind} environment for library '{library_name}'. Failed due to: {e}"
         library_venv_python_path = venv_init.python_path
 
         if not self._can_write_to_venv_location(library_venv_python_path):
-            details = f"Attempted to set up the environment for library '{library_name}' at {venv_path}. Failed due to: the location is not writable."
+            details = f"Attempted to set up the {venv_kind} environment for library '{library_name}' at {venv_path}. Failed due to: the location is not writable."
             logger.warning(details)
-            return InstallLibraryDependenciesResultFailure(result_details=details)
+            return details
 
-        # Check disk space
         config_manager = self.engine.config_manager
         min_space_gb = config_manager.get_config_value("minimum_disk_space_gb_libraries")
         if not OSManager.check_available_disk_space(Path(venv_path), min_space_gb):
             error_msg = OSManager.format_disk_space_error(Path(venv_path))
-            details = f"Attempted to install the components required by library '{library_name}'. Failed due to insufficient disk space (requires {min_space_gb} GB): {error_msg}"
-            return InstallLibraryDependenciesResultFailure(result_details=details)
+            return f"Attempted to install the components required by library '{library_name}'. Failed due to insufficient disk space (requires {min_space_gb} GB): {error_msg}"
 
         if not pip_dependencies:
-            details = f"Library '{library_name}' has no dependencies to install"
-            logger.info(details)
-            return InstallLibraryDependenciesResultSuccess(
-                library_name=library_name, dependencies_installed=0, result_details=details
-            )
+            return None
 
-        # Install dependencies
-        logger.info("Installing %d dependencies for library '%s'", len(pip_dependencies), library_name)
+        logger.info("Installing %d %s dependencies for library '%s'", len(pip_dependencies), venv_kind, library_name)
         is_debug = config_manager.get_config_value("log_level").upper() == "DEBUG"
 
         try:
@@ -6940,19 +7016,11 @@ class LibraryManager(EngineScoped):
                 )
         except subprocess.CalledProcessError as e:
             reason = e.stderr or f"the installer exited with code {e.returncode}"
-            details = (
-                f"Attempted to install the components required by library '{library_name}'. Failed due to: {reason}"
-            )
-            return InstallLibraryDependenciesResultFailure(result_details=details)
+            return f"Attempted to install the components required by library '{library_name}'. Failed due to: {reason}"
         except RuntimeError as e:
-            details = f"Attempted to rebuild the environment for library '{library_name}'. Failed due to: {e}"
-            return InstallLibraryDependenciesResultFailure(result_details=details)
+            return f"Attempted to rebuild the {venv_kind} environment for library '{library_name}'. Failed due to: {e}"
 
-        details = f"Installed {len(pip_dependencies)} dependencies for library '{library_name}'"
-        logger.info(details)
-        return InstallLibraryDependenciesResultSuccess(
-            library_name=library_name, dependencies_installed=len(pip_dependencies), result_details=details
-        )
+        return None
 
     async def _install_deps_with_recovery(
         self,

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -883,6 +883,29 @@ class LibraryManager(EngineScoped):
                 and library_info.library_name
                 and not self._is_worker
             ):
+                # A declared resource this machine does not have makes the whole spawn pointless:
+                # get_worker_for_library refuses on that reason before it ever consults a worker,
+                # so the process would resolve and download an entire execution environment --
+                # torch, gigabytes -- to serve nothing. Checked before the lifecycle moves below,
+                # because a legacy worker-mode library parked in WORKER_PENDING with no spawn
+                # coming would block boot for the whole startup grace.
+                #
+                # Only for libraries whose nodes already exist here. A legacy worker-mode library
+                # has none: the orchestrator skips its node modules entirely and its classes arrive
+                # as stubs from the worker's LibraryLoadedNotification. Skipping its spawn would
+                # leave the library with no node types at all -- an empty entry in the sidebar and
+                # placeholder nodes in any workflow using it. It still cannot execute, because the
+                # reset below preserves its refusal.
+                has_unmet_requirement = any(
+                    isinstance(problem, IncompatibleRequirementsProblem) for problem in library_info.problems
+                )
+                if has_unmet_requirement and not library_info.requires_worker:
+                    logger.info(
+                        "Not starting a worker for library '%s': %s",
+                        library_info.library_name,
+                        library_info.execution_unavailable_reason,
+                    )
+                    continue
                 # Legacy worker-mode libraries load AS the worker confirms (stubs meanwhile),
                 # so their lifecycle gates on the spawn. Exec-deps libraries loaded real
                 # nodes locally already: the worker gates execution availability only, and
@@ -896,12 +919,17 @@ class LibraryManager(EngineScoped):
                 # "Library not found". This event is set by the worker's LibraryLoadedNotification,
                 # and the execute path waits on it (wait_for_worker_library_load).
                 library_info.worker_ready = asyncio.Event()
-                # A fresh attempt, so whatever made execution unavailable before no longer
-                # describes the situation. Deliberately not conditioned on the result:
-                # StartWorkerRequest only SCHEDULES the spawn and always reports success, so a
-                # spawn that dies records its own reason from the task's exception handler
-                # (WorkerManager._log_spawn_error) rather than being inferred from here.
-                library_info.execution_unavailable_reason = None
+                # A fresh attempt, so an account of a PREVIOUS one no longer describes the
+                # situation. Not conditioned on the result: StartWorkerRequest only SCHEDULES the
+                # spawn and always reports success, so a spawn that dies records its own reason
+                # from the task's exception handler (WorkerManager._log_spawn_error).
+                #
+                # An unmet requirement is not an account of an attempt -- the machine still lacks
+                # the resource -- and it is the ONLY gate get_worker_for_library has. Clearing it
+                # would leave a legacy worker-mode library, whose spawn is deliberately not
+                # skipped above, dispatching to a worker that cannot load it.
+                if not has_unmet_requirement:
+                    library_info.execution_unavailable_reason = None
                 await self.engine.ahandle_request(StartWorkerRequest(library_name=library_info.library_name))
 
     def on_worker_evicted(self, worker_engine_id: str, library_name: str | None) -> None:

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -5059,6 +5059,28 @@ class LibraryManager(EngineScoped):
             return
 
         for path in paths:
+            # Modules are addressed by stem, and a directory declaration expands recursively, so
+            # execution/a/runner.py and execution/b/runner.py both answer to "runner". Left alone the
+            # later import won and the earlier module became unreachable, with get_execution_module
+            # listing one "runner" and no way to see which. Refused rather than resolved: only the
+            # author knows which was meant.
+            if path.stem in library_info.execution_modules:
+                library_info.execution_unavailable_reason = (
+                    f"two of its execution modules are both named '{path.stem}'. Execution modules "
+                    "are addressed by file name, so rename one of them."
+                )
+                # Cleared, not left half-built: get_execution_module reports the reason only when the
+                # name misses, so leaving the first-imported module bound would hand back whichever
+                # one rglob happened to reach first -- the silent wrong answer this refuses.
+                library_info.execution_modules.clear()
+                logger.error(
+                    "Library '%s' declares more than one execution module named '%s' (%s); "
+                    "the library stays editable but cannot run.",
+                    library_data.name,
+                    path.stem,
+                    path,
+                )
+                return
             try:
                 module = self._load_module_from_file(path, library_data.name)
             except Exception as exc:

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -56,6 +56,7 @@ from griptape_nodes.node_library.library_registry import (
     LibraryRegistry,
     LibraryRegistryError,
     LibrarySchema,
+    ModelAsset,
     NodeDefinition,
     NodeMetadata,
     WidgetDefinition,
@@ -185,6 +186,10 @@ from griptape_nodes.retained_mode.events.library_events import (
     UpdateLibraryResultFailure,
     UpdateLibraryResultSuccess,
     WidgetInfo,
+)
+from griptape_nodes.retained_mode.events.model_events import (
+    DownloadModelRequest,
+    DownloadModelResultSuccess,
 )
 from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
 from griptape_nodes.retained_mode.events.os_events import (
@@ -501,6 +506,9 @@ class LibraryManager(EngineScoped):
         # orchestrator never learns it -- the worker reports that itself when a run is attempted.
         # None means nothing is known to be wrong.
         execution_unavailable_reason: str | None = None
+        # Resources the library says it runs BETTER with and this machine lacks. Informational
+        # only: it never blocks loading or execution. None means nothing is known to be missing.
+        unmet_preferences: str | None = None
         # Declared execution modules, imported and keyed by their file stem. Populated only in a
         # worker: the orchestrator deliberately never imports these, so it holds an empty dict
         # and `get_execution_module` refuses there.
@@ -2502,6 +2510,25 @@ class LibraryManager(EngineScoped):
                         if library_data.metadata.resources is not None
                         else None
                     )
+                    preferred_requirements = (
+                        library_data.metadata.resources.preferred
+                        if library_data.metadata.resources is not None
+                        else None
+                    )
+                    if preferred_requirements is not None:
+                        # A preference is not a gate. It is recorded so the settings panel can
+                        # say "this runs better with a GPU" and so a slow run has an explanation,
+                        # and then execution proceeds either way.
+                        preferred_check = self._check_library_requirements(
+                            preferred_requirements, library_data.name, tier="preferred"
+                        )
+                        if preferred_check is not None:
+                            library_info.unmet_preferences = self._describe_unmet_requirements(preferred_check)
+                            logger.info(
+                                "Library '%s' runs better with resources this machine does not have: %s",
+                                library_data.name,
+                                library_info.unmet_preferences,
+                            )
                     if library_requirements is not None:
                         requirements_check_result = self._check_library_requirements(
                             library_requirements, library_data.name
@@ -3055,13 +3082,15 @@ class LibraryManager(EngineScoped):
         return f"it needs {wanted}, and this machine has {have}."
 
     def _check_library_requirements(
-        self, requirements: dict[str, Any], library_name: str
+        self, requirements: dict[str, Any], library_name: str, *, tier: str = "required"
     ) -> IncompatibleRequirementsProblem | None:
         """Check if the current system meets the library's resource requirements.
 
         Args:
             requirements: Dictionary of requirements in the format used by resource_instance.Requirements
             library_name: Name of the library being checked (for logging)
+            tier: Which declaration is being checked, "required" or "preferred". Only affects how
+                loudly an unmet result is logged: a preference is information, not a problem.
 
         Returns:
             IncompatibleRequirementsProblem if requirements are not met, None if they are met
@@ -3084,9 +3113,11 @@ class LibraryManager(EngineScoped):
 
             if isinstance(result, ListCompatibleResourceInstancesResultSuccess) and not result.instance_ids:
                 system_capabilities = self._get_system_capabilities()
-                logger.warning(
-                    "Library '%s' OS requirements not met. Required: %s, System: %s",
+                logger.log(
+                    logging.WARNING if tier == "required" else logging.INFO,
+                    "Library '%s' %s OS resources not met. Wanted: %s, System: %s",
                     library_name,
+                    tier,
                     os_requirements,
                     system_capabilities,
                 )
@@ -3105,9 +3136,11 @@ class LibraryManager(EngineScoped):
 
             if isinstance(result, ListCompatibleResourceInstancesResultSuccess) and not result.instance_ids:
                 system_capabilities = self._get_system_capabilities()
-                logger.warning(
-                    "Library '%s' compute requirements not met. Required: %s, System: %s",
+                logger.log(
+                    logging.WARNING if tier == "required" else logging.INFO,
+                    "Library '%s' %s compute resources not met. Wanted: %s, System: %s",
                     library_name,
+                    tier,
                     compute_requirements,
                     system_capabilities,
                 )
@@ -5094,7 +5127,9 @@ class LibraryManager(EngineScoped):
                 )
                 return
             library_info.execution_modules[path.stem] = module
-            logger.debug("Library '%s': imported execution module '%s'", library_data.name, path.stem)
+            # INFO, not debug: this is the record that a worker is ready to RUN this library, and
+            # the first thing to look for when it turns out it cannot.
+            logger.info("Library '%s': imported execution module '%s'", library_data.name, path.stem)
 
     def _check_execution_module_boundary(
         self,
@@ -5183,6 +5218,89 @@ class LibraryManager(EngineScoped):
             if resolved in library_info.declared_execution_module_paths:
                 return resolved
         return None
+
+    def get_model_asset(self, library_name: str, asset_id: str) -> Path:
+        """Return the local directory holding a declared model asset, fetching it if needed.
+
+        Weights are not dependencies, and they are not a library-load concern either. This resolves
+        on demand, in whichever process asks -- which is the one about to run the model -- and
+        caches under an engine-owned root so two libraries wanting the same revision share it and
+        neither has to invent a location.
+
+        Raises:
+            RuntimeError: If the library is unknown, declares no asset by that id, or the fetch
+                fails. Each message says which of those it was.
+        """
+        # Read through the registry rather than LibraryInfo: the registry holds the schema and
+        # resolves library-local declarations correctly in both the orchestrator and a worker,
+        # which is the same route get_declared_models takes.
+        try:
+            library = LibraryRegistry.get_library(library_name)
+        except KeyError as err:
+            msg = f"No library named '{library_name}' is registered, so its model assets cannot be resolved."
+            raise RuntimeError(msg) from err
+
+        declared = library.get_library_data().model_assets or {}
+        asset = declared.get(asset_id)
+        if asset is None:
+            available = ", ".join(sorted(declared)) or "none"
+            msg = (
+                f"Library '{library_name}' declares no model asset named '{asset_id}'. "
+                f"Declared: {available}. Add it to the manifest's model_assets."
+            )
+            raise RuntimeError(msg)
+
+        target = self._model_asset_path(library_name, asset_id, asset)
+        if target.exists() and any(target.iterdir()):
+            logger.debug("Model asset '%s' for library '%s' is already present at %s", asset_id, library_name, target)
+            return target
+
+        scheme, _, reference = asset.source.partition(":")
+        supported_schemes = ("hf",)
+        if scheme not in supported_schemes:
+            msg = (
+                f"Model asset '{asset_id}' of library '{library_name}' declares source "
+                f"'{asset.source}'. Supported schemes: {', '.join(supported_schemes)} "
+                "(e.g. 'hf:owner/repo')."
+            )
+            raise RuntimeError(msg)
+
+        logger.info(
+            "Fetching model asset '%s' for library '%s' from %s (revision %s)",
+            asset_id,
+            library_name,
+            reference,
+            asset.revision,
+        )
+        target.mkdir(parents=True, exist_ok=True)
+        result = self.engine.handle_request(
+            DownloadModelRequest(
+                model_id=reference,
+                local_dir=str(target),
+                revision=asset.revision,
+                allow_patterns=asset.files,
+            )
+        )
+        if not isinstance(result, DownloadModelResultSuccess):
+            msg = (
+                f"Attempted to fetch model asset '{asset_id}' for library '{library_name}' from "
+                f"{reference}. Failed with: {result.result_details}"
+            )
+            # isinstance here discriminates a result payload, the engine's universal idiom; the
+            # failure is a fetch failure, not a type error.
+            raise RuntimeError(msg)  # noqa: TRY004
+        return target
+
+    @staticmethod
+    def _model_asset_path(library_name: str, asset_id: str, asset: ModelAsset) -> Path:
+        """Where a model asset lives. Keyed by revision so a re-pin does not overwrite the old one.
+
+        Engine-owned rather than library-adjacent: a library directory can be read-only, can be
+        reinstalled underneath the weights, and is the wrong place for gigabytes that two libraries
+        might share.
+        """
+        safe_library = "".join(char if char.isalnum() or char in "-_" else "_" for char in library_name)
+        return xdg_data_home() / "griptape_nodes" / "model_assets" / safe_library / asset_id / asset.revision
 
     def get_execution_module(self, library_name: str, module_name: str) -> ModuleType:
         """Return one of a library's execution modules, or explain why it is not available here.

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -211,6 +211,7 @@ from griptape_nodes.retained_mode.managers.fitness_problems.libraries import (
     AfterLibraryCallbackProblem,
     BeforeLibraryCallbackProblem,
     CreateConfigCategoryProblem,
+    DependencyInstallationFailedProblem,
     DuplicateLibraryProblem,
     EngineVersionErrorProblem,
     IncompatibleRequirementsProblem,
@@ -493,6 +494,13 @@ class LibraryManager(EngineScoped):
         is_sandbox: bool
         library_name: str | None = None
         library_version: str | None = None
+        # Why this library cannot execute right now, phrased for whoever has to act on it.
+        # A library can be perfectly loaded and editable while execution is unavailable. Set when
+        # its worker is evicted. Deliberately NOT set when execution dependencies fail to install:
+        # that happens in the worker's own process against the worker's own LibraryInfo, so the
+        # orchestrator never learns it -- the worker reports that itself when a run is attempted.
+        # None means nothing is known to be wrong.
+        execution_unavailable_reason: str | None = None
         # The path string the user wrote in `libraries_to_register` before workspace
         # resolution / `~`-expansion / symlink-following. Surfaced to the GUI so the
         # settings panel can match library metadata back to its config row using the
@@ -746,8 +754,16 @@ class LibraryManager(EngineScoped):
                 notification.library_name,
             )
             return
-        library_info.fitness = LibraryManager.LibraryFitness(notification.fitness)
-        library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.LOADED
+        # Only a legacy worker-mode library takes its fitness from the worker: for that kind the
+        # orchestrator never loaded the library itself, so the worker's verdict is the only one
+        # there is. An exec-deps library loaded REAL nodes here and derived its own fitness from
+        # doing so. Overwriting that misreports both ways -- a clean worker paints over a
+        # genuinely FLAWED local load, leaving the settings panel claiming health while a broken
+        # node sits on the canvas; a FLAWED worker downgrades a copy that is perfectly editable --
+        # and in neither case does the reason travel, since only the log gets problem_details.
+        if library_info.requires_worker:
+            library_info.fitness = LibraryManager.LibraryFitness(notification.fitness)
+            library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.LOADED
         if notification.problem_details:
             logger.warning(
                 "Worker reported problems loading library '%s': %s",
@@ -792,10 +808,20 @@ class LibraryManager(EngineScoped):
                     worker = wm.get_worker_for_key(library_name)
                     if worker:
                         return worker
-                    msg = (
-                        f"Library '{library_name}' requires a dedicated worker process "
-                        "that is not yet registered. The worker may still be starting up."
-                    )
+                    # Distinguish "not ready yet" from "went away", which read identically
+                    # before: a library whose worker had been evicted reported that it might
+                    # still be starting up, forever.
+                    if library_info.execution_unavailable_reason:
+                        msg = (
+                            f"Library '{library_name}' cannot run right now: "
+                            f"{library_info.execution_unavailable_reason} Editing its nodes still "
+                            "works, and a saved workflow keeps them."
+                        )
+                    else:
+                        msg = (
+                            f"Library '{library_name}' requires a dedicated worker process "
+                            "that is not yet registered. The worker may still be starting up."
+                        )
                     raise RuntimeError(msg)
                 msg = (
                     f"Library '{library_name}' requires a dedicated worker process. "
@@ -843,7 +869,17 @@ class LibraryManager(EngineScoped):
         that worker creation is always tied to an active session.
         """
         for library_info in self._library_file_path_to_info.values():
-            if library_info.executes_in_worker and library_info.library_name and not self._is_worker:
+            # `enabled` matters: executes_in_worker is set before the lifecycle is overwritten with
+            # DISABLED, so without this a library the user turned off still got an idle worker
+            # subprocess -- and a legacy worker-mode one had its DISABLED state overwritten with
+            # WORKER_PENDING, then blocked boot for the full startup grace waiting on a worker that
+            # was never going to report.
+            if (
+                library_info.executes_in_worker
+                and library_info.enabled
+                and library_info.library_name
+                and not self._is_worker
+            ):
                 # Legacy worker-mode libraries load AS the worker confirms (stubs meanwhile),
                 # so their lifecycle gates on the spawn. Exec-deps libraries loaded real
                 # nodes locally already: the worker gates execution availability only, and
@@ -857,6 +893,12 @@ class LibraryManager(EngineScoped):
                 # "Library not found". This event is set by the worker's LibraryLoadedNotification,
                 # and the execute path waits on it (wait_for_worker_library_load).
                 library_info.worker_ready = asyncio.Event()
+                # A fresh attempt, so whatever made execution unavailable before no longer
+                # describes the situation. Deliberately not conditioned on the result:
+                # StartWorkerRequest only SCHEDULES the spawn and always reports success, so a
+                # spawn that dies records its own reason from the task's exception handler
+                # (WorkerManager._log_spawn_error) rather than being inferred from here.
+                library_info.execution_unavailable_reason = None
                 await self.engine.ahandle_request(StartWorkerRequest(library_name=library_info.library_name))
 
     def on_worker_evicted(self, worker_engine_id: str, library_name: str | None) -> None:
@@ -877,6 +919,14 @@ class LibraryManager(EngineScoped):
         # worker that is already gone.
         if library_info.worker_ready is not None:
             library_info.worker_ready.set()
+        # Record WHY execution stopped being possible, for every library that routes execution
+        # to a worker. Nothing respawns an evicted worker, so without this the next run reports
+        # that the worker "may still be starting up" -- for the rest of the session.
+        if library_info.executes_in_worker:
+            library_info.execution_unavailable_reason = (
+                "the worker process that runs it stopped responding and was shut down."
+            )
+
         if library_info.lifecycle_state == LibraryManager.LibraryLifecycleState.WORKER_PENDING:
             library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.FAILURE
             library_info.fitness = LibraryManager.LibraryFitness.UNUSABLE
@@ -2527,6 +2577,34 @@ class LibraryManager(EngineScoped):
                             InstallLibraryDependenciesRequest(library_file_path=library_info.library_path)
                         )
                         if isinstance(install_result, InstallLibraryDependenciesResultFailure):
+                            # Record WHY on the library itself. Until now a failed install left
+                            # no trace on the LibraryInfo, so anything that later asked the
+                            # library what was wrong with it -- the settings panel, or a worker
+                            # explaining why it cannot run a node -- had nothing to report, and
+                            # the resolver's actual complaint lived only in a log line.
+                            #
+                            # DependencyInstallationFailedProblem already existed for this and
+                            # was wired to nothing. Deliberately NOT LibraryDependencyProblem,
+                            # which means something else: that another griptape LIBRARY this one
+                            # depends on could not be fetched.
+                            #
+                            # Fitness is deliberately left alone. Registration already fails
+                            # here, and the fitness a library ends up with is decided by the
+                            # dependency block above; overriding it from this branch changes what
+                            # a skipped-dependency library reports.
+                            # Replaced, not appended: the lifecycle re-enters at EVALUATED on every
+                            # reload and project switch while the LibraryInfo is preserved, so
+                            # appending accumulated one copy per reload.
+                            # DependencyInstallationFailedProblem logs an error above one instance
+                            # and then displays the OLDEST, so a changed reason would show stale.
+                            library_info.problems = [
+                                problem
+                                for problem in library_info.problems
+                                if not isinstance(problem, DependencyInstallationFailedProblem)
+                            ]
+                            library_info.problems.append(
+                                DependencyInstallationFailedProblem(error_details=str(install_result.result_details))
+                            )
                             self._library_file_path_to_info[library_info.library_path] = library_info
                             return RegisterLibraryFromFileResultFailure(result_details=install_result.result_details)
 
@@ -3060,6 +3138,11 @@ class LibraryManager(EngineScoped):
         process: the orchestrator must never have a library's heavy dependencies on its import
         path, since keeping them out is what stops one library's pins from shadowing another's.
 
+        The execution environment goes on FIRST, so it wins for anything present in both. That is
+        safe only because it is resolved over the edit-time set as well (see
+        on_install_library_dependencies_request): one resolver saw both, so there is no version
+        of a shared package for it to disagree with.
+
         Args:
             library_name: Name of the library (for venv lookup)
             library_file_path: Path to the library JSON file (for venv lookup)
@@ -3069,7 +3152,12 @@ class LibraryManager(EngineScoped):
 
         await self._add_library_venv_to_sys_path(library_name, library_file_path, execution=False)
 
-        if self._is_worker:
+        # Same predicate as the install: a worker splices ONLY its own libraries' execution
+        # environments. Gating the build without gating this left the hole open from the other
+        # side -- once the other library's own worker had built the venv, a nested registration
+        # here would put its heavy pins at sys.path[0] of this worker, which is precisely the
+        # shadowing the edit/execution split exists to prevent.
+        if self._is_worker and self._is_one_of_my_target_libraries(library_name):
             await self._add_library_venv_to_sys_path(library_name, library_file_path, execution=True)
 
     async def _add_library_venv_to_sys_path(
@@ -7008,40 +7096,179 @@ class LibraryManager(EngineScoped):
             pip_dependencies_exec = library_metadata.dependencies.pip_dependencies_exec or []
             pip_install_flags = library_metadata.dependencies.pip_install_flags or []
 
-        edit_failure = await self._install_dependency_set(
-            library_name=library_name,
-            library_file_path=library_file_path,
-            pip_dependencies=pip_dependencies,
-            pip_install_flags=pip_install_flags,
-            execution=False,
-        )
-        if edit_failure is not None:
-            return InstallLibraryDependenciesResultFailure(result_details=edit_failure)
-
-        exec_failure = await self._install_dependency_set(
-            library_name=library_name,
-            library_file_path=library_file_path,
-            pip_dependencies=pip_dependencies_exec,
-            pip_install_flags=pip_install_flags,
-            execution=True,
-        )
-        if exec_failure is not None:
-            return InstallLibraryDependenciesResultFailure(result_details=exec_failure)
-
-        installed_count = len(pip_dependencies) + len(pip_dependencies_exec)
-        if installed_count == 0:
-            details = f"Library '{library_name}' has no dependencies to install"
-        elif pip_dependencies_exec:
-            details = (
-                f"Installed {len(pip_dependencies)} edit-time and {len(pip_dependencies_exec)} "
-                f"execution dependencies for library '{library_name}'"
+        owns_edit_venv = self._this_process_owns_the_edit_venv(library_file_path)
+        if owns_edit_venv:
+            edit_failure = await self._install_dependency_set(
+                library_name=library_name,
+                library_file_path=library_file_path,
+                pip_dependencies=pip_dependencies,
+                pip_install_flags=pip_install_flags,
+                execution=False,
             )
-        else:
-            details = f"Installed {len(pip_dependencies)} dependencies for library '{library_name}'"
+            if edit_failure is not None:
+                return InstallLibraryDependenciesResultFailure(result_details=edit_failure)
+
+        # Only a worker ever imports the execution set, and only a worker splices .venv-exec
+        # onto sys.path (see _add_library_paths_to_sys_path, which gates that on the same
+        # flag). Installing it here too made the orchestrator download and store the entire
+        # weight of every heavy library -- half a gigabyte for one torch pin -- to run code it
+        # will never import, which is the cost the edit/execution split exists to avoid.
+        #
+        # It also decided the wrong thing on failure. An unresolvable execution dependency
+        # returned a registration failure, so the library did not load at all: no node types,
+        # and placeholder nodes reading "Library not found" in any workflow that used it. The
+        # orchestrator needs nothing but the edit-time set to define, draw, and edit those
+        # nodes, so a broken execution dependency must cost execution and nothing else.
+        installed_exec_count = 0
+        # Gated on the heavy set, not the combined one: a library with no execution
+        # dependencies must still produce no .venv-exec at all.
+        if self._is_worker and pip_dependencies_exec and self._is_one_of_my_target_libraries(library_name):
+            # The edit-time set is resolved INTO the execution environment alongside the heavy
+            # one, not just listed beside it. The two venvs are fully isolated, so resolving them
+            # separately let uv pick a different version of anything they share -- numpy as an
+            # edit-time dep and numpy pulled in by torch, say. .venv-exec is spliced ahead of
+            # .venv in a worker, so the execution copy would then win, and a node module's
+            # `import numpy` would bind one version when the orchestrator built the node and
+            # another when the worker ran it, with no diagnostic anywhere. One resolution over
+            # both sets makes that impossible rather than merely unlikely.
+            exec_failure = await self._install_dependency_set(
+                library_name=library_name,
+                library_file_path=library_file_path,
+                pip_dependencies=[*pip_dependencies, *pip_dependencies_exec],
+                pip_install_flags=pip_install_flags,
+                execution=True,
+            )
+            if exec_failure is not None:
+                return InstallLibraryDependenciesResultFailure(result_details=exec_failure)
+            installed_exec_count = len(pip_dependencies_exec)
+
+        # Only count the edit-time set if this process actually installed it: a worker for an
+        # exec-deps library skips it (the orchestrator owns that venv), so counting it here
+        # reported dependencies nobody installed.
+        installed_edit_count = len(pip_dependencies) if owns_edit_venv else 0
+        installed_count = installed_edit_count + installed_exec_count
+        details = self._describe_dependency_install(
+            library_name=library_name,
+            declared_edit=len(pip_dependencies),
+            declared_exec=len(pip_dependencies_exec),
+            installed_edit=installed_edit_count,
+            installed_exec=installed_exec_count,
+        )
         logger.info(details)
         return InstallLibraryDependenciesResultSuccess(
             library_name=library_name, dependencies_installed=installed_count, result_details=details
         )
+
+    @staticmethod
+    def _describe_dependency_install(
+        *,
+        library_name: str,
+        declared_edit: int,
+        declared_exec: int,
+        installed_edit: int,
+        installed_exec: int,
+    ) -> str:
+        """Describe what THIS process installed, which is not always what the library declares.
+
+        The two environments have different owners: the orchestrator owns the edit-time venv for
+        an execution-dependency library, and only a worker builds an execution venv, and only for
+        its own libraries. So a count read off the manifest reported dependencies nobody here
+        installed.
+        """
+        installed_total = installed_edit + installed_exec
+        if installed_total == 0 and (declared_edit or declared_exec):
+            return (
+                f"Library '{library_name}' declares dependencies, none of which install in this "
+                f"process; whichever process owns each environment installs it"
+            )
+        if installed_total == 0:
+            return f"Library '{library_name}' has no dependencies to install"
+        if installed_exec:
+            return (
+                f"Installed {installed_edit} edit-time and {installed_exec} execution "
+                f"dependencies for library '{library_name}'"
+            )
+        if declared_exec:
+            return (
+                f"Installed {installed_edit} edit-time dependencies for library "
+                f"'{library_name}'; its {declared_exec} execution dependencies install in the "
+                f"worker that runs them"
+            )
+        return f"Installed {installed_edit} dependencies for library '{library_name}'"
+
+    def _is_one_of_my_target_libraries(self, library_name: str) -> bool:
+        """Whether this worker was spawned to serve `library_name`.
+
+        A worker is scoped to its target libraries by a filter in
+        `load_all_libraries_from_config`, but nested registration paths bypass that filter --
+        an unregistered library dependency reaches `download_library_request(auto_register=True)`
+        and runs a full registration for a DIFFERENT library inside this worker. Building that
+        library's `.venv-exec` here would put two writers on one directory, which
+        `_install_deps_with_recovery` can rmtree, and would splice another library's heavy pins
+        onto this worker's sys.path -- the shadowing the split exists to prevent. The
+        orchestrator has no target list and legitimately installs for anyone.
+
+        A nested dependency (one library declaring another) may still get its EDIT-time venv
+        built here -- see `_this_process_owns_the_edit_venv`, which claims it only when nothing
+        has built it yet. What it never gets here is an EXECUTION venv, so a nested dependency
+        whose node modules need the heavy set at IMPORT time fails to load in this worker. That
+        means a library whose MANIFEST declares worker mode (`requires_worker_process`), since
+        such modules are not base-clean by contract -- not the per-entry `worker_mode_override`,
+        which cannot apply to a nested registration at all because it is keyed on a registered
+        config path that a nested library does not have. So auditing configs for the override
+        would not find this case. The alternative is letting one worker's sys.path be rewritten
+        by another library's pins, which is the collision the split exists to end.
+        """
+        if self._target_library_names is None:
+            return True
+        return library_name in self._target_library_names
+
+    def _this_process_owns_the_edit_venv(self, library_file_path: str) -> bool:
+        """Whether this process may write `<library>/.venv`. Exactly one process may.
+
+        An execution-dependency library is loaded on the ORCHESTRATOR (real node classes, not
+        stubs), so the orchestrator builds that venv and keeps it on its own sys.path for the
+        session. A worker for such a library must not touch it: two concurrent `uv pip install`
+        runs at one target is the mild version, and the corrupt-install recovery path rmtrees
+        the directory outright -- so an execution-side retry would delete the environment the
+        orchestrator is importing from, which is the exact inverse of the isolation this design
+        exists to provide. The worker does not need it either way: `.venv-exec` is resolved
+        over BOTH dependency sets, so everything the edit-time set provides is already there.
+
+        A legacy worker-mode library is the other case: the orchestrator skips loading it
+        entirely (WORKER_DELEGATED), so nobody else creates `.venv` and the worker must.
+
+        A worker with NO record for the library cannot tell which case it is in, and guessing
+        wrong re-opens the double-writer hazard -- so it refuses, loudly.
+        """
+        if not self._is_worker:
+            return True
+        library_info = self._library_file_path_to_info.get(library_file_path)
+        # A library this worker was NOT spawned for arrives through a nested registration (one
+        # library declaring another as a dependency), and registration continues here into module
+        # imports -- which resolve against `<library>/.venv`. If nothing has built it, this
+        # process must, or the import fails and takes the outer library down as UNUSABLE.
+        #
+        # Only when nothing has built it, though: the orchestrator runs the same nested loop and
+        # may have built this venv already (and be importing from it). Claiming ownership of an
+        # existing directory would put this process on `_install_deps_with_recovery`, which
+        # rmtrees on a failed install -- the exact hazard this predicate exists to prevent, just
+        # reached from the other side.
+        if (
+            library_info is not None
+            and library_info.library_name is not None
+            and not self._is_one_of_my_target_libraries(library_info.library_name)
+        ):
+            venv_path = self._get_library_venv_path(library_info.library_name, library_file_path, execution=False)
+            return not Path(venv_path).exists()
+        if library_info is None:
+            logger.warning(
+                "No library record found for '%s' in this worker; skipping the edit-time "
+                "environment install rather than risk writing a venv another process owns.",
+                library_file_path,
+            )
+            return False
+        return library_info.requires_worker
 
     async def _install_dependency_set(  # noqa: PLR0911
         self,

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -510,6 +510,13 @@ class LibraryManager(EngineScoped):
         # parsed (discovery or lifecycle progression). Absence of the relevant
         # declarations falls through to False.
         requires_worker: bool = False
+        # True when this library's nodes EXECUTE in a dedicated worker process, for either
+        # reason: legacy worker-mode declarations (requires_worker above, which also skips
+        # orchestrator-side loading in favor of stubs) or execution dependencies
+        # (pip_dependencies_exec -- the library loads REAL nodes on the orchestrator and
+        # only its process() runs in the worker, where .venv-exec is on sys.path).
+        # Consumed by execution routing; never by load-time skips.
+        executes_in_worker: bool = False
         # Set when the library enters WORKER_PENDING state. The orchestrator waits on this
         # event before returning RegisterLibraryFromFileResultSuccess so callers see the real
         # fitness once the worker has loaded and reported back.
@@ -750,7 +757,10 @@ class LibraryManager(EngineScoped):
         # Register stub node classes from the worker-reported schemas so the orchestrator
         # can display nodes in the sidebar and recreate them during workflow loading.
         # Skip on the worker itself -- it already has the real node classes registered.
-        if notification.node_schemas and not self._is_worker:
+        # Exec-deps libraries registered REAL node classes locally at load; overwriting
+        # them with schema stubs would throw away converters/validators/traits/hooks.
+        # Only legacy worker-mode libraries (requires_worker) use stub registration.
+        if notification.node_schemas and not self._is_worker and library_info.requires_worker:
             self._register_nodes_from_worker_schemas(notification.library_name, notification.node_schemas)
         # Unblock any code awaiting this library's worker_ready event.
         if library_info.worker_ready is not None:
@@ -776,7 +786,7 @@ class LibraryManager(EngineScoped):
         """
         if library_name:
             library_info = self.get_library_info_by_library_name(library_name)
-            if library_info and library_info.requires_worker:
+            if library_info and library_info.executes_in_worker:
                 wm = self._worker_manager
                 if wm:
                     worker = wm.get_worker_for_key(library_name)
@@ -802,10 +812,15 @@ class LibraryManager(EngineScoped):
         that worker creation is always tied to an active session.
         """
         for library_info in self._library_file_path_to_info.values():
-            if library_info.requires_worker and library_info.library_name and not self._is_worker:
-                library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.WORKER_PENDING
-                # Create (or reset) the worker_ready event for this spawn.
-                library_info.worker_ready = asyncio.Event()
+            if library_info.executes_in_worker and library_info.library_name and not self._is_worker:
+                # Legacy worker-mode libraries load AS the worker confirms (stubs meanwhile),
+                # so their lifecycle gates on the spawn. Exec-deps libraries loaded real
+                # nodes locally already: the worker gates execution availability only, and
+                # registration must not block on it.
+                if library_info.requires_worker:
+                    library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.WORKER_PENDING
+                    # Create (or reset) the worker_ready event for this spawn.
+                    library_info.worker_ready = asyncio.Event()
                 await self.engine.ahandle_request(StartWorkerRequest(library_name=library_info.library_name))
 
     def on_worker_evicted(self, worker_engine_id: str, library_name: str | None) -> None:
@@ -2183,11 +2198,15 @@ class LibraryManager(EngineScoped):
                 )
 
                 # Update or create LibraryInfo
+                executes_in_worker = self._resolve_executes_in_worker(
+                    requires_worker=requires_worker, metadata=metadata_result.library_schema.metadata
+                )
                 if lib_info:
                     lib_info.library_name = library_name
                     lib_info.library_version = metadata_result.library_schema.metadata.library_version
                     lib_info.lifecycle_state = LibraryManager.LibraryLifecycleState.METADATA_LOADED
                     lib_info.requires_worker = requires_worker
+                    lib_info.executes_in_worker = executes_in_worker
                 else:
                     # Create new LibraryInfo since it doesn't exist yet
                     lib_info = LibraryManager.LibraryInfo(
@@ -2199,6 +2218,7 @@ class LibraryManager(EngineScoped):
                         fitness=LibraryManager.LibraryFitness.NOT_EVALUATED,
                         problems=[],
                         requires_worker=requires_worker,
+                        executes_in_worker=executes_in_worker,
                     )
                     self._library_file_path_to_info[file_path] = lib_info
             else:
@@ -2316,6 +2336,10 @@ class LibraryManager(EngineScoped):
                     library_info.requires_worker = self._resolve_requires_worker(
                         library_info.registered_path,
                         metadata_result.library_schema.metadata.declarations,
+                    )
+                    library_info.executes_in_worker = self._resolve_executes_in_worker(
+                        requires_worker=library_info.requires_worker,
+                        metadata=metadata_result.library_schema.metadata,
                     )
                     library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.METADATA_LOADED
 
@@ -5115,6 +5139,14 @@ class LibraryManager(EngineScoped):
         registered node type to extract its parameter layout, so the orchestrator
         can create stub classes without importing the library's Python modules.
         """
+        # Only a legacy worker-mode library is stubbed on the orchestrator: an
+        # execution-dependency library is loaded there for real (its node modules are
+        # base-clean by contract), and stub registration is gated on `requires_worker`.
+        # The two stub-loss detectors below are gated on the same fact, or they warn that
+        # converters, traits and hooks "will not execute on the orchestrator stub" for a
+        # library that has no stub -- sending an author to fix code that is already correct.
+        library_info = self.get_library_info_by_library_name(library_name)
+        will_be_stubbed = library_info is None or library_info.requires_worker
         try:
             library = LibraryRegistry.get_library(library_name)
         except KeyError:
@@ -5158,8 +5190,9 @@ class LibraryManager(EngineScoped):
                 # Run the parameter-behavior-drop and inert-hook detectors
                 # inside the scope so warnings attach to the same LOAD_PROBE
                 # scope that owns the probe attempt.
-                self._report_parameter_behavior_losses(probe)
-                self._report_inert_worker_hooks(probe)
+                if will_be_stubbed:
+                    self._report_parameter_behavior_losses(probe)
+                    self._report_inert_worker_hooks(probe)
 
             # Drop the class only when a rule flagged drops_class_from_schema
             # fired. Severity is a logging concern; drops_class_from_schema is
@@ -5437,6 +5470,18 @@ class LibraryManager(EngineScoped):
 
         return manifest_default
 
+    @staticmethod
+    def _resolve_executes_in_worker(*, requires_worker: bool, metadata: LibraryMetadata) -> bool:
+        """Whether this library's nodes execute in a dedicated worker process.
+
+        True for legacy worker-mode libraries (requires_worker) and for libraries that
+        declare execution dependencies: their heavy packages live in .venv-exec, which is
+        only on sys.path in a worker, so process() can only run there.
+        """
+        dependencies = metadata.dependencies
+        has_exec_dependencies = bool(dependencies and dependencies.pip_dependencies_exec)
+        return requires_worker or has_exec_dependencies
+
     def _remove_missing_libraries_from_config(self, config_category: str) -> None:
         # Now remove all libraries that were missing from the user's config.
         config_mgr = self.engine.config_manager
@@ -5691,6 +5736,7 @@ class LibraryManager(EngineScoped):
         library_name = None
         library_version = None
         requires_worker = False
+        executes_in_worker = False
         lifecycle_state = LibraryManager.LibraryLifecycleState.DISCOVERED
 
         if isinstance(metadata_result, LoadLibraryMetadataFromFileResultSuccess):
@@ -5699,6 +5745,9 @@ class LibraryManager(EngineScoped):
             requires_worker = self._resolve_requires_worker(
                 registered_path,
                 metadata_result.library_schema.metadata.declarations,
+            )
+            executes_in_worker = self._resolve_executes_in_worker(
+                requires_worker=requires_worker, metadata=metadata_result.library_schema.metadata
             )
             lifecycle_state = LibraryManager.LibraryLifecycleState.METADATA_LOADED
 
@@ -5715,6 +5764,7 @@ class LibraryManager(EngineScoped):
             library_version=library_version,
             registered_path=registered_path,
             requires_worker=requires_worker,
+            executes_in_worker=executes_in_worker,
         )
 
     async def discover_libraries_request(

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -2577,26 +2577,10 @@ class LibraryManager(EngineScoped):
                             InstallLibraryDependenciesRequest(library_file_path=library_info.library_path)
                         )
                         if isinstance(install_result, InstallLibraryDependenciesResultFailure):
-                            # Record WHY on the library itself. Until now a failed install left
-                            # no trace on the LibraryInfo, so anything that later asked the
-                            # library what was wrong with it -- the settings panel, or a worker
-                            # explaining why it cannot run a node -- had nothing to report, and
-                            # the resolver's actual complaint lived only in a log line.
-                            #
-                            # DependencyInstallationFailedProblem already existed for this and
-                            # was wired to nothing. Deliberately NOT LibraryDependencyProblem,
-                            # which means something else: that another griptape LIBRARY this one
-                            # depends on could not be fetched.
-                            #
-                            # Fitness is deliberately left alone. Registration already fails
-                            # here, and the fitness a library ends up with is decided by the
-                            # dependency block above; overriding it from this branch changes what
-                            # a skipped-dependency library reports.
                             # Replaced, not appended: the lifecycle re-enters at EVALUATED on every
-                            # reload and project switch while the LibraryInfo is preserved, so
-                            # appending accumulated one copy per reload.
-                            # DependencyInstallationFailedProblem logs an error above one instance
-                            # and then displays the OLDEST, so a changed reason would show stale.
+                            # reload while the LibraryInfo survives, and the display shows the
+                            # OLDEST instance -- appending would keep reporting the first reason.
+                            # Fitness stays with the dependency block above, which decides it.
                             library_info.problems = [
                                 problem
                                 for problem in library_info.problems

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -13,6 +13,7 @@ import shutil
 import subprocess
 import sys
 import sysconfig
+import threading
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -305,6 +306,11 @@ logger = logging.getLogger("griptape_nodes")
 
 # Directories to exclude when scanning for Python source files (in addition to any directory starting with '.')
 EXCLUDED_SCAN_DIRECTORIES = frozenset({"venv", "__pycache__"})
+
+# One in-flight fetch per model-asset directory. Module-level rather than per-manager because what
+# it guards is a directory on disk: two engines in one process resolving the same asset would
+# otherwise hold separate locks and race each other into it.
+_MODEL_ASSET_FETCH_LOCKS: dict[Path, threading.Lock] = {}
 
 TRegisteredEventData = TypeVar("TRegisteredEventData")
 
@@ -5246,32 +5252,50 @@ class LibraryManager(EngineScoped):
             )
             raise RuntimeError(msg)
 
-        logger.info(
-            "Fetching model asset '%s' for library '%s' from %s (revision %s)",
-            asset_id,
-            library_name,
-            reference,
-            asset.revision,
-        )
-        target.mkdir(parents=True, exist_ok=True)
-        result = self.engine.handle_request(
-            DownloadModelRequest(
-                model_id=reference,
-                local_dir=str(target),
-                revision=asset.revision,
-                allow_patterns=asset.files,
+        # Serialized per directory, and re-checked inside. Node execution is concurrent, so two
+        # nodes asking for one asset both passed the marker check above, both downloaded into the
+        # same directory, and the first to return marked it complete while the second was still
+        # writing -- after which every later call short-circuits on the marker and hands back a
+        # truncated model, which is the outcome the marker exists to prevent.
+        with self._model_asset_lock(target):
+            if complete_marker.exists():
+                logger.debug("Model asset '%s' for library '%s' was fetched while waiting", asset_id, library_name)
+                return target
+            logger.info(
+                "Fetching model asset '%s' for library '%s' from %s (revision %s)",
+                asset_id,
+                library_name,
+                reference,
+                asset.revision,
             )
-        )
-        if not isinstance(result, DownloadModelResultSuccess):
-            msg = (
-                f"Attempted to fetch model asset '{asset_id}' for library '{library_name}' from "
-                f"{reference}. Failed with: {result.result_details}"
+            target.mkdir(parents=True, exist_ok=True)
+            result = self.engine.handle_request(
+                DownloadModelRequest(
+                    model_id=reference,
+                    local_dir=str(target),
+                    revision=asset.revision,
+                    allow_patterns=asset.files,
+                )
             )
-            # isinstance here discriminates a result payload, the engine's universal idiom; the
-            # failure is a fetch failure, not a type error.
-            raise RuntimeError(msg)  # noqa: TRY004
-        complete_marker.touch()
+            if not isinstance(result, DownloadModelResultSuccess):
+                msg = (
+                    f"Attempted to fetch model asset '{asset_id}' for library '{library_name}' from "
+                    f"{reference}. Failed with: {result.result_details}"
+                )
+                # isinstance here discriminates a result payload, the engine's universal idiom; the
+                # failure is a fetch failure, not a type error.
+                raise RuntimeError(msg)  # noqa: TRY004
+            complete_marker.touch()
         return target
+
+    @staticmethod
+    def _model_asset_lock(target: Path) -> threading.Lock:
+        """The lock owning fetches into `target`, created on first ask.
+
+        `setdefault` needs no guard of its own: two callers may each build a Lock, but both receive
+        whichever one landed in the map.
+        """
+        return _MODEL_ASSET_FETCH_LOCKS.setdefault(target, threading.Lock())
 
     @staticmethod
     def _model_asset_path(library_name: str, asset_id: str, asset: ModelAsset) -> Path:

--- a/src/griptape_nodes/retained_mode/managers/library_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/library_manager.py
@@ -804,6 +804,37 @@ class LibraryManager(EngineScoped):
                 raise RuntimeError(msg)
         return None
 
+    async def wait_for_worker_library_load(self, library_name: str) -> None:
+        """Block until this library's worker has reported the library fully loaded, if one is expected.
+
+        A worker registers with the orchestrator at process start, BEFORE it has loaded its
+        library -- so a node executed in that window would reach a worker that cannot create
+        it yet. The worker's LibraryLoadedNotification is what "loaded" means, exactly as it
+        did for legacy worker-mode libraries; this waits for it, bounded by the same startup
+        grace the boot-time wait uses. Returns immediately for a library with no spawned
+        worker. An eviction during the wait also releases it: the reason is recorded, and
+        get_worker_for_library reports it to the caller.
+
+        Raises:
+            RuntimeError: If the worker did not report the library loaded within the grace
+                period.
+        """
+        library_info = self.get_library_info_by_library_name(library_name)
+        if library_info is None or library_info.worker_ready is None or library_info.worker_ready.is_set():
+            return
+        config_mgr = self.engine.config_manager
+        wait_seconds = config_mgr.get_config_value(WORKER_HEARTBEAT_STARTUP_GRACE_KEY, default=600.0, cast_type=float)
+        logger.info("Waiting for library '%s' to finish loading in its worker before running the node", library_name)
+        try:
+            with anyio.fail_after(wait_seconds):
+                await library_info.worker_ready.wait()
+        except TimeoutError:
+            msg = (
+                f"Attempted to run a node from library '{library_name}'. Failed because its worker "
+                f"process did not finish loading the library within {wait_seconds:.0f} seconds."
+            )
+            raise RuntimeError(msg) from None
+
     async def _start_workers(self) -> None:
         """Issue StartWorkerRequest for every library that requires a dedicated worker.
 
@@ -819,8 +850,13 @@ class LibraryManager(EngineScoped):
                 # registration must not block on it.
                 if library_info.requires_worker:
                     library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.WORKER_PENDING
-                    # Create (or reset) the worker_ready event for this spawn.
-                    library_info.worker_ready = asyncio.Event()
+                # Create (or reset) the worker_ready event for this spawn -- for EVERY spawned
+                # worker, not only legacy ones. A worker registers with the orchestrator at
+                # process start, BEFORE it has loaded its library, so registration alone cannot
+                # gate execution: a node routed in that window fails in the worker with
+                # "Library not found". This event is set by the worker's LibraryLoadedNotification,
+                # and the execute path waits on it (wait_for_worker_library_load).
+                library_info.worker_ready = asyncio.Event()
                 await self.engine.ahandle_request(StartWorkerRequest(library_name=library_info.library_name))
 
     def on_worker_evicted(self, worker_engine_id: str, library_name: str | None) -> None:
@@ -835,12 +871,15 @@ class LibraryManager(EngineScoped):
         library_info = self.get_library_info_by_library_name(library_name)
         if library_info is None:
             return
+        # Unblock any code awaiting this library's worker_ready event, whatever the
+        # lifecycle: an exec-deps library stays LOADED through an eviction, and a waiter
+        # on the execute path would otherwise hold on for the full grace period for a
+        # worker that is already gone.
+        if library_info.worker_ready is not None:
+            library_info.worker_ready.set()
         if library_info.lifecycle_state == LibraryManager.LibraryLifecycleState.WORKER_PENDING:
             library_info.lifecycle_state = LibraryManager.LibraryLifecycleState.FAILURE
             library_info.fitness = LibraryManager.LibraryFitness.UNUSABLE
-            # Unblock any code awaiting this library's worker_ready event.
-            if library_info.worker_ready is not None:
-                library_info.worker_ready.set()
             logger.warning(
                 "Worker '%s' evicted before confirming load of library '%s'; library marked as FAILURE.",
                 worker_engine_id,
@@ -4463,10 +4502,16 @@ class LibraryManager(EngineScoped):
         the orchestrator ceiling stays aligned with the worker self-timeout; first-time
         installs of large libraries can easily exceed the default heartbeat timeout.
         """
+        # Only legacy WORKER_PENDING libraries gate BOOT: their nodes arrive as stubs from
+        # the worker, so nothing exists until it reports. An exec-deps library has real node
+        # classes locally and its worker gates execution only -- blocking startup on its
+        # worker's heavy imports would put torch back on the boot path.
         pending_events = [
             info.worker_ready
             for info in self._library_file_path_to_info.values()
-            if info.worker_ready is not None and not info.worker_ready.is_set()
+            if info.worker_ready is not None
+            and not info.worker_ready.is_set()
+            and info.lifecycle_state == LibraryManager.LibraryLifecycleState.WORKER_PENDING
         ]
         if not pending_events:
             return

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -3146,6 +3146,12 @@ class NodeManager(EngineScoped):
         # scope, not ours. Decide forwarding first; only open a local scope when
         # this process is actually going to execute the node.
         if not is_worker:
+            # The worker registers before it has loaded its library; routing in that window
+            # fails in the worker with "Library not found". Wait for the worker's
+            # LibraryLoadedNotification first -- immediate for any library without a
+            # spawned worker.
+            if library_name:
+                await library_manager.wait_for_worker_library_load(library_name)
             worker = library_manager.get_worker_for_library(library_name) if library_name else None
             wm = self.engine.worker_manager
             if wm is not None and worker is not None:

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -3359,7 +3359,7 @@ class NodeManager(EngineScoped):
         # installed (register_remote_handlers is worker-only), so opening the
         # scope there would just bump a refcount that nothing reads. Skip it
         # to keep the depth counter accurate to its name.
-        is_worker = self.engine.library_manager._is_worker
+        is_worker = self.engine.library_manager.is_worker
         scope_cm = self.engine.event_manager.worker_node_execution_scope() if is_worker else contextlib.nullcontext()
         with scope_cm:
             # Rehydrate serialized artifacts that crossed the orchestrator->worker JSON boundary.
@@ -3411,10 +3411,38 @@ class NodeManager(EngineScoped):
                     result_details=f"Attempted to execute node '{node_name}'. Failed with error: {e}",
                     exception=e,
                 )
+        if self.engine.library_manager.is_worker:
+            unshippable = self._unshippable_output_names(node)
+            if unshippable:
+                library_name = node.metadata.get("library", "its library")
+                details = (
+                    f"Node '{node_name}' produced {', '.join(unshippable)}, which cannot leave "
+                    f"'{library_name}'s isolated process. Either make the value serializable, or keep "
+                    f"it inside the library: cache it library-side and output a small serializable "
+                    f"descriptor that the consuming node trades back."
+                )
+                return ExecuteNodeResultFailure(result_details=details)
+
         return ExecuteNodeResultSuccess(
             parameter_output_values=dict(node.parameter_output_values),
             result_details=f"Node '{node_name}' executed successfully.",
         )
+
+    @staticmethod
+    def _unshippable_output_names(node: BaseNode) -> list[str]:
+        """Output parameter names holding values that cannot cross the process boundary.
+
+        ``serializable=False`` is the author declaring the value unreasonable to move (a live
+        tensor, an open pipeline). In a worker those outputs would be dropped or mangled on
+        the wire, so producing one is a failure with an actionable message rather than a
+        silent hole in the graph.
+        """
+        names = []
+        for parameter_name in node.parameter_output_values:
+            parameter = node.get_parameter_by_name(parameter_name)
+            if parameter is not None and not parameter.serializable:
+                names.append(f"'{parameter_name}'")
+        return names
 
     def on_validate_node_dependencies_request(self, request: ValidateNodeDependenciesRequest) -> ResultPayload:
         node_name = request.node_name

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -3429,24 +3429,9 @@ class NodeManager(EngineScoped):
         with scope_cm:
             # Rehydrate serialized artifacts that crossed the orchestrator->worker JSON boundary.
             parameter_values = hydrate_parameter_values(request.parameter_values)
-            for param_name, value in parameter_values.items():
-                # Skip when the node already holds this value. The local path
-                # calls ExecuteNodeRequest with dict(node.parameter_values) on
-                # the same in-memory instance, so every iteration would be a
-                # no-op mutation that still ran before/after_value_set hooks
-                # and emitted a lifecycle event -- observably breaking nodes
-                # like LoadImage. On the worker the node is fresh, so current
-                # is _PARAM_MISSING and the normal set path runs.
-                current = node.parameter_values.get(param_name, _PARAM_MISSING)
-                if current is value or current == value:
-                    continue
-                try:
-                    node.set_parameter_value(param_name, value)
-                except Exception as e:
-                    return ExecuteNodeResultFailure(
-                        result_details=f"Attempted to set parameter '{param_name}' on node '{node_name}'. Failed with error: {e}",
-                        exception=e,
-                    )
+            hydration_failure = self._apply_hydrated_values(node, node_name, parameter_values)
+            if hydration_failure is not None:
+                return hydration_failure
             # Materialize parameter defaults into parameter_values so that user
             # process() code reading self.parameter_values[name] directly (rather
             # than via get_parameter_value) sees the default. Newly-dropped nodes
@@ -3492,6 +3477,71 @@ class NodeManager(EngineScoped):
             parameter_output_values=dict(node.parameter_output_values),
             result_details=f"Node '{node_name}' executed successfully.",
         )
+
+    def _apply_hydrated_values(
+        self, node: BaseNode, node_name: str, parameter_values: dict[str, Any]
+    ) -> ExecuteNodeResultFailure | None:
+        """Apply hydrated parameter values to an executing node. Returns a failure or None.
+
+        Applied in passes until a fixpoint, because parameter STRUCTURE derives from values
+        (the authoring contract): setting a value fires the node's value hooks, and hooks are
+        where a node like the diffusers VAE decoder creates the parameters its other values
+        belong to. A fresh worker-side node starts with only its __init__ shape, so a value
+        for a derived parameter can arrive before the value that derives it -- hydration
+        order is dict order, which promises nothing. Each pass sets every value whose
+        parameter exists (running the derivations) and defers the rest; deferred values are
+        retried as long as a pass made progress, so a derivation CHAIN (provider creates
+        model, model creates options) hydrates fully no matter how the values were ordered.
+        Termination is guaranteed: a productive pass strictly shrinks the deferred set, and
+        an unproductive one ends the loop.
+
+        A value still unclaimed after both passes belongs to a parameter nothing on this copy
+        derives -- most often one added to the authoritative node by request (a user-added
+        parameter in the editor, or a node that added one mid-execution and expected it to
+        persist). Skipped rather than failed: the authoritative value is untouched on the
+        orchestrator, and failing here made any user-added parameter fatal to a worker-routed
+        node. The warning names the contract so the author of a node that MEANT this
+        parameter to exist knows what to change.
+        """
+        pending = parameter_values
+        deferred: dict[str, Any] = {}
+        made_progress = True
+        while pending and made_progress:
+            deferred = {}
+            made_progress = False
+            for param_name, value in pending.items():
+                if node.get_parameter_by_name(param_name) is None:
+                    deferred[param_name] = value
+                    continue
+                made_progress = True
+                # Skip when the node already holds this value. The local path calls
+                # ExecuteNodeRequest with dict(node.parameter_values) on the same in-memory
+                # instance, so every iteration would be a no-op mutation that still ran
+                # before/after_value_set hooks and emitted a lifecycle event -- observably
+                # breaking nodes like LoadImage. On the worker the node is fresh, so current
+                # is _PARAM_MISSING and the normal set path runs.
+                current = node.parameter_values.get(param_name, _PARAM_MISSING)
+                if current is value or current == value:
+                    continue
+                try:
+                    node.set_parameter_value(param_name, value)
+                except Exception as e:
+                    return ExecuteNodeResultFailure(
+                        result_details=f"Attempted to set parameter '{param_name}' on node '{node_name}'. Failed with error: {e}",
+                        exception=e,
+                    )
+            pending = deferred
+        for param_name in deferred:
+            logger.warning(
+                "Node '%s' received a value for parameter '%s', which does not exist on the "
+                "executing copy and was not created by its value hooks. The value was left "
+                "unapplied for this run. Parameter structure must derive from parameter "
+                "values (created in __init__ or by a value hook); a parameter added only by "
+                "request does not carry over to execution.",
+                node_name,
+                param_name,
+            )
+        return None
 
     @staticmethod
     def _unshippable_output_names(node: BaseNode) -> list[str]:

--- a/src/griptape_nodes/retained_mode/managers/node_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/node_manager.py
@@ -238,6 +238,7 @@ from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
     CheckpointDenial,
     CheckpointSubjectType,
 )
+from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
 from griptape_nodes.retained_mode.retained_mode import RetainedMode
 from griptape_nodes.utils.exception_utils import readable_exception_message
 
@@ -3146,13 +3147,22 @@ class NodeManager(EngineScoped):
         # scope, not ours. Decide forwarding first; only open a local scope when
         # this process is actually going to execute the node.
         if not is_worker:
-            # The worker registers before it has loaded its library; routing in that window
-            # fails in the worker with "Library not found". Wait for the worker's
-            # LibraryLoadedNotification first -- immediate for any library without a
-            # spawned worker.
-            if library_name:
-                await library_manager.wait_for_worker_library_load(library_name)
-            worker = library_manager.get_worker_for_library(library_name) if library_name else None
+            # "This library cannot run right now" is an expected, recoverable state -- an evicted
+            # worker, or one that never started -- and get_worker_for_library reports it by raising.
+            # Left to propagate it came out of the handler as "Unhandled exception while processing
+            # async ExecuteNodeRequest: ..." with advice to restart the engine, burying a message
+            # written specifically for an artist. It is a node failure, so report it as one.
+            #
+            # The wait comes first: a worker registers before it has loaded its library, and
+            # routing in that window fails in the worker with "Library not found". Waiting on the
+            # worker's LibraryLoadedNotification is immediate for any library without a spawned
+            # worker, and a timeout is the same kind of node failure as a missing worker.
+            try:
+                if library_name:
+                    await library_manager.wait_for_worker_library_load(library_name)
+                worker = library_manager.get_worker_for_library(library_name) if library_name else None
+            except RuntimeError as err:
+                return ExecuteNodeResultFailure(result_details=str(err), exception=err)
             wm = self.engine.worker_manager
             if wm is not None and worker is not None:
                 return await self._execute_node_via_worker(request, wm, worker)
@@ -3226,9 +3236,58 @@ class NodeManager(EngineScoped):
                 specific_library_name=library_name,
             )
         except Exception as e:
-            return ExecuteNodeResultFailure(
-                result_details=f"Failed to create node '{node_name}' of type '{node_type}': {e}",
+            # In a worker, this almost always means the process could not load the one library
+            # it exists to run -- most often because an execution dependency would not install.
+            # The orchestrator holds that library perfectly well and is drawing its nodes on the
+            # canvas, so "Library not found" sends whoever reads it hunting for a missing library
+            # that is right in front of them. When this process knows better, say that instead.
+            reason = self._local_library_load_failure(library_name)
+            if reason is None:
+                return ExecuteNodeResultFailure(
+                    result_details=f"Failed to create node '{node_name}' of type '{node_type}': {e}"
+                )
+
+            # The library's own account of why -- resolver output, environment paths, version
+            # solving -- is for whoever maintains the library, and an artist cannot act on any of
+            # it. It goes to the log, the way a model-policy failure's diagnostic does, while the
+            # surfaced message stays about what happened and what still works.
+            logger.error(
+                "The worker for library '%s' could not load it, so node '%s' (%s) cannot run: %s (%s)",
+                library_name,
+                node_name,
+                node_type,
+                reason,
+                e,
             )
+            return ExecuteNodeResultFailure(
+                result_details=(
+                    f"Attempted to run '{node_name}' ({node_type}). Failed because the separate process "
+                    f"that runs '{library_name}' could not start it up. Editing the node still works and "
+                    f"your workflow keeps it. Ask whoever maintains '{library_name}' to check its "
+                    f"installation; the details are in the engine log."
+                )
+            )
+
+    def _local_library_load_failure(self, library_name: str | None) -> str | None:
+        """What THIS process recorded about failing to load ``library_name``, if anything.
+
+        Worker-only: on the orchestrator a library that failed to load has no nodes to execute
+        in the first place, so there is nothing to explain here.
+        """
+        library_manager = self.engine.library_manager
+        if not library_name or not library_manager.is_worker:
+            return None
+        library_info = library_manager.get_library_info_by_library_name(library_name)
+        if library_info is None:
+            return None
+        # Whether the library LOADED, not whether it has any problem. A library can be LOADED and
+        # FLAWED -- one node module of twenty failed to import, a duplicate node name -- and be
+        # running everything else perfectly well. Treating that as "the process could not start"
+        # would misattribute a single broken node type to the whole library. Note the state after
+        # a failed dependency install is EVALUATED, not FAILURE, so this cannot test for FAILURE.
+        if library_info.lifecycle_state is LibraryManager.LibraryLifecycleState.LOADED:
+            return None
+        return library_manager.get_collated_problems_for_library(library_name)
 
     async def _execute_node_via_worker(
         self,

--- a/src/griptape_nodes/retained_mode/managers/resource_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/resource_manager.py
@@ -13,6 +13,9 @@ from griptape_nodes.retained_mode.events.resource_events import (
     FreeResourceInstanceRequest,
     FreeResourceInstanceResultFailure,
     FreeResourceInstanceResultSuccess,
+    GetExecutionDeviceRequest,
+    GetExecutionDeviceResultFailure,
+    GetExecutionDeviceResultSuccess,
     GetResourceInstanceStatusRequest,
     GetResourceInstanceStatusResultFailure,
     GetResourceInstanceStatusResultSuccess,
@@ -32,6 +35,7 @@ from griptape_nodes.retained_mode.events.resource_events import (
 )
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 from griptape_nodes.retained_mode.managers.resource_components.resource_type import ResourceType
+from griptape_nodes.retained_mode.managers.resource_types.compute_resource import ComputeBackend, ComputeInstance
 
 if TYPE_CHECKING:
     from griptape_nodes.retained_mode.managers.resource_components.resource_instance import ResourceInstance
@@ -49,6 +53,10 @@ class ResourceStatus:
     def is_locked(self) -> bool:
         """Check if this resource is currently locked."""
         return self.owner_of_lock is not None
+
+
+# Most capable first. A node that wants something else passes it as `preferred`.
+DEVICE_PREFERENCE = (ComputeBackend.CUDA, ComputeBackend.MPS, ComputeBackend.CPU)
 
 
 class ResourceManager:
@@ -77,6 +85,9 @@ class ResourceManager:
         )
         event_manager.assign_manager_to_request_type(
             request_type=ReleaseResourceInstanceLockRequest, callback=self.on_release_resource_instance_lock_request
+        )
+        event_manager.assign_manager_to_request_type(
+            request_type=GetExecutionDeviceRequest, callback=self.on_get_execution_device_request
         )
         event_manager.assign_manager_to_request_type(
             request_type=ListCompatibleResourceInstancesRequest,
@@ -226,6 +237,49 @@ class ResourceManager:
         return ReleaseResourceInstanceLockResultSuccess(
             result_details=f"Successfully released lock on resource instance {request.instance_id} from {request.owner_id}"
         )
+
+    def on_get_execution_device_request(self, request: GetExecutionDeviceRequest) -> ResultPayload:
+        """Answer which compute device to run on, without importing a framework to find out.
+
+        `preferred` wins when this machine has it -- that is the user or config pin. Otherwise the
+        answer is the most capable backend present, cuda before mps before cpu.
+
+        A `preferred` value this machine lacks is deliberately NOT an error. A workflow authored on
+        a CUDA box should still open and run on a laptop; what changes is the device, not the file.
+        """
+        available = self._detected_compute_backends()
+        if not available:
+            return GetExecutionDeviceResultFailure(
+                result_details=(
+                    "Attempted to determine the execution device. Failed because no compute "
+                    "resource instance is registered, so the machine's backends are unknown."
+                )
+            )
+
+        if request.preferred and request.preferred in available:
+            return GetExecutionDeviceResultSuccess(
+                device=request.preferred,
+                available=available,
+                honored_preference=True,
+                result_details=f"Using the preferred device '{request.preferred}'.",
+            )
+
+        device = next((backend.value for backend in DEVICE_PREFERENCE if backend.value in available), available[0])
+        detail = f"Chose '{device}' from {available}."
+        if request.preferred:
+            detail += f" The preferred '{request.preferred}' is not available on this machine."
+        return GetExecutionDeviceResultSuccess(
+            device=device, available=available, honored_preference=False, result_details=detail
+        )
+
+    def _detected_compute_backends(self) -> list[str]:
+        """The machine's compute backends, read off the registered compute resource."""
+        for instance in self._instances.values():
+            if not isinstance(instance, ComputeInstance):
+                continue
+            backends = instance.get_capability_value("compute") or []
+            return [str(getattr(backend, "value", backend)) for backend in backends]
+        return []
 
     def on_list_compatible_resource_instances_request(
         self, request: ListCompatibleResourceInstancesRequest

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -469,16 +469,12 @@ class StaticFilesManager(EngineScoped):
         if not isinstance(self.storage_driver, LocalStorageDriver):
             return
 
-        # Checked ahead of the payload deliberately. A parent that set this is telling us it
-        # serves the shared workspace on a port that outlives this process, which is a strictly
-        # stronger signal than "some process serves it" -- and the host announces its own URL on
-        # the payload either way, so testing the payload first made this branch unreachable and
-        # the app repo the only thing standing between a worker and an ephemeral-port URL.
-        # Gated on being a worker: only a spawning orchestrator sets this variable on purpose,
-        # so in any other process it is a leaked shell export, and adopting it would silently
-        # point every asset URL at an address nothing here controls. The payload's own flag is
-        # the only race-free source: the engine-level worker flag is set by LibraryManager's
-        # listener for this same event, and listeners run concurrently in no defined order.
+        # The env var outranks the payload: a parent that set it serves the shared workspace on a
+        # port outliving this process, a stronger signal than "some process serves it". Gated on
+        # being a worker, because anywhere else the variable is a leaked shell export and adopting
+        # it would point every asset URL at an address nothing here controls. Read from the payload
+        # rather than the engine-level worker flag, which LibraryManager sets from a concurrent
+        # listener for this same event.
         if payload.is_worker and os.getenv(ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV):
             adopted = os.environ[ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV].rstrip("/")
             self._static_server_base_url = adopted

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -1,6 +1,7 @@
 import base64
 import binascii
 import logging
+import os
 import threading
 from pathlib import Path
 from typing import NamedTuple
@@ -52,7 +53,13 @@ from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 from griptape_nodes.retained_mode.managers.secrets_manager import SecretsManager
 from griptape_nodes.servers import bind_free_socket
-from griptape_nodes.servers.static import STATIC_SERVER_HOST, STATIC_SERVER_PORT, STATIC_SERVER_URL, start_static_server
+from griptape_nodes.servers.static import (
+    ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV,
+    STATIC_SERVER_HOST,
+    STATIC_SERVER_PORT,
+    STATIC_SERVER_URL,
+    start_static_server,
+)
 from griptape_nodes.utils.url_utils import uri_to_path
 
 logger = logging.getLogger("griptape_nodes")
@@ -472,6 +479,13 @@ class StaticFilesManager(EngineScoped):
             # Initialization can complete more than once per process: a workflow executor
             # broadcasts it for its own run. Where the workspace is served is already settled.
             logger.debug("Static server already settled at %s", self._static_server_base_url)
+        elif os.getenv(ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV):
+            # A worker: the orchestrator that spawned this process already serves the shared
+            # workspace, and its server outlives this one. Adopting it keeps asset URLs valid
+            # after this worker is evicted, where a URL on our own ephemeral port would not be.
+            adopted = os.environ[ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV].rstrip("/")
+            self._static_server_base_url = adopted
+            logger.debug("Adopted the orchestrator's static server at %s", adopted)
         else:
             # No host-provided server, so serve the workspace here.
             #

--- a/src/griptape_nodes/retained_mode/managers/static_files_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/static_files_manager.py
@@ -469,7 +469,21 @@ class StaticFilesManager(EngineScoped):
         if not isinstance(self.storage_driver, LocalStorageDriver):
             return
 
-        if payload.static_server_base_url is not None:
+        # Checked ahead of the payload deliberately. A parent that set this is telling us it
+        # serves the shared workspace on a port that outlives this process, which is a strictly
+        # stronger signal than "some process serves it" -- and the host announces its own URL on
+        # the payload either way, so testing the payload first made this branch unreachable and
+        # the app repo the only thing standing between a worker and an ephemeral-port URL.
+        # Gated on being a worker: only a spawning orchestrator sets this variable on purpose,
+        # so in any other process it is a leaked shell export, and adopting it would silently
+        # point every asset URL at an address nothing here controls. The payload's own flag is
+        # the only race-free source: the engine-level worker flag is set by LibraryManager's
+        # listener for this same event, and listeners run concurrently in no defined order.
+        if payload.is_worker and os.getenv(ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV):
+            adopted = os.environ[ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV].rstrip("/")
+            self._static_server_base_url = adopted
+            logger.debug("Adopted the orchestrator's static server at %s", adopted)
+        elif payload.static_server_base_url is not None:
             # The host process serves this workspace and told us where. Pointing at its server
             # keeps asset URLs valid for as long as the host runs, rather than only as long as
             # this engine does.
@@ -479,13 +493,6 @@ class StaticFilesManager(EngineScoped):
             # Initialization can complete more than once per process: a workflow executor
             # broadcasts it for its own run. Where the workspace is served is already settled.
             logger.debug("Static server already settled at %s", self._static_server_base_url)
-        elif os.getenv(ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV):
-            # A worker: the orchestrator that spawned this process already serves the shared
-            # workspace, and its server outlives this one. Adopting it keeps asset URLs valid
-            # after this worker is evicted, where a URL on our own ephemeral port would not be.
-            adopted = os.environ[ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV].rstrip("/")
-            self._static_server_base_url = adopted
-            logger.debug("Adopted the orchestrator's static server at %s", adopted)
         else:
             # No host-provided server, so serve the workspace here.
             #

--- a/src/griptape_nodes/retained_mode/managers/worker_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/worker_manager.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from griptape_nodes.bootstrap.utils.subprocess_websocket_base import WebSocketMessage
+from griptape_nodes.drivers.storage.local_storage_driver import LocalStorageDriver
 from griptape_nodes.retained_mode.engine import EngineScoped
 from griptape_nodes.retained_mode.events import worker_events
 from griptape_nodes.retained_mode.events.app_events import ConfigChanged, CurrentProjectChanged, SecretChanged
@@ -446,7 +447,21 @@ class WorkerManager(EngineScoped):
         try:
             return self.engine.static_files_manager.static_server_base_url
         except RuntimeError:
-            # Raised when accessed before on_app_initialization_complete resolved it.
+            # Raised when accessed before on_app_initialization_complete resolved it. The two
+            # listeners involved run as concurrent tasks, so this is a race the static one normally
+            # wins -- but losing it hands the worker no URL, and it falls back to serving on its own
+            # ephemeral port, which is the dead-links bug this exists to prevent. Loud, because it
+            # is invisible otherwise.
+            #
+            # Only for local storage. On a cloud backend nothing resolves this property at all, and
+            # a worker's URLs come from the same bucket as the orchestrator's, so they outlive it
+            # regardless -- warning there would fire on every single spawn and be false.
+            if isinstance(self.engine.static_files_manager.storage_driver, LocalStorageDriver):
+                logger.warning(
+                    "The static server URL was not resolved yet when a worker was spawned, so the "
+                    "worker will serve assets on its own port. URLs it produces will stop working "
+                    "when it exits."
+                )
             return None
 
     async def evict_worker(self, worker_engine_id: str) -> None:
@@ -645,11 +660,12 @@ class WorkerManager(EngineScoped):
         ]
         await self.spawn_worker(args, library_name)
 
-    @staticmethod
-    def _log_spawn_error(task: asyncio.Task, library_name: str) -> None:
+    def _log_spawn_error(self, task: asyncio.Task, library_name: str) -> None:
+        """Log a spawn that never produced a worker."""
         exc = task.exception()
-        if exc is not None:
-            logger.error("Failed to spawn worker for library '%s': %s", library_name, exc)
+        if exc is None:
+            return
+        logger.error("Failed to spawn worker for library '%s': %s", library_name, exc)
 
     def get_topics_to_subscribe(self, *, is_worker: bool) -> list[str]:
         """Build the list of topics to subscribe to at connection start.

--- a/src/griptape_nodes/retained_mode/managers/worker_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/worker_manager.py
@@ -661,11 +661,21 @@ class WorkerManager(EngineScoped):
         await self.spawn_worker(args, library_name)
 
     def _log_spawn_error(self, task: asyncio.Task, library_name: str) -> None:
-        """Log a spawn that never produced a worker."""
+        """Record a spawn that never produced a worker.
+
+        `handle_start_worker_request` schedules the spawn and returns Success immediately, so its
+        caller cannot tell that a bad interpreter, an OSError, or a missing session stopped the
+        worker ever existing. Without recording it here the library reports that its worker "may
+        still be starting up" for the rest of the session -- which is exactly the message
+        `execution_unavailable_reason` exists to replace, for the most likely failure.
+        """
         exc = task.exception()
         if exc is None:
             return
         logger.error("Failed to spawn worker for library '%s': %s", library_name, exc)
+        library_info = self.engine.library_manager.get_library_info_by_library_name(library_name)
+        if library_info is not None:
+            library_info.execution_unavailable_reason = f"the worker process that runs it could not be started ({exc})."
 
     def get_topics_to_subscribe(self, *, is_worker: bool) -> list[str]:
         """Build the list of topics to subscribe to at connection start.

--- a/src/griptape_nodes/retained_mode/managers/worker_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/worker_manager.py
@@ -21,6 +21,7 @@ from griptape_nodes.retained_mode.managers.settings import (
     WORKER_HEARTBEAT_STARTUP_GRACE_KEY,
     WORKER_HEARTBEAT_TIMEOUT_KEY,
 )
+from griptape_nodes.servers.static import ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV
 from griptape_nodes.utils.version_utils import engine_version
 
 if TYPE_CHECKING:
@@ -340,6 +341,16 @@ class WorkerManager(EngineScoped):
         # desktop app); unbuffered output keeps worker log lines from stalling in Python's
         # block buffer and from being lost on a crash.
         worker_environ["PYTHONUNBUFFERED"] = "1"
+
+        # Hand the worker the URL of the static server the orchestrator is ALREADY serving
+        # this workspace on. Without it the worker starts its own server, wins an arbitrary
+        # OS-assigned port, and hands back asset URLs on that port -- which die when the
+        # worker is evicted and are already dead by the time a saved workflow is reopened.
+        # Both processes share the workspace on disk, so the orchestrator's long-lived
+        # server is the right place to serve anything a worker writes.
+        static_base_url = self._orchestrator_static_server_base_url()
+        if static_base_url is not None:
+            worker_environ[ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV] = static_base_url
         # Hand the orchestrator's own stdout/stderr to the worker explicitly so worker log
         # lines land in the same stream as orchestrator logs. Implicit inheritance is
         # POSIX-only: on Windows, redirected std handles (e.g. the desktop app's pipes) are
@@ -424,6 +435,19 @@ class WorkerManager(EngineScoped):
         # RequestClient.cancel_requests_by_tag, so a dead worker still surfaces
         # to the caller without a per-request ceiling.
         return await future
+
+    def _orchestrator_static_server_base_url(self) -> str | None:
+        """The base URL this engine serves the workspace on, when it has resolved one.
+
+        Returns None before app initialization settles it (nothing to hand a worker yet) or
+        when this engine serves nothing itself, in which case the worker falls back to its
+        own server exactly as before.
+        """
+        try:
+            return self.engine.static_files_manager.static_server_base_url
+        except RuntimeError:
+            # Raised when accessed before on_app_initialization_complete resolved it.
+            return None
 
     async def evict_worker(self, worker_engine_id: str) -> None:
         """Remove a worker from the registry and unsubscribe from its response topic."""

--- a/src/griptape_nodes/retained_mode/publishing/project_packager.py
+++ b/src/griptape_nodes/retained_mode/publishing/project_packager.py
@@ -92,6 +92,10 @@ WORKSPACE_DIRECTORY_KEY = "workspace_directory"
 _MIRROR_IGNORE_PATTERNS = [
     ".env",
     ".venv",
+    # Matched by fnmatch, so ".venv" does not cover it. An execution venv is a full torch
+    # install with host-specific binaries and absolute paths in pyvenv.cfg -- gigabytes that
+    # are wrong on any other machine.
+    ".venv-exec",
     ".git",
     "__pycache__",
     ".griptape-nodes-previews",

--- a/src/griptape_nodes/retained_mode/publishing/workflow_packager.py
+++ b/src/griptape_nodes/retained_mode/publishing/workflow_packager.py
@@ -177,7 +177,7 @@ class WorkflowPackager:
         default exclusions.
         """
         if ignore_patterns is None:
-            ignore_patterns = [".venv", "__pycache__", ".git"]
+            ignore_patterns = [".venv", ".venv-exec", "__pycache__", ".git"]
         result = GriptapeNodes.handle_request(
             CopyTreeRequest(
                 source_path=str(source_path),

--- a/src/griptape_nodes/servers/static.py
+++ b/src/griptape_nodes/servers/static.py
@@ -21,9 +21,8 @@ from rich.logging import RichHandler
 
 # Reaches managers through the ambient engine rather than the GriptapeNodes facade. This module
 # runs on uvicorn's thread, and the facade's worker guard keys off a PROCESS-WIDE
-# in-node-execution refcount rather than a contextvar -- so serving a workspace asset while any
-# node was executing raised, and a worker running its own static server would 500 on every
-# fetch. servers/** is TID251-allowlisted, so nothing would have flagged it.
+# in-node-execution refcount rather than a contextvar, so serving a workspace asset would raise
+# whenever any node happened to be executing.
 from griptape_nodes.retained_mode.engine import current_engine
 
 # Whether to enable the static server

--- a/src/griptape_nodes/servers/static.py
+++ b/src/griptape_nodes/servers/static.py
@@ -19,7 +19,12 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from rich.logging import RichHandler
 
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+# Reaches managers through the ambient engine rather than the GriptapeNodes facade. This module
+# runs on uvicorn's thread, and the facade's worker guard keys off a PROCESS-WIDE
+# in-node-execution refcount rather than a contextvar -- so serving a workspace asset while any
+# node was executing raised, and a worker running its own static server would 500 on every
+# fetch. servers/** is TID251-allowlisted, so nothing would have flagged it.
+from griptape_nodes.retained_mode.engine import current_engine
 
 # Whether to enable the static server
 STATIC_SERVER_ENABLED = os.getenv("STATIC_SERVER_ENABLED", "true").lower() == "true"
@@ -45,7 +50,7 @@ async def _create_static_file_upload_url(request: Request) -> dict:
 
     Similar to a presigned URL, but for uploading files to the static server.
     """
-    base_url = GriptapeNodes.StaticFilesManager().static_server_base_url
+    base_url = current_engine().static_files_manager.static_server_base_url
 
     body = await request.json()
     file_path = body["file_path"].lstrip("/")
@@ -60,7 +65,7 @@ async def _create_static_file(request: Request, file_path: str) -> dict:
         msg = "Static server is not enabled. Please set STATIC_SERVER_ENABLED to True."
         raise ValueError(msg)
 
-    workspace_directory = GriptapeNodes.ConfigManager().workspace_path
+    workspace_directory = current_engine().config_manager.workspace_path
     full_file_path = workspace_directory / file_path
 
     # Create parent directories if they don't exist
@@ -78,7 +83,7 @@ async def _create_static_file(request: Request, file_path: str) -> dict:
         logger.error(msg)
         raise HTTPException(status_code=500, detail=msg) from e
 
-    base_url = GriptapeNodes.StaticFilesManager().static_server_base_url
+    base_url = current_engine().static_files_manager.static_server_base_url
     static_url = urljoin(f"{base_url}{STATIC_SERVER_URL}/", file_path)
     return {"url": static_url}
 
@@ -89,7 +94,7 @@ async def _list_static_files(file_path_prefix: str = "") -> dict:
         msg = "Static server is not enabled. Please set STATIC_SERVER_ENABLED to True."
         raise HTTPException(status_code=500, detail=msg)
 
-    workspace_directory = GriptapeNodes.ConfigManager().workspace_path
+    workspace_directory = current_engine().config_manager.workspace_path
 
     # Handle the prefix path
     if file_path_prefix:
@@ -119,7 +124,7 @@ async def _delete_static_file(file_path: str) -> dict:
         msg = "Static server is not enabled. Please set STATIC_SERVER_ENABLED to True."
         raise HTTPException(status_code=500, detail=msg)
 
-    workspace_directory = GriptapeNodes.ConfigManager().workspace_path
+    workspace_directory = current_engine().config_manager.workspace_path
     file_full_path = workspace_directory / file_path
 
     anyio_file_path = anyio.Path(file_full_path)
@@ -163,7 +168,7 @@ async def _serve_library_widget(library_name: str, file_path: str) -> FileRespon
     Raises:
         HTTPException: If library not found, file not found, or path traversal detected
     """
-    library_manager = GriptapeNodes.LibraryManager()
+    library_manager = current_engine().library_manager
 
     # Find the library's directory by looking up its info
     library_info = library_manager.get_library_info_by_library_name(library_name)
@@ -278,7 +283,7 @@ class WorkspaceStaticFiles(StaticFiles):
         return super().lookup_path(path)
 
     def _current_directory(self) -> Path:
-        workspace_directory = GriptapeNodes.ConfigManager().workspace_path
+        workspace_directory = current_engine().config_manager.workspace_path
         if self._subdirectory is None:
             return workspace_directory
         return workspace_directory / self._subdirectory
@@ -321,7 +326,7 @@ def start_static_server(sock: socket.socket) -> None:
         "http://localhost:5173",
         "http://localhost:5174",
         "gtn-editor://editor",
-        GriptapeNodes.StaticFilesManager().static_server_base_url,
+        current_engine().static_files_manager.static_server_base_url,
     ]
 
     # Add CORS middleware
@@ -336,8 +341,8 @@ def start_static_server(sock: socket.socket) -> None:
 
     # Mount static files. The served directories resolve the workspace live on each request
     # (see WorkspaceStaticFiles) so they follow runtime workspace changes such as project switches.
-    workspace_directory = GriptapeNodes.ConfigManager().workspace_path
-    static_files_directory = GriptapeNodes.ConfigManager().get_config_value("static_files_directory")
+    workspace_directory = current_engine().config_manager.workspace_path
+    static_files_directory = current_engine().config_manager.get_config_value("static_files_directory")
 
     app.mount(
         STATIC_SERVER_URL,

--- a/src/griptape_nodes/servers/static.py
+++ b/src/griptape_nodes/servers/static.py
@@ -27,6 +27,10 @@ STATIC_SERVER_ENABLED = os.getenv("STATIC_SERVER_ENABLED", "true").lower() == "t
 STATIC_SERVER_HOST = os.getenv("STATIC_SERVER_HOST", "localhost")
 # Port of the static server (where uvicorn binds). Falls back to an OS-assigned free port if unavailable.
 STATIC_SERVER_PORT = int(os.getenv("STATIC_SERVER_PORT", "8124"))
+# Set by the orchestrator on a worker subprocess's environment: the URL of the static server
+# the orchestrator already serves this workspace on. A worker adopts it instead of starting a
+# server of its own, so asset URLs a worker produces outlive that worker.
+ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV = "GTN_ORCHESTRATOR_STATIC_SERVER_BASE_URL"
 # URL path for the static server
 STATIC_SERVER_URL = os.getenv("STATIC_SERVER_URL", "/workspace")
 # Log level for the static server

--- a/src/griptape_nodes/utils/artifact_normalization.py
+++ b/src/griptape_nodes/utils/artifact_normalization.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from griptape_nodes.files.path_utils import parse_static_server_url
-from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+from griptape_nodes.retained_mode.engine import current_engine
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +54,7 @@ def _resolve_file_path(file_path: str) -> Path | None:  # noqa: PLR0911
 
     # Get workspace path (can raise exceptions from ConfigManager)
     try:
-        workspace_path = GriptapeNodes.ConfigManager().workspace_path
+        workspace_path = current_engine().config_manager.workspace_path
     except (AttributeError, RuntimeError, KeyError) as e:
         logger.debug("Failed to get workspace path: %s", e)
         return None
@@ -117,7 +117,7 @@ def _upload_file_to_static_storage(file_path: Path, artifact_type: type[Any]) ->
     try:
         file_data = file_path.read_bytes()
         file_name = file_path.name
-        static_files_manager = GriptapeNodes.StaticFilesManager()
+        static_files_manager = current_engine().static_files_manager
         url = static_files_manager.save_static_file(file_data, file_name)
         return artifact_type(url)
     except Exception as e:

--- a/src/griptape_nodes/utils/async_utils.py
+++ b/src/griptape_nodes/utils/async_utils.py
@@ -18,6 +18,13 @@ logger = logging.getLogger(__name__)
 async def call_function(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
     """Call a function, handling both sync and async cases.
 
+    Awaits on what the call RETURNS rather than asking whether ``func`` is a coroutine
+    function. The two differ for a callable object: ``inspect.iscoroutinefunction`` inspects
+    the object, not its ``__call__``, so an instance with an ``async def __call__`` looks
+    synchronous and its coroutine comes back unawaited -- as a value, silently, to be handed
+    on as though it were the result. Every caller here dispatches to registered callbacks,
+    and a callback is as likely to be an instance as a function.
+
     Args:
         func: The function to call (sync or async)
         *args: Positional arguments to pass to the function
@@ -26,9 +33,10 @@ async def call_function(func: Callable[..., Any], *args: Any, **kwargs: Any) -> 
     Returns:
         The result of the function call
     """
-    if inspect.iscoroutinefunction(func):
-        return await func(*args, **kwargs)
-    return func(*args, **kwargs)
+    result = func(*args, **kwargs)
+    if inspect.isawaitable(result):
+        return await result
+    return result
 
 
 async def to_thread(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:

--- a/tests/e2e/fixtures/behavior_preservation_library/behavior_preservation_node.py
+++ b/tests/e2e/fixtures/behavior_preservation_library/behavior_preservation_node.py
@@ -1,0 +1,102 @@
+"""Node carrying everything a schema stub drops, for a library routed to a worker.
+
+The point of this fixture is the combination: the library declares execution dependencies, so
+its execution goes to a worker -- and yet the ORCHESTRATOR holds this real class, so the
+parameter behaviors that only exist in Python survive. A stub rebuilt from
+``WorkerParameterSchema`` carries scalar fields and ``ui_options`` only, so all three of these
+would be gone:
+
+- a ``Button`` trait, whose click handler lives on the trait rather than on the node. This is
+  the worst of the family, because ``ui_options`` DO serialize, so the button renders and
+  looks clickable while being guaranteed to fail (griptape-nodes-engine#5420).
+- a converter, which rewrites an incoming value.
+- a validator, which refuses one.
+- a value hook and a connection hook override, which a stub class does not carry at all.
+
+Module scope stays clean of the execution dependency on purpose: that is the contract that
+lets the orchestrator import this at all.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import NodeMessageResult, Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import DataNode
+from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
+
+CLICK_ACKNOWLEDGEMENT = "the node's own handler ran on the orchestrator"
+
+
+def _shout(value: Any) -> Any:
+    if isinstance(value, str):
+        return value.upper()
+    return value
+
+
+def _reject_forbidden(parameter: Parameter, value: Any) -> None:  # noqa: ARG001
+    if value == "FORBIDDEN":
+        msg = "forbidden value"
+        raise ValueError(msg)
+
+
+class BehaviorPreservationNode(DataNode):
+    BUTTON_PARAMETER = "model_manager"
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        button = Button(full_width=True)
+        button.on_click_callback = self._on_button_clicked
+        self.add_parameter(
+            Parameter(
+                name=self.BUTTON_PARAMETER,
+                type="str",
+                default_value="",
+                tooltip="Opens the model manager",
+                allowed_modes={ParameterMode.PROPERTY},
+                traits={button},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="mode",
+                type="str",
+                default_value="plain",
+                tooltip="Converted to upper case; refuses FORBIDDEN",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                converters=[_shout],
+                validators=[_reject_forbidden],
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="observed_mode",
+                type="str",
+                default_value="",
+                tooltip="",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def _on_button_clicked(self, _button: Button, _details: ButtonDetailsMessagePayload) -> NodeMessageResult:
+        return NodeMessageResult(success=True, details=CLICK_ACKNOWLEDGEMENT)
+
+    def after_value_set(self, parameter: Parameter, value: Any) -> None:
+        """Overridden so the value-hook detector has something to find."""
+        super().after_value_set(parameter, value)
+
+    def after_incoming_connection(
+        self,
+        source_node: Any,
+        source_parameter: Parameter,
+        target_parameter: Parameter,
+    ) -> None:
+        """Overridden so the connection-hook detector has something to find."""
+        super().after_incoming_connection(source_node, source_parameter, target_parameter)
+
+    def process(self) -> None:
+        # Deferred on purpose: this library declares it as execution-only, so it is absent
+        # from the orchestrator by design.
+        import fakeexec  # type: ignore[reportMissingImports]  # noqa: F401
+
+        self.parameter_output_values["observed_mode"] = self.get_parameter_value("mode")

--- a/tests/e2e/fixtures/behavior_preservation_library/griptape_nodes_library.json
+++ b/tests/e2e/fixtures/behavior_preservation_library/griptape_nodes_library.json
@@ -1,0 +1,38 @@
+{
+  "name": "Behavior Preservation Library",
+  "library_schema_version": "0.12.0",
+  "metadata": {
+    "author": "Test Fixture",
+    "description": "Library whose nodes carry traits, converters and validators",
+    "library_version": "0.1.0",
+    "engine_version": "0.0.0",
+    "tags": [
+      "test"
+    ],
+    "dependencies": {
+      "pip_dependencies": [],
+      "pip_dependencies_exec": []
+    }
+  },
+  "categories": [
+    {
+      "test": {
+        "title": "test",
+        "description": "Test nodes",
+        "color": "border-gray-500",
+        "icon": "Folder"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "class_name": "BehaviorPreservationNode",
+      "file_path": "behavior_preservation_node.py",
+      "metadata": {
+        "category": "test",
+        "description": "Node carrying a Button trait, a converter and a validator",
+        "display_name": "Behavior Preservation Node"
+      }
+    }
+  ]
+}

--- a/tests/e2e/fixtures/exec_dep_library/exec_dep_node.py
+++ b/tests/e2e/fixtures/exec_dep_library/exec_dep_node.py
@@ -1,0 +1,51 @@
+"""Node that splits its dependencies the way the execution-environment design requires.
+
+The two imports in this file are the whole point:
+
+- ``fakeedit`` is imported at module scope, so it is an EDIT-TIME dependency. It has to resolve
+  anywhere a node is merely defined or instantiated, which includes the orchestrator.
+- ``fakeexec`` is imported inside ``process``, so it is an EXECUTION dependency. It only has to
+  resolve where nodes actually execute.
+
+Real heavy libraries have this shape with torch and diffusers standing in for ``fakeexec``.
+"""
+
+from __future__ import annotations
+
+import fakeedit  # type: ignore[reportMissingImports]  # Edit-time dep: only importable from the library's edit venv.
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import DataNode
+
+
+class ExecDepNode(DataNode):
+    def __init__(self, name: str, metadata: dict | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        # Reading the edit-time dep here proves it is available at instantiation, not just import.
+        self.add_parameter(
+            Parameter(
+                name="edit_dep_version",
+                tooltip="Version of the edit-time dependency seen at instantiation",
+                type="str",
+                default_value=fakeedit.__version__,
+                allowed_modes={ParameterMode.PROPERTY, ParameterMode.OUTPUT},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="exec_dep_version",
+                tooltip="Version of the execution dependency seen while running",
+                type="str",
+                default_value="",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        # Deliberate deferred import, not a circular-import workaround: this dependency is
+        # declared as execution-only, so it is absent from the orchestrator by design and
+        # importing it at module scope would make this node impossible to instantiate there.
+        import fakeexec  # type: ignore[reportMissingImports]
+
+        self.parameter_output_values["edit_dep_version"] = fakeedit.__version__
+        self.parameter_output_values["exec_dep_version"] = fakeexec.__version__

--- a/tests/e2e/fixtures/exec_dep_library/griptape_nodes_library.json
+++ b/tests/e2e/fixtures/exec_dep_library/griptape_nodes_library.json
@@ -1,0 +1,36 @@
+{
+  "name": "Exec Dep Library",
+  "library_schema_version": "0.12.0",
+  "metadata": {
+    "author": "Test Fixture",
+    "description": "Library that declares edit-time and execution dependencies separately",
+    "library_version": "0.1.0",
+    "engine_version": "0.0.0",
+    "tags": ["test"],
+    "dependencies": {
+      "pip_dependencies": [],
+      "pip_dependencies_exec": []
+    }
+  },
+  "categories": [
+    {
+      "test": {
+        "title": "test",
+        "description": "Test nodes",
+        "color": "border-gray-500",
+        "icon": "Folder"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "class_name": "ExecDepNode",
+      "file_path": "exec_dep_node.py",
+      "metadata": {
+        "category": "test",
+        "description": "Node whose module needs an edit-time dep and whose process needs an execution dep",
+        "display_name": "Exec Dep Node"
+      }
+    }
+  ]
+}

--- a/tests/e2e/fixtures/execution_module_library/boundary_node.py
+++ b/tests/e2e/fixtures/execution_module_library/boundary_node.py
@@ -18,6 +18,24 @@ class BoundaryNode(DataNode):
         super().__init__(name, metadata=metadata)
         self.add_parameter(
             Parameter(
+                name="probe_boundary",
+                type="str",
+                default_value="",
+                tooltip="Set anything to make the value hook report what the boundary answers here",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="boundary_answer",
+                type="str",
+                default_value="",
+                tooltip="What execution_module() answered in whichever process ran the hook",
+                allowed_modes={ParameterMode.OUTPUT, ParameterMode.PROPERTY},
+            )
+        )
+        self.add_parameter(
+            Parameter(
                 name="reported_version",
                 type="str",
                 default_value="",
@@ -25,6 +43,21 @@ class BoundaryNode(DataNode):
                 allowed_modes={ParameterMode.OUTPUT},
             )
         )
+
+    def after_value_set(self, parameter: Parameter, value: Any) -> None:  # noqa: ARG002
+        """Record what reaching for an execution module does wherever this hook runs.
+
+        Value hooks fire on the orchestrator when a user edits, and again in the worker during
+        hydration -- so this one parameter reports the boundary's answer from both sides without
+        needing to inspect either process.
+        """
+        if parameter.name != "probe_boundary":
+            return
+        try:
+            self.execution_module("runner")
+            self.set_parameter_value("boundary_answer", "reached it")
+        except RuntimeError as err:
+            self.set_parameter_value("boundary_answer", str(err))
 
     def process(self) -> None:
         runner = self.execution_module("runner")

--- a/tests/e2e/fixtures/execution_module_library/boundary_node.py
+++ b/tests/e2e/fixtures/execution_module_library/boundary_node.py
@@ -1,0 +1,31 @@
+"""A node module that is base-clean because it has nowhere to put a heavy import.
+
+Nothing here imports the library's execution dependency, not even deferred inside a method.
+The heavy work lives behind the declared execution-module boundary, and this module reaches it
+through the engine rather than importing it -- so there is no import discipline to forget.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import DataNode
+
+
+class BoundaryNode(DataNode):
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="reported_version",
+                type="str",
+                default_value="",
+                tooltip="Version the execution module read from the execution dependency",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        runner = self.execution_module("runner")
+        self.parameter_output_values["reported_version"] = runner.dependency_version()

--- a/tests/e2e/fixtures/execution_module_library/boundary_node.py
+++ b/tests/e2e/fixtures/execution_module_library/boundary_node.py
@@ -36,6 +36,24 @@ class BoundaryNode(DataNode):
         )
         self.add_parameter(
             Parameter(
+                name="chosen_device",
+                type="str",
+                default_value="",
+                tooltip="The device the engine chose, with no framework imported to ask",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="run_summary",
+                type="str",
+                default_value="",
+                tooltip="What the execution module produced from the device and the asset path",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+        self.add_parameter(
+            Parameter(
                 name="reported_version",
                 type="str",
                 default_value="",
@@ -60,5 +78,14 @@ class BoundaryNode(DataNode):
             self.set_parameter_value("boundary_answer", str(err))
 
     def process(self) -> None:
+        # Three engine-owned answers, none of which this module could compute for itself without
+        # importing something that does not exist in the process that edits it.
         runner = self.execution_module("runner")
         self.parameter_output_values["reported_version"] = runner.dependency_version()
+        self.parameter_output_values["chosen_device"] = self.execution_device
+        try:
+            weights = self.model_asset("stand-in-weights")
+        except RuntimeError as err:
+            self.parameter_output_values["run_summary"] = f"no weights: {err}"
+            return
+        self.parameter_output_values["run_summary"] = runner.load_and_run(self.execution_device, weights)

--- a/tests/e2e/fixtures/execution_module_library/execution/runner.py
+++ b/tests/e2e/fixtures/execution_module_library/execution/runner.py
@@ -1,9 +1,11 @@
 """Execution-only module: imports the heavy dependency at module scope, normally.
 
-This is the point of the boundary. `fakeexec` stands in for torch: it is declared as an
-execution dependency, so it exists only in the worker's environment. A module-scope import
-here is correct and safe, because the orchestrator never imports this file.
+This is the point of the boundary. `fakeexec` stands in for torch: it is declared as an execution
+dependency, so it exists only in the worker's environment. A module-scope import here is correct
+and safe, because the orchestrator never imports this file.
 """
+
+from pathlib import Path
 
 import fakeexec  # type: ignore[reportMissingImports]
 
@@ -11,3 +13,14 @@ import fakeexec  # type: ignore[reportMissingImports]
 def dependency_version() -> str:
     """Version of the execution dependency, read where it is actually importable."""
     return fakeexec.__version__
+
+
+def load_and_run(device: str, weights: Path) -> str:
+    """The shape a real model runner has: a device to place on, weights to load.
+
+    Both arrive as ARGUMENTS. That is the whole arrangement -- the node asked the engine for the
+    device and the asset path, so nothing here had to import a framework to find a GPU or invent a
+    cache location, and nothing in the node had to import this module.
+    """
+    weight_files = sorted(path.name for path in weights.iterdir()) if weights.is_dir() else []
+    return f"{fakeexec.__version__} on {device} with {weight_files}"

--- a/tests/e2e/fixtures/execution_module_library/execution/runner.py
+++ b/tests/e2e/fixtures/execution_module_library/execution/runner.py
@@ -1,0 +1,13 @@
+"""Execution-only module: imports the heavy dependency at module scope, normally.
+
+This is the point of the boundary. `fakeexec` stands in for torch: it is declared as an
+execution dependency, so it exists only in the worker's environment. A module-scope import
+here is correct and safe, because the orchestrator never imports this file.
+"""
+
+import fakeexec  # type: ignore[reportMissingImports]
+
+
+def dependency_version() -> str:
+    """Version of the execution dependency, read where it is actually importable."""
+    return fakeexec.__version__

--- a/tests/e2e/fixtures/execution_module_library/griptape_nodes_library.json
+++ b/tests/e2e/fixtures/execution_module_library/griptape_nodes_library.json
@@ -1,0 +1,41 @@
+{
+  "name": "Execution Module Library",
+  "library_schema_version": "0.13.0",
+  "metadata": {
+    "author": "Test Fixture",
+    "description": "Library whose heavy imports live behind a declared execution-module boundary",
+    "library_version": "0.1.0",
+    "engine_version": "0.0.0",
+    "tags": [
+      "test"
+    ],
+    "dependencies": {
+      "pip_dependencies": [],
+      "pip_dependencies_exec": []
+    }
+  },
+  "categories": [
+    {
+      "test": {
+        "title": "test",
+        "description": "Test nodes",
+        "color": "border-gray-500",
+        "icon": "Folder"
+      }
+    }
+  ],
+  "execution_modules": [
+    "execution"
+  ],
+  "nodes": [
+    {
+      "class_name": "BoundaryNode",
+      "file_path": "boundary_node.py",
+      "metadata": {
+        "category": "test",
+        "description": "Reaches execution code through the engine",
+        "display_name": "Boundary Node"
+      }
+    }
+  ]
+}

--- a/tests/e2e/fixtures/execution_module_library/leak_helper.py
+++ b/tests/e2e/fixtures/execution_module_library/leak_helper.py
@@ -1,0 +1,8 @@
+"""A helper that imports the execution module, making the violation transitive.
+
+Imported the way a real library would: the engine puts the library's base directory on
+sys.path, so its own subpackages import by plain name. Two node modules sharing a helper like
+this is the case a scan of the node modules' own imports calls clean.
+"""
+
+from execution import runner  # noqa: F401

--- a/tests/e2e/fixtures/execution_module_library/leaky_node.py
+++ b/tests/e2e/fixtures/execution_module_library/leaky_node.py
@@ -1,0 +1,32 @@
+"""A node module that violates the boundary, for the detector to catch.
+
+It imports the execution module at module scope -- through a helper, which is the case a
+source scan of node modules misses -- so importing this on the orchestrator would drag the
+library's execution dependency onto the editing process's import path.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import leak_helper  # noqa: F401
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import DataNode
+
+
+class LeakyNode(DataNode):
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="unused",
+                type="str",
+                default_value="",
+                tooltip="",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        return

--- a/tests/e2e/fixtures/worker_behavior_library/griptape_nodes_library.json
+++ b/tests/e2e/fixtures/worker_behavior_library/griptape_nodes_library.json
@@ -114,6 +114,15 @@
         "description": "Writes binary through File and verifies it survived",
         "display_name": "WriteBytesNode"
       }
+    },
+    {
+      "class_name": "DerivedStructureNode",
+      "file_path": "worker_behavior_nodes.py",
+      "metadata": {
+        "category": "test",
+        "description": "Derives parameter structure from a value",
+        "display_name": "DerivedStructureNode"
+      }
     }
   ]
 }

--- a/tests/e2e/fixtures/worker_behavior_library/griptape_nodes_library.json
+++ b/tests/e2e/fixtures/worker_behavior_library/griptape_nodes_library.json
@@ -87,6 +87,33 @@
         "description": "Converters, validators, dynamic parameters",
         "display_name": "EditorBehaviorNode"
       }
+    },
+    {
+      "class_name": "ReadSecretNode",
+      "file_path": "worker_behavior_nodes.py",
+      "metadata": {
+        "category": "test",
+        "description": "Reads a secret via a request",
+        "display_name": "ReadSecretNode"
+      }
+    },
+    {
+      "class_name": "UnshippableOutputNode",
+      "file_path": "worker_behavior_nodes.py",
+      "metadata": {
+        "category": "test",
+        "description": "Outputs a value that cannot be serialized",
+        "display_name": "UnshippableOutputNode"
+      }
+    },
+    {
+      "class_name": "WriteBytesNode",
+      "file_path": "worker_behavior_nodes.py",
+      "metadata": {
+        "category": "test",
+        "description": "Writes binary through File and verifies it survived",
+        "display_name": "WriteBytesNode"
+      }
     }
   ]
 }

--- a/tests/e2e/fixtures/worker_behavior_library/griptape_nodes_library.json
+++ b/tests/e2e/fixtures/worker_behavior_library/griptape_nodes_library.json
@@ -1,0 +1,92 @@
+{
+  "name": "Worker Behavior Library",
+  "library_schema_version": "0.12.0",
+  "metadata": {
+    "author": "Test Fixture",
+    "description": "Behaviors a heavy library depends on when executing in a worker",
+    "library_version": "0.1.0",
+    "engine_version": "0.0.0",
+    "tags": [
+      "test"
+    ],
+    "dependencies": {
+      "pip_dependencies": [],
+      "pip_dependencies_exec": []
+    }
+  },
+  "categories": [
+    {
+      "test": {
+        "title": "test",
+        "description": "Test nodes",
+        "color": "border-gray-500",
+        "icon": "Folder"
+      }
+    }
+  ],
+  "nodes": [
+    {
+      "class_name": "SaveMediaNode",
+      "file_path": "worker_behavior_nodes.py",
+      "metadata": {
+        "category": "test",
+        "description": "Writes bytes and returns a URL",
+        "display_name": "SaveMediaNode"
+      }
+    },
+    {
+      "class_name": "ReadConfigNode",
+      "file_path": "worker_behavior_nodes.py",
+      "metadata": {
+        "category": "test",
+        "description": "Reads engine config via a request",
+        "display_name": "ReadConfigNode"
+      }
+    },
+    {
+      "class_name": "StreamingNode",
+      "file_path": "worker_behavior_nodes.py",
+      "metadata": {
+        "category": "test",
+        "description": "Streams progress and yields work",
+        "display_name": "StreamingNode"
+      }
+    },
+    {
+      "class_name": "ChainStartNode",
+      "file_path": "worker_behavior_nodes.py",
+      "metadata": {
+        "category": "test",
+        "description": "First hop of a three-node chain",
+        "display_name": "ChainStartNode"
+      }
+    },
+    {
+      "class_name": "ChainMiddleNode",
+      "file_path": "worker_behavior_nodes.py",
+      "metadata": {
+        "category": "test",
+        "description": "Second hop of a three-node chain",
+        "display_name": "ChainMiddleNode"
+      }
+    },
+    {
+      "class_name": "ChainEndNode",
+      "file_path": "worker_behavior_nodes.py",
+      "metadata": {
+        "category": "test",
+        "description": "Third hop of a three-node chain",
+        "display_name": "ChainEndNode"
+      }
+    },
+    {
+      "class_name": "EditorBehaviorNode",
+      "file_path": "worker_behavior_nodes.py",
+      "metadata": {
+        "category": "test",
+        "description": "Converters, validators, dynamic parameters",
+        "display_name": "EditorBehaviorNode"
+      }
+    }
+  ]
+}

--- a/tests/e2e/fixtures/worker_behavior_library/worker_behavior_nodes.py
+++ b/tests/e2e/fixtures/worker_behavior_library/worker_behavior_nodes.py
@@ -1,0 +1,257 @@
+"""Nodes exercising the behaviors a heavy library depends on when it runs in a worker.
+
+Each node here stands in for something a real library (diffusers, advanced media) does that
+the minimal fixtures did not cover:
+
+- ``SaveMediaNode``: writes bytes and returns a URL. Proves a worker's asset URLs are served
+  by the orchestrator's long-lived server rather than the worker's ephemeral one.
+- ``ReadConfigNode``: reads config and a secret through requests. Proves the sanctioned
+  state-access path works from inside a worker.
+- ``StreamingNode``: streams progress and uses the ``AsyncResult`` yield pattern, which 24
+  standard-library files rely on.
+- ``ChainStartNode`` / ``ChainMiddleNode`` / ``ChainEndNode``: a three-hop chain of
+  serializable values, so every hop round-trips through the orchestrator.
+- ``EditorBehaviorNode``: converters, validators, and parameters added and removed from
+  ``after_value_set`` -- all of which now run orchestrator-side on the real class instead of
+  being lost to a schema stub.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
+from griptape_nodes.retained_mode.events.config_events import GetConfigValueRequest, GetConfigValueResultSuccess
+from griptape_nodes.retained_mode.events.parameter_events import (
+    AddParameterToNodeRequest,
+    RemoveParameterFromNodeRequest,
+)
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
+
+MEDIA_BYTES = b"\x89PNG\r\n\x1a\n" + b"fixture-media-payload"
+
+
+class SaveMediaNode(DataNode):
+    """Writes bytes through the storage driver and outputs the resulting URL."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="url",
+                type="str",
+                default_value="",
+                tooltip="URL of the saved media",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        # Storage is the one capability a worker keeps locally: the bytes must not cross the
+        # process boundary. The URL, however, has to point at a server that outlives us.
+        url = GriptapeNodes.StaticFilesManager().save_static_file(MEDIA_BYTES, f"{self.name}.png")
+        self.parameter_output_values["url"] = url
+
+
+class ReadConfigNode(DataNode):
+    """Reads engine state the sanctioned way: a request, not a manager reference."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="config_key",
+                type="str",
+                default_value="workspace_directory",
+                tooltip="Config key to read",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="config_value",
+                type="str",
+                default_value="",
+                tooltip="Value the engine reported",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        key = self.get_parameter_value("config_key")
+        result = GriptapeNodes.handle_request(GetConfigValueRequest(category_and_key=key))
+        value = result.value if isinstance(result, GetConfigValueResultSuccess) else ""
+        self.parameter_output_values["config_value"] = str(value)
+
+
+class StreamingNode(DataNode):
+    """Streams progress mid-execution and yields work the framework runs off-thread."""
+
+    CHUNKS = ("alpha", "beta", "gamma")
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="stream",
+                type="str",
+                default_value="",
+                tooltip="Accumulated streamed output",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> AsyncResult:
+        def work() -> str:
+            return "".join(self.CHUNKS)
+
+        for chunk in self.CHUNKS:
+            self.append_value_to_parameter("stream", chunk)
+        # The yield-a-callable pattern: the framework runs this off the event loop and sends
+        # the result back into the generator.
+        total = yield work
+        self.parameter_output_values["stream"] = total
+
+
+class ChainStartNode(DataNode):
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="out",
+                type="str",
+                default_value="",
+                tooltip="",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        self.parameter_output_values["out"] = "start"
+
+
+class ChainMiddleNode(DataNode):
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="in_value",
+                type="str",
+                default_value="",
+                tooltip="",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="out",
+                type="str",
+                default_value="",
+                tooltip="",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        self.parameter_output_values["out"] = f"{self.get_parameter_value('in_value')}->middle"
+
+
+class ChainEndNode(DataNode):
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="in_value",
+                type="str",
+                default_value="",
+                tooltip="",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="final",
+                type="str",
+                default_value="",
+                tooltip="",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        self.parameter_output_values["final"] = f"{self.get_parameter_value('in_value')}->end"
+
+
+def _shout(value: Any) -> Any:
+    """Converter: proves converters run where the node object is real."""
+    if isinstance(value, str):
+        return value.upper()
+    return value
+
+
+def _reject_forbidden(parameter: Parameter, value: Any) -> None:  # noqa: ARG001 (validator signature)
+    """Validator: proves validators run where the node object is real."""
+    if value == "FORBIDDEN":
+        msg = "value 'forbidden' is not allowed"
+        raise ValueError(msg)
+
+
+class EditorBehaviorNode(DataNode):
+    """Carries converters, validators, and dynamic parameters driven by value changes.
+
+    A schema stub would drop all of this: the converter and validator would not travel, and
+    the dynamic parameter would never appear. With a real class on the orchestrator they all
+    work at edit time, which is what the dependency split buys.
+    """
+
+    DYNAMIC_PARAMETER = "dynamic_extra"
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="mode",
+                type="str",
+                default_value="plain",
+                tooltip="Set to 'expand' to grow a dynamic parameter",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                converters=[_shout],
+                validators=[_reject_forbidden],
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="observed_mode",
+                type="str",
+                default_value="",
+                tooltip="",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def after_value_set(self, parameter: Parameter, value: Any) -> None:
+        if parameter.name != "mode":
+            return
+        wants_extra = value == "EXPAND"
+        has_extra = self.get_parameter_by_name(self.DYNAMIC_PARAMETER) is not None
+        if wants_extra and not has_extra:
+            GriptapeNodes.handle_request(
+                AddParameterToNodeRequest(
+                    node_name=self.name,
+                    parameter_name=self.DYNAMIC_PARAMETER,
+                    type="str",
+                    default_value="grown",
+                    tooltip="Added because mode is expand",
+                    mode_allowed_input=True,
+                    mode_allowed_property=True,
+                    mode_allowed_output=False,
+                )
+            )
+        elif not wants_extra and has_extra:
+            GriptapeNodes.handle_request(
+                RemoveParameterFromNodeRequest(node_name=self.name, parameter_name=self.DYNAMIC_PARAMETER)
+            )
+
+    def process(self) -> None:
+        self.parameter_output_values["observed_mode"] = self.get_parameter_value("mode")

--- a/tests/e2e/fixtures/worker_behavior_library/worker_behavior_nodes.py
+++ b/tests/e2e/fixtures/worker_behavior_library/worker_behavior_nodes.py
@@ -10,6 +10,10 @@ the minimal fixtures did not cover:
   refused and a local read would answer from the wrong process.
 - ``UnshippableOutputNode``: outputs a value its author declared unserializable, which a
   worker must refuse to ship rather than drop on the wire.
+- ``DerivedStructureNode``: the authoring contract's reference shape -- parameter structure
+  derives from parameter values. Its value hook creates and removes a parameter as a pure
+  function of ``shape``, so any fresh copy of the node converges on the right structure the
+  moment its values hydrate, in any order.
 - ``WriteBytesNode``: writes binary through ``File``, the ordinary way a node emits a file.
   Reads it back and reports whether the bytes survived, so a routing change that sends file
   I/O across the process boundary fails a test instead of silently writing mojibake.
@@ -237,6 +241,15 @@ class EditorBehaviorNode(DataNode):
                 allowed_modes={ParameterMode.OUTPUT},
             )
         )
+        self.add_parameter(
+            Parameter(
+                name="dynamic_visible_in_process",
+                type="bool",
+                default_value=False,
+                tooltip="Whether the parameter after_value_set added is visible to process()",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
 
     def after_value_set(self, parameter: Parameter, value: Any) -> None:
         if parameter.name != "mode":
@@ -263,6 +276,13 @@ class EditorBehaviorNode(DataNode):
 
     def process(self) -> None:
         self.parameter_output_values["observed_mode"] = self.get_parameter_value("mode")
+        # Whether the parameter this node's own after_value_set added is present on the instance
+        # that is executing. In a worker the add is a REQUEST, and requests are answered by the
+        # orchestrator -- so the parameter can land on the orchestrator's node while this copy,
+        # the one running process(), never sees it.
+        self.parameter_output_values["dynamic_visible_in_process"] = (
+            self.get_parameter_by_name(self.DYNAMIC_PARAMETER) is not None
+        )
 
 
 class ReadSecretNode(DataNode):
@@ -371,3 +391,86 @@ class WriteBytesNode(DataNode):
         read_back = target.read_bytes()
         self.parameter_output_values["bytes_survived"] = read_back == self.PAYLOAD
         self.parameter_output_values["byte_count"] = len(read_back)
+
+
+class DerivedStructureNode(DataNode):
+    """Parameter structure as a deterministic function of parameter values.
+
+    This is the sanctioned dynamic-structure pattern (the diffusers VAE decoder's, minus the
+    pipeline): the value hook mutates the LOCAL node directly, so the derivation runs wherever
+    the values land -- on the orchestrator at edit time, and again on a fresh worker copy as
+    hydration applies the same values. Nothing needs to sync structure, because structure is
+    recomputed. Contrast EditorBehaviorNode, whose hook goes through a request and therefore
+    mutates only the authoritative node.
+    """
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="shape",
+                type="str",
+                default_value="plain",
+                tooltip="Set to 'expanded' to derive the extra parameter",
+                allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="echo",
+                type="str",
+                default_value="",
+                tooltip="Echoes the derived parameter's hydrated value",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="deep_echo",
+                type="str",
+                default_value="",
+                tooltip="Echoes the second-level derived parameter's hydrated value",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def after_value_set(self, parameter: Parameter, value: Any) -> None:
+        if parameter.name == "shape":
+            wants_derived = value == "expanded"
+            has_derived = self.get_parameter_by_name("derived_in") is not None
+            if wants_derived and not has_derived:
+                self.add_parameter(
+                    Parameter(
+                        name="derived_in",
+                        type="str",
+                        default_value="",
+                        tooltip="Exists exactly when shape is 'expanded'",
+                        allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                    )
+                )
+            elif not wants_derived and has_derived:
+                self.remove_parameter_element_by_name("derived_in")
+            return
+        if parameter.name == "derived_in":
+            # Second derivation level: the chain shape real dynamic UIs take (provider creates
+            # model, model creates options). Exists exactly when derived_in is 'deeper'.
+            wants_deep = value == "deeper"
+            has_deep = self.get_parameter_by_name("derived_deep") is not None
+            if wants_deep and not has_deep:
+                self.add_parameter(
+                    Parameter(
+                        name="derived_deep",
+                        type="str",
+                        default_value="",
+                        tooltip="Exists exactly when derived_in is 'deeper'",
+                        allowed_modes={ParameterMode.INPUT, ParameterMode.PROPERTY},
+                    )
+                )
+            elif not wants_deep and has_deep:
+                self.remove_parameter_element_by_name("derived_deep")
+
+    def process(self) -> None:
+        derived = self.get_parameter_value("derived_in") if self.get_parameter_by_name("derived_in") else ""
+        self.parameter_output_values["echo"] = derived
+        deep = self.get_parameter_value("derived_deep") if self.get_parameter_by_name("derived_deep") else ""
+        self.parameter_output_values["deep_echo"] = deep

--- a/tests/e2e/fixtures/worker_behavior_library/worker_behavior_nodes.py
+++ b/tests/e2e/fixtures/worker_behavior_library/worker_behavior_nodes.py
@@ -5,8 +5,14 @@ the minimal fixtures did not cover:
 
 - ``SaveMediaNode``: writes bytes and returns a URL. Proves a worker's asset URLs are served
   by the orchestrator's long-lived server rather than the worker's ephemeral one.
-- ``ReadConfigNode``: reads config and a secret through requests. Proves the sanctioned
-  state-access path works from inside a worker.
+- ``ReadConfigNode`` / ``ReadSecretNode``: read config and a secret through requests. Prove
+  the sanctioned state-access path works from inside a worker, where the manager path is
+  refused and a local read would answer from the wrong process.
+- ``UnshippableOutputNode``: outputs a value its author declared unserializable, which a
+  worker must refuse to ship rather than drop on the wire.
+- ``WriteBytesNode``: writes binary through ``File``, the ordinary way a node emits a file.
+  Reads it back and reports whether the bytes survived, so a routing change that sends file
+  I/O across the process boundary fails a test instead of silently writing mojibake.
 - ``StreamingNode``: streams progress and uses the ``AsyncResult`` yield pattern, which 24
   standard-library files rely on.
 - ``ChainStartNode`` / ``ChainMiddleNode`` / ``ChainEndNode``: a three-hop chain of
@@ -22,11 +28,13 @@ from typing import Any
 
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import AsyncResult, DataNode
+from griptape_nodes.files.file import File
 from griptape_nodes.retained_mode.events.config_events import GetConfigValueRequest, GetConfigValueResultSuccess
 from griptape_nodes.retained_mode.events.parameter_events import (
     AddParameterToNodeRequest,
     RemoveParameterFromNodeRequest,
 )
+from griptape_nodes.retained_mode.events.secrets_events import GetSecretValueRequest, GetSecretValueResultSuccess
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
 MEDIA_BYTES = b"\x89PNG\r\n\x1a\n" + b"fixture-media-payload"
@@ -255,3 +263,111 @@ class EditorBehaviorNode(DataNode):
 
     def process(self) -> None:
         self.parameter_output_values["observed_mode"] = self.get_parameter_value("mode")
+
+
+class ReadSecretNode(DataNode):
+    """Reads a secret the sanctioned way: a request, not a manager reference.
+
+    Secrets are the case that matters most in practice -- almost every real node needs an API
+    key -- and the one where reading the worker's own copy is most likely to differ from the
+    orchestrator's, because a worker's environment is frozen when it spawns.
+    """
+
+    # The NAME of a secret, not a secret.
+    SECRET_NAME = "GTN_WORKER_FIXTURE_SECRET"  # noqa: S105
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="secret_value",
+                type="str",
+                default_value="",
+                tooltip="Value the engine reported for the fixture secret",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        result = GriptapeNodes.handle_request(
+            GetSecretValueRequest(key=self.SECRET_NAME, should_error_on_not_found=False)
+        )
+        value = result.value if isinstance(result, GetSecretValueResultSuccess) else None
+        self.parameter_output_values["secret_value"] = value or ""
+
+
+class UnshippableOutputNode(DataNode):
+    """Produces a value that cannot cross a process boundary.
+
+    ``serializable=False`` is the author saying "this is unreasonable to move" -- a live
+    tensor, an open pipeline handle. Executing in a worker, that output has nowhere to go, and
+    the engine must say so instead of silently dropping it and leaving a hole in the graph.
+    """
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="live_handle",
+                type="Any",
+                default_value=None,
+                tooltip="Stands in for a tensor or an open pipeline",
+                allowed_modes={ParameterMode.OUTPUT},
+                serializable=False,
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="summary",
+                type="str",
+                default_value="",
+                tooltip="A serializable descriptor, which is what a library should output instead",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        # An object with no meaningful serialized form, which is the whole point.
+        self.parameter_output_values["live_handle"] = object()
+        self.parameter_output_values["summary"] = "handle-1"
+
+
+class WriteBytesNode(DataNode):
+    """Writes binary through ``File`` and reports whether it survived the round trip.
+
+    ``File.write_bytes`` goes through ``WriteFileRequest``, so this is the path a node takes to
+    emit a file. It exists because that request was briefly forwarded from workers, and the wire
+    form turned bytes into a base64 string that came back as ``str`` -- every write landing
+    corrupted, with no error anywhere. Asserting on the bytes read back is the only thing that
+    catches it.
+    """
+
+    PAYLOAD = b"\x89PNG\r\n\x1a\n\x00\xff\xfe binary-payload"
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        self.add_parameter(
+            Parameter(
+                name="bytes_survived",
+                type="bool",
+                default_value=False,
+                tooltip="True when the bytes read back match the bytes written",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+        self.add_parameter(
+            Parameter(
+                name="byte_count",
+                type="int",
+                default_value=0,
+                tooltip="Length of what was read back",
+                allowed_modes={ParameterMode.OUTPUT},
+            )
+        )
+
+    def process(self) -> None:
+        target = File(f"{self.name}-payload.bin")
+        target.write_bytes(self.PAYLOAD)
+        read_back = target.read_bytes()
+        self.parameter_output_values["bytes_survived"] = read_back == self.PAYLOAD
+        self.parameter_output_values["byte_count"] = len(read_back)

--- a/tests/e2e/offline_wheels.py
+++ b/tests/e2e/offline_wheels.py
@@ -1,0 +1,48 @@
+"""Hand-built wheels for dependency-environment tests.
+
+Building the wheel by hand keeps these tests fully offline: no network, no build backend, and
+no dependency on any package that happens to be installed. Because the packages built here
+exist nowhere else, a successful import of one is proof that the environment it was installed
+into was created AND wired onto ``sys.path``.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import zipfile
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def build_wheel(wheel_dir: Path, name: str, version: str = "1.0.0") -> Path:
+    """Write a minimal importable wheel for ``name`` into ``wheel_dir``.
+
+    The built package exposes ``__version__`` so tests can assert *which* environment
+    satisfied an import.
+    """
+    wheel_dir.mkdir(parents=True, exist_ok=True)
+    wheel_path = wheel_dir / f"{name}-{version}-py3-none-any.whl"
+    dist_info = f"{name}-{version}.dist-info"
+    files = {
+        f"{name}/__init__.py": f'__version__ = "{version}"\n',
+        f"{dist_info}/METADATA": f"Metadata-Version: 2.1\nName: {name}\nVersion: {version}\n",
+        f"{dist_info}/WHEEL": "Wheel-Version: 1.0\nGenerator: test-fixture\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+    }
+    record_rows = []
+    with zipfile.ZipFile(wheel_path, "w") as zf:
+        for file_name, content in files.items():
+            data = content.encode()
+            zf.writestr(file_name, data)
+            digest = base64.urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=").decode()
+            record_rows.append(f"{file_name},sha256={digest},{len(data)}")
+        record_rows.append(f"{dist_info}/RECORD,,")
+        zf.writestr(f"{dist_info}/RECORD", "\n".join(record_rows) + "\n")
+    return wheel_path
+
+
+def offline_install_flags(wheel_dir: Path) -> list[str]:
+    """Pip flags that install only from ``wheel_dir``, never the network."""
+    return ["--no-index", "--find-links", str(wheel_dir)]

--- a/tests/e2e/test_exec_dep_worker_routing.py
+++ b/tests/e2e/test_exec_dep_worker_routing.py
@@ -1,0 +1,461 @@
+"""End-to-end tests for the exec-dep worker MVP.
+
+A library that declares execution dependencies (``pip_dependencies_exec``) gets a different
+deal than either mode that exists today:
+
+- It loads REAL node classes on the orchestrator (not schema stubs), because its node
+  modules import with edit-time deps only.
+- Its nodes EXECUTE in its dedicated worker process, where ``.venv-exec`` is on
+  ``sys.path``.
+- While executing there, node code cannot reach orchestrator-owned managers directly; it
+  asks the orchestrator with a request instead.
+- A value it produces that cannot leave that process fails loudly with instructions.
+
+These tests pin those four behaviors, plus the crucial negative: a library that declares no
+execution dependencies is untouched by any of it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+from pathlib import Path
+
+import pytest
+
+from griptape_nodes.node_library.library_registry import LibraryRegistry, LibrarySchema
+from griptape_nodes.retained_mode.engine import current_engine
+from griptape_nodes.retained_mode.events.app_events import LibraryLoadedNotification
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.events.node_events import (
+    SendNodeMessageRequest,
+    SendNodeMessageResultSuccess,
+)
+
+# The facade import survives for the dummy-manager guard tests, whose subject it is.
+from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes  # noqa: TID251
+from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
+from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
+from griptape_nodes.utils.version_utils import engine_version
+from tests.e2e.fixtures.behavior_preservation_library.behavior_preservation_node import CLICK_ACKNOWLEDGEMENT
+from tests.e2e.offline_wheels import build_wheel, offline_install_flags
+
+EXEC_FIXTURE = Path(__file__).parent / "fixtures" / "exec_dep_library"
+NONSERIALIZABLE_FIXTURE = Path(__file__).parent / "fixtures" / "nonserializable_library"
+BEHAVIOR_FIXTURE = Path(__file__).parent / "fixtures" / "behavior_preservation_library"
+
+
+def _register(  # noqa: PLR0913 (a test-library builder; each knob is one manifest field)
+    tmp_path: Path,
+    *,
+    fixture_dir: Path,
+    node_file: str,
+    name: str,
+    exec_dependencies: list[str] | None = None,
+    edit_dependencies: list[str] | None = None,
+) -> str:
+    """Register a fixture library, optionally declaring execution dependencies."""
+    library_dir = tmp_path / name.replace(" ", "_")
+    library_dir.mkdir(parents=True, exist_ok=True)
+    schema = json.loads((fixture_dir / "griptape_nodes_library.json").read_text())
+    schema["name"] = name
+    schema["library_schema_version"] = LibrarySchema.LATEST_SCHEMA_VERSION
+    schema["metadata"]["engine_version"] = engine_version
+    dependencies: dict[str, list[str]] = {"pip_dependencies": list(edit_dependencies or [])}
+    if exec_dependencies:
+        wheel_dir = tmp_path / "wheels"
+        for dep in [*(edit_dependencies or []), *exec_dependencies]:
+            build_wheel(wheel_dir, dep, "1.0.0")
+        dependencies["pip_dependencies_exec"] = exec_dependencies
+        dependencies["pip_install_flags"] = offline_install_flags(wheel_dir)
+    elif edit_dependencies:
+        wheel_dir = tmp_path / "wheels"
+        for dep in edit_dependencies:
+            build_wheel(wheel_dir, dep, "1.0.0")
+        dependencies["pip_install_flags"] = offline_install_flags(wheel_dir)
+    schema["metadata"]["dependencies"] = dependencies
+    library_json = library_dir / "griptape_nodes_library.json"
+    library_json.write_text(json.dumps(schema, indent=2))
+    shutil.copy(fixture_dir / node_file, library_dir / node_file)
+    result = current_engine().handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    assert isinstance(result, RegisterLibraryFromFileResultSuccess), getattr(result, "result_details", result)
+    return str(library_json)
+
+
+def _library_info(library_json: str) -> LibraryManager.LibraryInfo:
+    return current_engine().library_manager._library_file_path_to_info[library_json]
+
+
+class TestRoutingFact:
+    def test_exec_dependencies_mean_execution_in_a_worker(self, tmp_path: Path) -> None:
+        """Declaring exec deps routes execution to a worker WITHOUT the legacy stub path."""
+        library_json = _register(
+            tmp_path,
+            fixture_dir=EXEC_FIXTURE,
+            node_file="exec_dep_node.py",
+            name="Routing Heavy",
+            edit_dependencies=["fakeedit"],
+            exec_dependencies=["fakeexec"],
+        )
+
+        info = _library_info(library_json)
+        assert info.executes_in_worker is True
+        # Crucially NOT the legacy worker mode: no stub path, no WORKER_PENDING gating.
+        assert info.requires_worker is False
+        assert info.lifecycle_state is LibraryManager.LibraryLifecycleState.LOADED
+
+    def test_no_exec_dependencies_means_no_worker(self, tmp_path: Path) -> None:
+        library_json = _register(
+            tmp_path,
+            fixture_dir=NONSERIALIZABLE_FIXTURE,
+            node_file="nonserializable_nodes.py",
+            name="Routing Light",
+        )
+
+        info = _library_info(library_json)
+        assert info.executes_in_worker is False
+        assert info.requires_worker is False
+
+    def test_worker_is_required_once_declared(self, tmp_path: Path) -> None:
+        """With no worker registered, routing raises instead of silently running locally.
+
+        Falling back to in-process execution would run the node in the one process that
+        deliberately lacks its execution dependencies.
+        """
+        _register(
+            tmp_path,
+            fixture_dir=EXEC_FIXTURE,
+            node_file="exec_dep_node.py",
+            name="Routing Guard",
+            edit_dependencies=["fakeedit"],
+            exec_dependencies=["fakeexec"],
+        )
+
+        with pytest.raises(RuntimeError, match="requires a dedicated worker"):
+            current_engine().library_manager.get_worker_for_library("Routing Guard")
+
+
+class TestRealNodesOnOrchestrator:
+    def test_orchestrator_holds_real_node_classes_not_stubs(self, tmp_path: Path) -> None:
+        """The point of the dep split: real classes in the editor, heavy deps elsewhere.
+
+        The node instantiates here with its edit-time dependency importable and its
+        execution dependency absent from this process.
+        """
+        _register(
+            tmp_path,
+            fixture_dir=EXEC_FIXTURE,
+            node_file="exec_dep_node.py",
+            name="Real Nodes",
+            edit_dependencies=["fakeedit"],
+            exec_dependencies=["fakeexec"],
+        )
+
+        node = LibraryRegistry.create_node(node_type="ExecDepNode", name="real", specific_library_name="Real Nodes")
+
+        # A stub would carry parameter shape only; this is the real class, so its
+        # __init__ ran and read its edit-time dependency.
+        assert node.get_parameter_value("edit_dep_version") == "1.0.0"
+        assert type(node).__name__ == "ExecDepNode"
+        assert type(node).__module__ != "griptape_nodes.retained_mode.managers.library_manager"
+
+
+class TestParameterBehaviorsSurviveOnRealClasses:
+    """What a schema stub drops, and what these libraries keep by not being stubbed.
+
+    A stub is rebuilt from ``WorkerParameterSchema``, which carries scalar fields and
+    ``ui_options`` only. Traits, converters and validators live in Python and cannot travel,
+    so a worker-mode library loses all of them on the orchestrator -- see
+    griptape-nodes-engine#5420 for the trait case, which is the worst of the family because
+    ``ui_options`` DO serialize: the button renders, looks clickable, and cannot work.
+
+    An execution-dependency library sets ``executes_in_worker`` WITHOUT setting
+    ``requires_worker``, and stub registration is gated on the latter, so these libraries keep
+    the real class. ``test_the_orchestrator_refuses_worker_schemas_that_would_clobber_real_classes``
+    is the one that drives that gate; the rest cover what survives on the class itself.
+    """
+
+    def _register_behavior_library(self, tmp_path: Path) -> str:
+        return _register(
+            tmp_path,
+            fixture_dir=BEHAVIOR_FIXTURE,
+            node_file="behavior_preservation_node.py",
+            name="Behavior Library",
+            exec_dependencies=["fakeexec"],
+        )
+
+    def test_a_button_trait_survives_and_its_click_resolves(self, tmp_path: Path) -> None:
+        """The #5420 case: the trait is present, so the click reaches the node's handler."""
+        self._register_behavior_library(tmp_path)
+        node = LibraryRegistry.create_node(
+            node_type="BehaviorPreservationNode", name="behaviors", specific_library_name="Behavior Library"
+        )
+        current_engine().object_manager.add_object_by_name("behaviors", node)
+
+        parameter = node.get_parameter_by_name("model_manager")
+        assert parameter is not None
+        assert list(parameter.find_elements_by_type(Button)), "the Button trait did not survive"
+
+        result = current_engine().handle_request(
+            SendNodeMessageRequest(
+                node_name="behaviors",
+                optional_element_name="model_manager",
+                message_type="on_click",
+                message=ButtonDetailsMessagePayload(label="Open", variant="default", size="md", state="ready"),
+            )
+        )
+
+        assert isinstance(result, SendNodeMessageResultSuccess), getattr(result, "result_details", result)
+        # The trait's bound callback is what produced this, so the string proves the node's own
+        # handler ran rather than something merely accepting the message.
+        assert CLICK_ACKNOWLEDGEMENT in str(result.result_details)
+
+    @pytest.mark.asyncio
+    async def test_the_orchestrator_refuses_worker_schemas_that_would_clobber_real_classes(
+        self, tmp_path: Path
+    ) -> None:
+        """Drive the gate itself: a worker's schemas must not replace real classes.
+
+        The tests above load a library in-process, which is true of any library and never
+        reaches the gate. The clobber happens later and elsewhere: the worker sends a
+        LibraryLoadedNotification carrying serialized schemas, and the ORCHESTRATOR decides
+        whether to build stub classes from them. `Library.register_new_node_type` overwrites
+        unconditionally, so a gate keyed on the wrong flag silently swaps this library's real
+        classes -- traits and all -- for stubs after load.
+        """
+        self._register_behavior_library(tmp_path)
+        library_manager = current_engine().library_manager
+        library_info = library_manager.get_library_info_by_library_name("Behavior Library")
+        assert library_info is not None
+        assert library_info.executes_in_worker is True, "the library must be worker-routed for this to mean anything"
+        assert library_info.requires_worker is False, "...but not via the legacy stub path"
+
+        # Exactly what a worker broadcasts after loading the library.
+        schemas = await library_manager._serialize_library_node_schemas("Behavior Library")
+        await library_manager._on_library_loaded_notification(
+            LibraryLoadedNotification(
+                library_name="Behavior Library",
+                fitness=LibraryManager.LibraryFitness.GOOD,
+                node_schemas=schemas,
+            )
+        )
+
+        node = LibraryRegistry.create_node(
+            node_type="BehaviorPreservationNode", name="post_notification", specific_library_name="Behavior Library"
+        )
+        parameter = node.get_parameter_by_name("model_manager")
+        assert parameter is not None
+        assert list(parameter.find_elements_by_type(Button)), (
+            "the worker's schemas replaced the real class with a stub, dropping the Button trait"
+        )
+
+    def test_converters_and_validators_survive(self, tmp_path: Path) -> None:
+        """The quieter half of the same family: both only exist as Python callables."""
+        self._register_behavior_library(tmp_path)
+        node = LibraryRegistry.create_node(
+            node_type="BehaviorPreservationNode", name="callables", specific_library_name="Behavior Library"
+        )
+
+        node.set_parameter_value("mode", "expand")
+        assert node.get_parameter_value("mode") == "EXPAND", "the converter did not run"
+
+        with pytest.raises(ValueError, match="forbidden"):
+            node.set_parameter_value("mode", "FORBIDDEN")
+
+    @pytest.mark.asyncio
+    async def test_the_stub_loss_warnings_stay_quiet_for_a_library_that_is_not_stubbed(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The detectors describe what a stub loses, so they must not fire when there is none.
+
+        Both fire from the worker-side schema probe, which runs for every library a worker
+        loads -- including execution-dependency libraries, whose schemas the orchestrator
+        then ignores. Ungated, this node's converter, validator and trait each produced a
+        warning saying they "will not execute on the orchestrator stub", for a library whose
+        orchestrator copy is the real class. That sends an author to fix correct code.
+        """
+        self._register_behavior_library(tmp_path)
+        library_manager = current_engine().library_manager
+
+        with caplog.at_level(logging.WARNING):
+            await library_manager._serialize_library_node_schemas("Behavior Library")
+
+        assert "will not execute on the orchestrator stub" not in caplog.text
+        assert "parameter-behaviors-dropped-in-schema" not in caplog.text
+        # The other two gated rules carry their own wording; assert each, or half the gate
+        # can be reverted with nothing failing.
+        assert "connection hooks run on the orchestrator against a stub" not in caplog.text
+        assert "these fire only during" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_the_stub_loss_warnings_still_fire_for_a_legacy_worker_mode_library(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The other direction: a library that IS stubbed still gets told what it loses."""
+        self._register_behavior_library(tmp_path)
+        library_manager = current_engine().library_manager
+        library_info = library_manager.get_library_info_by_library_name("Behavior Library")
+        assert library_info is not None
+        library_info.requires_worker = True
+
+        with caplog.at_level(logging.WARNING):
+            await library_manager._serialize_library_node_schemas("Behavior Library")
+
+        assert "will not execute on the orchestrator stub" in caplog.text
+        assert "connection hooks run on the orchestrator against a stub" in caplog.text
+        assert "these fire only during" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_the_stub_path_these_libraries_avoid_would_drop_the_button(self, tmp_path: Path) -> None:
+        """Negative control: the same parameters through stub synthesis lose the trait.
+
+        Without this, the test above passes for any ordinary library and proves nothing about
+        the routing decision. Driving the real serializer and stub builder shows the loss is in
+        stub synthesis, and reproduces the reported failure message exactly.
+        """
+        self._register_behavior_library(tmp_path)
+        library_manager = current_engine().library_manager
+
+        schemas = await library_manager._serialize_library_node_schemas("Behavior Library")
+        node_schema = next(s for s in schemas if s.class_name == "BehaviorPreservationNode")
+        stub_class = library_manager._make_worker_stub_class("BehaviorPreservationNode", node_schema.parameters)
+        stub = stub_class(name="stubbed")
+        current_engine().object_manager.add_object_by_name("stubbed", stub)
+
+        stub_parameter = stub.get_parameter_by_name("model_manager")
+        assert stub_parameter is not None, "the parameter itself should survive -- only its trait is lost"
+        assert not list(stub_parameter.find_elements_by_type(Button))
+
+        result = current_engine().handle_request(
+            SendNodeMessageRequest(
+                node_name="stubbed",
+                optional_element_name="model_manager",
+                message_type="on_click",
+                message=ButtonDetailsMessagePayload(label="Open", variant="default", size="md", state="ready"),
+            )
+        )
+
+        assert not isinstance(result, SendNodeMessageResultSuccess)
+        assert "no handler was available" in str(result.result_details)
+
+
+class TestUnshippableOutputGuardrail:
+    @pytest.mark.asyncio
+    async def test_worker_producing_an_unshippable_value_fails_with_instructions(self, tmp_path: Path) -> None:
+        """A serializable=False output cannot cross the boundary, so say so usefully."""
+        from griptape_nodes.retained_mode.events.execution_events import (
+            ExecuteNodeRequest,
+            ExecuteNodeResultFailure,
+        )
+
+        _register(
+            tmp_path,
+            fixture_dir=NONSERIALIZABLE_FIXTURE,
+            node_file="nonserializable_nodes.py",
+            name="Guardrail Library",
+        )
+        library_manager = current_engine().library_manager
+        library_manager._is_worker = True
+        node = LibraryRegistry.create_node(
+            node_type="ProducerNode", name="Producer", specific_library_name="Guardrail Library"
+        )
+        current_engine().object_manager.add_object_by_name("Producer", node)
+
+        result = await current_engine().ahandle_request(
+            ExecuteNodeRequest(
+                node_name="Producer",
+                node_metadata={"node_type": "ProducerNode", "library": "Guardrail Library"},
+            )
+        )
+
+        assert isinstance(result, ExecuteNodeResultFailure)
+        details = str(result.result_details)
+        assert "'session'" in details
+        assert "cannot leave" in details
+        # The message must teach the way forward, not just refuse.
+        assert "descriptor" in details
+
+    @pytest.mark.asyncio
+    async def test_serializable_outputs_are_unaffected(self, tmp_path: Path) -> None:
+        from griptape_nodes.retained_mode.events.execution_events import (
+            ExecuteNodeRequest,
+            ExecuteNodeResultSuccess,
+        )
+
+        _register(
+            tmp_path,
+            fixture_dir=EXEC_FIXTURE,
+            node_file="exec_dep_node.py",
+            name="Guardrail Serializable",
+            edit_dependencies=["fakeedit"],
+        )
+        current_engine().library_manager._is_worker = True
+        node = LibraryRegistry.create_node(
+            node_type="ExecDepNode", name="Fine", specific_library_name="Guardrail Serializable"
+        )
+        current_engine().object_manager.add_object_by_name("Fine", node)
+
+        result = await current_engine().ahandle_request(
+            ExecuteNodeRequest(
+                node_name="Fine",
+                node_metadata={"node_type": "ExecDepNode", "library": "Guardrail Serializable"},
+            )
+        )
+
+        # fakeexec is not importable here, so process() raises -- but on the exec dep, NOT
+        # on the guardrail. What matters is the guardrail did not fire for its string outputs.
+        if isinstance(result, ExecuteNodeResultSuccess):
+            assert result.parameter_output_values["edit_dep_version"] == "1.0.0"
+        else:
+            assert "cannot leave" not in str(result.result_details)
+
+
+class TestManagerAccessDuringWorkerExecution:
+    def test_config_manager_is_refused_inside_worker_execution(self) -> None:
+        """In a worker, node code must ask the orchestrator rather than read local state."""
+        library_manager = current_engine().library_manager
+        library_manager._is_worker = True
+        event_manager = current_engine().event_manager
+
+        with event_manager.worker_node_execution_scope(), pytest.raises(RuntimeError) as excinfo:
+            GriptapeNodes.ConfigManager()
+
+        message = str(excinfo.value)
+        assert "ConfigManager" in message
+        assert "GetConfigValueRequest" in message
+
+    def test_secrets_and_os_managers_are_refused_too(self) -> None:
+        current_engine().library_manager._is_worker = True
+        event_manager = current_engine().event_manager
+
+        with event_manager.worker_node_execution_scope():
+            with pytest.raises(RuntimeError, match="GetSecretValueRequest"):
+                GriptapeNodes.SecretsManager()
+            with pytest.raises(RuntimeError, match="ReadFileRequest"):
+                GriptapeNodes.OSManager()
+
+    def test_managers_work_outside_node_execution_in_a_worker(self) -> None:
+        """Engine boot and library load happen in the worker too, and need real managers."""
+        current_engine().library_manager._is_worker = True
+
+        assert GriptapeNodes.ConfigManager() is not None
+        assert GriptapeNodes.SecretsManager() is not None
+
+    def test_managers_work_during_execution_on_the_orchestrator(self) -> None:
+        """The refusal is about being in a worker, not about executing."""
+        event_manager = current_engine().event_manager
+
+        with event_manager.worker_node_execution_scope():
+            assert GriptapeNodes.ConfigManager() is not None
+
+    def test_static_files_manager_stays_available(self) -> None:
+        """Storage is the one local capability: media bytes cannot cross the boundary."""
+        current_engine().library_manager._is_worker = True
+        event_manager = current_engine().event_manager
+
+        with event_manager.worker_node_execution_scope():
+            assert GriptapeNodes.StaticFilesManager() is not None

--- a/tests/e2e/test_exec_dep_worker_routing.py
+++ b/tests/e2e/test_exec_dep_worker_routing.py
@@ -63,7 +63,6 @@ def _register(  # noqa: PLR0913 (a test-library builder; each knob is one manife
     exec_dependencies: list[str] | None = None,
     edit_dependencies: list[str] | None = None,
     required_resources: dict[str, object] | None = None,
-    preferred_resources: dict[str, object] | None = None,
 ) -> str:
     """Register a fixture library, optionally declaring execution dependencies."""
     library_dir = tmp_path / name.replace(" ", "_")
@@ -85,12 +84,10 @@ def _register(  # noqa: PLR0913 (a test-library builder; each knob is one manife
             build_wheel(wheel_dir, dep, "1.0.0")
         dependencies["pip_install_flags"] = offline_install_flags(wheel_dir)
     schema["metadata"]["dependencies"] = dependencies
-    if required_resources is not None or preferred_resources is not None:
+    if required_resources is not None:
         resources: dict[str, object] = {}
         if required_resources is not None:
             resources["required"] = required_resources
-        if preferred_resources is not None:
-            resources["preferred"] = preferred_resources
         schema["metadata"]["resources"] = resources
     library_json = library_dir / "griptape_nodes_library.json"
     library_json.write_text(json.dumps(schema, indent=2))
@@ -440,57 +437,27 @@ class TestUnmetResourcesCostExecutionNotLoading:
         assert info.fitness is LibraryManager.LibraryFitness.GOOD
 
 
-class TestPreferredResourcesAreInformationNotGates:
-    """Needing a resource and preferring one are different claims, and libraries had to pick.
+class TestUnmetRequirementCostsExecutionNotEditing:
+    """A resource this machine lacks must not stop the library loading.
 
-    Before the second tier existed an author who wanted to say "this really wants a GPU" chose
-    between a hard gate and silence. SAM3 chose the gate and declared cuda-only, which is why it
-    could not be edited on a laptop at all.
+    SAM3 declares cuda-only, and refusing to register it took editing away from every machine that
+    was only ever going to edit -- placeholder nodes reading "Library not found" on a laptop. The
+    requirement now gates the run instead, so the refusal arrives when someone presses run.
     """
 
     IMPOSSIBLE_COMPUTE: ClassVar[dict[str, object]] = {"compute": [["definitely-not-a-real-backend"], "has_any"]}
 
-    def test_an_unmet_preference_does_not_gate_anything(self, tmp_path: Path) -> None:
-        library_json = _register(
-            tmp_path,
-            fixture_dir=BEHAVIOR_FIXTURE,
-            node_file="behavior_preservation_node.py",
-            name="Prefers The Impossible",
-            preferred_resources=self.IMPOSSIBLE_COMPUTE,
-        )
-
-        info = _library_info(library_json)
-        assert info.fitness is LibraryManager.LibraryFitness.GOOD, "a preference must not change fitness"
-        assert info.execution_unavailable_reason is None, "a preference must not block execution"
-        assert info.unmet_preferences is not None, "but it should be recorded"
-        assert "definitely-not-a-real-backend" in info.unmet_preferences
-
-    def test_a_met_preference_records_nothing(self, tmp_path: Path) -> None:
-        library_json = _register(
-            tmp_path,
-            fixture_dir=BEHAVIOR_FIXTURE,
-            node_file="behavior_preservation_node.py",
-            name="Prefers The Possible",
-            preferred_resources={"compute": [["cpu"], "has_any"]},
-        )
-
-        info = _library_info(library_json)
-        assert info.unmet_preferences is None
-        assert info.fitness is LibraryManager.LibraryFitness.GOOD
-
-    def test_execution_still_refuses_for_an_unmet_REQUIREMENT(self, tmp_path: Path) -> None:
-        """The tiers are independent: adding a preference does not soften a requirement."""
+    def test_execution_refuses_for_an_unmet_requirement(self, tmp_path: Path) -> None:
         _register(
             tmp_path,
             fixture_dir=BEHAVIOR_FIXTURE,
             node_file="behavior_preservation_node.py",
-            name="Requires And Prefers",
+            name="Requires The Impossible",
             required_resources=self.IMPOSSIBLE_COMPUTE,
-            preferred_resources={"compute": [["cpu"], "has_any"]},
         )
 
         with pytest.raises(RuntimeError, match="definitely-not-a-real-backend"):
-            current_engine().library_manager.get_worker_for_library("Requires And Prefers")
+            current_engine().library_manager.get_worker_for_library("Requires The Impossible")
 
 
 class TestUnshippableOutputGuardrail:

--- a/tests/e2e/test_exec_dep_worker_routing.py
+++ b/tests/e2e/test_exec_dep_worker_routing.py
@@ -22,7 +22,7 @@ import logging
 import shutil
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 import pytest
 
@@ -62,6 +62,7 @@ def _register(  # noqa: PLR0913 (a test-library builder; each knob is one manife
     name: str,
     exec_dependencies: list[str] | None = None,
     edit_dependencies: list[str] | None = None,
+    required_resources: dict[str, object] | None = None,
 ) -> str:
     """Register a fixture library, optionally declaring execution dependencies."""
     library_dir = tmp_path / name.replace(" ", "_")
@@ -83,6 +84,8 @@ def _register(  # noqa: PLR0913 (a test-library builder; each knob is one manife
             build_wheel(wheel_dir, dep, "1.0.0")
         dependencies["pip_install_flags"] = offline_install_flags(wheel_dir)
     schema["metadata"]["dependencies"] = dependencies
+    if required_resources is not None:
+        schema["metadata"]["resources"] = {"required": required_resources}
     library_json = library_dir / "griptape_nodes_library.json"
     library_json.write_text(json.dumps(schema, indent=2))
     shutil.copy(fixture_dir / node_file, library_dir / node_file)
@@ -369,6 +372,66 @@ class TestParameterBehaviorsSurviveOnRealClasses:
 
         assert not isinstance(result, SendNodeMessageResultSuccess)
         assert "no handler was available" in str(result.result_details)
+
+
+class TestUnmetResourcesCostExecutionNotLoading:
+    """A capability this machine lacks must not take the library away.
+
+    Nothing about a missing GPU stops the orchestrator importing base-clean node modules,
+    drawing their parameters, or saving a workflow that uses them. Refusing to REGISTER took
+    all of that away: fitness UNUSABLE, no node types, and placeholder nodes reading "Library
+    not found" on every machine that was only ever going to edit. This is the same rule the
+    engine applies to a dependency that will not install -- the capability gates the run.
+    """
+
+    IMPOSSIBLE_COMPUTE: ClassVar[dict[str, object]] = {"compute": [["definitely-not-a-real-backend"], "has_any"]}
+
+    def test_the_library_still_registers_and_its_nodes_still_load(self, tmp_path: Path) -> None:
+        library_json = _register(
+            tmp_path,
+            fixture_dir=BEHAVIOR_FIXTURE,
+            node_file="behavior_preservation_node.py",
+            name="Unmet Resources",
+            required_resources=self.IMPOSSIBLE_COMPUTE,
+        )
+
+        info = _library_info(library_json)
+        assert info.lifecycle_state is not LibraryManager.LibraryLifecycleState.FAILURE
+        assert info.fitness is LibraryManager.LibraryFitness.FLAWED
+        node = LibraryRegistry.create_node(
+            node_type="BehaviorPreservationNode", name="editable", specific_library_name="Unmet Resources"
+        )
+        assert node.get_parameter_by_name("mode") is not None
+
+    def test_execution_refuses_and_names_the_capability(self, tmp_path: Path) -> None:
+        _register(
+            tmp_path,
+            fixture_dir=BEHAVIOR_FIXTURE,
+            node_file="behavior_preservation_node.py",
+            name="Unmet Resources Refuses",
+            required_resources=self.IMPOSSIBLE_COMPUTE,
+        )
+
+        with pytest.raises(RuntimeError) as excinfo:
+            current_engine().library_manager.get_worker_for_library("Unmet Resources Refuses")
+
+        message = str(excinfo.value)
+        assert "definitely-not-a-real-backend" in message, "the artist is not told what is missing"
+        assert "Editing its nodes still works" in message
+
+    def test_a_library_whose_resources_are_met_is_unaffected(self, tmp_path: Path) -> None:
+        """The gate must not fire for a requirement this machine does satisfy."""
+        library_json = _register(
+            tmp_path,
+            fixture_dir=BEHAVIOR_FIXTURE,
+            node_file="behavior_preservation_node.py",
+            name="Met Resources",
+            required_resources={"compute": [["cpu"], "has_any"]},
+        )
+
+        info = _library_info(library_json)
+        assert info.execution_unavailable_reason is None
+        assert info.fitness is LibraryManager.LibraryFitness.GOOD
 
 
 class TestUnshippableOutputGuardrail:

--- a/tests/e2e/test_exec_dep_worker_routing.py
+++ b/tests/e2e/test_exec_dep_worker_routing.py
@@ -20,7 +20,9 @@ from __future__ import annotations
 import json
 import logging
 import shutil
+import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -43,6 +45,9 @@ from griptape_nodes.traits.button import Button, ButtonDetailsMessagePayload
 from griptape_nodes.utils.version_utils import engine_version
 from tests.e2e.fixtures.behavior_preservation_library.behavior_preservation_node import CLICK_ACKNOWLEDGEMENT
 from tests.e2e.offline_wheels import build_wheel, offline_install_flags
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 EXEC_FIXTURE = Path(__file__).parent / "fixtures" / "exec_dep_library"
 NONSERIALIZABLE_FIXTURE = Path(__file__).parent / "fixtures" / "nonserializable_library"
@@ -88,6 +93,29 @@ def _register(  # noqa: PLR0913 (a test-library builder; each knob is one manife
 
 def _library_info(library_json: str) -> LibraryManager.LibraryInfo:
     return current_engine().library_manager._library_file_path_to_info[library_json]
+
+
+EDIT_DEP = "fakeedit"
+EXEC_DEP = "fakeexec"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_import_state() -> Iterator[None]:
+    """Keep sys.path and sys.modules from leaking between tests.
+
+    Every registration inserts paths and imports modules. Without this, a dependency imported
+    by one test would satisfy the next test's import from the module cache, which would hide
+    exactly the wiring these tests exist to check.
+    """
+    original_path = list(sys.path)
+    original_is_worker = current_engine().library_manager._is_worker
+    for dep in (EDIT_DEP, EXEC_DEP):
+        sys.modules.pop(dep, None)
+    yield
+    sys.path[:] = original_path
+    current_engine().library_manager._is_worker = original_is_worker
+    for dep in (EDIT_DEP, EXEC_DEP):
+        sys.modules.pop(dep, None)
 
 
 class TestRoutingFact:
@@ -386,14 +414,20 @@ class TestUnshippableOutputGuardrail:
             ExecuteNodeResultSuccess,
         )
 
+        # Set BEFORE registering: the execution venv is spliced onto sys.path during load, and only
+        # for a worker, so flipping the flag afterwards leaves the heavy import unavailable.
+        current_engine().library_manager._is_worker = True
         _register(
             tmp_path,
             fixture_dir=EXEC_FIXTURE,
             node_file="exec_dep_node.py",
             name="Guardrail Serializable",
             edit_dependencies=["fakeedit"],
+            # Installed so process() actually completes. Without it the node raised on the missing
+            # import every time, so the branch this test is named for never ran and the assertion
+            # below could not distinguish success from any unrelated failure.
+            exec_dependencies=["fakeexec"],
         )
-        current_engine().library_manager._is_worker = True
         node = LibraryRegistry.create_node(
             node_type="ExecDepNode", name="Fine", specific_library_name="Guardrail Serializable"
         )
@@ -406,12 +440,14 @@ class TestUnshippableOutputGuardrail:
             )
         )
 
-        # fakeexec is not importable here, so process() raises -- but on the exec dep, NOT
-        # on the guardrail. What matters is the guardrail did not fire for its string outputs.
-        if isinstance(result, ExecuteNodeResultSuccess):
-            assert result.parameter_output_values["edit_dep_version"] == "1.0.0"
-        else:
-            assert "cannot leave" not in str(result.result_details)
+        # A node whose outputs are all serializable must ship them, so the unshippable-output
+        # guardrail must NOT fire. Asserted on success rather than either-branch: the previous
+        # version passed whether or not the node ran.
+        assert isinstance(result, ExecuteNodeResultSuccess), getattr(result, "result_details", result)
+        # This suite builds both wheels at 1.0.0; the version itself is not the point, having
+        # BOTH outputs is -- one proves the edit environment, the other the execution one.
+        assert result.parameter_output_values["edit_dep_version"] == "1.0.0"
+        assert result.parameter_output_values["exec_dep_version"] == "1.0.0"
 
 
 class TestManagerAccessDuringWorkerExecution:
@@ -437,6 +473,31 @@ class TestManagerAccessDuringWorkerExecution:
                 GriptapeNodes.SecretsManager()
             with pytest.raises(RuntimeError, match="ReadFileRequest"):
                 GriptapeNodes.OSManager()
+
+    def test_the_guard_covers_every_manager_but_static_files(self) -> None:
+        """The guard is broad by design: silently-wrong local answers are worse than errors.
+
+        Sweeps every manager accessor on the facade rather than naming a few, so adding an
+        accessor without deciding its worker story fails here instead of shipping unguarded.
+        """
+        current_engine().library_manager._is_worker = True
+        event_manager = current_engine().event_manager
+
+        minimum_believable_sweep = 20
+        accessors = [
+            name
+            for name, member in vars(GriptapeNodes).items()
+            if isinstance(member, classmethod) and name[0].isupper() and name.endswith("Manager")
+        ]
+        assert len(accessors) > minimum_believable_sweep, "sweep found too few accessors to be believed"
+
+        with event_manager.worker_node_execution_scope():
+            for name in accessors:
+                if name == "StaticFilesManager":
+                    assert getattr(GriptapeNodes, name)() is not None
+                    continue
+                with pytest.raises(RuntimeError, match=name):
+                    getattr(GriptapeNodes, name)()
 
     def test_managers_work_outside_node_execution_in_a_worker(self) -> None:
         """Engine boot and library load happen in the worker too, and need real managers."""

--- a/tests/e2e/test_exec_dep_worker_routing.py
+++ b/tests/e2e/test_exec_dep_worker_routing.py
@@ -63,6 +63,7 @@ def _register(  # noqa: PLR0913 (a test-library builder; each knob is one manife
     exec_dependencies: list[str] | None = None,
     edit_dependencies: list[str] | None = None,
     required_resources: dict[str, object] | None = None,
+    preferred_resources: dict[str, object] | None = None,
 ) -> str:
     """Register a fixture library, optionally declaring execution dependencies."""
     library_dir = tmp_path / name.replace(" ", "_")
@@ -84,8 +85,13 @@ def _register(  # noqa: PLR0913 (a test-library builder; each knob is one manife
             build_wheel(wheel_dir, dep, "1.0.0")
         dependencies["pip_install_flags"] = offline_install_flags(wheel_dir)
     schema["metadata"]["dependencies"] = dependencies
-    if required_resources is not None:
-        schema["metadata"]["resources"] = {"required": required_resources}
+    if required_resources is not None or preferred_resources is not None:
+        resources: dict[str, object] = {}
+        if required_resources is not None:
+            resources["required"] = required_resources
+        if preferred_resources is not None:
+            resources["preferred"] = preferred_resources
+        schema["metadata"]["resources"] = resources
     library_json = library_dir / "griptape_nodes_library.json"
     library_json.write_text(json.dumps(schema, indent=2))
     shutil.copy(fixture_dir / node_file, library_dir / node_file)
@@ -432,6 +438,59 @@ class TestUnmetResourcesCostExecutionNotLoading:
         info = _library_info(library_json)
         assert info.execution_unavailable_reason is None
         assert info.fitness is LibraryManager.LibraryFitness.GOOD
+
+
+class TestPreferredResourcesAreInformationNotGates:
+    """Needing a resource and preferring one are different claims, and libraries had to pick.
+
+    Before the second tier existed an author who wanted to say "this really wants a GPU" chose
+    between a hard gate and silence. SAM3 chose the gate and declared cuda-only, which is why it
+    could not be edited on a laptop at all.
+    """
+
+    IMPOSSIBLE_COMPUTE: ClassVar[dict[str, object]] = {"compute": [["definitely-not-a-real-backend"], "has_any"]}
+
+    def test_an_unmet_preference_does_not_gate_anything(self, tmp_path: Path) -> None:
+        library_json = _register(
+            tmp_path,
+            fixture_dir=BEHAVIOR_FIXTURE,
+            node_file="behavior_preservation_node.py",
+            name="Prefers The Impossible",
+            preferred_resources=self.IMPOSSIBLE_COMPUTE,
+        )
+
+        info = _library_info(library_json)
+        assert info.fitness is LibraryManager.LibraryFitness.GOOD, "a preference must not change fitness"
+        assert info.execution_unavailable_reason is None, "a preference must not block execution"
+        assert info.unmet_preferences is not None, "but it should be recorded"
+        assert "definitely-not-a-real-backend" in info.unmet_preferences
+
+    def test_a_met_preference_records_nothing(self, tmp_path: Path) -> None:
+        library_json = _register(
+            tmp_path,
+            fixture_dir=BEHAVIOR_FIXTURE,
+            node_file="behavior_preservation_node.py",
+            name="Prefers The Possible",
+            preferred_resources={"compute": [["cpu"], "has_any"]},
+        )
+
+        info = _library_info(library_json)
+        assert info.unmet_preferences is None
+        assert info.fitness is LibraryManager.LibraryFitness.GOOD
+
+    def test_execution_still_refuses_for_an_unmet_REQUIREMENT(self, tmp_path: Path) -> None:
+        """The tiers are independent: adding a preference does not soften a requirement."""
+        _register(
+            tmp_path,
+            fixture_dir=BEHAVIOR_FIXTURE,
+            node_file="behavior_preservation_node.py",
+            name="Requires And Prefers",
+            required_resources=self.IMPOSSIBLE_COMPUTE,
+            preferred_resources={"compute": [["cpu"], "has_any"]},
+        )
+
+        with pytest.raises(RuntimeError, match="definitely-not-a-real-backend"):
+            current_engine().library_manager.get_worker_for_library("Requires And Prefers")
 
 
 class TestUnshippableOutputGuardrail:

--- a/tests/e2e/test_execution_module_boundary.py
+++ b/tests/e2e/test_execution_module_boundary.py
@@ -1,0 +1,202 @@
+"""The execution-module boundary: where a library's heavy imports live.
+
+Base-clean node modules used to be an author's discipline problem. An author with a heavy
+dependency either scattered deferred imports through every function that touched it -- fragile,
+because the next edit puts one back at module scope and nothing catches it until an orchestrator
+import fails -- or kept it at module scope and lost orchestrator loading entirely.
+
+A library now declares which modules are execution-only. Those may import anything at module
+scope; the orchestrator never imports them, a worker imports them eagerly at library load, and
+node code reaches them through `BaseNode.execution_module(...)`.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.node_library.library_registry import LibraryRegistry, LibrarySchema
+from griptape_nodes.retained_mode.engine import current_engine
+from griptape_nodes.retained_mode.events.execution_events import ExecuteNodeRequest, ExecuteNodeResultSuccess
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.utils.version_utils import engine_version
+from tests.e2e.offline_wheels import build_wheel, offline_install_flags
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
+
+FIXTURE = Path(__file__).parent / "fixtures" / "execution_module_library"
+LIBRARY = "Execution Module Library"
+EXEC_DEP = "fakeexec"
+EXEC_DEP_VERSION = "1.0.0"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_import_state() -> Iterator[None]:
+    """Keep sys.path and the fixture's own modules from leaking between tests.
+
+    Scoped to what these tests introduce -- the execution dependency and the fixture's own
+    module names. Clearing every newly-imported module instead would take engine and beartype
+    internals with it and break the next test's imports.
+    """
+    original_path = list(sys.path)
+    original_is_worker = current_engine().library_manager._is_worker
+    fixture_modules = (EXEC_DEP, "execution", "execution.runner", "leak_helper")
+    for name in fixture_modules:
+        sys.modules.pop(name, None)
+    yield
+    sys.path[:] = original_path
+    current_engine().library_manager._is_worker = original_is_worker
+    for name in fixture_modules:
+        sys.modules.pop(name, None)
+
+
+def _register(tmp_path: Path, *, extra_nodes: list[dict] | None = None) -> str:
+    """Materialise the fixture with a real installable execution dependency."""
+    library_dir = tmp_path / "execution_module_library"
+    shutil.copytree(FIXTURE, library_dir)
+    wheel_dir = tmp_path / "wheels"
+    build_wheel(wheel_dir, EXEC_DEP, EXEC_DEP_VERSION)
+
+    manifest_path = library_dir / "griptape_nodes_library.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["library_schema_version"] = LibrarySchema.LATEST_SCHEMA_VERSION
+    manifest["metadata"]["engine_version"] = engine_version
+    manifest["metadata"]["dependencies"] = {
+        "pip_dependencies": [],
+        "pip_dependencies_exec": [EXEC_DEP],
+        "pip_install_flags": offline_install_flags(wheel_dir),
+    }
+    if extra_nodes:
+        manifest["nodes"].extend(extra_nodes)
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+
+    result = current_engine().handle_request(RegisterLibraryFromFileRequest(file_path=str(manifest_path)))
+    assert isinstance(result, RegisterLibraryFromFileResultSuccess), getattr(result, "result_details", result)
+    return str(manifest_path)
+
+
+def _library_info(manifest_path: str) -> LibraryManager.LibraryInfo:
+    return current_engine().library_manager._library_file_path_to_info[manifest_path]
+
+
+class TestTheOrchestratorNeverImportsExecutionModules:
+    def test_the_library_loads_and_its_node_instantiates(self, tmp_path: Path) -> None:
+        """The whole point: heavy dependencies exist, and the editing process is unaffected."""
+        manifest_path = _register(tmp_path)
+
+        info = _library_info(manifest_path)
+        assert info.execution_modules == {}, "the orchestrator imported an execution module"
+        node = LibraryRegistry.create_node(node_type="BoundaryNode", name="editable", specific_library_name=LIBRARY)
+        assert node.get_parameter_by_name("reported_version") is not None
+
+    def test_reaching_an_execution_module_here_says_why_and_what_to_do(self, tmp_path: Path) -> None:
+        """An author who calls this on the orchestrator gets an instruction, not ImportError."""
+        _register(tmp_path)
+        node = LibraryRegistry.create_node(node_type="BoundaryNode", name="refused", specific_library_name=LIBRARY)
+
+        with pytest.raises(RuntimeError) as excinfo:
+            node.execution_module("runner")
+
+        message = str(excinfo.value)
+        assert "runner" in message
+        assert "process()" in message, "the message must say where execution modules ARE available"
+
+
+class TestAWorkerImportsThemEagerly:
+    def test_the_worker_imports_them_at_library_load(self, tmp_path: Path) -> None:
+        """Eagerly, so a broken execution module fails once at load rather than mid-graph."""
+        current_engine().library_manager._is_worker = True
+        manifest_path = _register(tmp_path)
+
+        info = _library_info(manifest_path)
+        assert "runner" in info.execution_modules
+        assert info.execution_unavailable_reason is None
+
+    @pytest.mark.asyncio
+    async def test_the_node_reaches_its_heavy_dependency_through_the_boundary(self, tmp_path: Path) -> None:
+        """End to end: node code with no heavy import of its own uses the execution dependency."""
+        current_engine().library_manager._is_worker = True
+        _register(tmp_path)
+        node = LibraryRegistry.create_node(node_type="BoundaryNode", name="runs", specific_library_name=LIBRARY)
+        current_engine().object_manager.add_object_by_name("runs", node)
+
+        result = await current_engine().ahandle_request(
+            ExecuteNodeRequest(
+                node_name="runs",
+                parameter_values={},
+                node_metadata={"node_type": "BoundaryNode", "library": LIBRARY},
+            )
+        )
+
+        assert isinstance(result, ExecuteNodeResultSuccess), getattr(result, "result_details", result)
+        assert result.parameter_output_values["reported_version"] == EXEC_DEP_VERSION
+
+    def test_an_unimportable_execution_module_costs_execution_not_editing(self, tmp_path: Path) -> None:
+        """Same rule as a dependency that will not install: the nodes stay editable."""
+        current_engine().library_manager._is_worker = True
+        library_dir = tmp_path / "execution_module_library"
+        shutil.copytree(FIXTURE, library_dir)
+        (library_dir / "execution" / "runner.py").write_text("import a_module_that_does_not_exist\n")
+        manifest_path = library_dir / "griptape_nodes_library.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["library_schema_version"] = LibrarySchema.LATEST_SCHEMA_VERSION
+        manifest["metadata"]["engine_version"] = engine_version
+        manifest_path.write_text(json.dumps(manifest, indent=2))
+
+        result = current_engine().handle_request(RegisterLibraryFromFileRequest(file_path=str(manifest_path)))
+        assert isinstance(result, RegisterLibraryFromFileResultSuccess), getattr(result, "result_details", result)
+
+        info = _library_info(str(manifest_path))
+        assert info.execution_unavailable_reason is not None
+        assert "runner.py" in info.execution_unavailable_reason
+        node = LibraryRegistry.create_node(
+            node_type="BoundaryNode", name="still_editable", specific_library_name=LIBRARY
+        )
+        assert node.get_parameter_by_name("reported_version") is not None
+
+
+class TestTheBoundaryIsEnforced:
+    def test_a_node_module_that_imports_an_execution_module_is_reported(self, tmp_path: Path) -> None:
+        """Caught transitively, which is the case a source scan of node modules misses.
+
+        `leaky_node` imports a helper, and the helper imports the execution module. Detection is
+        by file location over what the import actually added to sys.modules, so the indirection
+        does not hide it.
+        """
+        manifest_path = _register(
+            tmp_path,
+            extra_nodes=[
+                {
+                    "class_name": "LeakyNode",
+                    "file_path": "leaky_node.py",
+                    "metadata": {"category": "test", "description": "violates the boundary", "display_name": "Leaky"},
+                }
+            ],
+        )
+
+        # Node modules load lazily, so nothing imports until a class is resolved. Resolving it is
+        # what triggers the violation -- and here it also RAISES, because the execution module's
+        # dependency is (correctly) absent from this process. That failure path is the one authors
+        # will actually hit, and it must still produce the boundary message rather than a bare
+        # ImportError naming a module they did not write.
+        with pytest.raises(Exception, match=r"fakeexec|leaky|Leaky"):
+            LibraryRegistry.create_node(node_type="LeakyNode", name="leaks", specific_library_name=LIBRARY)
+
+        info = _library_info(manifest_path)
+        leaks = [p for p in info.problems if "execution module" in str(getattr(p, "error_message", ""))]
+        assert leaks, "importing an execution module from a node module was not reported"
+        message = str(getattr(leaks[0], "error_message", ""))
+        assert "leaky_node.py" in message
+        assert "runner.py" in message
+        assert "self.execution_module" in message, "the message must name the sanctioned alternative"

--- a/tests/e2e/test_execution_module_boundary.py
+++ b/tests/e2e/test_execution_module_boundary.py
@@ -51,12 +51,14 @@ def _isolate_import_state() -> Iterator[None]:
     """
     original_path = list(sys.path)
     original_is_worker = current_engine().library_manager._is_worker
+    original_targets = current_engine().library_manager._target_library_names
     fixture_modules = (EXEC_DEP, "execution", "execution.runner", "leak_helper")
     for name in fixture_modules:
         sys.modules.pop(name, None)
     yield
     sys.path[:] = original_path
     current_engine().library_manager._is_worker = original_is_worker
+    current_engine().library_manager._target_library_names = original_targets
     for name in fixture_modules:
         sys.modules.pop(name, None)
 
@@ -164,6 +166,50 @@ class TestAWorkerImportsThemEagerly:
             node_type="BoundaryNode", name="still_editable", specific_library_name=LIBRARY
         )
         assert node.get_parameter_by_name("reported_version") is not None
+
+    def test_reaching_a_module_that_failed_to_import_reports_the_import_failure(self, tmp_path: Path) -> None:
+        """Not "no module by that name", which sends the author hunting for a manifest typo."""
+        current_engine().library_manager._is_worker = True
+        library_dir = tmp_path / "execution_module_library"
+        shutil.copytree(FIXTURE, library_dir)
+        (library_dir / "execution" / "runner.py").write_text("import a_module_that_does_not_exist\n")
+        manifest_path = library_dir / "griptape_nodes_library.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["library_schema_version"] = LibrarySchema.LATEST_SCHEMA_VERSION
+        manifest["metadata"]["engine_version"] = engine_version
+        manifest_path.write_text(json.dumps(manifest, indent=2))
+        current_engine().handle_request(RegisterLibraryFromFileRequest(file_path=str(manifest_path)))
+        node = LibraryRegistry.create_node(node_type="BoundaryNode", name="asks", specific_library_name=LIBRARY)
+
+        with pytest.raises(RuntimeError) as excinfo:
+            node.execution_module("runner")
+
+        message = str(excinfo.value)
+        assert "runner.py" in message, "the recorded import failure must reach the caller"
+        assert "no execution module named" not in message, "a typo is not the problem here"
+
+    def test_a_library_this_worker_does_not_serve_is_left_alone(self, tmp_path: Path) -> None:
+        """A worker also loads its library's DEPENDENCIES, which have no execution environment here.
+
+        Importing their execution modules would either fail with a traceback for a perfectly
+        healthy library, or succeed against this worker's pins -- silently binding someone else's
+        heavy imports to them.
+        """
+        library_manager = current_engine().library_manager
+        library_manager._is_worker = True
+        library_manager._target_library_names = ["Some Other Library"]
+
+        manifest_path = _register(tmp_path)
+
+        info = _library_info(manifest_path)
+        assert info.execution_modules == {}, "a worker imported an execution module it does not serve"
+        # The discriminating assertion. Without the gate the import is ATTEMPTED and fails, because
+        # this library got no execution environment here -- so the modules are empty either way,
+        # and only the absence of a recorded reason says they were left alone rather than broken.
+        assert info.execution_unavailable_reason is None, (
+            "a library this worker does not serve was reported as unrunnable"
+        )
+        assert info.declared_execution_module_paths, "the declaration is still recorded, for the boundary check"
 
 
 class TestTheBoundaryIsEnforced:

--- a/tests/e2e/test_execution_module_boundary.py
+++ b/tests/e2e/test_execution_module_boundary.py
@@ -167,6 +167,42 @@ class TestAWorkerImportsThemEagerly:
         )
         assert node.get_parameter_by_name("reported_version") is not None
 
+    def test_two_execution_modules_with_one_name_is_refused(self, tmp_path: Path) -> None:
+        """Modules are addressed by file name, and a directory declaration expands recursively.
+
+        Two files sharing a stem left the later import winning and the earlier module unreachable,
+        with the listing showing one name and no way to tell which had been bound. Only the author
+        knows which was meant, so this is refused rather than resolved -- and the library stays
+        editable, like any other execution-side failure.
+        """
+        current_engine().library_manager._is_worker = True
+        library_dir = tmp_path / "execution_module_library"
+        shutil.copytree(FIXTURE, library_dir)
+        nested = library_dir / "execution" / "nested"
+        nested.mkdir(parents=True, exist_ok=True)
+        (nested / "runner.py").write_text("VALUE = 'the other one'\n")
+        manifest_path = library_dir / "griptape_nodes_library.json"
+        manifest = json.loads(manifest_path.read_text())
+        manifest["library_schema_version"] = LibrarySchema.LATEST_SCHEMA_VERSION
+        manifest["metadata"]["engine_version"] = engine_version
+        manifest_path.write_text(json.dumps(manifest, indent=2))
+
+        result = current_engine().handle_request(RegisterLibraryFromFileRequest(file_path=str(manifest_path)))
+        assert isinstance(result, RegisterLibraryFromFileResultSuccess), getattr(result, "result_details", result)
+
+        info = _library_info(str(manifest_path))
+        # Specifically the collision, not merely "some reason mentioning runner": this fixture's own
+        # runner.py also fails to import here (its execution dependency is not installed in this
+        # test), and asserting on the name alone passed with the guard removed.
+        assert info.execution_unavailable_reason is not None
+        assert "both named 'runner'" in info.execution_unavailable_reason, info.execution_unavailable_reason
+        # Only one of the two was bound, and neither is reachable, so nothing was silently chosen.
+        assert "runner" not in info.execution_modules
+        node = LibraryRegistry.create_node(
+            node_type="BoundaryNode", name="still_editable_on_collision", specific_library_name=LIBRARY
+        )
+        assert node.get_parameter_by_name("reported_version") is not None
+
     def test_reaching_a_module_that_failed_to_import_reports_the_import_failure(self, tmp_path: Path) -> None:
         """Not "no module by that name", which sends the author hunting for a manifest typo."""
         current_engine().library_manager._is_worker = True

--- a/tests/e2e/test_execution_module_boundary.py
+++ b/tests/e2e/test_execution_module_boundary.py
@@ -347,6 +347,11 @@ class TestAllThreeMechanismsTogether:
         )
         target.mkdir(parents=True, exist_ok=True)
         (target / "model.safetensors").write_text("weights")
+        # The completion marker is what makes the cache authoritative. Files alone do not qualify:
+        # the directory is created before a download starts, so a partial fetch leaves those too.
+        # Without it the engine attempts a real fetch, which is exactly the network call standing in
+        # here avoids.
+        (target / ".griptape-nodes-complete").touch()
 
         node = LibraryRegistry.create_node(node_type="BoundaryNode", name="all_three", specific_library_name=LIBRARY)
         current_engine().object_manager.add_object_by_name("all_three", node)

--- a/tests/e2e/test_execution_module_boundary.py
+++ b/tests/e2e/test_execution_module_boundary.py
@@ -12,14 +12,17 @@ node code reaches them through `BaseNode.execution_module(...)`.
 
 from __future__ import annotations
 
+import ast
 import json
 import shutil
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
 
+import griptape_nodes.retained_mode.managers.library_manager as library_manager_module
 from griptape_nodes.node_library.library_registry import LibraryRegistry, LibrarySchema
 from griptape_nodes.retained_mode.engine import current_engine
 from griptape_nodes.retained_mode.events.execution_events import ExecuteNodeRequest, ExecuteNodeResultSuccess
@@ -39,6 +42,19 @@ FIXTURE = Path(__file__).parent / "fixtures" / "execution_module_library"
 LIBRARY = "Execution Module Library"
 EXEC_DEP = "fakeexec"
 EXEC_DEP_VERSION = "1.0.0"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_asset_root(tmp_path: Path) -> Iterator[Path]:
+    """Point the engine-owned model-asset cache at a scratch dir.
+
+    Its real root is under xdg_data_home, which is right for production and wrong for a suite: it
+    persists across runs and it is the developer's own home directory.
+    """
+    root = tmp_path / "asset_root"
+    root.mkdir(exist_ok=True)
+    with patch.object(library_manager_module, "xdg_data_home", return_value=root):
+        yield root
 
 
 @pytest.fixture(autouse=True)
@@ -63,7 +79,12 @@ def _isolate_import_state() -> Iterator[None]:
         sys.modules.pop(name, None)
 
 
-def _register(tmp_path: Path, *, extra_nodes: list[dict] | None = None) -> str:
+def _register(
+    tmp_path: Path,
+    *,
+    extra_nodes: list[dict] | None = None,
+    model_assets: dict[str, dict[str, object]] | None = None,
+) -> str:
     """Materialise the fixture with a real installable execution dependency."""
     library_dir = tmp_path / "execution_module_library"
     shutil.copytree(FIXTURE, library_dir)
@@ -81,6 +102,8 @@ def _register(tmp_path: Path, *, extra_nodes: list[dict] | None = None) -> str:
     }
     if extra_nodes:
         manifest["nodes"].extend(extra_nodes)
+    if model_assets is not None:
+        manifest["model_assets"] = model_assets
     manifest_path.write_text(json.dumps(manifest, indent=2))
 
     result = current_engine().handle_request(RegisterLibraryFromFileRequest(file_path=str(manifest_path)))
@@ -282,3 +305,84 @@ class TestTheBoundaryIsEnforced:
         assert "leaky_node.py" in message
         assert "runner.py" in message
         assert "self.execution_module" in message, "the message must name the sanctioned alternative"
+
+
+class TestAllThreeMechanismsTogether:
+    """One node, no heavy import in it, three answers it could not compute for itself.
+
+    This is the arrangement the engine-owned mechanisms exist to produce: the framework import
+    lives behind the boundary, the device comes from the engine's own detection, and the weights
+    come from a declaration with an engine-owned cache. A node written this way contains no import
+    that could fail on a machine that only edits.
+    """
+
+    def test_the_node_module_imports_nothing_heavy(self) -> None:
+        """Asserted on the source, because this is the property the whole design is for."""
+        source = (FIXTURE / "boundary_node.py").read_text()
+        tree = ast.parse(source)
+        imported: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported |= {alias.name.split(".")[0] for alias in node.names}
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module.split(".")[0])
+
+        assert EXEC_DEP not in imported, "the node module imports the execution dependency"
+        assert "execution" not in imported, "the node module imports the execution module directly"
+        # Not even deferred: no import statement anywhere in the file mentions them.
+        assert EXEC_DEP not in source
+
+    @pytest.mark.asyncio
+    async def test_device_and_weights_reach_the_execution_module(self, tmp_path: Path) -> None:
+        """The node hands the engine's answers to the execution module, which uses both."""
+        current_engine().library_manager._is_worker = True
+        _register(tmp_path, model_assets={"stand-in-weights": {"source": "hf:owner/repo", "revision": "pinned"}})
+
+        # Stand in for a fetch: put files where the engine-owned cache would have written them.
+        from griptape_nodes.node_library.library_registry import ModelAsset
+
+        manager = current_engine().library_manager
+        target = manager._model_asset_path(
+            LIBRARY, "stand-in-weights", ModelAsset(source="hf:owner/repo", revision="pinned")
+        )
+        target.mkdir(parents=True, exist_ok=True)
+        (target / "model.safetensors").write_text("weights")
+
+        node = LibraryRegistry.create_node(node_type="BoundaryNode", name="all_three", specific_library_name=LIBRARY)
+        current_engine().object_manager.add_object_by_name("all_three", node)
+        result = await current_engine().ahandle_request(
+            ExecuteNodeRequest(
+                node_name="all_three",
+                parameter_values={},
+                node_metadata={"node_type": "BoundaryNode", "library": LIBRARY},
+            )
+        )
+
+        assert isinstance(result, ExecuteNodeResultSuccess), getattr(result, "result_details", result)
+        outputs = result.parameter_output_values
+        assert outputs["reported_version"] == EXEC_DEP_VERSION
+        assert outputs["chosen_device"] in {"cuda", "mps", "cpu"}
+        # The execution module saw both the device and the weight file.
+        assert outputs["chosen_device"] in outputs["run_summary"]
+        assert "model.safetensors" in outputs["run_summary"]
+
+    @pytest.mark.asyncio
+    async def test_a_missing_asset_declaration_fails_the_node_with_a_reason(self, tmp_path: Path) -> None:
+        """Weights that were never declared should say so, not fail somewhere far away."""
+        current_engine().library_manager._is_worker = True
+        _register(tmp_path)  # no model_assets declared
+
+        node = LibraryRegistry.create_node(node_type="BoundaryNode", name="no_assets", specific_library_name=LIBRARY)
+        current_engine().object_manager.add_object_by_name("no_assets", node)
+        result = await current_engine().ahandle_request(
+            ExecuteNodeRequest(
+                node_name="no_assets",
+                parameter_values={},
+                node_metadata={"node_type": "BoundaryNode", "library": LIBRARY},
+            )
+        )
+
+        assert isinstance(result, ExecuteNodeResultSuccess), getattr(result, "result_details", result)
+        summary = result.parameter_output_values["run_summary"]
+        assert "declares no model asset" in summary
+        assert "stand-in-weights" in summary

--- a/tests/e2e/test_library_execution_dependency_split.py
+++ b/tests/e2e/test_library_execution_dependency_split.py
@@ -123,11 +123,17 @@ def _import_fresh(module_name: str) -> object:
 
 
 class TestOrchestratorHoldsEditTimeDepsOnly:
-    def test_execution_dependencies_are_installed_but_absent_from_sys_path(self, tmp_path: Path) -> None:
-        """The orchestrator installs both sets but only imports against the edit-time one.
+    def test_the_orchestrator_does_not_install_execution_dependencies_at_all(self, tmp_path: Path) -> None:
+        """The orchestrator builds the edit-time environment and stops there.
 
-        This is the isolation the whole design rests on: the heavy packages exist on disk, ready
-        for a worker, and cannot be reached from the process that runs the editor.
+        It never imports the execution set -- only a worker splices .venv-exec onto sys.path --
+        so installing it here bought nothing and cost everything the split exists to save: the
+        whole weight of every heavy library, downloaded and stored by the process that merely
+        draws the nodes. Half a gigabyte for a single torch pin, measured.
+
+        The library still loads, with real node classes and GOOD fitness, because defining and
+        editing a node needs the edit-time set alone. That is the same reason a broken
+        execution dependency must not stop a library from loading.
         """
         wheel_dir = tmp_path / "wheels"
         _build_both_wheels(wheel_dir)
@@ -142,18 +148,74 @@ class TestOrchestratorHoldsEditTimeDepsOnly:
         assert info.lifecycle_state is LibraryManager.LibraryLifecycleState.LOADED
         assert info.fitness is LibraryManager.LibraryFitness.GOOD
 
-        # Both environments were built on disk.
         edit_venv = library_dir / ".venv"
         exec_venv = library_dir / ".venv-exec"
         assert edit_venv.exists()
-        assert exec_venv.exists()
+        # The worker that runs the nodes builds this one, in its own process.
+        assert not exec_venv.exists()
 
-        # Only the edit-time one is importable from here.
+        # And the heavy dependency is unreachable from here either way.
         assert _site_packages(edit_venv) in sys.path
         assert _site_packages(exec_venv) not in sys.path
         assert _import_fresh(EDIT_DEP).__version__ == EDIT_DEP_VERSION  # type: ignore[attr-defined]
         with pytest.raises(ImportError):
             _import_fresh(EXEC_DEP)
+
+    def test_the_execution_environment_also_holds_the_edit_time_set(self, tmp_path: Path) -> None:
+        """One resolution over both sets, so a shared package cannot end up at two versions.
+
+        The two venvs are isolated, and .venv-exec is spliced AHEAD of .venv in a worker. Resolved
+        separately, anything present in both (numpy as an edit dep, numpy pulled in by torch) could
+        differ, and the execution copy would win -- so a node module would bind one version when
+        the orchestrator built the node and another when the worker ran it.
+
+        Asserted on disk rather than by import: .venv is on sys.path too, so an import proves
+        nothing about which environment satisfied it.
+        """
+        wheel_dir = tmp_path / "wheels"
+        _build_both_wheels(wheel_dir)
+        library_dir = tmp_path / "library"
+        library_json = _materialize_library(
+            library_dir, wheel_dir=wheel_dir, name="Exec Dep Union", exec_dependencies=[EXEC_DEP]
+        )
+        current_engine().library_manager._is_worker = True
+
+        _register(library_json)
+
+        exec_site_packages = Path(_site_packages(library_dir / ".venv-exec"))
+        assert (exec_site_packages / EXEC_DEP).exists(), "execution dependency missing from .venv-exec"
+        assert (exec_site_packages / EDIT_DEP).exists(), (
+            "edit-time dependency missing from .venv-exec: the two environments were resolved "
+            "separately, so a shared package can differ between them"
+        )
+
+    def test_an_unresolvable_execution_dependency_still_leaves_the_library_editable(self, tmp_path: Path) -> None:
+        """A broken execution dependency must cost execution and nothing else.
+
+        Before, it failed registration outright: no node types, and placeholder nodes reading
+        "Library not found" in every workflow that used the library -- even though the
+        orchestrator needs nothing but the edit-time set to define and edit those nodes. An
+        artist who could not run a node also could not open their workflow.
+        """
+        wheel_dir = tmp_path / "wheels"
+        _build_both_wheels(wheel_dir)
+        library_dir = tmp_path / "library"
+        library_json = _materialize_library(
+            library_dir,
+            wheel_dir=wheel_dir,
+            name="Exec Dep Unresolvable",
+            exec_dependencies=["gtn-nonexistent-exec-dependency-2f9a1c"],
+        )
+
+        _register(library_json)
+
+        info = _library_info(library_json)
+        assert info.lifecycle_state is LibraryManager.LibraryLifecycleState.LOADED
+        # The node class is real and instantiable, which is what editing needs.
+        node = LibraryRegistry.create_node(
+            node_type="ExecDepNode", name="unresolvable_dep_node", specific_library_name="Exec Dep Unresolvable"
+        )
+        assert node is not None
 
     def test_node_instantiates_on_the_orchestrator_without_execution_dependencies(self, tmp_path: Path) -> None:
         """A real node class, instantiated for real, with the heavy dependency unreachable.
@@ -179,7 +241,17 @@ class TestOrchestratorHoldsEditTimeDepsOnly:
 
 
 class TestWorkerHoldsBothEnvironments:
-    def test_worker_puts_both_environments_on_sys_path(self, tmp_path: Path) -> None:
+    def test_a_worker_can_import_both_dependency_sets(self, tmp_path: Path) -> None:
+        """What a worker needs is both sets importable -- not two directories on sys.path.
+
+        Asserted as a capability because the ownership changed: `<library>/.venv` belongs to the
+        ORCHESTRATOR, which loads exec-dependency libraries itself and keeps that venv on its own
+        sys.path for the session. A worker building it too gave one directory two writers, and the
+        corrupt-install recovery path rmtrees it -- so an execution-side retry could delete the
+        environment the orchestrator was importing from.
+
+        The worker instead gets everything from `.venv-exec`, which is resolved over both sets.
+        """
         wheel_dir = tmp_path / "wheels"
         _build_both_wheels(wheel_dir)
         library_dir = tmp_path / "library"
@@ -190,10 +262,72 @@ class TestWorkerHoldsBothEnvironments:
 
         _register(library_json)
 
-        assert _site_packages(library_dir / ".venv") in sys.path
         assert _site_packages(library_dir / ".venv-exec") in sys.path
         assert _import_fresh(EDIT_DEP).__version__ == EDIT_DEP_VERSION  # type: ignore[attr-defined]
         assert _import_fresh(EXEC_DEP).__version__ == EXEC_DEP_VERSION  # type: ignore[attr-defined]
+
+    def test_a_worker_does_not_build_the_orchestrators_edit_venv(self, tmp_path: Path) -> None:
+        """One writer per directory. With two, an execution-side retry deletes an edit-time env."""
+        wheel_dir = tmp_path / "wheels"
+        _build_both_wheels(wheel_dir)
+        library_dir = tmp_path / "library"
+        library_json = _materialize_library(
+            library_dir, wheel_dir=wheel_dir, name="Exec Dep Single Writer", exec_dependencies=[EXEC_DEP]
+        )
+        current_engine().library_manager._is_worker = True
+
+        _register(library_json)
+
+        assert not (library_dir / ".venv").exists()
+
+    def test_a_worker_serves_its_own_library_when_scoped_to_it(self, tmp_path: Path) -> None:
+        """The gate on target libraries must not lock a worker out of the library it exists for.
+
+        The other tests here leave `_target_library_names` unset, which short-circuits that gate
+        to True -- so they traverse it without exercising it, and a regression that skipped the
+        worker's OWN execution environment would pass them all and surface as an ImportError at
+        node execution. This one sets the scope a real spawn sets.
+        """
+        wheel_dir = tmp_path / "wheels"
+        _build_both_wheels(wheel_dir)
+        library_dir = tmp_path / "library"
+        library_json = _materialize_library(
+            library_dir, wheel_dir=wheel_dir, name="Exec Dep Scoped", exec_dependencies=[EXEC_DEP]
+        )
+        library_manager = current_engine().library_manager
+        library_manager._is_worker = True
+        library_manager._target_library_names = ["Exec Dep Scoped"]
+
+        _register(library_json)
+
+        assert (library_dir / ".venv-exec").exists()
+        assert _site_packages(library_dir / ".venv-exec") in sys.path
+        assert _import_fresh(EXEC_DEP).__version__ == EXEC_DEP_VERSION  # type: ignore[attr-defined]
+
+    def test_a_worker_builds_no_execution_environment_for_a_library_it_does_not_serve(self, tmp_path: Path) -> None:
+        """A nested registration must not put another library's heavy pins on this sys.path.
+
+        One library declaring another as a dependency registers it inside whichever process is
+        loading -- so without this gate a worker built and spliced a second library's `.venv-exec`
+        at position 0 of its own sys.path, which is the shadowing the edit/execution split exists
+        to end. The edit-time venv IS still built here, because nobody else will: the orchestrator
+        never loaded this library.
+        """
+        wheel_dir = tmp_path / "wheels"
+        _build_both_wheels(wheel_dir)
+        library_dir = tmp_path / "library"
+        library_json = _materialize_library(
+            library_dir, wheel_dir=wheel_dir, name="Exec Dep Foreign", exec_dependencies=[EXEC_DEP]
+        )
+        library_manager = current_engine().library_manager
+        library_manager._is_worker = True
+        library_manager._target_library_names = ["Some Other Library"]
+
+        _register(library_json)
+
+        assert not (library_dir / ".venv-exec").exists()
+        assert _site_packages(library_dir / ".venv-exec") not in sys.path
+        assert (library_dir / ".venv").exists(), "the edit-time venv has no other owner here"
 
     def test_process_runs_in_a_worker(self, tmp_path: Path) -> None:
         """The payoff: the same node whose process is unrunnable on the orchestrator runs here."""

--- a/tests/e2e/test_library_execution_dependency_split.py
+++ b/tests/e2e/test_library_execution_dependency_split.py
@@ -1,0 +1,250 @@
+"""End-to-end tests for the edit-time / execution dependency split.
+
+A library declares its dependencies in two sets. Edit-time dependencies are what the engine
+needs to import node modules and instantiate nodes; execution dependencies are the heavy
+packages only ``process`` needs. The split exists so the orchestrator can hold real node
+classes for every library without ever putting those heavy packages on its import path, which
+is what stops one library's pins from shadowing another's.
+
+The contract these tests pin:
+
+- **On the orchestrator**: edit-time dependencies are importable and nodes instantiate, while
+  execution dependencies are installed on disk but deliberately absent from ``sys.path``.
+- **In a worker**: both environments are on ``sys.path``, so ``process`` runs.
+- **For a library that declares no execution dependencies**: nothing changes, and no second
+  environment appears on disk.
+
+Both dependencies are hand-built wheels installed from a local ``--find-links`` directory with
+``--no-index``, so the tests are fully offline. Because ``fakeedit`` and ``fakeexec`` exist
+nowhere except those wheels, a successful import IS proof the matching environment was created
+and wired onto ``sys.path`` -- and an ImportError is proof it was not.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import sysconfig
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.node_library.library_registry import LibraryRegistry, LibrarySchema
+from griptape_nodes.retained_mode.engine import current_engine
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
+from griptape_nodes.utils.version_utils import engine_version
+from tests.e2e.offline_wheels import build_wheel, offline_install_flags
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "exec_dep_library"
+FIXTURE_FILES = ("exec_dep_node.py",)
+EDIT_DEP = "fakeedit"
+EXEC_DEP = "fakeexec"
+EDIT_DEP_VERSION = "1.0.0"
+EXEC_DEP_VERSION = "2.0.0"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_import_state() -> Iterator[None]:
+    """Keep sys.path and sys.modules from leaking between tests.
+
+    Every registration inserts paths and imports modules. Without this, a dependency imported
+    by one test would satisfy the next test's import from the module cache, which would hide
+    exactly the wiring these tests exist to check.
+    """
+    original_path = list(sys.path)
+    original_is_worker = current_engine().library_manager._is_worker
+    for dep in (EDIT_DEP, EXEC_DEP):
+        sys.modules.pop(dep, None)
+    yield
+    sys.path[:] = original_path
+    current_engine().library_manager._is_worker = original_is_worker
+    for dep in (EDIT_DEP, EXEC_DEP):
+        sys.modules.pop(dep, None)
+
+
+def _materialize_library(
+    target_dir: Path,
+    *,
+    wheel_dir: Path,
+    name: str,
+    exec_dependencies: list[str],
+) -> Path:
+    """Write a registrable copy of the fixture library, declaring the given dependency split."""
+    schema = json.loads((FIXTURE_DIR / "griptape_nodes_library.json").read_text())
+    schema["name"] = name
+    schema["library_schema_version"] = LibrarySchema.LATEST_SCHEMA_VERSION
+    schema["metadata"]["engine_version"] = engine_version
+    schema["metadata"]["dependencies"] = {
+        "pip_dependencies": [EDIT_DEP],
+        "pip_dependencies_exec": exec_dependencies,
+        "pip_install_flags": offline_install_flags(wheel_dir),
+    }
+    target_dir.mkdir(parents=True, exist_ok=True)
+    library_json = target_dir / "griptape_nodes_library.json"
+    library_json.write_text(json.dumps(schema, indent=2))
+    for file_name in FIXTURE_FILES:
+        (target_dir / file_name).write_text((FIXTURE_DIR / file_name).read_text())
+    return library_json
+
+
+def _build_both_wheels(wheel_dir: Path) -> None:
+    build_wheel(wheel_dir, EDIT_DEP, EDIT_DEP_VERSION)
+    build_wheel(wheel_dir, EXEC_DEP, EXEC_DEP_VERSION)
+
+
+def _register(library_json: Path) -> RegisterLibraryFromFileResultSuccess:
+    result = current_engine().handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    assert isinstance(result, RegisterLibraryFromFileResultSuccess), getattr(result, "result_details", result)
+    return result
+
+
+def _library_info(library_json: Path) -> LibraryManager.LibraryInfo:
+    return current_engine().library_manager._library_file_path_to_info[str(library_json)]
+
+
+def _site_packages(venv_path: Path) -> str:
+    return str(Path(sysconfig.get_path("purelib", vars={"base": str(venv_path), "platbase": str(venv_path)})))
+
+
+def _import_fresh(module_name: str) -> object:
+    """Import a module without letting a previous test's cache answer for it."""
+    sys.modules.pop(module_name, None)
+    importlib.invalidate_caches()
+    return importlib.import_module(module_name)
+
+
+class TestOrchestratorHoldsEditTimeDepsOnly:
+    def test_execution_dependencies_are_installed_but_absent_from_sys_path(self, tmp_path: Path) -> None:
+        """The orchestrator installs both sets but only imports against the edit-time one.
+
+        This is the isolation the whole design rests on: the heavy packages exist on disk, ready
+        for a worker, and cannot be reached from the process that runs the editor.
+        """
+        wheel_dir = tmp_path / "wheels"
+        _build_both_wheels(wheel_dir)
+        library_dir = tmp_path / "library"
+        library_json = _materialize_library(
+            library_dir, wheel_dir=wheel_dir, name="Exec Dep Orchestrator", exec_dependencies=[EXEC_DEP]
+        )
+
+        _register(library_json)
+
+        info = _library_info(library_json)
+        assert info.lifecycle_state is LibraryManager.LibraryLifecycleState.LOADED
+        assert info.fitness is LibraryManager.LibraryFitness.GOOD
+
+        # Both environments were built on disk.
+        edit_venv = library_dir / ".venv"
+        exec_venv = library_dir / ".venv-exec"
+        assert edit_venv.exists()
+        assert exec_venv.exists()
+
+        # Only the edit-time one is importable from here.
+        assert _site_packages(edit_venv) in sys.path
+        assert _site_packages(exec_venv) not in sys.path
+        assert _import_fresh(EDIT_DEP).__version__ == EDIT_DEP_VERSION  # type: ignore[attr-defined]
+        with pytest.raises(ImportError):
+            _import_fresh(EXEC_DEP)
+
+    def test_node_instantiates_on_the_orchestrator_without_execution_dependencies(self, tmp_path: Path) -> None:
+        """A real node class, instantiated for real, with the heavy dependency unreachable.
+
+        This is what lets the orchestrator drop stub nodes: it holds the actual class, and the
+        actual class only needs edit-time dependencies to exist.
+        """
+        wheel_dir = tmp_path / "wheels"
+        _build_both_wheels(wheel_dir)
+        library_dir = tmp_path / "library"
+        library_json = _materialize_library(
+            library_dir, wheel_dir=wheel_dir, name="Exec Dep Instantiate", exec_dependencies=[EXEC_DEP]
+        )
+        _register(library_json)
+
+        node = LibraryRegistry.create_node(
+            node_type="ExecDepNode", name="exec_dep_node", specific_library_name="Exec Dep Instantiate"
+        )
+
+        assert node.get_parameter_value("edit_dep_version") == EDIT_DEP_VERSION
+        with pytest.raises(ImportError):
+            _import_fresh(EXEC_DEP)
+
+
+class TestWorkerHoldsBothEnvironments:
+    def test_worker_puts_both_environments_on_sys_path(self, tmp_path: Path) -> None:
+        wheel_dir = tmp_path / "wheels"
+        _build_both_wheels(wheel_dir)
+        library_dir = tmp_path / "library"
+        library_json = _materialize_library(
+            library_dir, wheel_dir=wheel_dir, name="Exec Dep Worker", exec_dependencies=[EXEC_DEP]
+        )
+        current_engine().library_manager._is_worker = True
+
+        _register(library_json)
+
+        assert _site_packages(library_dir / ".venv") in sys.path
+        assert _site_packages(library_dir / ".venv-exec") in sys.path
+        assert _import_fresh(EDIT_DEP).__version__ == EDIT_DEP_VERSION  # type: ignore[attr-defined]
+        assert _import_fresh(EXEC_DEP).__version__ == EXEC_DEP_VERSION  # type: ignore[attr-defined]
+
+    def test_process_runs_in_a_worker(self, tmp_path: Path) -> None:
+        """The payoff: the same node whose process is unrunnable on the orchestrator runs here."""
+        wheel_dir = tmp_path / "wheels"
+        _build_both_wheels(wheel_dir)
+        library_dir = tmp_path / "library"
+        library_json = _materialize_library(
+            library_dir, wheel_dir=wheel_dir, name="Exec Dep Worker Process", exec_dependencies=[EXEC_DEP]
+        )
+        current_engine().library_manager._is_worker = True
+        _register(library_json)
+        node = LibraryRegistry.create_node(
+            node_type="ExecDepNode", name="exec_dep_node", specific_library_name="Exec Dep Worker Process"
+        )
+
+        node.process()
+
+        assert node.parameter_output_values["edit_dep_version"] == EDIT_DEP_VERSION
+        assert node.parameter_output_values["exec_dep_version"] == EXEC_DEP_VERSION
+
+
+class TestLibrariesWithoutExecutionDependencies:
+    def test_no_execution_environment_is_created(self, tmp_path: Path) -> None:
+        """A library that declares no execution dependencies gets exactly today's layout.
+
+        Backward compatibility is the point: the split is opt-in, and opting out leaves no new
+        artifacts on disk.
+        """
+        wheel_dir = tmp_path / "wheels"
+        _build_both_wheels(wheel_dir)
+        library_dir = tmp_path / "library"
+        library_json = _materialize_library(
+            library_dir, wheel_dir=wheel_dir, name="Exec Dep None Declared", exec_dependencies=[]
+        )
+
+        _register(library_json)
+
+        info = _library_info(library_json)
+        assert info.lifecycle_state is LibraryManager.LibraryLifecycleState.LOADED
+        assert (library_dir / ".venv").exists()
+        assert not (library_dir / ".venv-exec").exists()
+        assert _import_fresh(EDIT_DEP).__version__ == EDIT_DEP_VERSION  # type: ignore[attr-defined]
+
+    def test_manifest_without_the_field_still_validates(self) -> None:
+        """An older manifest that never heard of execution dependencies loads unchanged."""
+        schema = json.loads((FIXTURE_DIR / "griptape_nodes_library.json").read_text())
+        schema["library_schema_version"] = "0.11.0"
+        schema["metadata"]["dependencies"] = {"pip_dependencies": ["something"]}
+
+        parsed = LibrarySchema.model_validate(schema)
+
+        assert parsed.metadata.dependencies is not None
+        assert parsed.metadata.dependencies.pip_dependencies == ["something"]
+        assert parsed.metadata.dependencies.pip_dependencies_exec is None

--- a/tests/e2e/test_worker_behavior_suite.py
+++ b/tests/e2e/test_worker_behavior_suite.py
@@ -1,0 +1,249 @@
+"""End-to-end tests for the behaviors a heavy library needs when it executes in a worker.
+
+The minimal fixtures proved routing and isolation. These prove the things a real library
+(diffusers, advanced media) actually does all day, each of which has its own way of breaking
+across a process boundary:
+
+- saving media and handing back a URL that outlives the worker that wrote it
+- reading engine state through requests rather than local managers
+- streaming progress and using the yield-a-callable pattern
+- chaining serializable values across several nodes, each hop crossing the boundary
+- converters, validators, and dynamic parameters, which run on the orchestrator's real class
+
+Run against the ``worker_behavior_library`` fixture, in both roles: the orchestrator (where
+nodes are instantiated and edited) and a worker (where ``process`` runs).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.node_library.library_registry import LibraryRegistry, LibrarySchema
+from griptape_nodes.retained_mode.engine import current_engine
+from griptape_nodes.retained_mode.events.app_events import AppInitializationComplete
+from griptape_nodes.retained_mode.events.execution_events import (
+    ExecuteNodeRequest,
+    ExecuteNodeResultSuccess,
+)
+from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest, CreateNodeResultSuccess
+from griptape_nodes.retained_mode.events.parameter_events import SetParameterValueRequest
+from griptape_nodes.servers.static import ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV
+from griptape_nodes.utils.version_utils import engine_version
+
+if TYPE_CHECKING:
+    from griptape_nodes.exe_types.node_types import BaseNode
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "worker_behavior_library"
+LIBRARY = "Worker Behavior Library"
+
+
+@pytest.fixture(autouse=True)
+def _register_library(tmp_path: Path) -> None:
+    library_dir = tmp_path / "worker_behavior_library"
+    library_dir.mkdir()
+    schema = json.loads((FIXTURE_DIR / "griptape_nodes_library.json").read_text())
+    schema["library_schema_version"] = LibrarySchema.LATEST_SCHEMA_VERSION
+    schema["metadata"]["engine_version"] = engine_version
+    (library_dir / "griptape_nodes_library.json").write_text(json.dumps(schema, indent=2))
+    shutil.copy(FIXTURE_DIR / "worker_behavior_nodes.py", library_dir / "worker_behavior_nodes.py")
+    result = current_engine().handle_request(
+        RegisterLibraryFromFileRequest(file_path=str(library_dir / "griptape_nodes_library.json"))
+    )
+    assert isinstance(result, RegisterLibraryFromFileResultSuccess), getattr(result, "result_details", result)
+
+
+def _make(node_type: str, name: str) -> BaseNode:
+    """Create a node directly, for tests that only execute it."""
+    node = LibraryRegistry.create_node(node_type=node_type, name=name, specific_library_name=LIBRARY)
+    current_engine().object_manager.add_object_by_name(name, node)
+    return node
+
+
+def _make_in_flow(node_type: str, name: str) -> BaseNode:
+    """Create a node inside a real flow.
+
+    Editing a parameter unresolves downstream nodes, which needs a parent flow, so anything
+    exercising value hooks has to go through the normal creation path.
+    """
+    current_engine().context_manager.push_workflow(workflow_name=f"wf_{name}")
+    flow_result = current_engine().handle_request(
+        CreateFlowRequest(parent_flow_name=None, flow_name=f"flow_{name}", set_as_new_context=False)
+    )
+    assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
+    create_result = current_engine().handle_request(
+        CreateNodeRequest(
+            node_type=node_type,
+            specific_library_name=LIBRARY,
+            node_name=name,
+            override_parent_flow_name=flow_result.flow_name,
+        )
+    )
+    assert isinstance(create_result, CreateNodeResultSuccess), getattr(create_result, "result_details", create_result)
+    return current_engine().node_manager.get_node_by_name(create_result.node_name)
+
+
+async def _execute(node_type: str, name: str, **parameter_values: object) -> ExecuteNodeResultSuccess:
+    result = await current_engine().ahandle_request(
+        ExecuteNodeRequest(
+            node_name=name,
+            parameter_values=dict(parameter_values),
+            node_metadata={"node_type": node_type, "library": LIBRARY},
+        )
+    )
+    assert isinstance(result, ExecuteNodeResultSuccess), getattr(result, "result_details", result)
+    return result
+
+
+class TestMediaFromAWorker:
+    @pytest.mark.asyncio
+    async def test_worker_asset_url_uses_the_orchestrators_server(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A URL a worker produces must be served by something that outlives the worker.
+
+        Without this the worker advertises its own OS-assigned port, so the URL dies with the
+        worker and a saved workflow reopens with a dead link.
+        """
+        orchestrator_url = "http://localhost:8124"
+        monkeypatch.setenv(ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV, orchestrator_url)
+        # Re-resolve the static server with the worker's environment in place. The payload
+        # carries no host URL, which is exactly the worker case: without the env var this
+        # would start a server here and advertise its own ephemeral port.
+        static_files_manager = current_engine().static_files_manager
+        static_files_manager._static_server_base_url = None
+        static_files_manager.on_app_initialization_complete(AppInitializationComplete(is_worker=True))
+
+        assert static_files_manager.static_server_base_url == orchestrator_url
+
+    def test_without_the_env_var_a_process_serves_the_workspace_itself(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The orchestrator's own path is unchanged: no env var, so it serves and advertises."""
+        monkeypatch.delenv(ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV, raising=False)
+        static_files_manager = current_engine().static_files_manager
+        static_files_manager._static_server_base_url = None
+        static_files_manager.on_app_initialization_complete(AppInitializationComplete())
+
+        assert static_files_manager.static_server_base_url.startswith("http://")
+
+    @pytest.mark.asyncio
+    async def test_media_bytes_are_written_and_a_url_returned(self) -> None:
+        """Bytes stay local (they cannot cross the boundary); the URL is what travels."""
+        _make("SaveMediaNode", "Media")
+
+        result = await _execute("SaveMediaNode", "Media")
+
+        url = result.parameter_output_values["url"]
+        assert isinstance(url, str)
+        assert url  # a real URL, not an empty default
+        assert "Media.png" in url
+
+
+class TestStateAccessFromAWorker:
+    @pytest.mark.asyncio
+    async def test_config_read_through_a_request_succeeds_in_a_worker(self) -> None:
+        """The sanctioned path works from inside a worker, where the manager path is refused."""
+        current_engine().library_manager._is_worker = True
+        _make("ReadConfigNode", "Reader")
+
+        result = await _execute("ReadConfigNode", "Reader", config_key="workspace_directory")
+
+        # A real value came back, which means the request resolved rather than being blocked.
+        assert result.parameter_output_values["config_value"]
+
+    def test_config_getter_forwards_from_a_worker(self) -> None:
+        """The getter must be in the forwarded set, or a worker reads its own stale copy.
+
+        The guardrail tells authors to use this request instead of the manager; that advice is
+        only true if the request actually reaches the orchestrator.
+        """
+        from griptape_nodes.app.worker_routing import FORWARDED_REQUEST_TYPES
+        from griptape_nodes.retained_mode.events.config_events import GetConfigValueRequest
+        from griptape_nodes.retained_mode.events.secrets_events import GetSecretValueRequest
+
+        assert GetConfigValueRequest in FORWARDED_REQUEST_TYPES
+        assert GetSecretValueRequest in FORWARDED_REQUEST_TYPES
+
+
+class TestStreamingAndAsyncResult:
+    @pytest.mark.asyncio
+    async def test_streaming_node_yields_work_and_accumulates_output(self) -> None:
+        """The AsyncResult yield pattern (24 standard-library files use it) works here."""
+        _make("StreamingNode", "Streamer")
+
+        result = await _execute("StreamingNode", "Streamer")
+
+        assert result.parameter_output_values["stream"] == "alphabetagamma"
+
+    @pytest.mark.asyncio
+    async def test_streaming_works_in_a_worker_too(self) -> None:
+        current_engine().library_manager._is_worker = True
+        _make("StreamingNode", "WorkerStreamer")
+
+        result = await _execute("StreamingNode", "WorkerStreamer")
+
+        assert result.parameter_output_values["stream"] == "alphabetagamma"
+
+
+class TestMultiHopChain:
+    @pytest.mark.asyncio
+    async def test_three_hops_of_serializable_values(self) -> None:
+        """Each hop's value round-trips through the orchestrator, as per-node dispatch requires."""
+        current_engine().library_manager._is_worker = True
+        for node_type, name in (
+            ("ChainStartNode", "Start"),
+            ("ChainMiddleNode", "Middle"),
+            ("ChainEndNode", "End"),
+        ):
+            _make(node_type, name)
+
+        start = await _execute("ChainStartNode", "Start")
+        middle = await _execute("ChainMiddleNode", "Middle", in_value=start.parameter_output_values["out"])
+        end = await _execute("ChainEndNode", "End", in_value=middle.parameter_output_values["out"])
+
+        assert end.parameter_output_values["final"] == "start->middle->end"
+
+
+class TestEditorTimeBehaviorOnRealNodes:
+    """These are exactly what a schema stub would have dropped."""
+
+    def test_converter_runs_on_the_orchestrator(self) -> None:
+        node = _make_in_flow("EditorBehaviorNode", "Editor")
+
+        current_engine().handle_request(
+            SetParameterValueRequest(node_name="Editor", parameter_name="mode", value="expand")
+        )
+
+        # The converter uppercased the value; a stub would have stored it verbatim.
+        assert node.get_parameter_value("mode") == "EXPAND"
+
+    def test_validator_runs_on_the_orchestrator(self) -> None:
+        _make_in_flow("EditorBehaviorNode", "Validated")
+
+        result = current_engine().handle_request(
+            SetParameterValueRequest(node_name="Validated", parameter_name="mode", value="forbidden")
+        )
+
+        # The validator rejected it; a stub carries no validators at all.
+        assert result.failed()
+
+    def test_dynamic_parameter_grows_and_shrinks_from_a_value_hook(self) -> None:
+        """after_value_set mutating the parameter set, which diffusers relies on heavily."""
+        node = _make_in_flow("EditorBehaviorNode", "Dynamic")
+        assert node.get_parameter_by_name("dynamic_extra") is None
+
+        current_engine().handle_request(
+            SetParameterValueRequest(node_name="Dynamic", parameter_name="mode", value="expand")
+        )
+        assert node.get_parameter_by_name("dynamic_extra") is not None
+
+        current_engine().handle_request(
+            SetParameterValueRequest(node_name="Dynamic", parameter_name="mode", value="plain")
+        )
+        assert node.get_parameter_by_name("dynamic_extra") is None

--- a/tests/e2e/test_worker_behavior_suite.py
+++ b/tests/e2e/test_worker_behavior_suite.py
@@ -20,6 +20,7 @@ import json
 import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
 
@@ -105,18 +106,40 @@ async def _execute(node_type: str, name: str, **parameter_values: object) -> Exe
 
 
 class TestMediaFromAWorker:
-    @pytest.mark.asyncio
-    async def test_worker_asset_url_uses_the_orchestrators_server(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """A URL a worker produces must be served by something that outlives the worker.
+    """Where a worker's asset URLs point, which decides whether they survive the worker.
 
-        Without this the worker advertises its own OS-assigned port, so the URL dies with the
-        worker and a saved workflow reopens with a dead link.
-        """
+    Both branches below reach the same place, and BOTH are needed. An earlier version of this
+    class tested only the env-var branch, with a payload carrying no URL -- a state the real
+    host never produces, because it starts a static server for every role and announces it.
+    So the assertion passed while a live worker still advertised its own ephemeral port. A
+    precondition no caller can produce proves nothing about the caller.
+    """
+
+    @pytest.mark.asyncio
+    async def test_worker_adopts_the_url_the_host_announces(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The live path: the host resolves the orchestrator's server and rides it on the payload."""
+        monkeypatch.delenv(ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV, raising=False)
         orchestrator_url = "http://localhost:8124"
+        static_files_manager = current_engine().static_files_manager
+        static_files_manager._static_server_base_url = None
+        static_files_manager.on_app_initialization_complete(
+            AppInitializationComplete(is_worker=True, static_server_base_url=orchestrator_url)
+        )
+
+        assert static_files_manager.static_server_base_url == orchestrator_url
+
+    @pytest.mark.asyncio
+    async def test_worker_falls_back_to_the_spawn_environment(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The fallback: a host that spawns a worker without announcing a server.
+
+        WorkerManager puts the orchestrator's URL on the spawn environment, so a worker whose
+        host stays silent still has somewhere durable to point.
+        """
+        # Deliberately NOT the static server's default port: an earlier version of this test
+        # used 8124, and a broken adoption gate passed it anyway because the self-serve branch
+        # bound the default port and produced the same URL by coincidence.
+        orchestrator_url = "http://localhost:18125"
         monkeypatch.setenv(ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV, orchestrator_url)
-        # Re-resolve the static server with the worker's environment in place. The payload
-        # carries no host URL, which is exactly the worker case: without the env var this
-        # would start a server here and advertise its own ephemeral port.
         static_files_manager = current_engine().static_files_manager
         static_files_manager._static_server_base_url = None
         static_files_manager.on_app_initialization_complete(AppInitializationComplete(is_worker=True))
@@ -124,13 +147,65 @@ class TestMediaFromAWorker:
         assert static_files_manager.static_server_base_url == orchestrator_url
 
     def test_without_the_env_var_a_process_serves_the_workspace_itself(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """The orchestrator's own path is unchanged: no env var, so it serves and advertises."""
+        """The orchestrator's own path is unchanged: no env var, so it serves and advertises.
+
+        Patched rather than actually started. Letting it bind left a uvicorn thread running for the
+        rest of the session, and the next test's engine reset made that thread raise -- reported
+        against whichever unrelated test happened to be running. What matters here is the branch
+        taken, not that a socket got bound.
+        """
         monkeypatch.delenv(ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV, raising=False)
         static_files_manager = current_engine().static_files_manager
         static_files_manager._static_server_base_url = None
-        static_files_manager.on_app_initialization_complete(AppInitializationComplete())
+        with (
+            patch("griptape_nodes.retained_mode.managers.static_files_manager.start_static_server"),
+            patch("griptape_nodes.retained_mode.managers.static_files_manager.bind_free_socket") as mock_bind,
+        ):
+            mock_bind.return_value.getsockname.return_value = ("localhost", 18124)
+            static_files_manager.on_app_initialization_complete(AppInitializationComplete())
 
         assert static_files_manager.static_server_base_url.startswith("http://")
+
+    @pytest.mark.asyncio
+    async def test_the_spawn_environment_outranks_the_hosts_own_announcement(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Both sources present, different values: the parent's durable server must win.
+
+        This is the ordering, and it is load-bearing. The host announces a URL for every role, so
+        checking the payload first made the environment branch unreachable -- leaving one repo's
+        code as the only thing preventing a worker from advertising its own ephemeral port. With
+        only one source set at a time, flipping the branches back passes.
+        """
+        orchestrator_url = "http://localhost:8124"
+        worker_own_url = "http://localhost:59999"
+        monkeypatch.setenv(ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV, orchestrator_url)
+        static_files_manager = current_engine().static_files_manager
+        static_files_manager._static_server_base_url = None
+        static_files_manager.on_app_initialization_complete(
+            AppInitializationComplete(is_worker=True, static_server_base_url=worker_own_url)
+        )
+
+        assert static_files_manager.static_server_base_url == orchestrator_url
+
+    @pytest.mark.asyncio
+    async def test_a_leaked_environment_variable_does_not_redirect_an_orchestrator(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The env var only means something in a worker the orchestrator spawned.
+
+        An orchestrator started from a shell where the variable leaked (an export left over
+        from debugging, a stale wrapper script) must not silently point every asset URL it
+        mints at an address nothing in this process controls.
+        """
+        monkeypatch.setenv(ORCHESTRATOR_STATIC_SERVER_BASE_URL_ENV, "http://localhost:4444")
+        static_files_manager = current_engine().static_files_manager
+        static_files_manager._static_server_base_url = None
+        static_files_manager.on_app_initialization_complete(
+            AppInitializationComplete(static_server_base_url="http://localhost:8124")
+        )
+
+        assert static_files_manager.static_server_base_url == "http://localhost:8124"
 
     @pytest.mark.asyncio
     async def test_media_bytes_are_written_and_a_url_returned(self) -> None:
@@ -144,11 +219,33 @@ class TestMediaFromAWorker:
         assert url  # a real URL, not an empty default
         assert "Media.png" in url
 
+    @pytest.mark.asyncio
+    async def test_media_bytes_are_written_from_inside_a_worker(self) -> None:
+        """The same save, in the role that actually performs it.
+
+        Saving is the one capability a worker keeps local, and the storage driver reaches the
+        workspace path to do it. The manager guard that stops NODE code reading divergent state
+        must not fire on that: a worker shares the workspace on disk, so the read is correct, and
+        refusing it left every worker unable to write a single file.
+        """
+        current_engine().library_manager._is_worker = True
+        _make("SaveMediaNode", "WorkerMedia")
+
+        result = await _execute("SaveMediaNode", "WorkerMedia")
+
+        assert "WorkerMedia.png" in result.parameter_output_values["url"]
+
 
 class TestStateAccessFromAWorker:
     @pytest.mark.asyncio
     async def test_config_read_through_a_request_succeeds_in_a_worker(self) -> None:
-        """The sanctioned path works from inside a worker, where the manager path is refused."""
+        """The request path resolves for a node marked as running in a worker.
+
+        Scoped honestly: this process has no forwarding configured, so the request is answered
+        locally. What it pins is that the facade guard does not block the request path. That
+        forwarding itself works over the wire is covered by test_worker_forwarding_reentrancy.py
+        and by the real two-process verification.
+        """
         current_engine().library_manager._is_worker = True
         _make("ReadConfigNode", "Reader")
 
@@ -158,21 +255,44 @@ class TestStateAccessFromAWorker:
         assert result.parameter_output_values["config_value"]
 
     def test_config_getter_forwards_from_a_worker(self) -> None:
-        """The getter must be in the forwarded set, or a worker reads its own stale copy.
+        """Config and secrets must forward; file I/O must NOT.
 
-        The guardrail tells authors to use this request instead of the manager; that advice is
-        only true if the request actually reaches the orchestrator.
+        Config and secrets can differ between the two processes -- a worker's environment is
+        frozen when it spawns -- so the guardrail's advice to use a request is only true if the
+        request reaches the orchestrator.
+
+        Files are the opposite, and the reason is concrete rather than philosophical. The
+        workspace is shared on disk, so the local answer is already right; and forwarding
+        actively corrupted it, because `content` is `str | bytes` and the wire form base64s
+        bytes into a JSON string that cattrs resolves back to `str`. A path carrying macro
+        variables could not be structured at all.
         """
         from griptape_nodes.app.worker_routing import LOCAL_ONLY_REQUEST_TYPES
         from griptape_nodes.retained_mode.events.config_events import GetConfigValueRequest
         from griptape_nodes.retained_mode.events.os_events import ReadFileRequest, WriteFileRequest
         from griptape_nodes.retained_mode.events.secrets_events import GetSecretValueRequest
 
-        # Forwarding is the default now, so the assertion is that these are NOT excluded.
-        # Every request the guardrails name has to reach the orchestrator, or the advice
-        # they give authors is false.
-        for request_type in (GetConfigValueRequest, GetSecretValueRequest, ReadFileRequest, WriteFileRequest):
+        for request_type in (GetConfigValueRequest, GetSecretValueRequest):
             assert request_type not in LOCAL_ONLY_REQUEST_TYPES, request_type.__name__
+        for request_type in (ReadFileRequest, WriteFileRequest):
+            assert request_type in LOCAL_ONLY_REQUEST_TYPES, request_type.__name__
+
+    def test_forwarding_a_file_write_would_corrupt_the_bytes(self) -> None:
+        """Pin the mechanism, so nobody moves file I/O back into the forwarded set.
+
+        This is the round trip `forward_to_orchestrator` performs on a result: unstructure to
+        JSON, structure back. `content` is `str | bytes`, and the union resolves to `str`, so the
+        bytes come back as mojibake rather than raising -- which is why the corruption was silent.
+        """
+        from griptape_nodes.retained_mode.events.event_converter import converter
+        from griptape_nodes.retained_mode.events.os_events import WriteFileRequest
+
+        original = b"\x89PNG\r\n\x1a\n\x00\xff\xfe"
+        wire = json.loads(json.dumps(converter.unstructure(WriteFileRequest(file_path="x.png", content=original))))
+        round_tripped = converter.structure(wire, WriteFileRequest).content
+
+        assert round_tripped != original, "if this now round-trips, file I/O could safely forward"
+        assert isinstance(round_tripped, str)
 
 
 class TestStreamingAndAsyncResult:
@@ -251,3 +371,128 @@ class TestEditorTimeBehaviorOnRealNodes:
             SetParameterValueRequest(node_name="Dynamic", parameter_name="mode", value="plain")
         )
         assert node.get_parameter_by_name("dynamic_extra") is None
+
+
+class TestUnshippableOutputsAreRefused:
+    """A value the author declared unserializable must not silently vanish across the boundary.
+
+    Dropping it would leave the consuming node reading None with no error anywhere, which is
+    the failure mode this guardrail exists to convert into a message an author can act on.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_worker_refuses_to_ship_an_unserializable_output(self) -> None:
+        current_engine().library_manager._is_worker = True
+        _make("UnshippableOutputNode", "Unshippable")
+
+        result = await current_engine().ahandle_request(
+            ExecuteNodeRequest(
+                node_name="Unshippable",
+                parameter_values={},
+                node_metadata={"node_type": "UnshippableOutputNode", "library": LIBRARY},
+            )
+        )
+
+        assert result.failed()
+        details = str(result.result_details)
+        # The message has to name the parameter and tell the author what to do instead.
+        assert "live_handle" in details
+        assert "serializable" in details
+
+    @pytest.mark.asyncio
+    async def test_the_same_node_is_fine_on_the_orchestrator(self) -> None:
+        """Nothing crosses a boundary in-process, so the value is legal there.
+
+        This is what keeps the guardrail from being a blanket ban on unserializable outputs:
+        they are only a problem when they have to travel.
+        """
+        current_engine().library_manager._is_worker = False
+        _make("UnshippableOutputNode", "LocalHandle")
+
+        result = await _execute("UnshippableOutputNode", "LocalHandle")
+
+        assert result.parameter_output_values["summary"] == "handle-1"
+
+
+class TestSecretsFromAWorker:
+    @pytest.mark.asyncio
+    async def test_secret_read_through_a_request_reaches_the_engine(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Almost every real node needs an API key, and this is the path it must take.
+
+        A worker's environment is frozen when it spawns, so a manager read can answer from a
+        stale copy; the request is what reaches the process that owns the secret.
+        """
+        monkeypatch.setenv("GTN_WORKER_FIXTURE_SECRET", "fixture-secret-value")
+        current_engine().library_manager._is_worker = True
+        _make("ReadSecretNode", "SecretReader")
+
+        result = await _execute("ReadSecretNode", "SecretReader")
+
+        assert result.parameter_output_values["secret_value"] == "fixture-secret-value"  # noqa: S105
+
+    def test_the_secret_getter_is_forwarded_from_a_worker(self) -> None:
+        """The request has to be forwarded, or the read answers locally and the advice is false."""
+        from griptape_nodes.app.worker_routing import LOCAL_ONLY_REQUEST_TYPES
+        from griptape_nodes.retained_mode.events.secrets_events import GetSecretValueRequest
+
+        assert GetSecretValueRequest not in LOCAL_ONLY_REQUEST_TYPES
+
+
+class TestProjectReadsStayLocalInAWorker:
+    """A worker answers project questions itself rather than forwarding them.
+
+    Two reasons, and the second is why this is pinned. A worker already adopts the
+    orchestrator's project and a project's base directory is shared on-disk state, so the
+    local answer is correct and a round trip buys nothing on a path as hot as writing sidecar
+    metadata for every saved file.
+
+    The round trip also corrupted the answer. Forwarded results are rebuilt with cattrs, and
+    GetCurrentProjectResultSuccess annotates `project_info: ProjectInfo` under TYPE_CHECKING to
+    break an import cycle; cattrs cannot resolve that name, so the converter's NameError
+    fallback hands the raw dict to the constructor. isinstance() then passes while
+    `.project_info` is a dict, and every sidecar write in a worker failed with
+    "'dict' object has no attribute 'project_base_dir'" and silently wrote nothing.
+
+    This asserts the routing decision, which is what an in-process test can reach. That the
+    sidecar file actually lands is checked by the real two-process verification, since the
+    corruption only happens when a result crosses the wire.
+    """
+
+    def test_get_current_project_is_not_forwarded(self) -> None:
+        from griptape_nodes.app.worker_routing import LOCAL_ONLY_REQUEST_TYPES
+        from griptape_nodes.retained_mode.events.project_events import GetCurrentProjectRequest
+
+        assert GetCurrentProjectRequest in LOCAL_ONLY_REQUEST_TYPES
+
+
+class TestBinaryFileWritesFromAWorker:
+    """A node's file output must survive being written from a worker.
+
+    Scoped honestly: this suite flips `_is_worker` but never installs the RemoteHandlers, so
+    WriteFileRequest is answered locally whatever the routing says -- these do not guard the
+    routing decision. What they cover is that a node writing binary through `File` works at all,
+    in both roles, which the suite had no node for. The routing itself is guarded by the
+    membership and converter tests above and by tests/unit/app/test_worker_routing_filesystem.py.
+    """
+
+    @pytest.mark.asyncio
+    async def test_binary_survives_a_write_from_a_worker(self) -> None:
+        current_engine().library_manager._is_worker = True
+        _make("WriteBytesNode", "WorkerBytes")
+
+        result = await _execute("WriteBytesNode", "WorkerBytes")
+
+        # `bytes_survived` is the oracle: the node compares what it read against what it wrote,
+        # in the one process where both values exist. The count guards against that comparison
+        # passing over two empty reads.
+        assert result.parameter_output_values["bytes_survived"] is True
+        assert result.parameter_output_values["byte_count"] > 0
+
+    @pytest.mark.asyncio
+    async def test_binary_survives_a_write_on_the_orchestrator(self) -> None:
+        current_engine().library_manager._is_worker = False
+        _make("WriteBytesNode", "OrchestratorBytes")
+
+        result = await _execute("WriteBytesNode", "OrchestratorBytes")
+
+        assert result.parameter_output_values["bytes_survived"] is True

--- a/tests/e2e/test_worker_behavior_suite.py
+++ b/tests/e2e/test_worker_behavior_suite.py
@@ -17,6 +17,7 @@ nodes are instantiated and edited) and a worker (where ``process`` runs).
 from __future__ import annotations
 
 import json
+import logging
 import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -496,3 +497,90 @@ class TestBinaryFileWritesFromAWorker:
         result = await _execute("WriteBytesNode", "OrchestratorBytes")
 
         assert result.parameter_output_values["bytes_survived"] is True
+
+    @pytest.mark.asyncio
+    async def test_a_request_added_parameter_lands_authoritatively_not_locally(self) -> None:
+        """Execute the request-pattern node in the worker role and pin both halves.
+
+        EditorBehaviorNode's hook adds its dynamic parameter via AddParameterToNodeRequest.
+        During worker hydration that hook fires on the fresh executing copy; the request
+        resolves against the AUTHORITATIVE node (looked up by name), so the parameter lands
+        there while the copy that is running process() never sees it. That asymmetry is the
+        documented contract -- the live harness proves it across a real process boundary;
+        this pins it in-repo.
+        """
+        current_engine().library_manager._is_worker = True
+        registered = _make("EditorBehaviorNode", "RequestPathNode")
+
+        result = await _execute("EditorBehaviorNode", "RequestPathNode", mode="expand")
+
+        assert result.parameter_output_values["dynamic_visible_in_process"] is False
+        assert registered.get_parameter_by_name("dynamic_extra") is not None
+
+
+class TestStructureDerivesFromValues:
+    """The authoring contract: parameter structure is a deterministic function of values.
+
+    A fresh worker-side copy starts with only its __init__ shape and receives values in dict
+    order, which promises nothing. If a value for a derived parameter arrives before the value
+    that derives it, hydration must wait for the derivation rather than fail -- and a value for
+    a parameter nothing derives must cost that one value, not the run.
+    """
+
+    @pytest.mark.asyncio
+    async def test_hydration_order_cannot_defeat_derivation(self) -> None:
+        """The derived parameter's value arrives FIRST, before the value that creates it.
+
+        Single-pass hydration failed the whole execution here: `derived_in` does not exist on
+        the fresh copy until the `shape` hook runs, and setting a value on a missing parameter
+        raises. The second pass applies it after the derivation.
+        """
+        current_engine().library_manager._is_worker = True
+        _make("DerivedStructureNode", "DerivedOrder")
+
+        result = await _execute("DerivedStructureNode", "DerivedOrder", derived_in="payload", shape="expanded")
+
+        assert result.parameter_output_values["echo"] == "payload"
+
+    @pytest.mark.asyncio
+    async def test_a_derivation_chain_hydrates_in_the_most_adversarial_order(self) -> None:
+        """Depth two, values ordered deepest-first: the fixpoint must chase the chain.
+
+        `shape` derives `derived_in`, whose own hook derives `derived_deep` -- the shape real
+        dynamic UIs take (provider creates model, model creates options). A fixed two-pass
+        hydration claims `derived_in` on its second pass but leaves `derived_deep` an orphan,
+        silently running the node with its default; the contract puts no depth bound on
+        derivation, so hydration must not either.
+        """
+        current_engine().library_manager._is_worker = True
+        _make("DerivedStructureNode", "DerivedChain")
+
+        result = await _execute(
+            "DerivedStructureNode",
+            "DerivedChain",
+            derived_deep="from the bottom",
+            derived_in="deeper",
+            shape="expanded",
+        )
+
+        assert result.parameter_output_values["echo"] == "deeper"
+        assert result.parameter_output_values["deep_echo"] == "from the bottom"
+
+    @pytest.mark.asyncio
+    async def test_a_value_nothing_derives_is_skipped_not_fatal(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A parameter added to the authoritative node by request does not exist here.
+
+        The canonical producer is a user adding a parameter in the editor: the orchestrator's
+        node has it, values ship at execute, and the fresh worker copy has no hook that
+        re-creates it. Failing hydration made every such parameter fatal to a worker-routed
+        node; the contract's answer is that the value goes unapplied, loudly.
+        """
+        current_engine().library_manager._is_worker = True
+        _make("DerivedStructureNode", "DerivedGhost")
+
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+            result = await _execute("DerivedStructureNode", "DerivedGhost", ghost="orphaned", shape="plain")
+
+        assert result.parameter_output_values["echo"] == ""
+        assert "ghost" in caplog.text
+        assert "derive" in caplog.text

--- a/tests/e2e/test_worker_behavior_suite.py
+++ b/tests/e2e/test_worker_behavior_suite.py
@@ -163,12 +163,16 @@ class TestStateAccessFromAWorker:
         The guardrail tells authors to use this request instead of the manager; that advice is
         only true if the request actually reaches the orchestrator.
         """
-        from griptape_nodes.app.worker_routing import FORWARDED_REQUEST_TYPES
+        from griptape_nodes.app.worker_routing import LOCAL_ONLY_REQUEST_TYPES
         from griptape_nodes.retained_mode.events.config_events import GetConfigValueRequest
+        from griptape_nodes.retained_mode.events.os_events import ReadFileRequest, WriteFileRequest
         from griptape_nodes.retained_mode.events.secrets_events import GetSecretValueRequest
 
-        assert GetConfigValueRequest in FORWARDED_REQUEST_TYPES
-        assert GetSecretValueRequest in FORWARDED_REQUEST_TYPES
+        # Forwarding is the default now, so the assertion is that these are NOT excluded.
+        # Every request the guardrails name has to reach the orchestrator, or the advice
+        # they give authors is false.
+        for request_type in (GetConfigValueRequest, GetSecretValueRequest, ReadFileRequest, WriteFileRequest):
+            assert request_type not in LOCAL_ONLY_REQUEST_TYPES, request_type.__name__
 
 
 class TestStreamingAndAsyncResult:

--- a/tests/e2e/test_worker_forwarding_reentrancy.py
+++ b/tests/e2e/test_worker_forwarding_reentrancy.py
@@ -1,0 +1,256 @@
+"""End-to-end tests for worker->orchestrator request forwarding under reentrancy.
+
+When a node executes off the orchestrator, every request it makes mid-execution forwards to
+the orchestrator, which must service those requests while it is itself awaiting the execution
+that produced them. These tests pin that machinery -- ``EventManager.forward_to_orchestrator``,
+``RequestClient`` response matching, and the cross-loop dispatch topology -- without a real
+websocket, using a fake broker that loops forwarded requests into a real engine's dispatch.
+
+The topology reproduced here is the real one, because it is exactly the topology that has
+bitten before (see ``configure_worker_forwarding``'s docstring): the ``RequestClient`` and its
+futures live on a daemon thread's event loop, while the code that forwards runs on the main
+loop, so every forward crosses loops twice. Awaiting the client's primitives from the wrong
+loop historically stalled for seconds per request; the latency assertions here exist to fail
+if that regression returns.
+
+The contract these tests pin:
+
+- **Service while awaiting**: a forwarded request is dispatched and answered while the main
+  loop coroutine that sent it is still awaiting the reply.
+- **Contention**: many concurrent forwards, including from foreign threads (the diffusers
+  thread-pool shape), all complete, and none stalls for seconds.
+- **Bounded failure**: when the orchestrator never replies, the forward raises TimeoutError
+  within the configured bound instead of hanging.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import time
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+import pytest_asyncio
+
+from griptape_nodes.api_client.request_client import RequestClient
+from griptape_nodes.retained_mode.engine import current_engine
+from griptape_nodes.retained_mode.events.app_events import GetEngineVersionRequest
+from griptape_nodes.retained_mode.events.base_events import (
+    EventResultFailure,
+    EventResultSuccess,
+)
+from griptape_nodes.retained_mode.events.event_converter import converter
+from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
+from griptape_nodes.retained_mode.managers.event_manager import ResultContext
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Callable
+
+    from griptape_nodes.retained_mode.events.base_events import RequestPayload
+
+ORCHESTRATOR_REQUEST_TOPIC = "sessions/test/request"
+WORKER_RESPONSE_TOPIC = "engines/test-worker/response"
+
+# Generous enough for CI noise, far below the seconds-long stalls this guards against.
+SINGLE_FORWARD_BUDGET_S = 2.0
+CONTENTION_TOTAL_BUDGET_S = 10.0
+CONTENTION_COUNT = 50
+
+
+class FakeBrokerClient:
+    """Stands in for the websocket Client: loops forwarded requests into a real engine.
+
+    ``publish`` to the orchestrator request topic dispatches the deserialized request into
+    the orchestrator engine on ``orchestrator_loop`` as its own task (mirroring the app's
+    task-per-request ingress), then delivers the result back through the registered message
+    filters on the broker loop, which is where ``RequestClient._try_match`` and its futures
+    live. Set ``drop_requests`` to simulate an orchestrator that never answers.
+    """
+
+    def __init__(self, orchestrator_loop: asyncio.AbstractEventLoop) -> None:
+        self.orchestrator_loop = orchestrator_loop
+        self.drop_requests = False
+        self._filters: list[Callable[[dict[str, Any]], Any]] = []
+        self.subscribed_topics: list[str] = []
+
+    def add_message_filter(self, filter_fn: Callable[[dict[str, Any]], Any]) -> None:
+        self._filters.append(filter_fn)
+
+    def remove_message_filter(self, filter_fn: Callable[[dict[str, Any]], Any]) -> None:
+        self._filters.remove(filter_fn)
+
+    async def subscribe(self, topic: str) -> None:
+        self.subscribed_topics.append(topic)
+
+    async def publish(self, event_type: str, payload: dict[str, Any], topic: str) -> None:
+        assert event_type == "EventRequest"
+        assert topic == ORCHESTRATOR_REQUEST_TOPIC
+        if self.drop_requests:
+            return
+
+        broker_loop = asyncio.get_running_loop()
+        request_type = PayloadRegistry.get_type(payload["request_type"])
+        assert request_type is not None
+        request = cast("RequestPayload", converter.structure(payload["request"], request_type))
+        request_id = payload.get("request_id")
+
+        async def dispatch_and_reply() -> None:
+            # Task-per-request, exactly like the app's ingress: nothing serializes behind
+            # whatever the orchestrator is currently awaiting.
+            result = await current_engine().ahandle_request(request)
+            event_cls = EventResultSuccess if result.succeeded() else EventResultFailure
+            reply = event_cls(request=request, request_id=request_id, result=result)
+            reply_payload = json.loads(reply.json())
+            broker_loop.call_soon_threadsafe(
+                lambda: broker_loop.create_task(self._deliver(reply_payload)),
+            )
+
+        self.orchestrator_loop.call_soon_threadsafe(
+            lambda: self.orchestrator_loop.create_task(dispatch_and_reply()),
+        )
+
+    async def _deliver(self, payload: dict[str, Any]) -> None:
+        message = {"payload": payload}
+        for filter_fn in list(self._filters):
+            claimed = await filter_fn(message)
+            if claimed:
+                return
+
+
+class BrokerThread:
+    """A daemon thread running its own event loop, like the app's websocket thread."""
+
+    def __init__(self) -> None:
+        self.loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self.loop.run_forever, daemon=True)
+        self._thread.start()
+
+    def run(self, coro: Any) -> Any:
+        return asyncio.run_coroutine_threadsafe(coro, self.loop).result(timeout=30)
+
+    def shutdown(self) -> None:
+        self.loop.call_soon_threadsafe(self.loop.stop)
+        self._thread.join(timeout=5)
+        self.loop.close()
+
+
+@pytest_asyncio.fixture
+async def forwarding() -> AsyncIterator[FakeBrokerClient]:
+    """Configure worker-style forwarding on a real engine, against the fake broker."""
+    orchestrator_loop = asyncio.get_running_loop()
+    broker = BrokerThread()
+    fake_client = FakeBrokerClient(orchestrator_loop)
+    request_client = RequestClient(fake_client)  # type: ignore[arg-type]
+    broker.run(request_client.__aenter__())
+
+    event_manager = current_engine().event_manager
+    event_manager.configure_worker_forwarding(
+        request_client=request_client,
+        orchestrator_request_topic=ORCHESTRATOR_REQUEST_TOPIC,
+        worker_response_topic=WORKER_RESPONSE_TOPIC,
+        websocket_event_loop=broker.loop,
+        timeout_ms=1_000,
+    )
+    yield fake_client
+    broker.run(request_client.__aexit__(None, None, None))
+    broker.shutdown()
+
+
+class TestServiceWhileAwaiting:
+    @pytest.mark.asyncio
+    async def test_forward_is_serviced_while_sender_awaits(self, forwarding: FakeBrokerClient) -> None:  # noqa: ARG002 (fixture wires forwarding)
+        """The main loop services the forwarded request while the forwarding coroutine awaits it.
+
+        This is the reentrancy shape the whole design depends on: the awaiting side and the
+        servicing side share the orchestrator loop.
+        """
+        event_manager = current_engine().event_manager
+        started = time.monotonic()
+
+        result = await event_manager.forward_to_orchestrator(GetEngineVersionRequest(), ResultContext())
+
+        elapsed = time.monotonic() - started
+        assert isinstance(result, EventResultSuccess)
+        assert result.result.succeeded()
+        assert elapsed < SINGLE_FORWARD_BUDGET_S, f"single forward took {elapsed:.2f}s; cross-loop stall regression"
+
+    @pytest.mark.asyncio
+    async def test_forward_inside_node_execution_scope(self, forwarding: FakeBrokerClient) -> None:  # noqa: ARG002 (fixture wires forwarding)
+        """Forwarding works from inside the scope that marks node execution."""
+        event_manager = current_engine().event_manager
+        with event_manager.worker_node_execution_scope():
+            assert event_manager.in_node_execution()
+            result = await event_manager.forward_to_orchestrator(GetEngineVersionRequest(), ResultContext())
+        assert isinstance(result, EventResultSuccess)
+
+
+class TestContention:
+    @pytest.mark.asyncio
+    async def test_many_concurrent_forwards_from_the_main_loop(self, forwarding: FakeBrokerClient) -> None:  # noqa: ARG002 (fixture wires forwarding)
+        event_manager = current_engine().event_manager
+        started = time.monotonic()
+
+        results = await asyncio.gather(
+            *(
+                event_manager.forward_to_orchestrator(GetEngineVersionRequest(), ResultContext())
+                for _ in range(CONTENTION_COUNT)
+            )
+        )
+
+        elapsed = time.monotonic() - started
+        assert all(isinstance(r, EventResultSuccess) for r in results)
+        assert elapsed < CONTENTION_TOTAL_BUDGET_S, f"{CONTENTION_COUNT} forwards took {elapsed:.2f}s"
+
+    @pytest.mark.asyncio
+    async def test_forwards_from_foreign_threads(self, forwarding: FakeBrokerClient) -> None:  # noqa: ARG002 (fixture wires forwarding)
+        """Requests emitted from library-internal threads (the diffusers thread-pool shape).
+
+        A foreign thread cannot await on the orchestrator loop, so it does what node code
+        effectively does: schedule the coroutine onto the loop and block on the result.
+        """
+        event_manager = current_engine().event_manager
+        orchestrator_loop = asyncio.get_running_loop()
+        errors: list[BaseException] = []
+
+        def forward_from_thread() -> None:
+            future = asyncio.run_coroutine_threadsafe(
+                event_manager.forward_to_orchestrator(GetEngineVersionRequest(), ResultContext()),
+                orchestrator_loop,
+            )
+            try:
+                result = future.result(timeout=SINGLE_FORWARD_BUDGET_S * 5)
+                assert isinstance(result, EventResultSuccess)
+            except BaseException as e:
+                errors.append(e)
+
+        with event_manager.worker_node_execution_scope():
+            threads = [threading.Thread(target=forward_from_thread) for _ in range(8)]
+            for t in threads:
+                t.start()
+            # The orchestrator loop must stay free to service while threads block on replies.
+            await asyncio.sleep(0)
+            deadline = time.monotonic() + CONTENTION_TOTAL_BUDGET_S
+            while any(t.is_alive() for t in threads):
+                if time.monotonic() > deadline:
+                    pytest.fail("foreign-thread forwards did not complete within budget")
+                await asyncio.sleep(0.05)
+
+        assert not errors, f"foreign-thread forwards failed: {errors!r}"
+
+
+class TestBoundedFailure:
+    @pytest.mark.asyncio
+    async def test_unanswered_forward_times_out_instead_of_hanging(self, forwarding: FakeBrokerClient) -> None:
+        """An orchestrator that never replies produces a TimeoutError within the bound."""
+        forwarding.drop_requests = True
+        event_manager = current_engine().event_manager
+        started = time.monotonic()
+
+        with pytest.raises(TimeoutError):
+            await event_manager.forward_to_orchestrator(GetEngineVersionRequest(), ResultContext())
+
+        elapsed = time.monotonic() - started
+        # Configured timeout is 1s; anything wildly past it means the bound is not real.
+        assert elapsed < SINGLE_FORWARD_BUDGET_S * 2, f"timeout took {elapsed:.2f}s to fire"

--- a/tests/unit/api_client/test_request_client_cross_loop.py
+++ b/tests/unit/api_client/test_request_client_cross_loop.py
@@ -117,3 +117,30 @@ class TestCrossLoopSettlement:
             elapsed = pending.result(timeout=WAITER_TIMEOUT_S + 5)
 
         assert elapsed < PROMPT_S, f"waiter learned of the cancel after {elapsed:.1f}s"
+
+
+class TestLockCrossesLoops:
+    """The pending map is mutated from more than one loop, through the real locked methods.
+
+    This does NOT reproduce a loop-bound lock's failure, and it passes with either primitive:
+    `asyncio.Lock.acquire` only consults its bound loop on the CONTENDED path, and no section this
+    lock guards contains an await, so a section is always released before anything else can reach
+    it. What the wrong primitive costs is exclusion rather than an exception -- two threads both
+    pass the uncontended fast path and mutate the dict together -- which is not deterministically
+    reachable from a test. Kept as a smoke test that the cross-loop path works at all.
+    """
+
+    def test_tracking_and_cancelling_from_different_loops(self) -> None:
+        with _LoopInThread() as other_loop:
+            client = _client()
+
+            asyncio.run(client.track_request("req-a", tag="worker-a"))
+
+            # Same lock, second loop, through the public API.
+            asyncio.run_coroutine_threadsafe(client.track_request("req-b", tag="worker-b"), other_loop).result(
+                timeout=5
+            )
+            asyncio.run_coroutine_threadsafe(client.cancel_requests_by_tag("worker-a"), other_loop).result(timeout=5)
+
+            assert "req-a" not in client._pending_requests
+            assert "req-b" in client._pending_requests

--- a/tests/unit/api_client/test_request_client_cross_loop.py
+++ b/tests/unit/api_client/test_request_client_cross_loop.py
@@ -1,0 +1,119 @@
+"""A response that arrives on a different loop than the requester must wake the requester.
+
+Websocket messages are handled on the transport loop; a request may have been issued from the loop
+running a flow. An asyncio future belongs to exactly one loop, and settling it from another one
+marks it done while scheduling the waiting task through a non-threadsafe `call_soon` -- which does
+not wake a loop sitting in its selector. The waiter then resumes only when something unrelated
+happens to wake that loop, so a node's result arrived tens of seconds late and a chattier log level
+made the symptom disappear.
+
+These tests drive the two-loop shape directly, and assert on ELAPSED TIME rather than on the
+future's done flag: the flag was always set promptly, which is exactly why the bug was invisible.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from griptape_nodes.api_client.request_client import RequestClient
+
+# Generous enough that a loaded CI box does not flake, far below the multi-second stall the bug
+# produced (which was bounded only by the waiter's own timeout).
+PROMPT_S = 2.0
+# The waiter's ceiling. With the bug the settle is picked up when this timer fires, so it must be
+# comfortably larger than PROMPT_S for the assertion to distinguish the two.
+WAITER_TIMEOUT_S = 20.0
+
+
+class _LoopInThread:
+    """A second event loop, running in its own thread, otherwise completely idle.
+
+    Idleness is the point: a busy loop wakes constantly and hides the missing wakeup.
+    """
+
+    def __enter__(self) -> asyncio.AbstractEventLoop:
+        self.loop = asyncio.new_event_loop()
+        self.thread = threading.Thread(target=self.loop.run_forever, daemon=True)
+        self.thread.start()
+        return self.loop
+
+    def __exit__(self, *_: object) -> None:
+        self.loop.call_soon_threadsafe(self.loop.stop)
+        self.thread.join(timeout=5)
+        self.loop.close()
+
+
+def _client() -> RequestClient:
+    return RequestClient(client=MagicMock())
+
+
+def _await_tracked(client: RequestClient, request_id: str) -> Any:
+    """Coroutine body: track `request_id`, then wait on it and report how long that took."""
+
+    async def run() -> tuple[Any, float]:
+        future = await client.track_request(request_id)
+        started = time.monotonic()
+        result = await asyncio.wait_for(future, timeout=WAITER_TIMEOUT_S)
+        return result, time.monotonic() - started
+
+    return run()
+
+
+class TestCrossLoopSettlement:
+    def test_result_settled_from_another_thread_wakes_the_waiter(self) -> None:
+        with _LoopInThread() as waiter_loop:
+            pending = asyncio.run_coroutine_threadsafe(_await_tracked(_c := _client(), "req-1"), waiter_loop)
+            # Let the tracking register and the loop settle back into its selector.
+            time.sleep(0.2)
+
+            # Settled from THIS thread, which has no running loop -- the shape the transport
+            # side has. The _unlocked internals are called directly because only one settle
+            # happens here, so there is nothing for the lock to serialize against.
+            _c._resolve_request_unlocked("req-1", {"ok": True})
+            result, elapsed = pending.result(timeout=WAITER_TIMEOUT_S + 5)
+
+        assert result == {"ok": True}
+        assert elapsed < PROMPT_S, f"waiter resumed after {elapsed:.1f}s; its loop was not woken"
+
+    def test_rejection_settled_from_another_thread_wakes_the_waiter(self) -> None:
+        with _LoopInThread() as waiter_loop:
+            client = _client()
+            pending = asyncio.run_coroutine_threadsafe(_await_tracked(client, "req-2"), waiter_loop)
+            time.sleep(0.2)
+
+            boom = RuntimeError("upstream said no")
+            client._reject_request_unlocked("req-2", boom)
+
+            with pytest.raises(RuntimeError, match="upstream said no"):
+                pending.result(timeout=PROMPT_S)
+
+    def test_cancellation_by_tag_from_another_thread_wakes_the_waiter(self) -> None:
+        """Worker eviction cancels by tag from the transport side; the waiter must feel it."""
+        with _LoopInThread() as waiter_loop:
+            client = _client()
+
+            async def track_and_wait() -> float:
+                future = await client.track_request("req-3", tag="worker-a")
+                started = time.monotonic()
+                try:
+                    await asyncio.wait_for(future, timeout=WAITER_TIMEOUT_S)
+                except asyncio.CancelledError:
+                    return time.monotonic() - started
+                msg = "expected cancellation"
+                raise AssertionError(msg)
+
+            pending = asyncio.run_coroutine_threadsafe(track_and_wait(), waiter_loop)
+            time.sleep(0.2)
+
+            # cancel_requests_by_tag is async only for its lock; drive its body from here.
+            entry = client._pending_requests.pop("req-3")
+            RequestClient._settle(entry, entry.future.cancel)
+            elapsed = pending.result(timeout=WAITER_TIMEOUT_S + 5)
+
+        assert elapsed < PROMPT_S, f"waiter learned of the cancel after {elapsed:.1f}s"

--- a/tests/unit/app/test_app_worker.py
+++ b/tests/unit/app/test_app_worker.py
@@ -45,9 +45,10 @@ class _FakeRequestClient:
     async def track_request(
         self, request_id: str, tag: str = "", *, resolve_failures_as_payload: bool = False
     ) -> asyncio.Future:
-        future: asyncio.Future = asyncio.Future()
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future = loop.create_future()
         self._pending_requests[request_id] = _PendingRequest(
-            future, tag, resolve_failures_as_payload=resolve_failures_as_payload
+            future, tag, loop, resolve_failures_as_payload=resolve_failures_as_payload
         )
         return future
 

--- a/tests/unit/app/test_worker_routing.py
+++ b/tests/unit/app/test_worker_routing.py
@@ -38,6 +38,11 @@ from griptape_nodes.retained_mode.events.parameter_events import (
     AddParameterToNodeRequest,
     SetParameterValueRequest,
 )
+from griptape_nodes.retained_mode.events.project_events import (
+    AttemptMapAbsolutePathToProjectRequest,
+    GetPathForMacroRequest,
+    GetSituationRequest,
+)
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 
 if TYPE_CHECKING:
@@ -191,6 +196,18 @@ class TestInstallRemoteHandlersSwap:
         """
         assert ActivateProjectRequest in LOCAL_ONLY_REQUEST_TYPES
         assert ReloadAllLibrariesRequest in LOCAL_ONLY_REQUEST_TYPES
+
+    def test_per_file_project_reads_stay_local(self) -> None:
+        """Three project-template reads on the per-saved-file path must not forward.
+
+        Each is a pure read of a project the worker has already adopted, and each sits on the path
+        taken for every file written, so forwarding them charged a round trip per file. The
+        write-side one is easy to miss because it runs after the write rather than before it.
+        """
+        for request_type in (GetSituationRequest, GetPathForMacroRequest, AttemptMapAbsolutePathToProjectRequest):
+            assert request_type in LOCAL_ONLY_REQUEST_TYPES, (
+                f"{request_type.__name__} must be answered by the worker, not forwarded"
+            )
 
     def test_unregistered_types_are_skipped_without_error(self) -> None:
         """Nothing to swap is not a bootstrap failure: only registered types are touched.

--- a/tests/unit/app/test_worker_routing.py
+++ b/tests/unit/app/test_worker_routing.py
@@ -23,6 +23,8 @@ import pytest
 
 from griptape_nodes.app.worker_routing import (
     LOCAL_ONLY_REQUEST_TYPES,
+    ActivateProjectRequest,
+    ReloadAllLibrariesRequest,
     RemoteHandler,
     register_remote_handlers,
 )
@@ -178,6 +180,17 @@ class TestInstallRemoteHandlersSwap:
             assert event_manager.get_manager_for_request_type(request_type) is original, (
                 f"{request_type.__name__} must not be forwarded"
             )
+
+    def test_a_project_activation_and_the_reload_it_causes_are_both_local(self) -> None:
+        """The orchestrator decides when libraries reload; a worker must not ask it to.
+
+        Adopting a project reloads the worker's libraries, and that dispatch goes through the bus.
+        Forwarded, it reaches the orchestrator's pre-reload callback -- reset_workers -- which
+        terminates the worker that asked, mid-node. The pair has to stay local together: making the
+        activation local while its consequence forwards is the same defect with an extra hop.
+        """
+        assert ActivateProjectRequest in LOCAL_ONLY_REQUEST_TYPES
+        assert ReloadAllLibrariesRequest in LOCAL_ONLY_REQUEST_TYPES
 
     def test_unregistered_types_are_skipped_without_error(self) -> None:
         """Nothing to swap is not a bootstrap failure: only registered types are touched.

--- a/tests/unit/app/test_worker_routing.py
+++ b/tests/unit/app/test_worker_routing.py
@@ -9,7 +9,7 @@ These tests pin down the two invariants that replaced the old
    library-load behaviour (e.g. nodes calling ``self.add_parameter(...)``
    during LOAD_PROBE).
 2. ``register_remote_handlers`` swaps the dispatch table entry for every
-   entry in ``FORWARDED_REQUEST_TYPES``, preserving the "one handler per
+   registered type outside ``LOCAL_ONLY_REQUEST_TYPES``, preserving the "one handler per
    request type" invariant enforced by ``assign_manager_to_request_type``.
    Missing an original handler raises with a bootstrap-order diagnostic.
 """
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 from griptape_nodes.app.worker_routing import (
-    FORWARDED_REQUEST_TYPES,
+    LOCAL_ONLY_REQUEST_TYPES,
     RemoteHandler,
     register_remote_handlers,
 )
@@ -32,7 +32,10 @@ from griptape_nodes.retained_mode.events.base_events import (
     ResultPayloadSuccess,
 )
 from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
-from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+from griptape_nodes.retained_mode.events.parameter_events import (
+    AddParameterToNodeRequest,
+    SetParameterValueRequest,
+)
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 
 if TYPE_CHECKING:
@@ -129,14 +132,13 @@ class _StubResult(ResultPayloadSuccess):
 
 
 class TestInstallRemoteHandlersSwap:
-    """register_remote_handlers must displace each FORWARDED type's handler."""
+    """register_remote_handlers forwards everything except the local-only exclusions."""
 
-    def test_swap_replaces_each_forwarded_handler(self) -> None:
+    def test_swap_replaces_every_registered_handler(self) -> None:
         event_manager = EventManager()
 
-        # Give every forwarded type a uniquely-identifiable async original.
         originals: dict[type[RequestPayload], Any] = {}
-        for request_type in FORWARDED_REQUEST_TYPES:
+        for request_type in (CreateNodeRequest, AddParameterToNodeRequest, SetParameterValueRequest):
 
             async def original(_request: RequestPayload) -> _StubResult:
                 return _StubResult(result_details="ok")
@@ -154,22 +156,46 @@ class TestInstallRemoteHandlersSwap:
             assert swapped.original is original
             assert swapped.event_manager is event_manager
 
-    def test_missing_original_raises_bootstrap_error(self) -> None:
-        event_manager = EventManager()
+    def test_local_only_types_are_left_alone(self) -> None:
+        """Excluded types must keep their own handler.
 
-        # Register everything except CreateNodeRequest so register_remote_handlers
-        # trips on the first missing original it encounters.
-        for request_type in FORWARDED_REQUEST_TYPES:
-            if request_type is CreateNodeRequest:
-                continue
+        ExecuteNodeRequest is the sharpest case: forwarding a worker's own execution request
+        would send it back to the orchestrator, which would route it straight here again.
+        """
+        event_manager = EventManager()
+        locals_registered: dict[type[RequestPayload], Any] = {}
+        for request_type in LOCAL_ONLY_REQUEST_TYPES:
 
             async def original(_request: RequestPayload) -> _StubResult:
-                return _StubResult(result_details="ok")
+                return _StubResult(result_details="local")
 
+            locals_registered[request_type] = original
             event_manager.assign_manager_to_request_type(request_type, original)
 
-        with pytest.raises(RuntimeError, match="CreateNodeRequest"):
-            register_remote_handlers(event_manager)
+        register_remote_handlers(event_manager)
+
+        for request_type, original in locals_registered.items():
+            assert event_manager.get_manager_for_request_type(request_type) is original, (
+                f"{request_type.__name__} must not be forwarded"
+            )
+
+    def test_unregistered_types_are_skipped_without_error(self) -> None:
+        """Nothing to swap is not a bootstrap failure: only registered types are touched.
+
+        The allowlist version raised when a listed type had no owner, because the list could
+        name types nobody had registered. Iterating what IS registered removes that failure
+        mode entirely.
+        """
+        event_manager = EventManager()
+
+        async def original(_request: RequestPayload) -> _StubResult:
+            return _StubResult(result_details="ok")
+
+        event_manager.assign_manager_to_request_type(CreateNodeRequest, original)
+
+        register_remote_handlers(event_manager)
+
+        assert isinstance(event_manager.get_manager_for_request_type(CreateNodeRequest), RemoteHandler)
 
     def test_post_install_out_of_scope_still_runs_original(self) -> None:
         """Bootstrap-path regression guard: LOAD_PROBE-style calls must stay local.
@@ -187,17 +213,7 @@ class TestInstallRemoteHandlersSwap:
             local_calls.append(request)
             return _StubResult(result_details="local")
 
-        # Register the single type we assert on; register_remote_handlers needs
-        # every forwarded type registered, so fill in trivial stubs for the rest.
         event_manager.assign_manager_to_request_type(AddParameterToNodeRequest, local_add_parameter)
-        for request_type in FORWARDED_REQUEST_TYPES:
-            if request_type is AddParameterToNodeRequest:
-                continue
-
-            async def stub(_request: RequestPayload) -> _StubResult:
-                return _StubResult(result_details="ok")
-
-            event_manager.assign_manager_to_request_type(request_type, stub)
 
         register_remote_handlers(event_manager)
 

--- a/tests/unit/app/test_worker_routing.py
+++ b/tests/unit/app/test_worker_routing.py
@@ -43,6 +43,7 @@ from griptape_nodes.retained_mode.events.project_events import (
     GetPathForMacroRequest,
     GetSituationRequest,
 )
+from griptape_nodes.retained_mode.events.resource_events import GetExecutionDeviceRequest
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 
 if TYPE_CHECKING:
@@ -208,6 +209,15 @@ class TestInstallRemoteHandlersSwap:
             assert request_type in LOCAL_ONLY_REQUEST_TYPES, (
                 f"{request_type.__name__} must be answered by the worker, not forwarded"
             )
+
+    def test_the_device_read_is_answered_by_the_worker(self) -> None:
+        """`execution_device` must describe the machine that will run the model.
+
+        Forwarding asked the orchestrator about its own hardware. Today both processes share a
+        machine so the answers coincide, which is exactly why this needs pinning: the moment a
+        venue runs somewhere else, a forwarded answer is silently the wrong machine's.
+        """
+        assert GetExecutionDeviceRequest in LOCAL_ONLY_REQUEST_TYPES
 
     def test_unregistered_types_are_skipped_without_error(self) -> None:
         """Nothing to swap is not a bootstrap failure: only registered types are touched.

--- a/tests/unit/app/test_worker_routing_filesystem.py
+++ b/tests/unit/app/test_worker_routing_filesystem.py
@@ -1,0 +1,212 @@
+"""Filesystem requests must not cross the worker boundary.
+
+Forwarding-by-default made "every request a node can issue survives a cattrs round trip" a
+requirement, and the filesystem family does not meet it. Three separate ways:
+
+- `content` is `str | bytes`. The wire form base64s bytes into a JSON string and cattrs resolves
+  the union back to `str`, so a worker's write landed on disk as mojibake with no error raised
+  anywhere. Silent data corruption.
+- A path carrying macro variables is a `MacroPath` wrapping a `ParsedMacro`, which will not
+  serialize at all. The worker blocked until the forward timed out.
+- Four failure results declare `SequenceScanFailureReason | FileIOFailureReason`, which cattrs
+  cannot disambiguate, so even the error could not travel.
+
+None of that is a reason to make the wire smarter: the workspace is shared on disk, so a worker's
+own answer was already the correct one. These tests pin the routing decision and the mechanism
+behind it, so neither can be undone by accident.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.app.worker_routing import (
+    _FORWARDING_FILESYSTEM_REQUESTS,
+    LOCAL_ONLY_REQUEST_TYPES,
+)
+from griptape_nodes.common.macro_parser import ParsedMacro
+from griptape_nodes.retained_mode.events import os_events
+from griptape_nodes.retained_mode.events.base_events import RequestPayload
+from griptape_nodes.retained_mode.events.event_converter import converter
+from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
+from griptape_nodes.retained_mode.events.project_events import MacroPath
+
+# Sanity floor for the derived list; os_events has 18 request types today.
+_MINIMUM_EXPECTED_REQUESTS = 10
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+
+def _requests_defined_in(module: ModuleType) -> list[type[RequestPayload]]:
+    """Request types this module DEFINES.
+
+    Filtered on `__module__` rather than namespace membership: these modules import request types
+    from each other, and an imported one becoming local-only by accident would let a worker answer
+    it against its own non-authoritative state.
+    """
+    return [
+        payload
+        for payload in vars(module).values()
+        if isinstance(payload, type)
+        and issubclass(payload, RequestPayload)
+        and payload is not RequestPayload
+        and payload.__module__ == module.__name__
+    ]
+
+
+def _filesystem_requests() -> list[type[RequestPayload]]:
+    return _requests_defined_in(os_events)
+
+
+def _macro_path_requests() -> list[type[RequestPayload]]:
+    """Every registered request carrying a MacroPath, wherever it is defined.
+
+    Derived from the whole payload registry on purpose. The first version of this rule was scoped
+    to os_events, which missed the artifact preview requests entirely -- and a test built from the
+    same scope agreed with the bug instead of failing.
+    """
+    carriers = []
+    for payload in PayloadRegistry.get_registry().values():
+        if not (isinstance(payload, type) and issubclass(payload, RequestPayload)):
+            continue
+        if not dataclasses.is_dataclass(payload):
+            continue
+        annotations = [f.type if isinstance(f.type, str) else str(f.type) for f in dataclasses.fields(payload)]
+        if any("MacroPath" in annotation for annotation in annotations):
+            carriers.append(payload)
+    return carriers
+
+
+class TestEveryFilesystemRequestHasARoutingDecision:
+    def test_the_module_is_not_empty(self) -> None:
+        """Guards the guard: a rename that empties this list would make the rest vacuous."""
+        assert len(_filesystem_requests()) > _MINIMUM_EXPECTED_REQUESTS
+
+    @pytest.mark.parametrize("request_type", _filesystem_requests(), ids=lambda cls: cls.__name__)
+    def test_it_is_either_local_only_or_deliberately_forwarded(self, request_type: type[RequestPayload]) -> None:
+        """A filesystem request added later must be routed on purpose, not by default.
+
+        Defaulting to local is the safe direction here, so this fails only if someone adds a
+        request AND puts it in the forwarding set without it being a user-facing side effect.
+        """
+        if request_type in _FORWARDING_FILESYSTEM_REQUESTS:
+            assert request_type not in LOCAL_ONLY_REQUEST_TYPES
+        else:
+            assert request_type in LOCAL_ONLY_REQUEST_TYPES
+
+    def test_opening_a_file_in_the_users_app_is_the_only_forwarded_one(self) -> None:
+        """It is a side effect, not a filesystem read: it belongs where the user is.
+
+        A headless worker subprocess launching a desktop application would be either invisible or
+        wrong, so this one goes to the process sitting next to the person.
+        """
+        assert {os_events.OpenAssociatedFileRequest} == _FORWARDING_FILESYSTEM_REQUESTS
+
+
+class TestNothingCarryingAMacroPathIsForwarded:
+    """A MacroPath cannot be serialized, so forwarding one hangs the worker until it times out.
+
+    Checked across the whole payload registry rather than one module: MacroPath is defined in
+    project_events and used by both os_events and artifact_events, and the artifact preview
+    requests are reachable from a handler a worker runs locally -- so a module-scoped rule let them
+    through while looking complete.
+    """
+
+    def test_the_sweep_finds_the_ones_we_know_about(self) -> None:
+        """Guards the guard: if the sweep silently found nothing, everything below is vacuous."""
+        names = {payload.__name__ for payload in _macro_path_requests()}
+        assert {"GetPreviewForArtifactRequest", "GetNextVersionIndexRequest"} <= names
+
+    @pytest.mark.parametrize("request_type", _macro_path_requests(), ids=lambda cls: cls.__name__)
+    def test_it_is_local_only(self, request_type: type[RequestPayload]) -> None:
+        assert request_type in LOCAL_ONLY_REQUEST_TYPES
+
+
+class TestTypeRegisteringRequestsAnswerLocally:
+    """The two provider-registration payloads carry a bare `type` field.
+
+    cattrs has no structure hook for `type`, and the point of the request is a
+    process-local registry -- so these must answer locally. They fell out of the
+    derivation once already: the bare builtin `type` annotation is an evaluated class,
+    and a matcher reading `str(annotation)` sees "<class 'type'>" and misses it.
+    """
+
+    def test_register_artifact_provider_is_local(self) -> None:
+        from griptape_nodes.retained_mode.events.artifact_events import RegisterArtifactProviderRequest
+
+        assert RegisterArtifactProviderRequest in LOCAL_ONLY_REQUEST_TYPES
+
+    def test_register_preview_generator_is_local(self) -> None:
+        from griptape_nodes.retained_mode.events.artifact_events import RegisterPreviewGeneratorRequest
+
+        assert RegisterPreviewGeneratorRequest in LOCAL_ONLY_REQUEST_TYPES
+
+
+class TestTheWireCannotCarryThese:
+    """Pin the mechanisms, so the exclusion is not "fixed" by routing these instead."""
+
+    def test_bytes_come_back_as_a_corrupted_string(self) -> None:
+        original = b"\x89PNG\r\n\x1a\n\x00\xff\xfe"
+        wire = json.loads(
+            json.dumps(converter.unstructure(os_events.WriteFileRequest(file_path="x.png", content=original)))
+        )
+
+        round_tripped = converter.structure(wire, os_events.WriteFileRequest).content
+
+        assert round_tripped != original, "if bytes now survive, revisit whether writes may forward"
+        assert isinstance(round_tripped, str)
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            os_events.GetNextVersionIndexRequest(
+                macro_path=MacroPath(parsed_macro=ParsedMacro("{outputs}/o.png"), variables={})
+            ),
+            os_events.ResolveMacroPathRequest(
+                macro_path=MacroPath(parsed_macro=ParsedMacro("{outputs}/o.png"), variables={})
+            ),
+            os_events.GetNextUnusedFilenameRequest(
+                file_path=MacroPath(parsed_macro=ParsedMacro("{outputs}/o.png"), variables={})
+            ),
+        ],
+        ids=lambda p: type(p).__name__,
+    )
+    def test_a_macro_path_will_not_serialize(self, payload: RequestPayload) -> None:
+        """`Directory("{outputs}/renders").with_versioning()` is the ordinary caller of these."""
+        with pytest.raises(Exception):  # noqa: B017, PT011 - any failure to serialize is the point
+            json.dumps(converter.unstructure(payload))
+
+    def test_the_sequence_failure_union_cannot_be_structured(self) -> None:
+        """So a worker could not even receive the error, let alone the result."""
+        failure = os_events.ScanSequencesResultFailure(
+            failure_reason=os_events.SequenceScanFailureReason.INVALID_TEMPLATE,
+            result_details="no",
+        )
+        wire = json.loads(json.dumps(converter.unstructure(failure)))
+
+        with pytest.raises(Exception):  # noqa: B017, PT011 - any failure to serialize is the point
+            converter.structure(wire, os_events.ScanSequencesResultFailure)
+
+    def test_the_ambiguous_union_is_still_declared_where_we_think(self) -> None:
+        """If these are ever given a structure hook, the test above stops meaning anything."""
+        annotated = [
+            cls.__name__
+            for cls in vars(os_events).values()
+            if isinstance(cls, type)
+            and dataclasses.is_dataclass(cls)
+            and any(
+                isinstance(f.type, str) and "SequenceScanFailureReason | FileIOFailureReason" in f.type
+                for f in dataclasses.fields(cls)
+            )
+        ]
+        assert sorted(annotated) == [
+            "DeduceSequencesFromFileListResultFailure",
+            "ListDirectoryResultFailure",
+            "ListDirectorySequencesResultFailure",
+            "ScanSequencesResultFailure",
+        ]

--- a/tests/unit/app/test_worker_routing_strict_mode.py
+++ b/tests/unit/app/test_worker_routing_strict_mode.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from griptape_nodes.app.worker_routing import (
-    FORWARDED_REQUEST_TYPES,
+    LOCAL_ONLY_REQUEST_TYPES,
     RemoteHandler,
     register_remote_handlers,
 )
@@ -40,6 +40,16 @@ from griptape_nodes.retained_mode.managers.event_manager import EventManager
 
 if TYPE_CHECKING:
     from griptape_nodes.retained_mode.managers.event_manager import ResultContext
+
+
+def _forwarded_sample() -> tuple[type, ...]:
+    """A few representative types that forward (i.e. are not local-only)."""
+    from griptape_nodes.retained_mode.events.node_events import CreateNodeRequest
+    from griptape_nodes.retained_mode.events.parameter_events import AddParameterToNodeRequest
+
+    sample = (CreateNodeRequest, AddParameterToNodeRequest)
+    assert not set(sample) & LOCAL_ONLY_REQUEST_TYPES
+    return sample
 
 
 @dataclass(kw_only=True)
@@ -224,8 +234,8 @@ class TestWorkerReachIntoOrchestrator:
         ``register_remote_handlers`` swaps a real FORWARDED type's handler
         for a ``RemoteHandler`` shim, and dispatching that real type
         directly through the shim records the violation. Locks in the
-        ``FORWARDED_REQUEST_TYPES`` <-> ``RemoteHandler`` integration: if
-        a future change drops a type from ``FORWARDED_REQUEST_TYPES``,
+        ``LOCAL_ONLY_REQUEST_TYPES`` <-> ``RemoteHandler`` integration: if
+        a future change adds a type to ``LOCAL_ONLY_REQUEST_TYPES``,
         this test stays green only because
         ``ListConnectionsForNodeRequest`` is still a member.
         """
@@ -253,10 +263,9 @@ class TestWorkerReachIntoOrchestrator:
 
         event_manager.forward_to_orchestrator = fake_forward  # type: ignore[method-assign]
 
-        # register_remote_handlers requires every FORWARDED type to have an
-        # original handler registered first. Stub them all with a trivial
-        # local handler; the swap installs RemoteHandler in their place.
-        for request_type in FORWARDED_REQUEST_TYPES:
+        # register_remote_handlers swaps whatever is registered, so the type this test
+        # asserts on has to be registered first. Stub it plus a couple of representatives.
+        for request_type in (ListConnectionsForNodeRequest, *_forwarded_sample()):
 
             async def stub(_request: RequestPayload) -> ResultPayloadSuccess:
                 return ListConnectionsForNodeResultSuccess(

--- a/tests/unit/common/test_node_executor_propagation.py
+++ b/tests/unit/common/test_node_executor_propagation.py
@@ -18,6 +18,10 @@ import pytest
 from griptape_nodes.common.node_executor import NodeExecutor
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import TrackedParameterOutputValues
+from griptape_nodes.retained_mode.events.connection_events import (
+    ListConnectionsForNodeRequest,
+    ListConnectionsForNodeResultSuccess,
+)
 from griptape_nodes.retained_mode.events.execution_events import ExecuteNodeResultSuccess
 from griptape_nodes.retained_mode.events.flow_events import (
     OriginalNodeParameter,
@@ -30,9 +34,9 @@ from tests.unit.exe_types.mocks import MockNode
 
 _EXPECTED_FRESH_OUTPUT_EMITS = 2
 
-# GriptapeNodes is lazy-imported inside the event emitters; patch it at the
-# source module so those imports pick up the mock at call time.
-_GN_PATCH = "griptape_nodes.retained_mode.griptape_nodes.GriptapeNodes"
+# A node built without an engine resolves the ambient one; patch that resolution at the
+# source module so the property picks up the stand-in at call time.
+_CURRENT_ENGINE_PATCH = "griptape_nodes.retained_mode.engine.current_engine"
 
 
 def _make_executor() -> NodeExecutor:
@@ -158,7 +162,7 @@ def _make_end_mapping(
 
 
 def _gn_mock_with_variable(name: str = "SHOT") -> Any:
-    """A GN patch where `name` is a real, defined flow variable.
+    """A stand-in engine where `name` is a real, defined flow variable.
 
     `should_preserve_stored_template` confirms substitution would actually rewrite
     the stored text before declining a write, so these tests have to define a
@@ -167,20 +171,22 @@ def _gn_mock_with_variable(name: str = "SHOT") -> Any:
     return a non-ListVariablesResultSuccess and fall back to trusting the regex
     heuristic -- but then they would no longer be testing the intended path.
     """
-    mock_gn = MagicMock()
-    mock_gn.WorkflowManager.return_value.is_variable_substitution_enabled.return_value = True
-    mock_gn.NodeManager.return_value.get_node_parent_flow_by_name.return_value = "test_flow"
-    mock_gn.FlowManager.return_value.get_connections.return_value = MagicMock(incoming_index={})
-    mock_gn.handle_request.side_effect = lambda req: (
+    engine = MagicMock()
+    engine.workflow_manager.is_variable_substitution_enabled.return_value = True
+    engine.node_manager.get_node_parent_flow_by_name.return_value = "test_flow"
+    engine.handle_request.side_effect = lambda req: (
         ListVariablesResultSuccess(
             variables=[FlowVariable(name=name, owning_flow_name="test_flow", type="str", value="hyperreal")],
             layers=[VariableLayerKind.FLOW],
             result_details="ok",
         )
         if isinstance(req, ListVariablesRequest)
+        else ListConnectionsForNodeResultSuccess(incoming_connections=[], outgoing_connections=[], result_details="ok")
+        if isinstance(req, ListConnectionsForNodeRequest)
         else MagicMock()
     )
-    return patch(_GN_PATCH, mock_gn)
+    # The nodes under test are built without an engine, so they resolve the ambient one.
+    return patch(_CURRENT_ENGINE_PATCH, return_value=engine)
 
 
 class TestGroupCopyBackPreservesTemplate:

--- a/tests/unit/exe_types/param_components/artifact_url/test_public_artifact_url_parameter.py
+++ b/tests/unit/exe_types/param_components/artifact_url/test_public_artifact_url_parameter.py
@@ -9,7 +9,7 @@ paths. See griptape-ai/griptape-nodes-engine#4688.
 import re
 from pathlib import Path
 from typing import Any, NamedTuple
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 from griptape.artifacts import ErrorArtifact
@@ -159,7 +159,7 @@ class TestGetBucketId:
     def test_valid_bucket_id_passes_through(self, mocker: Any) -> None:
         exists_mock, default_mock = self._patch(mocker, bucket_id_value="bucket-123", bucket_exists=True)
 
-        assert PublicArtifactUrlParameter._get_bucket_id("https://base", "key") == "bucket-123"
+        assert PublicArtifactUrlParameter._get_bucket_id(MagicMock(), "https://base", "key") == "bucket-123"
         # A configured ID is validated directly; the org default is never consulted.
         exists_mock.assert_called_once()
         default_mock.assert_not_called()
@@ -169,23 +169,23 @@ class TestGetBucketId:
         # `bucket_exists` (a direct GET) must be the source of truth, not the list.
         self._patch(mocker, bucket_id_value="page-2-bucket", bucket_exists=True)
 
-        assert PublicArtifactUrlParameter._get_bucket_id("https://base", "key") == "page-2-bucket"
+        assert PublicArtifactUrlParameter._get_bucket_id(MagicMock(), "https://base", "key") == "page-2-bucket"
 
     def test_unset_secret_falls_back_to_org_default_bucket(self, mocker: Any) -> None:
         self._patch(mocker, bucket_id_value=None, default_bucket_id="org-default")
 
-        assert PublicArtifactUrlParameter._get_bucket_id("https://base", "key") == "org-default"
+        assert PublicArtifactUrlParameter._get_bucket_id(MagicMock(), "https://base", "key") == "org-default"
 
     def test_blank_secret_falls_back_to_org_default_bucket(self, mocker: Any) -> None:
         self._patch(mocker, bucket_id_value="   ", default_bucket_id="org-default")
 
-        assert PublicArtifactUrlParameter._get_bucket_id("https://base", "key") == "org-default"
+        assert PublicArtifactUrlParameter._get_bucket_id(MagicMock(), "https://base", "key") == "org-default"
 
     def test_invalid_bucket_id_raises_clear_error(self, mocker: Any) -> None:
         self._patch(mocker, bucket_id_value="does-not-exist", bucket_exists=False)
 
         with pytest.raises(RuntimeError, match="invalid bucket ID") as excinfo:
-            PublicArtifactUrlParameter._get_bucket_id("https://base", "key")
+            PublicArtifactUrlParameter._get_bucket_id(MagicMock(), "https://base", "key")
 
         message = str(excinfo.value)
         assert PublicArtifactUrlParameter.BUCKET_ID_NAME in message
@@ -195,13 +195,13 @@ class TestGetBucketId:
         self._patch(mocker, bucket_id_value="", default_bucket_id=None)
 
         with pytest.raises(RuntimeError, match=PublicArtifactUrlParameter.BUCKET_ID_NAME):
-            PublicArtifactUrlParameter._get_bucket_id("https://base", "key")
+            PublicArtifactUrlParameter._get_bucket_id(MagicMock(), "https://base", "key")
 
     def test_unset_secret_with_no_default_bucket_raises_original_message(self, mocker: Any) -> None:
         self._patch(mocker, bucket_id_value=None, default_bucket_id=None)
 
         with pytest.raises(RuntimeError, match="No Griptape Cloud storage buckets found"):
-            PublicArtifactUrlParameter._get_bucket_id("https://base", "key")
+            PublicArtifactUrlParameter._get_bucket_id(MagicMock(), "https://base", "key")
 
 
 class TestUploadPathLifecycle:

--- a/tests/unit/exe_types/param_components/huggingface/test_huggingface_gating_against_real_catalog.py
+++ b/tests/unit/exe_types/param_components/huggingface/test_huggingface_gating_against_real_catalog.py
@@ -42,6 +42,8 @@ from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from griptape_nodes.retained_mode.engine import Engine
+
 _LIBRARY_NAME = "hf-gating-real-catalog-test-library"
 _MODULE = "griptape_nodes.exe_types.param_components.huggingface"
 
@@ -193,7 +195,7 @@ def _deny_denied_provider(checkpoint: AuthorizationCheckpoint) -> CheckpointDeni
 
 
 @pytest.fixture
-def denying_policy(engine) -> Iterator[None]:  # noqa: ANN001
+def denying_policy(engine: Engine) -> Iterator[None]:
     """Install the real deny hook for the duration of a test."""
     engine.event_manager.add_authorization_hook(_deny_denied_provider)
     try:

--- a/tests/unit/exe_types/param_components/huggingface/test_huggingface_repo_parameter_gating.py
+++ b/tests/unit/exe_types/param_components/huggingface/test_huggingface_repo_parameter_gating.py
@@ -65,7 +65,7 @@ def _stub_engine() -> Iterator[None]:
     with (
         patch(f"{module}.huggingface_repo_parameter.list_repo_revisions_in_cache", return_value=[]),
         patch(f"{module}.huggingface_repo_parameter.list_all_repo_revisions_in_cache", return_value=[]),
-        patch(f"{module}.huggingface_model_parameter.GriptapeNodes.handle_request", side_effect=handle_request),
+        patch("griptape_nodes.retained_mode.engine.Engine.handle_request", side_effect=handle_request),
     ):
         yield
 
@@ -124,9 +124,8 @@ class TestFailClosed:
 
     def test_policy_resolution_failure_denies_everything(self) -> None:
         """A library that cannot be resolved must not silently open the gate."""
-        module = "griptape_nodes.exe_types.param_components.huggingface"
         with patch(
-            f"{module}.huggingface_model_parameter.GriptapeNodes.handle_request",
+            "griptape_nodes.retained_mode.engine.Engine.handle_request",
             return_value=QueryModelAccessForNodeResultFailure(result_details="node type not found"),
         ):
             param = _param(gated=True)
@@ -152,9 +151,8 @@ class TestTheEmptyCachePlaceholderIsNotBadgedAsUnlicensed:
     """
 
     def _unresolvable_param(self, *, add_parameters: bool = False) -> HuggingFaceRepoParameter:
-        module = "griptape_nodes.exe_types.param_components.huggingface"
         with patch(
-            f"{module}.huggingface_model_parameter.GriptapeNodes.handle_request",
+            "griptape_nodes.retained_mode.engine.Engine.handle_request",
             return_value=QueryModelAccessForNodeResultFailure(result_details="node type not found"),
         ):
             # `repo_ids=[]` + `list_all_models=True` is the "offer whatever is cached" config, and
@@ -195,8 +193,7 @@ class TestUngatedIsUnchanged:
         assert param.query_for_denial(UNDECLARED_REPO) is None
 
     def test_ungated_does_not_query_policy(self) -> None:
-        module = "griptape_nodes.exe_types.param_components.huggingface"
-        with patch(f"{module}.huggingface_model_parameter.GriptapeNodes.handle_request") as handle:
+        with patch("griptape_nodes.retained_mode.engine.Engine.handle_request") as handle:
             _param(gated=False)
         access_calls = [
             call for call in handle.call_args_list if isinstance(call.args[0], QueryModelAccessForNodeRequest)
@@ -235,9 +232,8 @@ class TestAutoDetect:
 
     def test_stays_ungated_when_the_node_declares_nothing(self) -> None:
         """An empty verdict list means no catalog to gate against, so offer everything."""
-        module = "griptape_nodes.exe_types.param_components.huggingface"
         with patch(
-            f"{module}.huggingface_model_parameter.GriptapeNodes.handle_request",
+            "griptape_nodes.retained_mode.engine.Engine.handle_request",
             return_value=QueryModelAccessForNodeResultSuccess(verdicts=[], result_details="ok"),
         ):
             param = _param(gated=None)
@@ -252,9 +248,8 @@ class TestAutoDetect:
         not be resolved at all (unregistered, ambiguous across two libraries, or mid-reload), and
         treating that as "allow everything" let an admin's deny be bypassed by a lookup error.
         """
-        module = "griptape_nodes.exe_types.param_components.huggingface"
         with patch(
-            f"{module}.huggingface_model_parameter.GriptapeNodes.handle_request",
+            "griptape_nodes.retained_mode.engine.Engine.handle_request",
             return_value=QueryModelAccessForNodeResultFailure(result_details="node type not found"),
         ):
             param = _param(gated=None)
@@ -263,9 +258,8 @@ class TestAutoDetect:
 
     def test_stays_ungated_for_a_library_that_declares_nothing(self) -> None:
         """The real pre-adoption path: a Success carrying no verdicts leaves gating off."""
-        module = "griptape_nodes.exe_types.param_components.huggingface"
         with patch(
-            f"{module}.huggingface_model_parameter.GriptapeNodes.handle_request",
+            "griptape_nodes.retained_mode.engine.Engine.handle_request",
             return_value=QueryModelAccessForNodeResultSuccess(verdicts=[], result_details="ok"),
         ):
             param = _param(gated=None)
@@ -274,9 +268,8 @@ class TestAutoDetect:
 
     def test_explicit_true_still_fails_closed_on_resolution_failure(self) -> None:
         """Opting in explicitly keeps the loud behavior auto-detect deliberately softens."""
-        module = "griptape_nodes.exe_types.param_components.huggingface"
         with patch(
-            f"{module}.huggingface_model_parameter.GriptapeNodes.handle_request",
+            "griptape_nodes.retained_mode.engine.Engine.handle_request",
             return_value=QueryModelAccessForNodeResultFailure(result_details="node type not found"),
         ):
             param = _param(gated=True)
@@ -328,8 +321,7 @@ class TestConstructionDefersBusRequests:
         return param
 
     def test_construction_issues_no_bus_requests(self) -> None:
-        module = "griptape_nodes.exe_types.param_components.huggingface"
-        with patch(f"{module}.huggingface_model_parameter.GriptapeNodes.handle_request") as handle:
+        with patch("griptape_nodes.retained_mode.engine.Engine.handle_request") as handle:
             self._construct_deferred(gated=True)
         handle.assert_not_called()
 
@@ -412,7 +404,6 @@ class TestConstructionWithoutAScopeStillQueries:
                 return QueryModelAccessForNodeResultSuccess(verdicts=_verdicts(), result_details="ok")
             return object()  # not a ResultSuccess -> "nothing downloading", as in _stub_engine
 
-        module = "griptape_nodes.exe_types.param_components.huggingface"
-        with patch(f"{module}.huggingface_model_parameter.GriptapeNodes.handle_request", side_effect=handle_request):
+        with patch("griptape_nodes.retained_mode.engine.Engine.handle_request", side_effect=handle_request):
             self._construct_in_init()
         assert ListModelDownloadsRequest in seen

--- a/tests/unit/exe_types/param_components/huggingface/test_huggingface_subclass_gating.py
+++ b/tests/unit/exe_types/param_components/huggingface/test_huggingface_subclass_gating.py
@@ -57,7 +57,7 @@ def _stub(verdicts: list[ModelAccessVerdict]):  # noqa: ANN202
         msg = f"unexpected request: {type(request).__name__}"
         raise AssertionError(msg)
 
-    return patch(f"{_MODULE}.huggingface_model_parameter.GriptapeNodes.handle_request", side_effect=handle_request)
+    return patch("griptape_nodes.retained_mode.engine.Engine.handle_request", side_effect=handle_request)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/exe_types/param_components/test_model_access_component.py
+++ b/tests/unit/exe_types/param_components/test_model_access_component.py
@@ -21,6 +21,7 @@ Focused on:
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
@@ -28,6 +29,10 @@ import pytest
 from griptape_nodes.exe_types.core_types import Parameter
 from griptape_nodes.exe_types.node_types import BaseNode
 from griptape_nodes.exe_types.param_components.model_access_component import ModelAccessComponent
+from griptape_nodes.retained_mode.engine import current_engine
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
 from griptape_nodes.retained_mode.events.access_events import QueryModelAccessForNodeResultFailure
 from griptape_nodes.traits.button import Button
 from griptape_nodes.traits.options import Options
@@ -185,7 +190,7 @@ class TestPickPermittedDefault:
         )
         assert helper.pick_permitted_default() == "alpha"
 
-    def test_falls_back_to_first_allowed_when_default_denied(self, engine) -> None:  # noqa: ANN001
+    def test_falls_back_to_first_allowed_when_default_denied(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
@@ -204,7 +209,7 @@ class TestPickPermittedDefault:
         finally:
             engine.event_manager.remove_authorization_hook(deny_alpha)
 
-    def test_returns_none_when_every_choice_is_denied(self, engine) -> None:  # noqa: ANN001
+    def test_returns_none_when_every_choice_is_denied(self, engine: Engine) -> None:
         """Every declared choice denied -> None. Caller decides what to do next.
 
         The helper does not silently return a denied model as the default -- that
@@ -237,7 +242,7 @@ class TestInstall:
         assert len(param.find_elements_by_type(Options)) == 1
         assert len(param.find_elements_by_type(Button)) == 1
 
-    def test_install_populates_ui_options_with_dropdown_data(self, engine) -> None:  # noqa: ANN001
+    def test_install_populates_ui_options_with_dropdown_data(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
@@ -280,7 +285,7 @@ class TestInstall:
         # update_ui_options merges; display_name set by the node must survive.
         assert post_param.ui_options.get("display_name") == pre_display_name
 
-    def test_install_applies_initial_badge_when_stored_value_denied(self, engine) -> None:  # noqa: ANN001
+    def test_install_applies_initial_badge_when_stored_value_denied(self, engine: Engine) -> None:
         """A node born with a denied stored value shows the badge immediately.
 
         Setup: every choice is denied so ``pick_permitted_default()`` returns
@@ -308,7 +313,7 @@ class TestInstall:
         finally:
             engine.event_manager.remove_authorization_hook(deny_everything)
 
-    def test_constructor_relocates_stored_value_off_denied_default(self, engine) -> None:  # noqa: ANN001
+    def test_constructor_relocates_stored_value_off_denied_default(self, engine: Engine) -> None:
         """Constructor moves the stored value off a denied default to a permitted alternative.
 
         The parameter's declarative default_value is preserved (unchanged); only
@@ -532,7 +537,7 @@ class TestEngineFailureIsFailClosedAtRuntime:
 
 
 class TestOnValueChanged:
-    def test_sets_badge_when_switching_to_denied_value(self, engine) -> None:  # noqa: ANN001
+    def test_sets_badge_when_switching_to_denied_value(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
@@ -556,7 +561,7 @@ class TestOnValueChanged:
         finally:
             engine.event_manager.remove_authorization_hook(deny_alpha)
 
-    def test_clears_badge_when_switching_to_allowed_value(self, engine) -> None:  # noqa: ANN001
+    def test_clears_badge_when_switching_to_allowed_value(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
@@ -596,7 +601,7 @@ class TestOnValueChanged:
 
 
 class TestRefreshAndQueryForDenial:
-    def test_query_for_denial_returns_denial_for_denied_model(self, engine) -> None:  # noqa: ANN001
+    def test_query_for_denial_returns_denial_for_denied_model(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
@@ -616,7 +621,7 @@ class TestRefreshAndQueryForDenial:
         finally:
             engine.event_manager.remove_authorization_hook(deny_alpha)
 
-    def test_query_for_denial_honors_a_grant_made_since_the_last_refresh(self, engine) -> None:  # noqa: ANN001
+    def test_query_for_denial_honors_a_grant_made_since_the_last_refresh(self, engine: Engine) -> None:
         """The run-path re-query must work in BOTH directions, not just allow -> deny.
 
         The snapshot is captured at construction/refresh time. If a cached denial short-circuited
@@ -641,7 +646,7 @@ class TestRefreshAndQueryForDenial:
 
         assert helper.query_for_denial("alpha") is None
 
-    def test_an_unanswerable_live_requery_falls_back_to_the_cached_denial(self, engine) -> None:  # noqa: ANN001
+    def test_an_unanswerable_live_requery_falls_back_to_the_cached_denial(self, engine: Engine) -> None:  # noqa: ARG002 - boots the ambient engine
         """A transient lookup failure must not forget a denial we already hold.
 
         The run path re-asks policy live so grants are honored. If that query cannot be answered
@@ -655,20 +660,19 @@ class TestRefreshAndQueryForDenial:
                 return CheckpointDenial(failures=(CheckpointFailure(detail="Alpha not enabled."),))
             return None
 
-        engine.event_manager.add_authorization_hook(deny_alpha)
+        current_engine().event_manager.add_authorization_hook(deny_alpha)
         try:
             _, helper = _install_probe_node_with_helper(model_choices=["alpha", "beta"], default_model="beta")
             assert helper.query_for_denial("alpha") is not None
 
             # The live re-query now comes back unanswerable.
-            with patch.object(
-                engine,
-                "handle_request",
+            with patch(
+                "griptape_nodes.retained_mode.engine.Engine.handle_request",
                 return_value=QueryModelAccessForNodeResultFailure(result_details="library unregistered"),
             ):
                 assert helper.query_for_denial("alpha") is not None
         finally:
-            engine.event_manager.remove_authorization_hook(deny_alpha)
+            current_engine().event_manager.remove_authorization_hook(deny_alpha)
 
     def test_query_for_denial_ignores_non_string_values(self) -> None:
         _, helper = _install_probe_node_with_helper(model_choices=["alpha", "beta"], default_model="alpha")
@@ -688,7 +692,7 @@ class TestRefreshAndQueryForDenial:
 
         assert helper.query_for_denial("never-heard-of-this-model") is None
 
-    def test_refresh_picks_up_hook_change(self, engine) -> None:  # noqa: ANN001
+    def test_refresh_picks_up_hook_change(self, engine: Engine) -> None:
         """refresh() re-fetches the denial map so a policy change becomes visible."""
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
@@ -722,7 +726,7 @@ class TestRefreshAndQueryForDenial:
 
 
 class TestRaiseIfDenied:
-    def test_raises_runtimeerror_with_denial_reason(self, engine) -> None:  # noqa: ANN001
+    def test_raises_runtimeerror_with_denial_reason(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
@@ -753,7 +757,7 @@ class TestRaiseIfDenied:
 
 
 class TestRefreshButton:
-    def test_refresh_button_click_rebuilds_state(self, engine) -> None:  # noqa: ANN001
+    def test_refresh_button_click_rebuilds_state(self, engine: Engine) -> None:
         """The inline Button trait's on_click hook invokes refresh()."""
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
@@ -788,7 +792,7 @@ class TestRefreshButton:
 
 
 class TestSuccessFailureUsagePattern:
-    def test_query_for_denial_supports_early_return_without_raising(self, engine) -> None:  # noqa: ANN001
+    def test_query_for_denial_supports_early_return_without_raising(self, engine: Engine) -> None:
         """A SuccessFailure-style caller can inspect the denial and route without an exception.
 
         Verifies that the helper never raises on its own -- the caller decides
@@ -835,7 +839,7 @@ class TestModelChoicesProperty:
 
 
 class TestReinstallOptions:
-    def test_reinstall_puts_options_and_decoration_back(self, engine) -> None:  # noqa: ANN001
+    def test_reinstall_puts_options_and_decoration_back(self, engine: Engine) -> None:
         """After remove_trait(Options), reinstall_options() re-adds it with decoration + badge."""
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
@@ -1064,7 +1068,7 @@ class TestSelectionReadingApi:
         node.set_parameter_value(param.name, "beta")
         assert helper.selected_value == "beta"
 
-    def test_selection_denial_gates_the_current_selection(self, engine) -> None:  # noqa: ANN001
+    def test_selection_denial_gates_the_current_selection(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
@@ -1086,7 +1090,7 @@ class TestSelectionReadingApi:
         finally:
             engine.event_manager.remove_authorization_hook(deny_alpha)
 
-    def test_raise_if_selection_denied_raises_for_the_current_selection(self, engine) -> None:  # noqa: ANN001
+    def test_raise_if_selection_denied_raises_for_the_current_selection(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
@@ -1107,7 +1111,7 @@ class TestSelectionReadingApi:
         finally:
             engine.event_manager.remove_authorization_hook(deny_alpha)
 
-    def test_on_value_set_ignores_other_parameters(self, engine) -> None:  # noqa: ANN001
+    def test_on_value_set_ignores_other_parameters(self, engine: Engine) -> None:
         """The component filters for its own parameter so nodes can forward unconditionally."""
         from griptape_nodes.exe_types.core_types import Parameter
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
@@ -1145,7 +1149,7 @@ class TestConstructionDeferral:
     ``TestConstructionWithoutAScopeStillQueries``.
     """
 
-    def test_construction_defers_the_query_and_keeps_the_default(self, engine) -> None:  # noqa: ANN001
+    def test_construction_defers_the_query_and_keeps_the_default(self, engine: Engine) -> None:
         from unittest.mock import MagicMock
 
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
@@ -1158,7 +1162,7 @@ class TestConstructionDeferral:
         try:
             with (
                 patch(
-                    "griptape_nodes.exe_types.param_components.model_policy.GriptapeNodes.handle_request",
+                    "griptape_nodes.retained_mode.engine.Engine.handle_request",
                     handle,
                 ),
                 constructing_under_probe(),
@@ -1176,7 +1180,7 @@ class TestConstructionDeferral:
         finally:
             engine.event_manager.remove_authorization_hook(deny_all)
 
-    def test_query_for_denial_heals_a_deferred_snapshot(self, engine) -> None:  # noqa: ANN001
+    def test_query_for_denial_heals_a_deferred_snapshot(self, engine: Engine) -> None:
         """The enforcement-gap regression: run-time gating must not stay bypassed until a refresh.
 
         This component has no validate_before_node_run equivalent, so if query_for_denial
@@ -1203,7 +1207,7 @@ class TestConstructionDeferral:
         finally:
             engine.event_manager.remove_authorization_hook(deny_alpha)
 
-    def test_refresh_heals_decoration(self, engine) -> None:  # noqa: ANN001
+    def test_refresh_heals_decoration(self, engine: Engine) -> None:
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 
         def deny_alpha(checkpoint: object) -> CheckpointDenial | None:
@@ -1236,7 +1240,7 @@ class TestConstructionWithoutAScopeStillQueries:
     artist clicks refresh.
     """
 
-    def test_denial_decoration_and_default_relocation_happen_at_construction(self, engine) -> None:  # noqa: ANN001
+    def test_denial_decoration_and_default_relocation_happen_at_construction(self, engine: Engine) -> None:
         from griptape_nodes.node_library.library_registry import LibraryRegistry
         from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 

--- a/tests/unit/exe_types/param_components/test_model_policy.py
+++ b/tests/unit/exe_types/param_components/test_model_policy.py
@@ -7,6 +7,7 @@ in particular the one axis on which the two are ALLOWED to differ: `refuse_unrec
 """
 
 import logging
+from collections.abc import Callable
 from dataclasses import FrozenInstanceError
 from unittest.mock import MagicMock, patch
 
@@ -26,7 +27,20 @@ from griptape_nodes.retained_mode.events.access_events import (
 from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
 from tests.unit.exe_types.param_components.probe_scope import constructing_under_probe
 
-_HANDLE = "griptape_nodes.exe_types.param_components.model_policy.GriptapeNodes.handle_request"
+
+def _engine(result: object | None = None, *, side_effect: Callable[[object], object] | None = None) -> MagicMock:
+    """A stand-in engine whose ``handle_request`` answers with a canned result.
+
+    ``query_model_policy`` takes the engine to ask, so these tests hand it one rather than
+    patching a process-wide accessor.
+    """
+    engine = MagicMock()
+    if side_effect is not None:
+        engine.handle_request.side_effect = side_effect
+    else:
+        engine.handle_request.return_value = result
+    return engine
+
 
 DENIED = "owner/denied"
 ALLOWED = "owner/allowed"
@@ -45,16 +59,16 @@ class TestQueryModelPolicy:
             ModelAccessVerdict(model_id="md_denied", provider_model_id=DENIED, denial=_DENIAL),
             ModelAccessVerdict(model_id="md_allowed", provider_model_id=ALLOWED, denial=None),
         ]
-        with patch(_HANDLE, return_value=_success(verdicts)):
-            snapshot = query_model_policy("SomeNode")
+        snapshot = query_model_policy(_engine(_success(verdicts)), "SomeNode")
         assert snapshot.denial_by_provider_id == {DENIED: _DENIAL}
         assert snapshot.catalog_ids_by_provider_id == {DENIED: ("md_denied",), ALLOWED: ("md_allowed",)}
         assert snapshot.failure_detail is None
         assert snapshot.has_unmatchable_entries is False
 
     def test_fail_closed_records_a_failure_detail(self) -> None:
-        with patch(_HANDLE, return_value=QueryModelAccessForNodeResultFailure(result_details="not found")):
-            snapshot = query_model_policy("SomeNode")
+        snapshot = query_model_policy(
+            _engine(QueryModelAccessForNodeResultFailure(result_details="not found")), "SomeNode"
+        )
         assert snapshot.failure_detail is not None
         assert snapshot.denial_for(ALLOWED) is not None
 
@@ -66,11 +80,10 @@ class TestQueryModelPolicy:
         them, and a registration problem worded as a licensing one sends them looking in the wrong
         place entirely.
         """
-        with (
-            caplog.at_level(logging.WARNING, logger="griptape_nodes"),
-            patch(_HANDLE, return_value=QueryModelAccessForNodeResultFailure(result_details="not registered")),
-        ):
-            snapshot = query_model_policy("SomeNode")
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+            snapshot = query_model_policy(
+                _engine(QueryModelAccessForNodeResultFailure(result_details="not registered")), "SomeNode"
+            )
 
         detail = snapshot.failure_detail
         assert detail is not None
@@ -84,16 +97,16 @@ class TestQueryModelPolicy:
 
     def test_fail_open_records_nothing(self) -> None:
         """Auto-detect uses this: an unresolvable node means "has not adopted declarations"."""
-        with patch(_HANDLE, return_value=QueryModelAccessForNodeResultFailure(result_details="not found")):
-            snapshot = query_model_policy("SomeNode", fail_closed=False)
+        snapshot = query_model_policy(
+            _engine(QueryModelAccessForNodeResultFailure(result_details="not found")), "SomeNode", fail_closed=False
+        )
         assert snapshot.failure_detail is None
         assert snapshot.declares_models is False
 
     def test_a_model_without_a_provider_handle_is_declared_but_unmatchable(self) -> None:
         """`provider_model_id` is optional, and absence is NOT "unresolved"."""
         verdicts = [ModelAccessVerdict(model_id="md_no_handle", provider_model_id=None, denial=None)]
-        with patch(_HANDLE, return_value=_success(verdicts)):
-            snapshot = query_model_policy("SomeNode")
+        snapshot = query_model_policy(_engine(_success(verdicts)), "SomeNode")
         assert snapshot.has_unmatchable_entries is True
         assert snapshot.catalog_ids_by_provider_id == {}
         # Still counts as declaring models -- otherwise enforcement would silently switch off.
@@ -175,8 +188,7 @@ class TestAnUnattributableDenialIsNotDropped:
     """
 
     def test_the_whole_parameter_is_refused(self) -> None:
-        with patch(_HANDLE, return_value=_success([ModelAccessVerdict("md_flux_dev", None, _DENIAL)])):
-            snapshot = query_model_policy("SomeNode")
+        snapshot = query_model_policy(_engine(_success([ModelAccessVerdict("md_flux_dev", None, _DENIAL)])), "SomeNode")
         assert snapshot.unmatchable_denials == ("md_flux_dev",)
         denial = snapshot.denial_for(ALLOWED, refuse_unrecognized=True)
         assert denial is not None
@@ -187,16 +199,14 @@ class TestAnUnattributableDenialIsNotDropped:
 
     def test_a_permitted_handleless_entry_does_not_refuse_anything(self) -> None:
         """Only a DENIED unmatchable entry escalates; a permitted one is merely unmatchable."""
-        with patch(_HANDLE, return_value=_success([ModelAccessVerdict("md_no_handle", None, None)])):
-            snapshot = query_model_policy("SomeNode")
+        snapshot = query_model_policy(_engine(_success([ModelAccessVerdict("md_no_handle", None, None)])), "SomeNode")
         assert snapshot.unmatchable_denials == ()
         assert snapshot.has_unmatchable_entries is True
         assert snapshot.denial_for(ALLOWED, refuse_unrecognized=True) is None
 
     def test_it_applies_even_with_refuse_unrecognized_off(self) -> None:
         """A static dropdown must not run a model policy explicitly forbade either."""
-        with patch(_HANDLE, return_value=_success([ModelAccessVerdict("md_flux_dev", None, _DENIAL)])):
-            snapshot = query_model_policy("SomeNode")
+        snapshot = query_model_policy(_engine(_success([ModelAccessVerdict("md_flux_dev", None, _DENIAL)])), "SomeNode")
         assert snapshot.denial_for(ALLOWED) is not None
 
 
@@ -214,8 +224,7 @@ class TestASharedProviderModelIdIsNotLastWriteWins:
             ModelAccessVerdict(model_id="md_flux_byok", provider_model_id=shared, denial=_DENIAL),
             ModelAccessVerdict(model_id="md_flux_gtc", provider_model_id=shared, denial=None),
         ]
-        with patch(_HANDLE, return_value=_success(verdicts)):
-            snapshot = query_model_policy("SomeNode")
+        snapshot = query_model_policy(_engine(_success(verdicts)), "SomeNode")
         assert snapshot.denial_for(shared) is _DENIAL
 
     def test_every_catalog_id_behind_a_handle_is_retained(self) -> None:
@@ -225,8 +234,7 @@ class TestASharedProviderModelIdIsNotLastWriteWins:
             ModelAccessVerdict(model_id="md_flux_byok", provider_model_id=shared, denial=None),
             ModelAccessVerdict(model_id="md_flux_gtc", provider_model_id=shared, denial=None),
         ]
-        with patch(_HANDLE, return_value=_success(verdicts)):
-            snapshot = query_model_policy("SomeNode")
+        snapshot = query_model_policy(_engine(_success(verdicts)), "SomeNode")
         assert snapshot.catalog_ids_for(shared) == ("md_flux_byok", "md_flux_gtc")
 
     def test_an_unknown_handle_has_no_catalog_ids(self) -> None:
@@ -260,11 +268,7 @@ class TestBothComponentsAgreeOnAnUnattributableDenial:
         node = MockNode()
         parameter = Parameter(name="model", type="str", default_value="alpha", tooltip="m")
         node.add_parameter(parameter)
-        module = "griptape_nodes.exe_types.param_components"
-        with (
-            patch(f"{module}.model_policy.GriptapeNodes.handle_request", side_effect=handle),
-            patch(f"{module}.model_access_component.GriptapeNodes.handle_request", side_effect=handle),
-        ):
+        with patch("griptape_nodes.retained_mode.engine.Engine.handle_request", side_effect=handle):
             component = ModelAccessComponent(
                 node=node, parameter=parameter, model_choices=["alpha"], default_model="alpha"
             )
@@ -290,10 +294,10 @@ class TestConstructionDeferral:
     """
 
     def test_no_bus_request_while_constructing_under_a_probe_scope(self) -> None:
-        handle = MagicMock()
-        with patch(_HANDLE, handle), constructing_under_probe():
-            snapshot = query_model_policy("SomeNode")
-        handle.assert_not_called()
+        engine = _engine()
+        with constructing_under_probe():
+            snapshot = query_model_policy(engine, "SomeNode")
+        engine.handle_request.assert_not_called()
         assert snapshot.deferred is True
 
     def test_construction_outside_a_strict_mode_scope_queries_normally(self) -> None:
@@ -304,8 +308,8 @@ class TestConstructionDeferral:
         rows and the badge until the node ran.
         """
         verdicts = [ModelAccessVerdict(model_id="md_denied", provider_model_id=DENIED, denial=_DENIAL)]
-        with patch(_HANDLE, return_value=_success(verdicts)), LibraryRegistry.constructing_node():
-            snapshot = query_model_policy("SomeNode")
+        with LibraryRegistry.constructing_node():
+            snapshot = query_model_policy(_engine(_success(verdicts)), "SomeNode")
         assert snapshot.deferred is False
         assert snapshot.denial_for(DENIED) is _DENIAL
 
@@ -326,10 +330,10 @@ class TestConstructionDeferral:
 
     def test_the_query_goes_through_once_construction_ends(self) -> None:
         verdicts = [ModelAccessVerdict(model_id="md_denied", provider_model_id=DENIED, denial=_DENIAL)]
-        with patch(_HANDLE, return_value=_success(verdicts)):
-            with constructing_under_probe():
-                assert query_model_policy("SomeNode").deferred is True
-            snapshot = query_model_policy("SomeNode")
+        engine = _engine(_success(verdicts))
+        with constructing_under_probe():
+            assert query_model_policy(engine, "SomeNode").deferred is True
+        snapshot = query_model_policy(engine, "SomeNode")
         assert snapshot.deferred is False
         assert snapshot.denial_for(DENIED) is _DENIAL
 

--- a/tests/unit/exe_types/param_components/test_parameter_transition_component.py
+++ b/tests/unit/exe_types/param_components/test_parameter_transition_component.py
@@ -44,9 +44,7 @@ from tests.unit.exe_types.mocks import MockNode
 
 # Patch target — GriptapeNodes is imported INTO the component module, so the
 # binding to patch is the module-local reference, not the global singleton.
-_HANDLE_REQUEST_TARGET = (
-    "griptape_nodes.exe_types.param_components.parameter_transition_component.GriptapeNodes.handle_request"
-)
+_HANDLE_REQUEST_TARGET = "griptape_nodes.retained_mode.engine.Engine.handle_request"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/exe_types/test_variable_substitution.py
+++ b/tests/unit/exe_types/test_variable_substitution.py
@@ -1,6 +1,7 @@
 """Tests for inline workflow variable substitution in get_parameter_value()."""
 
-from contextlib import AbstractContextManager
+from collections.abc import Iterator
+from contextlib import AbstractContextManager, contextmanager
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -8,6 +9,11 @@ from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
 from griptape_nodes.exe_types.node_types import TrackedParameterOutputValues, aprocess_scope
 from griptape_nodes.exe_types.variable_resolver import _aprocess_variable_cache
 from griptape_nodes.retained_mode.events.base_events import ProgressEvent
+from griptape_nodes.retained_mode.events.connection_events import (
+    IncomingConnection,
+    ListConnectionsForNodeRequest,
+    ListConnectionsForNodeResultSuccess,
+)
 from griptape_nodes.retained_mode.events.execution_events import ParameterValueUpdateEvent
 from griptape_nodes.retained_mode.events.parameter_events import AlterElementEvent
 from griptape_nodes.retained_mode.events.variable_events import (
@@ -18,11 +24,11 @@ from griptape_nodes.retained_mode.variable_types import FlowVariable, VariableLa
 
 from .mocks import MockNode
 
-# GriptapeNodes is lazy-imported inside _param_has_incoming_connection and
-# _resolve_variables_in_string to break the exe_types <-> retained_mode cycle.
-# Patch it at the source module so the lazy `from ... import GriptapeNodes`
-# picks up the mock at call time.
-_GN_PATCH = "griptape_nodes.retained_mode.griptape_nodes.GriptapeNodes"
+# Node machinery reaches its collaborators through ``self.engine``, and a node built without
+# one falls back to the ambient engine. Patching that fallback is what puts a stand-in engine
+# under a MockNode; it is resolved lazily inside the property, so patching the source module
+# catches it at call time.
+_CURRENT_ENGINE_PATCH = "griptape_nodes.retained_mode.engine.current_engine"
 
 
 def _make_str_param(name: str, default: str = "", modes: set | None = None) -> Parameter:
@@ -51,13 +57,65 @@ def _make_property_output_param(name: str, default: Any) -> Parameter:
     )
 
 
+def _connections_result(connected_params: set[str]) -> ListConnectionsForNodeResultSuccess:
+    """The connections a real ListConnectionsForNodeRequest would report for "mock_node"."""
+    return ListConnectionsForNodeResultSuccess(
+        incoming_connections=[
+            IncomingConnection(
+                source_node_name="upstream",
+                source_parameter_name="out",
+                target_parameter_name=param_name,
+            )
+            for param_name in sorted(connected_params)
+        ],
+        outgoing_connections=[],
+        result_details="ok",
+    )
+
+
+def _engine_mock(
+    variables: dict,
+    connected_params: set[str],
+    captured: list | None = None,
+    *,
+    substitution_enabled: bool = True,
+) -> Any:
+    """A stand-in engine answering everything the substitution path asks of one.
+
+    Every gate is configured here rather than left to MagicMock's defaults, because a
+    MagicMock answers truthily by accident: that is how these tests used to pass while
+    ``_param_has_incoming_connection`` did ``param_name in <MagicMock>``, which is False
+    only because ``MagicMock.__contains__`` defaults to False. Any refactor of a lookup
+    left implicit would flip every assertion for the wrong reason.
+    """
+    engine = MagicMock()
+    engine.handle_request.side_effect = lambda req: (
+        _list_variables_result(variables)
+        if isinstance(req, ListVariablesRequest)
+        else _connections_result(connected_params)
+        if isinstance(req, ListConnectionsForNodeRequest)
+        else MagicMock()
+    )
+    engine.workflow_manager.is_variable_substitution_enabled.return_value = substitution_enabled
+    engine.node_manager.get_node_parent_flow_by_name.return_value = "test_flow"
+    if captured is not None:
+        engine.event_manager.put_event.side_effect = captured.append
+    return engine
+
+
+@contextmanager
+def _patch_engine(engine: Any) -> Iterator[None]:
+    with patch(_CURRENT_ENGINE_PATCH, return_value=engine):
+        yield
+
+
 def _mock_gn(
     variables: dict,
     *,
     connected_params: set[str] | None = None,
     substitution_enabled: bool = True,
 ) -> AbstractContextManager:
-    """Patch GriptapeNodes managers for substitution tests.
+    """Put a stand-in engine under the nodes these tests build.
 
     connected_params: parameter names on "mock_node" that have incoming connections.
     substitution_enabled: value returned by is_variable_substitution_enabled().
@@ -65,19 +123,7 @@ def _mock_gn(
     if connected_params is None:
         connected_params = set()
 
-    mock_gn = MagicMock()
-    mock_gn.NodeManager.return_value.get_node_parent_flow_by_name.return_value = "test_flow"
-    mock_gn.handle_request.side_effect = lambda req: (
-        _list_variables_result(variables) if isinstance(req, ListVariablesRequest) else MagicMock()
-    )
-
-    incoming_index = {"mock_node": dict.fromkeys(connected_params, True)} if connected_params else {}
-    mock_connections = MagicMock()
-    mock_connections.incoming_index = incoming_index
-    mock_gn.FlowManager.return_value.get_connections.return_value = mock_connections
-    mock_gn.WorkflowManager.return_value.is_variable_substitution_enabled.return_value = substitution_enabled
-
-    return patch(_GN_PATCH, mock_gn)
+    return _patch_engine(_engine_mock(variables, connected_params, substitution_enabled=substitution_enabled))
 
 
 def _list_variables_result(variables: dict) -> ListVariablesResultSuccess:
@@ -111,24 +157,8 @@ def _payloads_of_type(captured: list, payload_type: type) -> list:
 
 
 def _capturing_gn_mock(captured: list, variables: dict, *, connected_params: set[str] | None = None) -> Any:
-    """A GN patch that captures events and makes every suppression gate explicit.
-
-    Every gate in ``_variable_template_to_preserve`` is configured here rather than
-    left to MagicMock's defaults. Leaving them implicit is how these tests used to
-    pass: ``_param_has_incoming_connection`` did ``param_name in <MagicMock>``, which
-    is False only because ``MagicMock.__contains__`` defaults to False, so any
-    refactor of that lookup would flip every assertion for the wrong reason.
-    """
-    mock_gn = MagicMock()
-    mock_gn.NodeManager.return_value.get_node_parent_flow_by_name.return_value = "test_flow"
-    mock_gn.handle_request.side_effect = lambda req: (
-        _list_variables_result(variables) if isinstance(req, ListVariablesRequest) else MagicMock()
-    )
-    incoming_index = {"mock_node": dict.fromkeys(connected_params, True)} if connected_params else {}
-    mock_gn.FlowManager.return_value.get_connections.return_value = MagicMock(incoming_index=incoming_index)
-    mock_gn.WorkflowManager.return_value.is_variable_substitution_enabled.return_value = True
-    mock_gn.EventManager.return_value.put_event.side_effect = captured.append
-    return patch(_GN_PATCH, mock_gn)
+    """Like ``_mock_gn``, and also collects every event the engine is handed."""
+    return _patch_engine(_engine_mock(variables, connected_params or set(), captured))
 
 
 def _run_tracked_set(
@@ -351,13 +381,10 @@ class TestVariableSubstitutionFallbacks:
         node.add_parameter(_make_str_param("text", "{SHOT}"))
         node.parameter_values["text"] = "{SHOT}"
 
-        mock_gn = MagicMock()
-        mock_gn.NodeManager.return_value.get_node_parent_flow_by_name.side_effect = KeyError("mock_node")
-        mock_connections = MagicMock()
-        mock_connections.incoming_index = {}
-        mock_gn.FlowManager.return_value.get_connections.return_value = mock_connections
+        engine = _engine_mock({}, set())
+        engine.node_manager.get_node_parent_flow_by_name.side_effect = KeyError("mock_node")
 
-        with patch(_GN_PATCH, mock_gn), aprocess_scope():
+        with _patch_engine(engine), aprocess_scope():
             value = node.get_parameter_value("text")
 
         assert value == "{SHOT}"

--- a/tests/unit/exe_types/test_workflow_node.py
+++ b/tests/unit/exe_types/test_workflow_node.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import pytest
 
@@ -20,10 +20,8 @@ from griptape_nodes.exe_types.workflow_node import (
     pair_shape_nodes,
 )
 from griptape_nodes.node_library.workflow_registry import WorkflowMetadata, WorkflowRegistry, WorkflowShape
+from griptape_nodes.retained_mode.engine import current_engine
 from griptape_nodes.retained_mode.events.flow_events import CreateFlowRequest, CreateFlowResultSuccess
-
-if TYPE_CHECKING:
-    from griptape_nodes.retained_mode.engine import Engine
 
 CONTROL_TYPE = "parametercontroltype"
 
@@ -55,20 +53,20 @@ def _metadata(shape: WorkflowShape | None) -> WorkflowMetadata:
     )
 
 
-def _build_live_subflow(engine: Engine) -> str:
+def _build_live_subflow() -> str:
     """Create a flow standing in for an imported workflow, and return its name.
 
     Mirrors what an import produces for the shape used by `TestResolveLiveRoutes`: a parameterless
     Start Flow node, a Start Flow node exposing `text`, and an End Flow node exposing `result`, all
     renamed because their original names were already taken on the canvas.
     """
-    engine.context_manager.push_workflow(workflow_name="workflow_node_live_routes")
-    flow_result = engine.handle_request(
+    current_engine().context_manager.push_workflow(workflow_name="workflow_node_live_routes")
+    flow_result = current_engine().handle_request(
         CreateFlowRequest(parent_flow_name=None, flow_name="Subflow", set_as_new_context=False)
     )
     assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
 
-    flow = engine.flow_manager.get_flow_by_name(flow_result.flow_name)
+    flow = current_engine().flow_manager.get_flow_by_name(flow_result.flow_name)
     flow.add_node(StartNode(name="Start Flow_1"))
 
     start_with_text = StartNode(name="Start Flow_2")
@@ -251,7 +249,7 @@ class TestPairShapeNodes:
 class TestResolveLiveRoutes:
     """Routes are re-pointed at the imported copy of the workflow before every run."""
 
-    def test_parameterless_start_node_is_counted_and_skipped(self, engine: Engine) -> None:
+    def test_parameterless_start_node_is_counted_and_skipped(self) -> None:
         """A Start Flow node carrying only control flow contributes no route but still holds a slot.
 
         Pairing is positional, so the parameterless node has to be counted on the declared side or
@@ -270,7 +268,7 @@ class TestResolveLiveRoutes:
             workflow_metadata=_metadata(shape),
         )
         node = node_class(name="Shout It")
-        subflow_name = _build_live_subflow(engine)
+        subflow_name = _build_live_subflow()
 
         live_routes = node._resolve_live_routes(subflow_name)
 

--- a/tests/unit/files/drivers/test_local_file_driver.py
+++ b/tests/unit/files/drivers/test_local_file_driver.py
@@ -334,16 +334,15 @@ class TestLocalFileDriverRelativePaths:
 
     @pytest.fixture
     def mock_config_manager_accessor(self, mock_config_manager: Mock) -> Iterator[Mock]:
-        """Patch the facade accessor the driver uses to reach the ConfigManager.
+        """Patch the engine lookup the driver uses to reach the ConfigManager.
 
-        Patched by dotted string rather than an imported `GriptapeNodes` reference: the
-        driver (src/griptape_nodes/files/drivers/local_file_driver.py) still calls the
-        facade's `ConfigManager()` classmethod, and `patch()` handles saving and restoring
-        the classmethod descriptor correctly on teardown.
+        The tests assert on this mock to pin WHETHER the driver consulted the workspace at
+        all, which is the difference between anchoring a bare relative path and trusting the
+        process's cwd.
         """
         with patch(
-            "griptape_nodes.retained_mode.griptape_nodes.GriptapeNodes.ConfigManager",
-            return_value=mock_config_manager,
+            "griptape_nodes.files.drivers.local_file_driver.current_engine",
+            return_value=Mock(config_manager=mock_config_manager),
         ) as accessor:
             yield accessor
 

--- a/tests/unit/files/drivers/test_static_server_file_driver.py
+++ b/tests/unit/files/drivers/test_static_server_file_driver.py
@@ -86,8 +86,8 @@ class TestStaticServerFileDriver:
     ) -> None:
         """Test reading an existing file from localhost URL."""
         with patch(
-            "griptape_nodes.files.drivers.static_server_file_driver.GriptapeNodes.ConfigManager",
-            return_value=mock_config_manager,
+            "griptape_nodes.files.drivers.static_server_file_driver.current_engine",
+            return_value=MagicMock(config_manager=mock_config_manager),
         ):
             content = await driver.read(
                 "http://localhost:8124/workspace/static_files/test.png",
@@ -103,8 +103,8 @@ class TestStaticServerFileDriver:
     ) -> None:
         """Test that query parameters (cachebuster) are stripped before resolving."""
         with patch(
-            "griptape_nodes.files.drivers.static_server_file_driver.GriptapeNodes.ConfigManager",
-            return_value=mock_config_manager,
+            "griptape_nodes.files.drivers.static_server_file_driver.current_engine",
+            return_value=MagicMock(config_manager=mock_config_manager),
         ):
             content = await driver.read(
                 "http://localhost:8124/workspace/static_files/test.png?t=1234567890",
@@ -121,8 +121,8 @@ class TestStaticServerFileDriver:
         """Test reading a non-existent file raises FileNotFoundError."""
         with (
             patch(
-                "griptape_nodes.files.drivers.static_server_file_driver.GriptapeNodes.ConfigManager",
-                return_value=mock_config_manager,
+                "griptape_nodes.files.drivers.static_server_file_driver.current_engine",
+                return_value=MagicMock(config_manager=mock_config_manager),
             ),
             pytest.raises(FileNotFoundError, match="file not found"),
         ):
@@ -140,8 +140,8 @@ class TestStaticServerFileDriver:
         """Test reading a directory raises IsADirectoryError."""
         with (
             patch(
-                "griptape_nodes.files.drivers.static_server_file_driver.GriptapeNodes.ConfigManager",
-                return_value=mock_config_manager,
+                "griptape_nodes.files.drivers.static_server_file_driver.current_engine",
+                return_value=MagicMock(config_manager=mock_config_manager),
             ),
             pytest.raises(IsADirectoryError, match="directory"),
         ):
@@ -169,8 +169,8 @@ class TestStaticServerFileDriver:
     ) -> None:
         """Test exists returns True for existing file."""
         with patch(
-            "griptape_nodes.files.drivers.static_server_file_driver.GriptapeNodes.ConfigManager",
-            return_value=mock_config_manager,
+            "griptape_nodes.files.drivers.static_server_file_driver.current_engine",
+            return_value=MagicMock(config_manager=mock_config_manager),
         ):
             result = await driver.exists("http://localhost:8124/workspace/static_files/test.png")
         assert result is True
@@ -183,8 +183,8 @@ class TestStaticServerFileDriver:
     ) -> None:
         """Test exists returns False for non-existent file."""
         with patch(
-            "griptape_nodes.files.drivers.static_server_file_driver.GriptapeNodes.ConfigManager",
-            return_value=mock_config_manager,
+            "griptape_nodes.files.drivers.static_server_file_driver.current_engine",
+            return_value=MagicMock(config_manager=mock_config_manager),
         ):
             result = await driver.exists("http://localhost:8124/workspace/static_files/nonexistent.png")
         assert result is False
@@ -204,8 +204,8 @@ class TestStaticServerFileDriver:
     ) -> None:
         """Test get_size returns the correct file size."""
         with patch(
-            "griptape_nodes.files.drivers.static_server_file_driver.GriptapeNodes.ConfigManager",
-            return_value=mock_config_manager,
+            "griptape_nodes.files.drivers.static_server_file_driver.current_engine",
+            return_value=MagicMock(config_manager=mock_config_manager),
         ):
             size = driver.get_size("http://localhost:8124/workspace/static_files/test.png")
         assert size == len(b"fake image data")
@@ -218,8 +218,8 @@ class TestStaticServerFileDriver:
         """Test get_size raises FileNotFoundError for non-existent file."""
         with (
             patch(
-                "griptape_nodes.files.drivers.static_server_file_driver.GriptapeNodes.ConfigManager",
-                return_value=mock_config_manager,
+                "griptape_nodes.files.drivers.static_server_file_driver.current_engine",
+                return_value=MagicMock(config_manager=mock_config_manager),
             ),
             pytest.raises(FileNotFoundError, match="file not found"),
         ):
@@ -233,8 +233,8 @@ class TestStaticServerFileDriver:
         """Test get_size raises IsADirectoryError for directories."""
         with (
             patch(
-                "griptape_nodes.files.drivers.static_server_file_driver.GriptapeNodes.ConfigManager",
-                return_value=mock_config_manager,
+                "griptape_nodes.files.drivers.static_server_file_driver.current_engine",
+                return_value=MagicMock(config_manager=mock_config_manager),
             ),
             pytest.raises(IsADirectoryError, match="directory"),
         ):

--- a/tests/unit/files/test_file.py
+++ b/tests/unit/files/test_file.py
@@ -1,11 +1,8 @@
 """Unit tests for File and FileDestination."""
 
-from __future__ import annotations
-
 import base64
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
@@ -35,13 +32,12 @@ from griptape_nodes.retained_mode.events.project_events import (
     PathResolutionFailureReason,
 )
 
-if TYPE_CHECKING:
-    from griptape_nodes.retained_mode.engine import Engine
-
 HANDLE_REQUEST_PATH = "griptape_nodes.files.file.GriptapeNodes.handle_request"
 AHANDLE_REQUEST_PATH = "griptape_nodes.files.file.GriptapeNodes.ahandle_request"
-CONFIG_MANAGER_PATH = "griptape_nodes.files.file.GriptapeNodes.ConfigManager"
-STATIC_SERVER_CONFIG_MANAGER_PATH = "griptape_nodes.files.drivers.static_server_file_driver.GriptapeNodes.ConfigManager"
+# These modules read the workspace off the engine they resolve, so the tests patch that
+# resolution and hand back a stand-in whose config_manager is the mock.
+CURRENT_ENGINE_PATH = "griptape_nodes.files.file.current_engine"
+STATIC_SERVER_CURRENT_ENGINE_PATH = "griptape_nodes.files.drivers.static_server_file_driver.current_engine"
 
 
 class TestFileConstructor:
@@ -872,8 +868,8 @@ class TestFileDestinationWrite:
     def test_resolve_anchors_relative_path_to_workspace(self, tmp_path: Path) -> None:
         dest = FileDestination("output.png")
 
-        with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
-            mock_config_manager.return_value.workspace_path = tmp_path
+        with patch(CURRENT_ENGINE_PATH) as mock_config_manager:
+            mock_config_manager.return_value.config_manager.workspace_path = tmp_path
             resolved = dest.resolve()
 
         assert Path(resolved) == tmp_path / "output.png"
@@ -1121,16 +1117,16 @@ class TestFileResolve:
 
     def test_resolve_absolute_path_passes_through(self, tmp_path: Path) -> None:
         abs_path = tmp_path / "absolute" / "image.png"
-        with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
-            mock_config_manager.return_value.workspace_path = tmp_path
+        with patch(CURRENT_ENGINE_PATH) as mock_config_manager:
+            mock_config_manager.return_value.config_manager.workspace_path = tmp_path
             result = File(str(abs_path)).resolve()
 
         assert Path(result) == abs_path
 
     def test_resolve_anchors_relative_path_to_workspace(self, tmp_path: Path) -> None:
         """A workspace-relative path resolves against the workspace, not the process CWD."""
-        with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
-            mock_config_manager.return_value.workspace_path = tmp_path
+        with patch(CURRENT_ENGINE_PATH) as mock_config_manager:
+            mock_config_manager.return_value.config_manager.workspace_path = tmp_path
             result = File("outputs/images/result.png").resolve()
 
         assert Path(result) == tmp_path / "outputs" / "images" / "result.png"
@@ -1172,8 +1168,8 @@ class TestFileResolveUrls:
         """The reported repro: a Decode Media output wired into a video-processing node."""
         url = "http://localhost:8124/workspace/staticfiles/clip.mp4?t=1786574231"
 
-        with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
-            mock_config_manager.return_value.workspace_path = tmp_path
+        with patch(CURRENT_ENGINE_PATH) as mock_config_manager:
+            mock_config_manager.return_value.config_manager.workspace_path = tmp_path
             result = File(url).resolve()
 
         assert Path(result) == tmp_path / "staticfiles" / "clip.mp4"
@@ -1186,8 +1182,8 @@ class TestFileResolveUrls:
         """
         url = "http://localhost:8124/workspace/staticfiles/clip.mp4?t=1786574231"
 
-        with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
-            mock_config_manager.return_value.workspace_path = tmp_path
+        with patch(CURRENT_ENGINE_PATH) as mock_config_manager:
+            mock_config_manager.return_value.config_manager.workspace_path = tmp_path
             result = File(url).resolve()
 
         assert "http:" not in result
@@ -1203,12 +1199,12 @@ class TestFileResolveUrls:
         url = "http://localhost:8124/workspace/staticfiles/clip.mp4?t=1786574231"
         driver = StaticServerFileDriver()
 
-        with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
-            mock_config_manager.return_value.workspace_path = tmp_path
+        with patch(CURRENT_ENGINE_PATH) as mock_config_manager:
+            mock_config_manager.return_value.config_manager.workspace_path = tmp_path
             resolved = File(url).resolve()
 
-        with patch(STATIC_SERVER_CONFIG_MANAGER_PATH) as mock_config_manager:
-            mock_config_manager.return_value.workspace_path = tmp_path
+        with patch(STATIC_SERVER_CURRENT_ENGINE_PATH) as mock_config_manager:
+            mock_config_manager.return_value.config_manager.workspace_path = tmp_path
             driver_path = driver._resolve_to_local_path(url)
 
         assert Path(resolved) == driver_path
@@ -1220,8 +1216,8 @@ class TestFileResolveUrls:
         """
         url = "https://example.com/videos/clip.mp4"
 
-        with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
-            mock_config_manager.return_value.workspace_path = tmp_path
+        with patch(CURRENT_ENGINE_PATH) as mock_config_manager:
+            mock_config_manager.return_value.config_manager.workspace_path = tmp_path
             result = File(url).resolve()
 
         assert result == url
@@ -1230,8 +1226,8 @@ class TestFileResolveUrls:
         """A signed URL's query string is load-bearing and must survive intact."""
         url = "https://example.com/videos/clip.mp4?token=abc123&expires=1786574231"
 
-        with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
-            mock_config_manager.return_value.workspace_path = tmp_path
+        with patch(CURRENT_ENGINE_PATH) as mock_config_manager:
+            mock_config_manager.return_value.config_manager.workspace_path = tmp_path
             result = File(url).resolve()
 
         assert result == url
@@ -1240,8 +1236,8 @@ class TestFileResolveUrls:
         """A localhost URL that isn't a static-file URL names no workspace file."""
         url = "http://localhost:8124/api/videos/clip.mp4"
 
-        with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
-            mock_config_manager.return_value.workspace_path = tmp_path
+        with patch(CURRENT_ENGINE_PATH) as mock_config_manager:
+            mock_config_manager.return_value.config_manager.workspace_path = tmp_path
             result = File(url).resolve()
 
         assert result == url
@@ -1250,8 +1246,8 @@ class TestFileResolveUrls:
         """The pre-existing file:// behavior is unchanged."""
         target = tmp_path / "outputs" / "clip.mp4"
 
-        with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
-            mock_config_manager.return_value.workspace_path = tmp_path
+        with patch(CURRENT_ENGINE_PATH) as mock_config_manager:
+            mock_config_manager.return_value.config_manager.workspace_path = tmp_path
             result = File(target.as_uri()).resolve()
 
         assert Path(result) == target
@@ -1261,8 +1257,8 @@ class TestFileResolveUrls:
 
         `C://outputs/clip.mp4` is the spelling a naive `://` check misreads.
         """
-        with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
-            mock_config_manager.return_value.workspace_path = tmp_path
+        with patch(CURRENT_ENGINE_PATH) as mock_config_manager:
+            mock_config_manager.return_value.config_manager.workspace_path = tmp_path
             result = File("C://outputs/clip.mp4").resolve()
 
         assert result != "C://outputs/clip.mp4"
@@ -1270,8 +1266,8 @@ class TestFileResolveUrls:
 
     def test_resolve_relative_path_still_anchors_to_workspace(self, tmp_path: Path) -> None:
         """Non-URL locations are unaffected by the URL branch."""
-        with patch(CONFIG_MANAGER_PATH) as mock_config_manager:
-            mock_config_manager.return_value.workspace_path = tmp_path
+        with patch(CURRENT_ENGINE_PATH) as mock_config_manager:
+            mock_config_manager.return_value.config_manager.workspace_path = tmp_path
             result = File("outputs/clip.mp4").resolve()
 
         assert Path(result) == tmp_path / "outputs" / "clip.mp4"
@@ -1292,7 +1288,7 @@ def _jpeg_bytes() -> bytes:
 
 
 @pytest.fixture
-def _registered_providers(engine: Engine) -> None:
+def _registered_providers() -> None:
     """Ensure default artifact providers are registered with the ArtifactManager.
 
     Validation goes through ``ArtifactManager.sniff_extension``, which dispatches
@@ -1300,6 +1296,7 @@ def _registered_providers(engine: Engine) -> None:
     happens on ``AppInitializationComplete``, which doesn't fire in unit tests,
     so we register the default providers manually here.
     """
+    from griptape_nodes.retained_mode.engine import current_engine
     from griptape_nodes.retained_mode.events.artifact_events import RegisterArtifactProviderRequest
     from griptape_nodes.retained_mode.managers.artifact_providers import (
         AudioArtifactProvider,
@@ -1307,7 +1304,7 @@ def _registered_providers(engine: Engine) -> None:
         VideoArtifactProvider,
     )
 
-    artifact_manager = engine.artifact_manager
+    artifact_manager = current_engine().artifact_manager
     for provider_class in (ImageArtifactProvider, VideoArtifactProvider, AudioArtifactProvider):
         artifact_manager.on_handle_register_artifact_provider_request(
             RegisterArtifactProviderRequest(provider_class=provider_class)

--- a/tests/unit/machines/test_parallel_flow_execution.py
+++ b/tests/unit/machines/test_parallel_flow_execution.py
@@ -3,6 +3,7 @@
 # ruff: noqa: PLR2004
 
 import asyncio
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -14,6 +15,7 @@ from griptape_nodes.machines.control_flow import ControlFlowMachine
 from griptape_nodes.machines.dag_builder import DagBuilder, DagNode, NodeState
 from griptape_nodes.machines.fsm import WorkflowState
 from griptape_nodes.machines.parallel_resolution import (
+    DagCompleteState,
     ErrorState,
     ExecuteDagState,
     ParallelResolutionContext,
@@ -491,6 +493,104 @@ class TestParallelResolutionNodeDoneWhenTaskCompletes:
         dag_builder.node_to_reference["n"] = DagNode(node_reference=node, node_state=NodeState.PROCESSING)
 
         return ParallelResolutionContext("flow", max_nodes_in_parallel=5, dag_builder=dag_builder)
+
+    @staticmethod
+    def _context_with_real_node_mid_flight() -> tuple[ParallelResolutionContext, BaseNode]:
+        """A context holding a REAL node left in RESOLVING, as a failed run leaves it.
+
+        A real node rather than a MagicMock: the point is what `state` ends up as, and a mock
+        would happily report whatever it was told regardless of whether the code did anything.
+        """
+        from tests.unit.exe_types.mocks import MockNode
+
+        node = MockNode(name="n", engine=MagicMock())
+        node.state = NodeResolutionState.RESOLVING
+
+        graph = DirectedGraph()
+        graph.add_node("n")
+        dag_builder = DagBuilder()
+        dag_builder.graphs["n"] = graph
+        dag_builder.node_to_reference["n"] = DagNode(node_reference=node, node_state=NodeState.ERRORED)
+
+        return ParallelResolutionContext("flow", max_nodes_in_parallel=5, dag_builder=dag_builder), node
+
+    @pytest.mark.asyncio
+    async def test_a_cancel_that_never_reaches_error_state_still_gives_nodes_back(self) -> None:
+        """The path a user-initiated cancel actually takes.
+
+        `cancel_flow_run` calls `reset(cancel=True)`, which bumps the generation; every
+        `was_reset_since` guard in ExecuteDagState then abandons the run by returning None,
+        without entering ErrorState. So the ErrorState reset never runs for this path, and a
+        cancelled node kept reporting RESOLVING -- the editor spinning on it indefinitely.
+        """
+        context, node = self._context_with_real_node_mid_flight()
+
+        context.reset(cancel=True)
+
+        assert node.state is NodeResolutionState.UNRESOLVED
+        assert context.workflow_state == WorkflowState.CANCELED
+
+    @pytest.mark.asyncio
+    async def test_a_failed_run_gives_its_nodes_back_to_unresolved(self) -> None:
+        """A node the run never finished must not be left claiming to be mid-resolution.
+
+        `state` goes to RESOLVING at dispatch and to RESOLVED in handle_done_nodes, with nothing
+        in between for the failure case. A node that raised, or that was cancelled because a
+        sibling raised, therefore kept RESOLVING after the run ended -- so the editor showed it
+        spinning forever and GetNodeResolutionStateRequest kept answering RESOLVING. Nothing
+        else would ever move it, because the run finishes here.
+        """
+        context, node = self._context_with_real_node_mid_flight()
+        context.error_message = "boom"
+
+        state = await ErrorState.on_update(context)
+
+        assert state is DagCompleteState
+        assert node.state is NodeResolutionState.UNRESOLVED
+        assert context.workflow_state == WorkflowState.ERRORED
+
+    @pytest.mark.asyncio
+    async def test_giving_a_node_back_tells_the_editor(self) -> None:
+        """The editor learns state from events, so a silent reset would leave the spinner up."""
+        from griptape_nodes.retained_mode.events.execution_events import NodeUnresolvedEvent
+
+        context, node = self._context_with_real_node_mid_flight()
+        engine = cast("MagicMock", node.engine)
+
+        await ErrorState.on_update(context)
+
+        payloads = [
+            call.args[0].wrapped_event.payload
+            for call in engine.event_manager.put_event.call_args_list
+            if hasattr(call.args[0], "wrapped_event")
+        ]
+        assert any(isinstance(payload, NodeUnresolvedEvent) and payload.node_name == "n" for payload in payloads)
+
+    @pytest.mark.asyncio
+    async def test_a_cancelled_run_also_gives_its_nodes_back(self) -> None:
+        """Cancelling is not resolving either, and a clean cancel must not strand the node."""
+        context, node = self._context_with_real_node_mid_flight()
+        context.error_message = None  # a user-initiated cancel, not an exception
+
+        state = await ErrorState.on_update(context)
+
+        assert state is DagCompleteState
+        assert node.state is NodeResolutionState.UNRESOLVED
+        assert context.workflow_state == WorkflowState.CANCELED
+
+    @pytest.mark.asyncio
+    async def test_an_already_resolved_node_is_left_alone(self) -> None:
+        """A node that finished before a sibling failed keeps its result.
+
+        Its outputs are real and downstream consumers may already hold them, so unresolving it
+        would discard work the run actually completed.
+        """
+        context, node = self._context_with_real_node_mid_flight()
+        node.state = NodeResolutionState.RESOLVED
+
+        await ErrorState.on_update(context)
+
+        assert node.state is NodeResolutionState.RESOLVED
 
     @pytest.mark.asyncio
     async def test_reaping_a_completed_task_marks_node_done(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/node_library/test_advanced_node_library.py
+++ b/tests/unit/node_library/test_advanced_node_library.py
@@ -10,6 +10,7 @@ from griptape_nodes.node_library.library_registry import Library, LibrarySchema
 
 def _make_args() -> tuple[MagicMock, Library]:
     schema = MagicMock(spec=LibrarySchema)
+    schema.execution_modules = None
     schema.is_default_library = False
     schema.name = "TestLib"
     library = Library(library_data=schema)

--- a/tests/unit/node_library/test_lazy_node_loading.py
+++ b/tests/unit/node_library/test_lazy_node_loading.py
@@ -35,6 +35,7 @@ class _BetaNode(_LazyMockNode):
 
 def _make_library(name: str = "TestLib") -> Library:
     schema = MagicMock(spec=LibrarySchema)
+    schema.execution_modules = None
     schema.is_default_library = False
     schema.name = name
     return Library(library_data=schema)

--- a/tests/unit/node_library/test_library_declarations.py
+++ b/tests/unit/node_library/test_library_declarations.py
@@ -402,9 +402,9 @@ class TestRequiresWorkerProcess:
 
 
 class TestSchemaVersion:
-    def test_latest_schema_version_is_0_12_0(self) -> None:
-        # 0.12.0 added Dependencies.pip_dependencies_exec.
-        assert LibrarySchema.LATEST_SCHEMA_VERSION == "0.12.0"
+    def test_latest_schema_version_is_0_13_0(self) -> None:
+        # 0.12.0 added Dependencies.pip_dependencies_exec; 0.13.0 added execution_modules.
+        assert LibrarySchema.LATEST_SCHEMA_VERSION == "0.13.0"
 
 
 # ---------- Model catalog ----------

--- a/tests/unit/node_library/test_library_declarations.py
+++ b/tests/unit/node_library/test_library_declarations.py
@@ -402,8 +402,9 @@ class TestRequiresWorkerProcess:
 
 
 class TestSchemaVersion:
-    def test_latest_schema_version_is_0_11_0(self) -> None:
-        assert LibrarySchema.LATEST_SCHEMA_VERSION == "0.11.0"
+    def test_latest_schema_version_is_0_12_0(self) -> None:
+        # 0.12.0 added Dependencies.pip_dependencies_exec.
+        assert LibrarySchema.LATEST_SCHEMA_VERSION == "0.12.0"
 
 
 # ---------- Model catalog ----------

--- a/tests/unit/node_library/test_library_tracking_fields.py
+++ b/tests/unit/node_library/test_library_tracking_fields.py
@@ -9,6 +9,7 @@ from griptape_nodes.node_library.library_registry import Library, LibrarySchema
 
 def _make_library() -> Library:
     schema = MagicMock(spec=LibrarySchema)
+    schema.execution_modules = None
     schema.is_default_library = False
     schema.name = "TestLib"
     return Library(library_data=schema)

--- a/tests/unit/node_library/test_unregister_library.py
+++ b/tests/unit/node_library/test_unregister_library.py
@@ -12,6 +12,7 @@ from griptape_nodes.node_library.library_registry import Library, LibraryRegistr
 
 def _make_schema(name: str = "TestLib") -> LibrarySchema:
     schema = MagicMock(spec=LibrarySchema)
+    schema.execution_modules = None
     schema.is_default_library = False
     schema.name = name
     return schema

--- a/tests/unit/retained_mode/managers/test_execute_node.py
+++ b/tests/unit/retained_mode/managers/test_execute_node.py
@@ -36,6 +36,9 @@ def _make_mock_library_manager(*, is_worker: bool) -> MagicMock:
     lib_mgr.is_worker = is_worker
     lib_mgr._is_worker = is_worker
     lib_mgr.get_worker_for_library.return_value = None
+    # The execute path awaits this before consulting get_worker_for_library; a plain
+    # MagicMock attribute is not awaitable.
+    lib_mgr.wait_for_worker_library_load = AsyncMock()
     return lib_mgr
 
 
@@ -371,6 +374,7 @@ class TestExecuteNodeWorkerRoute:
         lib_mgr = MagicMock()
         lib_mgr.is_worker = False
         lib_mgr._is_worker = False
+        lib_mgr.wait_for_worker_library_load = AsyncMock()
         lib_mgr.get_worker_for_library.return_value = ("eng-id", "topic")
 
         node_manager = _make_node_manager(object_manager=mock_obj_mgr, library_manager=lib_mgr, worker_manager=wm)
@@ -402,6 +406,7 @@ class TestExecuteNodeWorkerRoute:
         lib_mgr = MagicMock()
         lib_mgr.is_worker = False
         lib_mgr._is_worker = False
+        lib_mgr.wait_for_worker_library_load = AsyncMock()
         lib_mgr.get_worker_for_library.return_value = ("eng-id", "topic")
 
         node_manager = _make_node_manager(object_manager=mock_obj_mgr, library_manager=lib_mgr, worker_manager=wm)

--- a/tests/unit/retained_mode/managers/test_execute_node.py
+++ b/tests/unit/retained_mode/managers/test_execute_node.py
@@ -10,6 +10,7 @@ from griptape_nodes.retained_mode.events.execution_events import (
     ExecuteNodeResultSuccess,
     NodeMetadata,
 )
+from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
 from griptape_nodes.retained_mode.managers.node_manager import NodeManager
 
 _LIBRARY_REGISTRY_CREATE_NODE_PATH = "griptape_nodes.retained_mode.managers.node_manager.LibraryRegistry.create_node"
@@ -31,7 +32,14 @@ def _make_mock_obj_mgr(existing_node: MagicMock | None = None) -> MagicMock:
     return mock_obj_mgr
 
 
-def _make_mock_library_manager(*, is_worker: bool) -> MagicMock:
+def _make_mock_library_manager(*, is_worker: bool, library_loaded: bool = True) -> MagicMock:
+    """A stub LibraryManager.
+
+    `library_loaded` matters because the worker-side failure path asks whether the library
+    actually LOADED before blaming the process for not starting. Left as a bare MagicMock, that
+    question answers with a truthy mock and every failure claims the process died -- so the state
+    is set explicitly here rather than left to mock defaults.
+    """
     lib_mgr = MagicMock()
     lib_mgr.is_worker = is_worker
     lib_mgr._is_worker = is_worker
@@ -39,6 +47,16 @@ def _make_mock_library_manager(*, is_worker: bool) -> MagicMock:
     # The execute path awaits this before consulting get_worker_for_library; a plain
     # MagicMock attribute is not awaitable.
     lib_mgr.wait_for_worker_library_load = AsyncMock()
+    if library_loaded:
+        lib_mgr.get_library_info_by_library_name.return_value.lifecycle_state = (
+            LibraryManager.LibraryLifecycleState.LOADED
+        )
+    else:
+        lib_mgr.get_library_info_by_library_name.return_value.lifecycle_state = (
+            LibraryManager.LibraryLifecycleState.EVALUATED
+        )
+        # The name the code actually calls; configuring the other one left the reason unexercised.
+        lib_mgr.get_collated_problems_for_library.return_value = "Dependency installation failed: no solution found"
     return lib_mgr
 
 
@@ -332,9 +350,37 @@ class TestExecuteNodeWorkerPathStateless:
             result = await node_manager.on_execute_node_request(request)
 
         assert isinstance(result, ExecuteNodeResultFailure)
-        assert "test_node" in str(result.result_details)
-        assert "SomeNodeType" in str(result.result_details)
-        assert "library not loaded" in str(result.result_details)
+        details = str(result.result_details)
+        assert "test_node" in details
+        assert "SomeNodeType" in details
+        # The library itself is LOADED, so this is one broken node type -- not a library that
+        # could not start. The underlying error is the useful thing to report.
+        assert "library not loaded" in details
+        assert "could not start it up" not in details
+
+    @pytest.mark.asyncio
+    async def test_a_library_that_never_loaded_explains_itself_without_the_raw_error(self) -> None:
+        """When the worker could not load the library, say that -- and not "not found".
+
+        "Library 'X' not found" is what LibraryRegistry raises, and it is actively misleading
+        here: the orchestrator holds that library and is drawing its nodes, so it sends the reader
+        hunting for something that is right in front of them. The cause belongs in the log.
+        """
+        mock_obj_mgr = _make_mock_obj_mgr(existing_node=None)
+        lib_mgr = _make_mock_library_manager(is_worker=True, library_loaded=False)
+        node_manager = _make_node_manager(object_manager=mock_obj_mgr, library_manager=lib_mgr)
+
+        with patch(_LIBRARY_REGISTRY_CREATE_NODE_PATH, side_effect=RuntimeError("Library 'some_library' not found")):
+            request = ExecuteNodeRequest(
+                node_name="test_node",
+                node_metadata={"node_type": "SomeNodeType", "library": "some_library"},
+            )
+            result = await node_manager.on_execute_node_request(request)
+
+        details = str(result.result_details)
+        assert "could not start it up" in details
+        assert "Editing the node still works" in details
+        assert "not found" not in details
 
 
 class TestExecuteNodeWorkerRoute:

--- a/tests/unit/retained_mode/managers/test_execution_device.py
+++ b/tests/unit/retained_mode/managers/test_execution_device.py
@@ -1,0 +1,134 @@
+"""Choosing a compute device without importing a framework to find out.
+
+Every model-wrapping library currently imports torch purely to call `torch.cuda.is_available()`.
+That pulls an execution-time dependency into whichever process asks the question -- including one
+that only edits workflows, where the import fails outright. The engine already detects the
+machine's backends (nvidia-smi for CUDA, a platform check for MPS) and registers them as a
+compute resource, so the answer is available without the import.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from griptape_nodes.retained_mode.events.resource_events import (
+    CreateResourceInstanceRequest,
+    CreateResourceInstanceResultSuccess,
+    GetExecutionDeviceRequest,
+    GetExecutionDeviceResultFailure,
+    GetExecutionDeviceResultSuccess,
+)
+from griptape_nodes.retained_mode.managers.resource_types.compute_resource import ComputeInstance
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
+
+
+@pytest.fixture(autouse=True)
+def _no_system_compute(engine: Engine) -> None:
+    """Drop the real machine's compute instance so these tests describe a machine, not this one.
+
+    OSManager registers one system compute instance at boot advertising whatever this host has.
+    A test that adds a second is not describing a second GPU -- there is one system instance, and
+    standing in for it is the only way to assert the choice for a machine we do not have.
+    """
+    manager = engine.resource_manager
+    for instance_id, instance in list(manager._instances.items()):
+        if isinstance(instance, ComputeInstance):
+            del manager._instances[instance_id]
+
+
+def _register_compute(engine: Engine, backends: list[str]) -> None:
+    """Stand in for the system compute instance, advertising exactly these backends."""
+    result = engine.handle_request(
+        CreateResourceInstanceRequest(
+            resource_type_name="ComputeResourceType",
+            capabilities={"compute": backends},
+        )
+    )
+    assert isinstance(result, CreateResourceInstanceResultSuccess), getattr(result, "result_details", result)
+
+
+class TestDevicePreference:
+    def test_cuda_wins_when_present(self, engine: Engine) -> None:
+        _register_compute(engine, ["cpu", "cuda"])
+
+        result = engine.handle_request(GetExecutionDeviceRequest())
+
+        assert isinstance(result, GetExecutionDeviceResultSuccess)
+        assert result.device == "cuda"
+        assert result.available == ["cpu", "cuda"]
+
+    def test_mps_wins_over_cpu(self, engine: Engine) -> None:
+        _register_compute(engine, ["cpu", "mps"])
+
+        result = engine.handle_request(GetExecutionDeviceRequest())
+
+        assert isinstance(result, GetExecutionDeviceResultSuccess)
+        assert result.device == "mps"
+
+    def test_cpu_when_it_is_all_there_is(self, engine: Engine) -> None:
+        _register_compute(engine, ["cpu"])
+
+        result = engine.handle_request(GetExecutionDeviceRequest())
+
+        assert isinstance(result, GetExecutionDeviceResultSuccess)
+        assert result.device == "cpu"
+
+
+class TestPreferredDevice:
+    def test_a_preference_this_machine_has_is_honored(self, engine: Engine) -> None:
+        """A user or config pin outranks the general order."""
+        _register_compute(engine, ["cpu", "cuda"])
+
+        result = engine.handle_request(GetExecutionDeviceRequest(preferred="cpu"))
+
+        assert isinstance(result, GetExecutionDeviceResultSuccess)
+        assert result.device == "cpu"
+        assert result.honored_preference is True
+
+    def test_a_preference_this_machine_lacks_falls_back_rather_than_failing(self, engine: Engine) -> None:
+        """A workflow authored on a CUDA box must still run on a laptop.
+
+        Failing here would make the device pin a portability barrier: the file would open and then
+        refuse to run for a reason the author never intended to encode.
+        """
+        _register_compute(engine, ["cpu", "mps"])
+
+        result = engine.handle_request(GetExecutionDeviceRequest(preferred="cuda"))
+
+        assert isinstance(result, GetExecutionDeviceResultSuccess)
+        assert result.device == "mps"
+        assert result.honored_preference is False
+        assert "cuda" in str(result.result_details), "the answer should say the preference was unavailable"
+
+
+class TestNoComputeResource:
+    def test_it_fails_rather_than_guessing(self, engine: Engine) -> None:
+        """With nothing registered the machine's backends are genuinely unknown."""
+        result = engine.handle_request(GetExecutionDeviceRequest())
+
+        assert isinstance(result, GetExecutionDeviceResultFailure)
+        assert "no compute resource instance" in str(result.result_details)
+
+
+class TestTheNodeAccessor:
+    def test_a_node_reads_the_device_without_importing_anything(self, engine: Engine) -> None:
+        from tests.unit.exe_types.mocks import MockNode
+
+        _register_compute(engine, ["cpu", "cuda"])
+        node = MockNode(name="device_reader")
+
+        assert node.execution_device == "cuda"
+        assert node.available_compute == ["cpu", "cuda"]
+
+    def test_a_node_falls_back_to_cpu_when_the_engine_cannot_say(self, engine: Engine) -> None:  # noqa: ARG002
+        """A node that cannot pick a device is worse than one running slowly."""
+        from tests.unit.exe_types.mocks import MockNode
+
+        node = MockNode(name="device_reader_no_resource")
+
+        assert node.execution_device == "cpu"
+        assert node.available_compute == ["cpu"]

--- a/tests/unit/retained_mode/managers/test_library_manager.py
+++ b/tests/unit/retained_mode/managers/test_library_manager.py
@@ -792,6 +792,7 @@ class TestLibraryManagerInstallLibraryDependencies:
         schema.metadata.library_version = "1.0.0"
         schema.metadata.dependencies.pip_dependencies = []
         schema.metadata.dependencies.pip_install_flags = []
+        schema.metadata.dependencies.pip_dependencies_exec = None
 
         with (
             patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
@@ -859,6 +860,7 @@ class TestLibraryManagerInstallLibraryDependencies:
         schema.metadata.library_version = "1.0.0"
         schema.metadata.dependencies.pip_dependencies = []
         schema.metadata.dependencies.pip_install_flags = []
+        schema.metadata.dependencies.pip_dependencies_exec = None
 
         with (
             patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
@@ -881,6 +883,7 @@ class TestLibraryManagerInstallLibraryDependencies:
         schema.metadata.library_version = "1.0.0"
         schema.metadata.dependencies.pip_dependencies = []
         schema.metadata.dependencies.pip_install_flags = []
+        schema.metadata.dependencies.pip_dependencies_exec = None
 
         with (
             patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
@@ -908,6 +911,7 @@ class TestLibraryManagerInstallLibraryDependencies:
         schema.metadata.library_version = "1.0.0"
         schema.metadata.dependencies.pip_dependencies = []
         schema.metadata.dependencies.pip_install_flags = []
+        schema.metadata.dependencies.pip_dependencies_exec = None
 
         with (
             patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
@@ -944,6 +948,7 @@ class TestLibraryManagerInstallLibraryDependencies:
         schema.metadata.library_version = "1.0.0"
         schema.metadata.dependencies.pip_dependencies = ["a==1"]
         schema.metadata.dependencies.pip_install_flags = []
+        schema.metadata.dependencies.pip_dependencies_exec = None
 
         with (
             patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
@@ -984,6 +989,7 @@ class TestLibraryManagerInstallLibraryDependencies:
         schema.metadata.library_version = "1.0.0"
         schema.metadata.dependencies.pip_dependencies = ["a==1"]
         schema.metadata.dependencies.pip_install_flags = []
+        schema.metadata.dependencies.pip_dependencies_exec = None
         expected_attempts = 2
 
         with (
@@ -1031,6 +1037,7 @@ class TestLibraryManagerInstallLibraryDependencies:
         schema.metadata.library_version = "1.0.0"
         schema.metadata.dependencies.pip_dependencies = ["a==1"]
         schema.metadata.dependencies.pip_install_flags = []
+        schema.metadata.dependencies.pip_dependencies_exec = None
 
         with (
             patch.object(mgr, "load_library_metadata_from_file_request", return_value=self._metadata_result(schema)),
@@ -1071,6 +1078,7 @@ class TestLibraryManagerInstallLibraryDependencies:
         schema.metadata.library_version = "1.0.0"
         schema.metadata.dependencies.pip_dependencies = ["a==1"]
         schema.metadata.dependencies.pip_install_flags = []
+        schema.metadata.dependencies.pip_dependencies_exec = None
         expected_attempts = 2
 
         with (

--- a/tests/unit/retained_mode/managers/test_library_manager_deps.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_deps.py
@@ -72,8 +72,8 @@ class TestLibraryDependencyDeclaration:
         assert not hasattr(deps, "library_dependencies")
 
     def test_schema_version_bumped(self) -> None:
-        # 0.12.0 added Dependencies.pip_dependencies_exec.
-        assert LibrarySchema.LATEST_SCHEMA_VERSION == "0.12.0"
+        # 0.12.0 added Dependencies.pip_dependencies_exec; 0.13.0 added execution_modules.
+        assert LibrarySchema.LATEST_SCHEMA_VERSION == "0.13.0"
 
 
 class TestLibraryDependencyProblem:

--- a/tests/unit/retained_mode/managers/test_library_manager_deps.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_deps.py
@@ -25,7 +25,10 @@ from griptape_nodes.retained_mode.events.library_events import (
     RegisterLibraryFromFileRequest,
     RegisterLibraryFromFileResultFailure,
 )
-from griptape_nodes.retained_mode.managers.fitness_problems.libraries import LibraryDependencyProblem
+from griptape_nodes.retained_mode.managers.fitness_problems.libraries import (
+    DependencyInstallationFailedProblem,
+    LibraryDependencyProblem,
+)
 from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
 from griptape_nodes.retained_mode.managers.settings import LibraryDependencyInstallBehavior
 
@@ -900,3 +903,66 @@ class TestRequiresWorkerResolvedOnFilePathRegistration:
 
         assert isinstance(result, LibraryManager.RegisterLibraryPrerequisites)
         assert result.library_info.requires_worker is False
+
+
+class TestPipInstallFailureIsRecordedOnTheLibrary:
+    """A failed dependency install must leave an account of itself on the LibraryInfo.
+
+    Until this was wired, a pip failure recorded nothing: the resolver's complaint went to a log
+    line and the library itself reported no problem at all. Anything that later asked the
+    library what was wrong with it -- the settings panel, or a worker explaining why it cannot
+    run a node -- had nothing to report.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_failed_install_records_a_dependency_installation_problem(self, engine: Engine) -> None:
+        mgr = engine.library_manager
+        lib_info = _make_lib_info()
+        schema = _make_schema_mock([])
+
+        failure = InstallLibraryDependenciesResultFailure(
+            result_details="No solution found when resolving dependencies: nonexistent-package"
+        )
+        with (
+            patch.object(mgr, "load_library_metadata_from_file_request", return_value=_metadata_success(schema)),
+            patch.object(mgr, "install_library_dependencies_request", return_value=failure),
+            patch.object(mgr, "_library_file_path_to_info", {"/mock.json": lib_info}),
+        ):
+            await mgr._progress_library_through_lifecycle(
+                library_info=lib_info,
+                file_path="/mock.json",
+                request=RegisterLibraryFromFileRequest(file_path="/mock.json"),
+            )
+
+        install_problems = [p for p in lib_info.problems if isinstance(p, DependencyInstallationFailedProblem)]
+        assert len(install_problems) == 1
+        assert "nonexistent-package" in install_problems[0].error_details
+        # Readable by the collator the settings panel and the worker both go through.
+        collated = mgr.collate_problems_for_lib_info(lib_info)
+        assert collated is not None
+        assert "nonexistent-package" in collated
+
+    @pytest.mark.asyncio
+    async def test_a_failed_install_is_not_reported_as_a_missing_library_dependency(self, engine: Engine) -> None:
+        """The two are different failures and must not be conflated.
+
+        LibraryDependencyProblem means another griptape LIBRARY could not be fetched. Reusing it
+        for a pip failure would misreport the cause, and would silently change what the existing
+        dependency tests observe, since they filter problems by exactly that type.
+        """
+        mgr = engine.library_manager
+        lib_info = _make_lib_info()
+        schema = _make_schema_mock([])
+
+        with (
+            patch.object(mgr, "load_library_metadata_from_file_request", return_value=_metadata_success(schema)),
+            patch.object(mgr, "install_library_dependencies_request", return_value=_INSTALL_STOP),
+            patch.object(mgr, "_library_file_path_to_info", {"/mock.json": lib_info}),
+        ):
+            await mgr._progress_library_through_lifecycle(
+                library_info=lib_info,
+                file_path="/mock.json",
+                request=RegisterLibraryFromFileRequest(file_path="/mock.json"),
+            )
+
+        assert not [p for p in lib_info.problems if isinstance(p, LibraryDependencyProblem)]

--- a/tests/unit/retained_mode/managers/test_library_manager_deps.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_deps.py
@@ -69,7 +69,8 @@ class TestLibraryDependencyDeclaration:
         assert not hasattr(deps, "library_dependencies")
 
     def test_schema_version_bumped(self) -> None:
-        assert LibrarySchema.LATEST_SCHEMA_VERSION == "0.11.0"
+        # 0.12.0 added Dependencies.pip_dependencies_exec.
+        assert LibrarySchema.LATEST_SCHEMA_VERSION == "0.12.0"
 
 
 class TestLibraryDependencyProblem:

--- a/tests/unit/retained_mode/managers/test_library_manager_post_dispatch_hooks.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_post_dispatch_hooks.py
@@ -42,6 +42,7 @@ def _make_library_info() -> LibraryManager.LibraryInfo:
 
 def _make_library(advanced_library: AdvancedNodeLibrary | None = None) -> Library:
     schema = MagicMock(spec=LibrarySchema)
+    schema.execution_modules = None
     schema.is_default_library = False
     schema.name = "TestLib"
     schema.nodes = []

--- a/tests/unit/retained_mode/managers/test_library_manager_request_handlers.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_request_handlers.py
@@ -48,6 +48,7 @@ def _make_library_info() -> LibraryManager.LibraryInfo:
 
 def _make_library(advanced_library: AdvancedNodeLibrary | None = None) -> Library:
     schema = MagicMock(spec=LibrarySchema)
+    schema.execution_modules = None
     schema.is_default_library = False
     schema.name = "TestLib"
     schema.nodes = []

--- a/tests/unit/retained_mode/managers/test_library_manager_strict_mode.py
+++ b/tests/unit/retained_mode/managers/test_library_manager_strict_mode.py
@@ -18,13 +18,12 @@ from griptape_nodes.common.strict_mode import STRICT_MODE
 from griptape_nodes.exe_types.core_types import Parameter, Trait
 from griptape_nodes.exe_types.param_components.huggingface.huggingface_repo_parameter import HuggingFaceRepoParameter
 from griptape_nodes.node_library.library_registry import LibraryRegistry
+from griptape_nodes.retained_mode.engine import current_engine
 from tests.unit.exe_types.mocks import MockNode
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
     from contextlib import AbstractContextManager
-
-    from griptape_nodes.retained_mode.engine import Engine
 
 
 @pytest.fixture
@@ -92,10 +91,8 @@ class _ViolatingProbe:
 
 class TestSerializeSchemasStrictMode:
     @pytest.mark.asyncio
-    async def test_clean_class_is_included(
-        self, engine: Engine, patched_registry: Callable[[dict[str, type]], Any]
-    ) -> None:
-        manager = engine.library_manager
+    async def test_clean_class_is_included(self, patched_registry: Callable[[dict[str, type]], Any]) -> None:
+        manager = current_engine().library_manager
         with patched_registry({"Clean": _CleanProbe}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
@@ -103,10 +100,10 @@ class TestSerializeSchemasStrictMode:
 
     @pytest.mark.asyncio
     async def test_violating_class_is_skipped(
-        self, engine: Engine, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.DEBUG, logger="griptape_nodes.strict_mode")
-        manager = engine.library_manager
+        manager = current_engine().library_manager
         with patched_registry({"Violator": _ViolatingProbe, "Clean": _CleanProbe}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
@@ -136,7 +133,7 @@ class _ProbeWithHuggingFaceRepoParam(MockNode):
 class TestHuggingFaceRepoParameterSurvivesTheProbe:
     @pytest.mark.asyncio
     async def test_hf_param_node_is_included_and_issues_no_bus_requests(
-        self, engine: Engine, patched_registry: Callable[[dict[str, type]], Any]
+        self, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         module = "griptape_nodes.exe_types.param_components.huggingface"
 
@@ -144,10 +141,10 @@ class TestHuggingFaceRepoParameterSurvivesTheProbe:
             msg = f"bus request issued during probe construction: {type(request).__name__}"
             raise AssertionError(msg)
 
-        manager = engine.library_manager
+        manager = current_engine().library_manager
         with (
             patch(f"{module}.huggingface_repo_parameter.list_repo_revisions_in_cache", return_value=[]),
-            patch(f"{module}.huggingface_model_parameter.GriptapeNodes.handle_request", side_effect=_refuse_bus),
+            patch("griptape_nodes.retained_mode.engine.Engine.handle_request", side_effect=_refuse_bus),
             patched_registry({"HFNode": _ProbeWithHuggingFaceRepoParam}),
         ):
             schemas = await manager._serialize_library_node_schemas("libA")
@@ -208,10 +205,10 @@ class TestParameterBehaviorsDropped:
 
     @pytest.mark.asyncio
     async def test_clean_parameters_produce_no_violation(
-        self, engine: Engine, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
-        manager = engine.library_manager
+        manager = current_engine().library_manager
         with patched_registry({"Clean": _ProbeWithCleanParams}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
@@ -220,10 +217,10 @@ class TestParameterBehaviorsDropped:
 
     @pytest.mark.asyncio
     async def test_parameter_with_converter_reports_warning_but_keeps_schema(
-        self, engine: Engine, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
-        manager = engine.library_manager
+        manager = current_engine().library_manager
         with patched_registry({"WithBehavior": _ProbeWithConverterParam}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
@@ -237,10 +234,10 @@ class TestParameterBehaviorsDropped:
 
     @pytest.mark.asyncio
     async def test_parameter_with_validator_reports_warning_but_keeps_schema(
-        self, engine: Engine, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
-        manager = engine.library_manager
+        manager = current_engine().library_manager
         with patched_registry({"WithValidator": _ProbeWithValidatorParam}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
@@ -251,10 +248,10 @@ class TestParameterBehaviorsDropped:
 
     @pytest.mark.asyncio
     async def test_parameter_with_trait_reports_warning_but_keeps_schema(
-        self, engine: Engine, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
-        manager = engine.library_manager
+        manager = current_engine().library_manager
         with patched_registry({"WithTrait": _ProbeWithTraitParam}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
@@ -314,10 +311,10 @@ class TestInertWorkerHooks:
 
     @pytest.mark.asyncio
     async def test_connection_hook_override_reports_warning_but_keeps_schema(
-        self, engine: Engine, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
-        manager = engine.library_manager
+        manager = current_engine().library_manager
         with patched_registry({"WithConnHook": _ProbeWithConnectionHook}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
@@ -331,10 +328,10 @@ class TestInertWorkerHooks:
 
     @pytest.mark.asyncio
     async def test_value_hook_override_reports_warning_but_keeps_schema(
-        self, engine: Engine, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
-        manager = engine.library_manager
+        manager = current_engine().library_manager
         with patched_registry({"WithValueHook": _ProbeWithValueHook}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
@@ -347,13 +344,13 @@ class TestInertWorkerHooks:
 
     @pytest.mark.asyncio
     async def test_engine_owned_hook_override_is_not_reported(
-        self, engine: Engine, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         # A hook implemented by an engine-owned base/component (module under
         # griptape_nodes.) is not the author's code; flagging it would nag on
         # something the library author cannot remediate.
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
-        manager = engine.library_manager
+        manager = current_engine().library_manager
         with patched_registry({"EngineHook": _ProbeInheritingEngineHook}):
             schemas = await manager._serialize_library_node_schemas("libA")
 
@@ -362,10 +359,10 @@ class TestInertWorkerHooks:
 
     @pytest.mark.asyncio
     async def test_hookless_class_produces_no_hook_violation(
-        self, engine: Engine, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
+        self, caplog: pytest.LogCaptureFixture, patched_registry: Callable[[dict[str, type]], Any]
     ) -> None:
         caplog.set_level(logging.WARNING, logger="griptape_nodes.strict_mode")
-        manager = engine.library_manager
+        manager = current_engine().library_manager
         with patched_registry({"Clean": _CleanProbe}):
             schemas = await manager._serialize_library_node_schemas("libA")
 

--- a/tests/unit/retained_mode/managers/test_library_worker_config.py
+++ b/tests/unit/retained_mode/managers/test_library_worker_config.py
@@ -120,12 +120,32 @@ class TestGetWorkerForLibrary:
 
 class TestOnLibraryLoadedNotification:
     def _make_lib_info(self, library_name: str) -> LibraryManager.LibraryInfo:
+        """A legacy worker-mode library awaiting its worker's verdict.
+
+        `requires_worker` is what puts a library in WORKER_PENDING in the first place (see
+        `_start_workers`), so a fixture in that state without the flag describes something the
+        engine never produces.
+        """
         return LibraryManager.LibraryInfo(
             lifecycle_state=LibraryManager.LibraryLifecycleState.WORKER_PENDING,
             fitness=LibraryManager.LibraryFitness.NOT_EVALUATED,
             library_path="/some/path.json",
             is_sandbox=False,
             library_name=library_name,
+            requires_worker=True,
+            executes_in_worker=True,
+        )
+
+    def _make_exec_deps_lib_info(self, library_name: str) -> LibraryManager.LibraryInfo:
+        """An execution-dependency library that already loaded its real nodes locally."""
+        return LibraryManager.LibraryInfo(
+            lifecycle_state=LibraryManager.LibraryLifecycleState.LOADED,
+            fitness=LibraryManager.LibraryFitness.FLAWED,
+            library_path="/some/exec-deps.json",
+            is_sandbox=False,
+            library_name=library_name,
+            requires_worker=False,
+            executes_in_worker=True,
         )
 
     @pytest.mark.asyncio
@@ -138,6 +158,26 @@ class TestOnLibraryLoadedNotification:
 
         assert lib_info.lifecycle_state == LibraryManager.LibraryLifecycleState.LOADED
         assert lib_info.fitness == LibraryManager.LibraryFitness.GOOD
+
+    @pytest.mark.asyncio
+    async def test_a_worker_does_not_overwrite_a_locally_derived_fitness(self) -> None:
+        """An exec-deps library's fitness is the orchestrator's own finding, not the worker's.
+
+        It loaded real node classes here, so its FLAWED verdict came from doing that -- an
+        edit-time dependency that failed, a node module that would not import. The worker only
+        knows whether ITS copy came up. Taking the worker's answer would paint over a broken node
+        that is sitting on the canvas, and the reason would not travel with it.
+        """
+        mgr = _make_library_manager()
+        lib_info = self._make_exec_deps_lib_info("exec_deps_lib")
+        mgr._library_file_path_to_info["/some/exec-deps.json"] = lib_info
+
+        await mgr._on_library_loaded_notification(
+            LibraryLoadedNotification(library_name="exec_deps_lib", fitness="GOOD")
+        )
+
+        assert lib_info.fitness == LibraryManager.LibraryFitness.FLAWED
+        assert lib_info.lifecycle_state == LibraryManager.LibraryLifecycleState.LOADED
 
     @pytest.mark.asyncio
     async def test_accepts_flawed_fitness(self) -> None:

--- a/tests/unit/retained_mode/managers/test_library_worker_config.py
+++ b/tests/unit/retained_mode/managers/test_library_worker_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any, cast
 from unittest.mock import MagicMock
 
@@ -218,3 +219,95 @@ class TestResolveExecutesInWorker:
             requires_worker=True, metadata=self._metadata(exec_deps=None)
         )
         assert result is True
+
+
+class TestExecuteWaitsForTheWorkerLibraryLoad:
+    """Routing must gate on the worker's LibraryLoadedNotification, not on registration.
+
+    A worker registers at process start, BEFORE it has loaded its library -- with eager
+    execution-module imports, seconds before. A node routed in that window failed in the
+    worker with "Library 'X' not found". The old worker system never had this window:
+    stub nodes did not exist until the worker confirmed the load, so nothing could execute.
+    """
+
+    def _spawned_info(self, *, loaded: bool) -> LibraryManager.LibraryInfo:
+        info = LibraryManager.LibraryInfo(
+            lifecycle_state=LibraryManager.LibraryLifecycleState.LOADED,
+            fitness=LibraryManager.LibraryFitness.GOOD,
+            library_path="/some/path.json",
+            is_sandbox=False,
+            library_name="Lib",
+            executes_in_worker=True,
+        )
+        info.worker_ready = asyncio.Event()
+        if loaded:
+            info.worker_ready.set()
+        return info
+
+    @pytest.mark.asyncio
+    async def test_the_wait_releases_when_the_notification_arrives(self) -> None:
+        mgr = _make_library_manager()
+        info = self._spawned_info(loaded=False)
+        mgr._library_file_path_to_info["/some/path.json"] = info
+        order: list[str] = []
+
+        async def executes() -> None:
+            await mgr.wait_for_worker_library_load("Lib")
+            order.append("routed")
+
+        async def worker_finishes_loading() -> None:
+            order.append("loaded")
+            await mgr._on_library_loaded_notification(LibraryLoadedNotification(library_name="Lib", fitness="GOOD"))
+
+        await asyncio.gather(executes(), worker_finishes_loading())
+
+        assert order == ["loaded", "routed"], "execution routed before the worker reported the library loaded"
+
+    @pytest.mark.asyncio
+    async def test_an_already_loaded_library_does_not_wait(self) -> None:
+        mgr = _make_library_manager()
+        mgr._library_file_path_to_info["/some/path.json"] = self._spawned_info(loaded=True)
+
+        await mgr.wait_for_worker_library_load("Lib")
+
+    @pytest.mark.asyncio
+    async def test_a_library_with_no_spawned_worker_does_not_wait(self) -> None:
+        mgr = _make_library_manager()
+        info = self._spawned_info(loaded=False)
+        info.worker_ready = None
+        mgr._library_file_path_to_info["/some/path.json"] = info
+
+        await mgr.wait_for_worker_library_load("Lib")
+
+    @pytest.mark.asyncio
+    async def test_the_timeout_names_the_library_and_the_ceiling(self) -> None:
+        mgr = _make_library_manager()
+        mgr._library_file_path_to_info["/some/path.json"] = self._spawned_info(loaded=False)
+        mgr._engine = MagicMock()  # type: ignore[assignment]
+        mgr._engine.config_manager.get_config_value.return_value = 0.01
+
+        with pytest.raises(RuntimeError, match="Lib"):
+            await mgr.wait_for_worker_library_load("Lib")
+
+    @pytest.mark.asyncio
+    async def test_an_eviction_during_the_wait_releases_it(self) -> None:
+        """The waiter must not hold on for the full grace for a worker that is already gone."""
+        mgr = _make_library_manager()
+        info = self._spawned_info(loaded=False)
+        mgr._library_file_path_to_info["/some/path.json"] = info
+        order: list[str] = []
+
+        async def executes() -> None:
+            await mgr.wait_for_worker_library_load("Lib")
+            order.append("released")
+
+        async def worker_dies() -> None:
+            order.append("evicted")
+            mgr.on_worker_evicted("worker-1", "Lib")
+
+        await asyncio.gather(executes(), worker_dies())
+
+        assert order == ["evicted", "released"]
+        assert info.lifecycle_state is LibraryManager.LibraryLifecycleState.LOADED, (
+            "an exec-deps library must stay editable through an eviction"
+        )

--- a/tests/unit/retained_mode/managers/test_library_worker_config.py
+++ b/tests/unit/retained_mode/managers/test_library_worker_config.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from griptape_nodes.node_library.library_registry import LibraryMetadata
+from griptape_nodes.node_library.library_registry import Dependencies, LibraryMetadata
 from griptape_nodes.retained_mode.events.app_events import LibraryLoadedNotification
 from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
 
@@ -69,6 +69,7 @@ class TestGetWorkerForLibrary:
             is_sandbox=False,
             library_name="my_lib",
             requires_worker=True,
+            executes_in_worker=True,
         )
 
         cast("MagicMock", mgr._worker_manager).get_worker_for_key.return_value = (
@@ -106,6 +107,7 @@ class TestGetWorkerForLibrary:
             is_sandbox=False,
             library_name="my_lib",
             requires_worker=True,
+            executes_in_worker=True,
         )
 
         cast("MagicMock", mgr._worker_manager).get_worker_for_key.return_value = None
@@ -174,3 +176,45 @@ class TestRegisterPreReloadCallback:
         mgr.register_pre_reload_callback(second)
 
         assert mgr._pre_reload_callbacks == [*baseline, first, second]
+
+
+class TestResolveExecutesInWorker:
+    """Execution placement is a fact about dependencies, derived not declared."""
+
+    def _metadata(self, *, exec_deps: list[str] | None) -> LibraryMetadata:
+        dependencies = None
+        if exec_deps is not None:
+            dependencies = Dependencies(pip_dependencies=["pillow"], pip_dependencies_exec=exec_deps)
+        return LibraryMetadata(
+            author="t",
+            description="d",
+            library_version="1.0.0",
+            engine_version="0.0.0",
+            tags=[],
+            dependencies=dependencies,
+        )
+
+    def test_exec_dependencies_require_a_worker(self) -> None:
+        result = LibraryManager._resolve_executes_in_worker(
+            requires_worker=False, metadata=self._metadata(exec_deps=["torch"])
+        )
+        assert result is True
+
+    def test_no_dependencies_section_means_no_worker(self) -> None:
+        result = LibraryManager._resolve_executes_in_worker(
+            requires_worker=False, metadata=self._metadata(exec_deps=None)
+        )
+        assert result is False
+
+    def test_empty_exec_dependencies_mean_no_worker(self) -> None:
+        result = LibraryManager._resolve_executes_in_worker(
+            requires_worker=False, metadata=self._metadata(exec_deps=[])
+        )
+        assert result is False
+
+    def test_legacy_worker_mode_still_executes_in_a_worker(self) -> None:
+        """The two reasons are independent: declaring worker mode is sufficient alone."""
+        result = LibraryManager._resolve_executes_in_worker(
+            requires_worker=True, metadata=self._metadata(exec_deps=None)
+        )
+        assert result is True

--- a/tests/unit/retained_mode/managers/test_library_worker_config.py
+++ b/tests/unit/retained_mode/managers/test_library_worker_config.py
@@ -351,3 +351,52 @@ class TestExecuteWaitsForTheWorkerLibraryLoad:
         assert info.lifecycle_state is LibraryManager.LibraryLifecycleState.LOADED, (
             "an exec-deps library must stay editable through an eviction"
         )
+
+
+class TestOnWorkerEvicted:
+    """What an evicted worker leaves behind, per library kind.
+
+    An exec-dependencies library loaded real node classes on the orchestrator before its worker
+    ever spawned, so losing the worker must cost EXECUTION and nothing else: still LOADED, still
+    editable, with a reason the next run can report. A legacy worker-mode library has only stubs
+    until its worker confirms, so losing the worker is a load failure. Neither was covered, and
+    the difference is the whole point of the split.
+    """
+
+    def _info(self, *, requires_worker: bool, lifecycle: LibraryManager.LibraryLifecycleState) -> Any:
+        return LibraryManager.LibraryInfo(
+            lifecycle_state=lifecycle,
+            fitness=LibraryManager.LibraryFitness.GOOD,
+            library_path="/some/path.json",
+            is_sandbox=False,
+            library_name="Lib",
+            requires_worker=requires_worker,
+            executes_in_worker=True,
+        )
+
+    def test_exec_deps_library_stays_loaded_and_records_why(self) -> None:
+        manager = _make_library_manager()
+        info = self._info(requires_worker=False, lifecycle=LibraryManager.LibraryLifecycleState.LOADED)
+        manager._library_file_path_to_info["/some/path.json"] = info
+
+        manager.on_worker_evicted("worker-1", "Lib")
+
+        assert info.lifecycle_state is LibraryManager.LibraryLifecycleState.LOADED
+        assert info.fitness is LibraryManager.LibraryFitness.GOOD
+        assert info.execution_unavailable_reason is not None
+        assert "stopped responding" in info.execution_unavailable_reason
+
+    def test_legacy_worker_pending_library_becomes_failure(self) -> None:
+        manager = _make_library_manager()
+        info = self._info(requires_worker=True, lifecycle=LibraryManager.LibraryLifecycleState.WORKER_PENDING)
+        manager._library_file_path_to_info["/some/path.json"] = info
+
+        manager.on_worker_evicted("worker-1", "Lib")
+
+        assert info.lifecycle_state is LibraryManager.LibraryLifecycleState.FAILURE
+        assert info.fitness is LibraryManager.LibraryFitness.UNUSABLE
+
+    def test_unknown_library_name_is_a_no_op(self) -> None:
+        manager = _make_library_manager()
+        manager.on_worker_evicted("worker-1", "Never Registered")
+        manager.on_worker_evicted("worker-1", None)

--- a/tests/unit/retained_mode/managers/test_library_worker_config.py
+++ b/tests/unit/retained_mode/managers/test_library_worker_config.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any, cast
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from griptape_nodes.node_library.library_registry import Dependencies, LibraryMetadata
 from griptape_nodes.retained_mode.events.app_events import LibraryLoadedNotification
+from griptape_nodes.retained_mode.managers.fitness_problems.libraries import (
+    IncompatibleRequirementsProblem,
+)
 from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
 
 
@@ -149,6 +152,7 @@ class TestOnLibraryLoadedNotification:
         )
 
     @pytest.mark.asyncio
+    @pytest.mark.asyncio
     async def test_updates_fitness_and_lifecycle_to_loaded(self) -> None:
         mgr = _make_library_manager()
         lib_info = self._make_lib_info("my_lib")
@@ -159,6 +163,7 @@ class TestOnLibraryLoadedNotification:
         assert lib_info.lifecycle_state == LibraryManager.LibraryLifecycleState.LOADED
         assert lib_info.fitness == LibraryManager.LibraryFitness.GOOD
 
+    @pytest.mark.asyncio
     @pytest.mark.asyncio
     async def test_a_worker_does_not_overwrite_a_locally_derived_fitness(self) -> None:
         """An exec-deps library's fitness is the orchestrator's own finding, not the worker's.
@@ -180,6 +185,7 @@ class TestOnLibraryLoadedNotification:
         assert lib_info.lifecycle_state == LibraryManager.LibraryLifecycleState.LOADED
 
     @pytest.mark.asyncio
+    @pytest.mark.asyncio
     async def test_accepts_flawed_fitness(self) -> None:
         mgr = _make_library_manager()
         lib_info = self._make_lib_info("my_lib")
@@ -192,6 +198,7 @@ class TestOnLibraryLoadedNotification:
         assert lib_info.lifecycle_state == LibraryManager.LibraryLifecycleState.LOADED
         assert lib_info.fitness == LibraryManager.LibraryFitness.FLAWED
 
+    @pytest.mark.asyncio
     @pytest.mark.asyncio
     async def test_does_nothing_for_unknown_library(self) -> None:
         mgr = _make_library_manager()
@@ -400,3 +407,82 @@ class TestOnWorkerEvicted:
         manager = _make_library_manager()
         manager.on_worker_evicted("worker-1", "Never Registered")
         manager.on_worker_evicted("worker-1", None)
+
+
+class TestSpawnSkipForUnmetRequirements:
+    """A pointless spawn is skipped -- but only where the nodes already exist locally.
+
+    An exec-dependencies library loaded real node classes on the orchestrator, so a worker it can
+    never use costs a whole execution environment -- torch, gigabytes -- for nothing. A legacy
+    worker-mode library is the opposite: the orchestrator skips its node modules entirely and its
+    classes arrive as stubs from the worker, so skipping the spawn would leave it with no node
+    types at all.
+    """
+
+    def _manager(self, *, requires_worker: bool, unmet: bool) -> LibraryManager:
+        manager = _make_library_manager()
+        manager._engine = MagicMock()  # type: ignore[assignment]
+        manager._engine.ahandle_request = AsyncMock()  # type: ignore[union-attr]
+        info = LibraryManager.LibraryInfo(
+            lifecycle_state=LibraryManager.LibraryLifecycleState.LOADED,
+            fitness=LibraryManager.LibraryFitness.GOOD,
+            library_path="/some/path.json",
+            is_sandbox=False,
+            library_name="Lib",
+            requires_worker=requires_worker,
+            executes_in_worker=True,
+        )
+        if unmet:
+            info.problems = [
+                IncompatibleRequirementsProblem(
+                    requirements={"compute": (["cuda"], "has_any")},
+                    system_capabilities={"compute": ["cpu"]},
+                )
+            ]
+            info.execution_unavailable_reason = "it needs compute cuda, and this machine has cpu."
+        manager._library_file_path_to_info["/some/path.json"] = info
+        return manager
+
+    @pytest.mark.asyncio
+    async def test_exec_deps_library_with_unmet_requirements_is_not_spawned(self) -> None:
+        manager = self._manager(requires_worker=False, unmet=True)
+
+        await manager._start_workers()
+
+        cast("MagicMock", manager._engine).ahandle_request.assert_not_awaited()
+        info = manager._library_file_path_to_info["/some/path.json"]
+        assert info.execution_unavailable_reason is not None, "the local refusal must survive"
+
+    @pytest.mark.asyncio
+    async def test_legacy_worker_library_still_spawns_even_when_unmet(self) -> None:
+        """Its nodes come from the worker, so no spawn means no node types at all."""
+        manager = self._manager(requires_worker=True, unmet=True)
+
+        await manager._start_workers()
+
+        cast("MagicMock", manager._engine).ahandle_request.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_the_spawn_a_legacy_library_still_gets_does_not_clear_its_refusal(self) -> None:
+        """execution_unavailable_reason is the only gate get_worker_for_library has.
+
+        This library's spawn is deliberately not skipped, so clearing the reason on a fresh attempt
+        would let execution dispatch to a worker that cannot load it. An unmet requirement is a
+        standing fact about the machine, not an account of a previous attempt.
+        """
+        manager = self._manager(requires_worker=True, unmet=True)
+
+        await manager._start_workers()
+
+        info = manager._library_file_path_to_info["/some/path.json"]
+        assert info.execution_unavailable_reason is not None
+
+    @pytest.mark.asyncio
+    async def test_a_library_with_met_requirements_spawns(self) -> None:
+        manager = self._manager(requires_worker=False, unmet=False)
+
+        await manager._start_workers()
+
+        cast("MagicMock", manager._engine).ahandle_request.assert_awaited_once()
+        # Nothing standing in the way, so a stale account of a previous attempt is cleared.
+        assert manager._library_file_path_to_info["/some/path.json"].execution_unavailable_reason is None

--- a/tests/unit/retained_mode/managers/test_model_assets.py
+++ b/tests/unit/retained_mode/managers/test_model_assets.py
@@ -1,0 +1,188 @@
+"""Weights are declared, not installed -- and never fetched at library load.
+
+Libraries have been acquiring model weights three ways: bundled inside a pip-installed source
+tree, downloaded by a `before_library_nodes_loaded` hook, or fetched ad hoc by node code. Only the
+last runs in the right process. A declaration lets the engine own the fetch, the cache location
+and the revision pin, and lets a node ask for a path.
+
+These tests never touch the network: the fetch request is intercepted, which also lets them assert
+exactly what the engine would have asked for.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+import griptape_nodes.retained_mode.managers.library_manager as library_manager_module
+from griptape_nodes.node_library.library_registry import LibrarySchema
+from griptape_nodes.retained_mode.engine import current_engine
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.events.model_events import DownloadModelRequest, DownloadModelResultSuccess
+from griptape_nodes.utils.version_utils import engine_version
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from pathlib import Path
+
+LIBRARY_PREFIX = "Model Asset Library"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_asset_root(tmp_path: Path) -> Generator[Path, None, None]:
+    """Point the engine-owned asset cache at a scratch dir.
+
+    The real root is under xdg_data_home, which is correct for production and wrong for a test
+    suite: without this, cases leak state into each other AND write into the developer's home.
+    """
+    root = tmp_path / "asset_root"
+    root.mkdir()
+    with patch.object(library_manager_module, "xdg_data_home", return_value=root):
+        yield root
+
+
+def _register(tmp_path: Path, assets: dict[str, dict[str, object]] | None, name: str) -> str:
+    """A minimal library declaring model assets and nothing else.
+
+    Takes a distinct name per test: LibraryRegistry is process-global and holds the schema first
+    registered under a given name, so reusing one lets a later test read an earlier declaration.
+    """
+    library_name = f"{LIBRARY_PREFIX} {name}"
+    library_dir = tmp_path / "model_asset_library"
+    library_dir.mkdir(parents=True, exist_ok=True)
+    (library_dir / "node.py").write_text(
+        "from griptape_nodes.exe_types.node_types import DataNode\n\n\n"
+        "class AssetNode(DataNode):\n"
+        "    def process(self) -> None:\n"
+        "        return\n"
+    )
+    manifest = {
+        "name": library_name,
+        "library_schema_version": LibrarySchema.LATEST_SCHEMA_VERSION,
+        "metadata": {
+            "author": "test",
+            "description": "declares model assets",
+            "library_version": "0.1.0",
+            "engine_version": engine_version,
+            "tags": ["test"],
+        },
+        "categories": [{"test": {"title": "t", "description": "d", "color": "border-gray-500", "icon": "Folder"}}],
+        "nodes": [
+            {
+                "class_name": "AssetNode",
+                "file_path": "node.py",
+                "metadata": {"category": "test", "description": "d", "display_name": "AssetNode"},
+            }
+        ],
+    }
+    if assets is not None:
+        manifest["model_assets"] = assets
+    manifest_path = library_dir / "griptape_nodes_library.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+    result = current_engine().handle_request(RegisterLibraryFromFileRequest(file_path=str(manifest_path)))
+    assert isinstance(result, RegisterLibraryFromFileResultSuccess), getattr(result, "result_details", result)
+    return library_name
+
+
+class TestNothingIsFetchedAtLibraryLoad:
+    def test_registering_a_library_downloads_nothing(self, tmp_path: Path) -> None:
+        """The whole point of declaring: loading a library must not pull gigabytes."""
+        with patch.object(current_engine(), "handle_request", wraps=current_engine().handle_request) as spy:
+            _register(tmp_path, {"weights": {"source": "hf:owner/repo", "revision": "abc123"}}, "load")
+
+        downloads = [
+            call for call in spy.call_args_list if isinstance(call.args[0] if call.args else None, DownloadModelRequest)
+        ]
+        assert downloads == [], "registering the library issued a model download"
+
+
+class TestResolvingAnAsset:
+    def test_it_asks_for_exactly_what_was_declared(self, tmp_path: Path) -> None:
+        """Revision and file patterns are the author's pin; the engine must not drop them."""
+        library = _register(
+            tmp_path,
+            {"weights": {"source": "hf:owner/repo", "revision": "abc123", "files": ["*.safetensors"]}},
+            "declared",
+        )
+        captured: list[DownloadModelRequest] = []
+
+        def fake_download(request: DownloadModelRequest) -> DownloadModelResultSuccess:
+            captured.append(request)
+            # Stand in for the real fetch by leaving a file where it would have written one.
+            # Stand in for the real fetch by leaving a file where it would have written one.
+            assert request.local_dir is not None
+            local = pathlib.Path(request.local_dir)
+            local.mkdir(parents=True, exist_ok=True)
+            (local / "model.safetensors").write_text("weights")
+            return DownloadModelResultSuccess(model_id=request.model_id, result_details="ok")
+
+        manager = current_engine().library_manager
+        with patch.object(current_engine(), "handle_request", side_effect=fake_download):
+            path = manager.get_model_asset(library, "weights")
+
+        assert len(captured) == 1
+        request = captured[0]
+        assert request.model_id == "owner/repo"
+        assert request.revision == "abc123"
+        assert request.allow_patterns == ["*.safetensors"]
+        assert path.exists()
+        assert (path / "model.safetensors").exists()
+
+    def test_the_path_is_keyed_by_revision(self, tmp_path: Path) -> None:
+        """Re-pinning must not overwrite the weights a saved workflow still refers to."""
+        library = _register(tmp_path, {"weights": {"source": "hf:owner/repo", "revision": "abc123"}}, "revkey")
+        manager = current_engine().library_manager
+        schema = manager  # readability: the helper below is a static method on the manager
+
+        from griptape_nodes.node_library.library_registry import ModelAsset
+
+        first = schema._model_asset_path(library, "weights", ModelAsset(source="hf:owner/repo", revision="abc123"))
+        second = schema._model_asset_path(library, "weights", ModelAsset(source="hf:owner/repo", revision="def456"))
+
+        assert first != second
+        assert first.name == "abc123"
+        assert second.name == "def456"
+
+    def test_an_already_present_asset_is_not_refetched(self, tmp_path: Path) -> None:
+        library = _register(tmp_path, {"weights": {"source": "hf:owner/repo", "revision": "abc123"}}, "cached")
+        manager = current_engine().library_manager
+
+        from griptape_nodes.node_library.library_registry import ModelAsset
+
+        target = manager._model_asset_path(library, "weights", ModelAsset(source="hf:owner/repo", revision="abc123"))
+        target.mkdir(parents=True, exist_ok=True)
+        (target / "model.safetensors").write_text("already here")
+
+        with patch.object(current_engine(), "handle_request", side_effect=AssertionError("must not fetch")):
+            path = manager.get_model_asset(library, "weights")
+
+        assert path == target
+
+
+class TestHonestFailures:
+    def test_an_undeclared_asset_lists_what_is_declared(self, tmp_path: Path) -> None:
+        library = _register(tmp_path, {"weights": {"source": "hf:owner/repo"}}, "undeclared")
+
+        with pytest.raises(RuntimeError, match="declares no model asset named 'missing'") as excinfo:
+            current_engine().library_manager.get_model_asset(library, "missing")
+
+        assert "weights" in str(excinfo.value), "the message should say what IS declared"
+
+    def test_an_unsupported_source_scheme_says_which_are_supported(self, tmp_path: Path) -> None:
+        library = _register(tmp_path, {"weights": {"source": "s3://bucket/key"}}, "scheme")
+
+        with pytest.raises(RuntimeError, match="Supported schemes"):
+            current_engine().library_manager.get_model_asset(library, "weights")
+
+    def test_a_library_with_no_declaration_at_all_still_errors_clearly(self, tmp_path: Path) -> None:
+        library = _register(tmp_path, None, "nodecl")
+
+        with pytest.raises(RuntimeError, match="declares no model asset"):
+            current_engine().library_manager.get_model_asset(library, "weights")

--- a/tests/unit/retained_mode/managers/test_model_assets.py
+++ b/tests/unit/retained_mode/managers/test_model_assets.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 import json
 import pathlib
+import time
+from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -188,6 +190,39 @@ class TestResolvingAnAsset:
 
         assert fetched == ["DownloadModelRequest"], "a partial download must be refetched"
         assert (target / ".griptape-nodes-complete").exists(), "a successful fetch must mark completion"
+
+    def test_two_nodes_asking_at_once_download_once(self, tmp_path: Path) -> None:
+        """Node execution is concurrent, and the check-fetch-mark window is not atomic.
+
+        Both callers saw no marker, both downloaded into the same directory, and the first to return
+        marked it complete while the second was still writing -- so every later call short-circuited
+        on the marker and got a truncated model, the exact outcome the marker exists to prevent.
+        """
+        library = _register(tmp_path, {"weights": {"source": "hf:owner/repo", "revision": "abc123"}}, "raced")
+        manager = current_engine().library_manager
+        in_flight = 0
+        overlaps: list[int] = []
+        fetches = 0
+
+        def _slow_download(_request: object) -> object:
+            nonlocal in_flight, fetches
+            fetches += 1
+            in_flight += 1
+            overlaps.append(in_flight)
+            time.sleep(0.15)
+            in_flight -= 1
+            return DownloadModelResultSuccess(model_id="owner/repo", result_details="ok")
+
+        with (
+            patch.object(current_engine(), "handle_request", side_effect=_slow_download),
+            ThreadPoolExecutor(max_workers=2) as pool,
+        ):
+            futures = [pool.submit(manager.get_model_asset, library, "weights") for _ in range(2)]
+            paths = [future.result(timeout=30) for future in futures]
+
+        assert max(overlaps) == 1, f"two fetches overlapped in one directory: {overlaps}"
+        assert fetches == 1, f"expected a single download, got {fetches}"
+        assert len(set(paths)) == 1
 
 
 class TestHonestFailures:

--- a/tests/unit/retained_mode/managers/test_model_assets.py
+++ b/tests/unit/retained_mode/managers/test_model_assets.py
@@ -19,7 +19,7 @@ from unittest.mock import patch
 import pytest
 
 import griptape_nodes.retained_mode.managers.library_manager as library_manager_module
-from griptape_nodes.node_library.library_registry import LibrarySchema
+from griptape_nodes.node_library.library_registry import LibrarySchema, ModelAsset
 from griptape_nodes.retained_mode.engine import current_engine
 from griptape_nodes.retained_mode.events.library_events import (
     RegisterLibraryFromFileRequest,
@@ -141,8 +141,6 @@ class TestResolvingAnAsset:
         manager = current_engine().library_manager
         schema = manager  # readability: the helper below is a static method on the manager
 
-        from griptape_nodes.node_library.library_registry import ModelAsset
-
         first = schema._model_asset_path(library, "weights", ModelAsset(source="hf:owner/repo", revision="abc123"))
         second = schema._model_asset_path(library, "weights", ModelAsset(source="hf:owner/repo", revision="def456"))
 
@@ -154,16 +152,42 @@ class TestResolvingAnAsset:
         library = _register(tmp_path, {"weights": {"source": "hf:owner/repo", "revision": "abc123"}}, "cached")
         manager = current_engine().library_manager
 
-        from griptape_nodes.node_library.library_registry import ModelAsset
-
         target = manager._model_asset_path(library, "weights", ModelAsset(source="hf:owner/repo", revision="abc123"))
         target.mkdir(parents=True, exist_ok=True)
         (target / "model.safetensors").write_text("already here")
+        # The completion marker is what "already present" means. Files alone do not qualify: the
+        # directory is created before the download starts, so a partial fetch also leaves files.
+        (target / ".griptape-nodes-complete").touch()
 
         with patch.object(current_engine(), "handle_request", side_effect=AssertionError("must not fetch")):
             path = manager.get_model_asset(library, "weights")
 
         assert path == target
+
+    def test_a_partial_download_is_refetched_rather_than_served(self, tmp_path: Path) -> None:
+        """Weights on disk without the marker are the shape an interrupted fetch leaves behind.
+
+        Serving them handed back a truncated model that failed in a way pointing at the model
+        rather than the cache, and nothing short of deleting the directory by hand recovered.
+        """
+        library = _register(tmp_path, {"weights": {"source": "hf:owner/repo", "revision": "abc123"}}, "partial")
+        manager = current_engine().library_manager
+
+        target = manager._model_asset_path(library, "weights", ModelAsset(source="hf:owner/repo", revision="abc123"))
+        target.mkdir(parents=True, exist_ok=True)
+        (target / "model.safetensors.incomplete").write_text("half a file")
+
+        fetched: list[str] = []
+
+        def _record(request: object) -> object:
+            fetched.append(type(request).__name__)
+            return DownloadModelResultSuccess(model_id="owner/repo", result_details="ok")
+
+        with patch.object(current_engine(), "handle_request", side_effect=_record):
+            manager.get_model_asset(library, "weights")
+
+        assert fetched == ["DownloadModelRequest"], "a partial download must be refetched"
+        assert (target / ".griptape-nodes-complete").exists(), "a successful fetch must mark completion"
 
 
 class TestHonestFailures:

--- a/tests/unit/retained_mode/managers/test_node_manager_strict_mode.py
+++ b/tests/unit/retained_mode/managers/test_node_manager_strict_mode.py
@@ -69,6 +69,9 @@ class TestExecuteNodeStrictMode:
         m.is_worker = is_worker
         m._is_worker = is_worker
         m.get_worker_for_library.return_value = None
+        # Awaited on the orchestrator route before a node is routed, so it has to be a coroutine
+        # rather than a plain MagicMock attribute.
+        m.wait_for_worker_library_load = AsyncMock(return_value=None)
         return m
 
     @pytest.mark.asyncio

--- a/tests/unit/servers/test_static.py
+++ b/tests/unit/servers/test_static.py
@@ -56,12 +56,17 @@ class TestWorkspaceStaticFiles:
     """Test that WorkspaceStaticFiles resolves the served directory live, per request."""
 
     def _patch_workspace(self, workspace: Path) -> AbstractContextManager[MagicMock]:
-        """Patch ConfigManager().workspace_path to return the given directory."""
+        """Point the served workspace at the given directory.
+
+        Patches the ambient engine lookup rather than the GriptapeNodes facade: this module reads
+        its managers off the engine, because the facade's worker guard keys off a process-wide
+        in-node-execution refcount and would raise on uvicorn's thread while any node ran.
+        """
         config_manager = MagicMock()
         config_manager.workspace_path = workspace
-        griptape_nodes = MagicMock()
-        griptape_nodes.ConfigManager.return_value = config_manager
-        return patch("griptape_nodes.servers.static.GriptapeNodes", griptape_nodes)
+        engine = MagicMock()
+        engine.config_manager = config_manager
+        return patch("griptape_nodes.servers.static.current_engine", return_value=engine)
 
     def test_lookup_follows_workspace_change(self, tmp_path: Path) -> None:
         """A file written under the new workspace resolves after the workspace changes at runtime."""

--- a/tests/unit/utils/test_async_utils.py
+++ b/tests/unit/utils/test_async_utils.py
@@ -1,0 +1,54 @@
+"""Tests for `call_function`, the dispatcher every registered callback goes through."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from griptape_nodes.utils.async_utils import call_function
+
+INPUT = 21
+DOUBLED = 42
+
+
+class TestCallFunction:
+    @pytest.mark.asyncio
+    async def test_calls_a_sync_function(self) -> None:
+        assert await call_function(lambda value: value * 2, INPUT) == DOUBLED
+
+    @pytest.mark.asyncio
+    async def test_awaits_an_async_function(self) -> None:
+        async def double(value: int) -> int:
+            return value * 2
+
+        assert await call_function(double, INPUT) == DOUBLED
+
+    @pytest.mark.asyncio
+    async def test_awaits_a_callable_object_with_an_async_call(self) -> None:
+        """The shape that broke every worker: a handler that is an instance, not a function.
+
+        `inspect.iscoroutinefunction` inspects the object rather than its `__call__`, so an
+        instance like this reads as synchronous. Returning its coroutine unawaited handed a
+        coroutine object onward as if it were the result, and the first attribute access on
+        the "result" failed far from the cause.
+        """
+
+        class Handler:
+            async def __call__(self, value: int) -> int:
+                return value * 2
+
+        assert await call_function(Handler(), INPUT) == DOUBLED
+
+    @pytest.mark.asyncio
+    async def test_passes_keyword_arguments_through(self) -> None:
+        def combine(first: str, *, second: str) -> str:
+            return first + second
+
+        assert await call_function(combine, "a", second="b") == "ab"
+
+    @pytest.mark.asyncio
+    async def test_a_sync_function_returning_a_plain_value_is_not_awaited(self) -> None:
+        """Only awaitables are awaited; ordinary values pass straight through."""
+        sentinel: dict[str, Any] = {"not": "awaitable"}
+        assert await call_function(lambda: sentinel) is sentinel


### PR DESCRIPTION
Stacked on #5456. A `main`-era defect in `request_client.py`, not something this stack introduced — but it is what made worker failures look lost, so it belongs with this series.

## The bug

The engine runs **two event loops**: the websocket transport on its own thread, and whichever loop is running a flow. `RequestClient` created each pending future with a bare `asyncio.Future()` — binding it to the *requesting* loop — then settled it with a bare `set_result` from the *transport* loop.

A future belongs to one loop. Settling it from another marks it done but schedules the waiting task's wakeup through `future._loop.call_soon`, which is **not threadsafe and does not wake a loop sitting in its selector**. The result sat in the owner loop's ready queue until something unrelated woke it.

All four terminal transitions had it — result, exception, and both cancel paths — so worker eviction was delayed the same way.

## Measured

Three-worker engine, library whose execution dependencies cannot resolve:

| | Time for the failure to surface |
|---|---|
| before | **33.1s** |
| after | **0.3s** |
| fix reverted | **33.1s** (identical) |

Reproduced with `workers/scripts/verify_multi_worker_failure_latency.py`. The pre-existing single-worker harness never crossed loops, which is why this went unnoticed.

## Why it hid

Raising `log_level` to DEBUG made it disappear — the extra log events woke the loop constantly. That is also why the tests assert **elapsed time** rather than the future's `done` flag: the flag was always set promptly. Reverted, they fail with `assert 20.002 < 2.0`, the waiter resuming at exactly its own timeout.

## Note for reviewers

`call_soon_threadsafe` is used unconditionally, including from the owning loop, so there is one path rather than a same-loop special case to keep in sync. The `done()` check moves inside the callback because it now runs later, on the other loop, where a cancellation may have landed first.