### PR TITLE
Wait out the writer instead of failing a status file read

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -99,7 +99,8 @@ class DownloadParams:
 
 _DOWNLOAD_PROGRESS_EMIT_INTERVAL = 1.0  # seconds between stdout progress events
 _PROGRESS_PIPE_ENV_VAR = "GRIPTAPE_NODES_PROGRESS_PIPE"  # set by parent to enable JSON stdout emission
-_STATUS_READ_ATTEMPTS = 5  # tries before giving up on a status file a writer is holding
+_STATUS_READ_LOCK_ATTEMPTS = 5  # tries before giving up on a status file a writer is holding
+_STATUS_READ_TORN_ATTEMPTS = 2  # a torn read clears on the next try; a file malformed on disk never does
 _STATUS_READ_RETRY_DELAY = 0.05  # seconds to wait out that writer between tries
 
 
@@ -237,20 +238,17 @@ def _load_status_file(status_file: Path) -> dict | None:
     """Read a download status file, waiting out a write in progress.
 
     Status files are written under an exclusive lock (`ModelManager._write_download_status`
-    -> `File.write_text` -> os_manager's portalocker write), and that write truncates the
-    file before it takes the lock. Windows byte-range locks are mandatory, so a reader that
-    lands inside the lock opens the file and then fails on the locked range with
-    `PermissionError: [Errno 13] Permission denied`; one that lands in the truncate window
-    sees an empty file instead. The lock is held per handle, so the writing process is no
-    more exempt than any other reader.
+    -> `File.write_text` -> os_manager's portalocker write) held across the write and the
+    fsync, and each platform fails a read inside that lock differently. Windows byte-range
+    locks are mandatory, so the reader opens the file and then fails on the locked range with
+    `PermissionError: [Errno 13] Permission denied`; the lock is per handle, so the writing
+    process is no more exempt than any other reader. POSIX `flock` is advisory, so the reader
+    is not stopped at all and parses the rewrite mid-flight instead -- portalocker truncates
+    under the lock rather than in `open`, so that read sees an empty or partial file.
 
-    griptape-ai/griptape-nodes-engine#5373 answered this for the startup scan by taking the
-    worker's reader away. This is the reader that has to stay: the editor asks what is
-    downloading while something is downloading. Both windows are milliseconds wide, but a
-    download rewrites its status file every second and again the moment it completes, so that
-    poll lands in them regularly -- reporting it is what turned a finished download into
-    "Failed to get download status: [Errno 13] Permission denied". Retrying reads the value
-    the writer was in the middle of committing instead.
+    A download rewrites its status file every second and again the moment it completes, so a
+    polling reader lands in these millisecond-wide windows regularly. Retrying reads the value
+    the writer was committing.
 
     Args:
         status_file: Path to the status file to read.
@@ -260,42 +258,71 @@ def _load_status_file(status_file: Path) -> dict | None:
             unreadable after every attempt, or does not hold a status record.
     """
     read_error: OSError | ValueError | None = None
+    # A budget per cause, spent only by the cause that failed: sharing one total would let a
+    # torn read spend the lock's tries. Either cause can happen on either platform, so
+    # neither budget is dead code.
+    lock_attempts = 0
+    torn_attempts = 0
 
-    for attempt in range(_STATUS_READ_ATTEMPTS):
+    while True:
         try:
             with status_file.open(encoding="utf-8") as f:
                 data = json.load(f)
         except FileNotFoundError:
             return None
-        # PermissionError is the held lock; the other two are a half-written file.
-        except (PermissionError, UnicodeDecodeError, json.JSONDecodeError) as e:
+        except PermissionError as e:
+            # Overwhelmingly the writer's lock, which clears as soon as its fsync returns.
+            # A permanently denied file (wrong owner, quarantined) spends the budget for
+            # nothing, which is the cheaper of the two ways to be wrong here.
             read_error = e
-            if attempt < _STATUS_READ_ATTEMPTS - 1:
-                time.sleep(_STATUS_READ_RETRY_DELAY)
+            lock_attempts += 1
+            exhausted = lock_attempts >= _STATUS_READ_LOCK_ATTEMPTS
+        except (UnicodeDecodeError, json.JSONDecodeError) as e:
+            # Indistinguishable here from a file malformed on disk, which no amount of
+            # waiting fixes, so this cause gets far fewer tries than the lock.
+            read_error = e
+            torn_attempts += 1
+            exhausted = torn_attempts >= _STATUS_READ_TORN_ATTEMPTS
         else:
             if not isinstance(data, dict):
                 logger.warning("Status file '%s' does not contain a download record; ignoring it", status_file)
                 return None
             return data
 
+        if exhausted:
+            break
+
+        time.sleep(_STATUS_READ_RETRY_DELAY)
+
     logger.warning(
-        "Could not read status file '%s' after %d attempts: %s", status_file, _STATUS_READ_ATTEMPTS, read_error
+        "Could not read status file '%s' after %d attempts: %s",
+        status_file,
+        lock_attempts + torn_attempts,
+        read_error,
     )
     return None
 
 
-def _build_download_status(data: dict) -> ModelDownloadStatus | None:
+def _build_download_status(data: dict, status_file: Path) -> ModelDownloadStatus | None:
     """Build a ModelDownloadStatus from the contents of a status file.
 
     Args:
         data: Parsed status file data.
+        status_file: Path the data came from, to name it when the data is unusable.
 
     Returns:
         ModelDownloadStatus | None: The status, or None if required fields are missing.
     """
-    missing_fields = [field for field in ("model_id", "status", "started_at", "updated_at") if field not in data]
+    # An empty value is as unusable as an absent key: `model_id` keys a row in the editor.
+    missing_fields = [field for field in ("model_id", "status", "started_at", "updated_at") if not data.get(field)]
     if missing_fields:
-        logger.warning("Skipping a download record missing required fields: %s", ", ".join(missing_fields))
+        # DEBUG, not WARNING: nothing prunes the status directory, so a single junk file
+        # would otherwise log once per poll of the download panel forever.
+        logger.debug(
+            "Skipping status file '%s' with missing or empty required fields: %s",
+            status_file,
+            ", ".join(missing_fields),
+        )
         return None
 
     # Get byte counts from status file
@@ -1098,7 +1125,7 @@ class ModelManager(EngineScoped):
         if data is None:
             return None
 
-        return _build_download_status(data)
+        return _build_download_status(data, status_file)
 
     def _list_all_download_statuses(self) -> list[ModelDownloadStatus]:
         """List all model download statuses from status files.
@@ -1113,14 +1140,13 @@ class ModelManager(EngineScoped):
 
         statuses = []
         for status_file in status_dir.glob("*.json"):
-            # Build from what this file holds rather than re-reading it through
-            # _read_model_download_status: the second read only doubles the odds of
-            # landing on a writer holding the lock.
+            # Build from this file's own contents; routing through _read_model_download_status
+            # would read every file twice and double the exposure to a writer's lock.
             data = _load_status_file(status_file)
             if data is None:
                 continue
 
-            status = _build_download_status(data)
+            status = _build_download_status(data, status_file)
             if status is not None:
                 statuses.append(status)
 

--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import sys
+import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -98,6 +99,8 @@ class DownloadParams:
 
 _DOWNLOAD_PROGRESS_EMIT_INTERVAL = 1.0  # seconds between stdout progress events
 _PROGRESS_PIPE_ENV_VAR = "GRIPTAPE_NODES_PROGRESS_PIPE"  # set by parent to enable JSON stdout emission
+_STATUS_READ_ATTEMPTS = 5  # tries before giving up on a status file a writer is holding
+_STATUS_READ_RETRY_DELAY = 0.05  # seconds to wait out that writer between tries
 
 
 def _create_progress_tracker(model_id: str) -> type[tqdm]:  # noqa: C901
@@ -228,6 +231,95 @@ def _create_progress_tracker(model_id: str) -> type[tqdm]:  # noqa: C901
             sys.stdout.flush()
 
     return BoundModelDownloadTracker
+
+
+def _load_status_file(status_file: Path) -> dict | None:
+    """Read a download status file, waiting out a write in progress.
+
+    Status files are written under an exclusive lock (`ModelManager._write_download_status`
+    -> `File.write_text` -> os_manager's portalocker write), and that write truncates the
+    file before it takes the lock. Windows byte-range locks are mandatory, so a reader that
+    lands inside the lock opens the file and then fails on the locked range with
+    `PermissionError: [Errno 13] Permission denied`; one that lands in the truncate window
+    sees an empty file instead. The lock is held per handle, so the writing process is no
+    more exempt than any other reader.
+
+    griptape-ai/griptape-nodes-engine#5373 answered this for the startup scan by taking the
+    worker's reader away. This is the reader that has to stay: the editor asks what is
+    downloading while something is downloading. Both windows are milliseconds wide, but a
+    download rewrites its status file every second and again the moment it completes, so that
+    poll lands in them regularly -- reporting it is what turned a finished download into
+    "Failed to get download status: [Errno 13] Permission denied". Retrying reads the value
+    the writer was in the middle of committing instead.
+
+    Args:
+        status_file: Path to the status file to read.
+
+    Returns:
+        dict | None: The parsed status data, or None if the file is missing, is still
+            unreadable after every attempt, or does not hold a status record.
+    """
+    read_error: OSError | ValueError | None = None
+
+    for attempt in range(_STATUS_READ_ATTEMPTS):
+        try:
+            with status_file.open(encoding="utf-8") as f:
+                data = json.load(f)
+        except FileNotFoundError:
+            return None
+        # PermissionError is the held lock; the other two are a half-written file.
+        except (PermissionError, UnicodeDecodeError, json.JSONDecodeError) as e:
+            read_error = e
+            if attempt < _STATUS_READ_ATTEMPTS - 1:
+                time.sleep(_STATUS_READ_RETRY_DELAY)
+        else:
+            if not isinstance(data, dict):
+                logger.warning("Status file '%s' does not contain a download record; ignoring it", status_file)
+                return None
+            return data
+
+    logger.warning(
+        "Could not read status file '%s' after %d attempts: %s", status_file, _STATUS_READ_ATTEMPTS, read_error
+    )
+    return None
+
+
+def _build_download_status(data: dict) -> ModelDownloadStatus | None:
+    """Build a ModelDownloadStatus from the contents of a status file.
+
+    Args:
+        data: Parsed status file data.
+
+    Returns:
+        ModelDownloadStatus | None: The status, or None if required fields are missing.
+    """
+    missing_fields = [field for field in ("model_id", "status", "started_at", "updated_at") if field not in data]
+    if missing_fields:
+        logger.warning("Skipping a download record missing required fields: %s", ", ".join(missing_fields))
+        return None
+
+    # Get byte counts from status file
+    total_bytes = data.get("total_bytes", 0)
+    downloaded_bytes = data.get("downloaded_bytes", 0)
+
+    # For simplified tracking, failed_bytes is calculated
+    failed_bytes = 0
+    if data["status"] == "failed":
+        failed_bytes = total_bytes - downloaded_bytes
+
+    return ModelDownloadStatus(
+        model_id=data["model_id"],
+        status=data["status"],
+        started_at=data["started_at"],
+        updated_at=data["updated_at"],
+        total_bytes=total_bytes,
+        completed_bytes=downloaded_bytes,
+        failed_bytes=failed_bytes,
+        completed_at=data.get("completed_at"),
+        local_path=data.get("local_path"),
+        failed_at=data.get("failed_at"),
+        error_message=data.get("error_message"),
+    )
 
 
 class ModelManager(EngineScoped):
@@ -1002,39 +1094,11 @@ class ModelManager(EngineScoped):
         """
         status_file = self._get_status_file_path(model_id)
 
-        if not status_file.exists():
+        data = _load_status_file(status_file)
+        if data is None:
             return None
 
-        try:
-            with status_file.open(encoding="utf-8") as f:
-                data = json.load(f)
-
-            # Get byte counts from status file
-            total_bytes = data.get("total_bytes", 0)
-            downloaded_bytes = data.get("downloaded_bytes", 0)
-
-            # For simplified tracking, failed_bytes is calculated
-            failed_bytes = 0
-            if data.get("status") == "failed":
-                failed_bytes = total_bytes - downloaded_bytes
-
-            return ModelDownloadStatus(
-                model_id=data["model_id"],
-                status=data["status"],
-                started_at=data["started_at"],
-                updated_at=data["updated_at"],
-                total_bytes=total_bytes,
-                completed_bytes=downloaded_bytes,
-                failed_bytes=failed_bytes,
-                completed_at=data.get("completed_at"),
-                local_path=data.get("local_path"),
-                failed_at=data.get("failed_at"),
-                error_message=data.get("error_message"),
-            )
-
-        except (json.JSONDecodeError, KeyError) as e:
-            logger.warning("Failed to read status file for model '%s': %s", model_id, e)
-            return None
+        return _build_download_status(data)
 
     def _list_all_download_statuses(self) -> list[ModelDownloadStatus]:
         """List all model download statuses from status files.
@@ -1049,19 +1113,16 @@ class ModelManager(EngineScoped):
 
         statuses = []
         for status_file in status_dir.glob("*.json"):
-            try:
-                with status_file.open(encoding="utf-8") as f:
-                    data = json.load(f)
-
-                model_id = data.get("model_id", "")
-                if model_id:
-                    status = self._read_model_download_status(model_id)
-                    if status:
-                        statuses.append(status)
-
-            except (json.JSONDecodeError, KeyError) as e:
-                logger.warning("Failed to read status file '%s': %s", status_file, e)
+            # Build from what this file holds rather than re-reading it through
+            # _read_model_download_status: the second read only doubles the odds of
+            # landing on a writer holding the lock.
+            data = _load_status_file(status_file)
+            if data is None:
                 continue
+
+            status = _build_download_status(data)
+            if status is not None:
+                statuses.append(status)
 
         return statuses
 
@@ -1078,19 +1139,15 @@ class ModelManager(EngineScoped):
 
         unfinished_models = []
         for status_file in status_dir.glob("*.json"):
-            try:
-                with status_file.open(encoding="utf-8") as f:
-                    data = json.load(f)
-
-                status = data.get("status", "")
-                model_id = data.get("model_id", "")
-
-                if model_id and status in ("downloading", "failed"):
-                    unfinished_models.append(model_id)
-
-            except (json.JSONDecodeError, KeyError) as e:
-                logger.warning("Failed to read status file '%s': %s", status_file, e)
+            data = _load_status_file(status_file)
+            if data is None:
                 continue
+
+            status = data.get("status", "")
+            model_id = data.get("model_id", "")
+
+            if model_id and status in ("downloading", "failed"):
+                unfinished_models.append(model_id)
 
         return unfinished_models
 

--- a/tests/unit/retained_mode/managers/test_model_manager.py
+++ b/tests/unit/retained_mode/managers/test_model_manager.py
@@ -38,7 +38,13 @@ from griptape_nodes.retained_mode.events.model_events import (
     SearchModelsResultSuccess,
 )
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
-from griptape_nodes.retained_mode.managers.model_manager import DownloadParams, ModelManager, _load_status_file
+from griptape_nodes.retained_mode.managers.model_manager import (
+    _STATUS_READ_LOCK_ATTEMPTS,
+    _STATUS_READ_TORN_ATTEMPTS,
+    DownloadParams,
+    ModelManager,
+    _load_status_file,
+)
 
 
 @pytest.fixture
@@ -566,11 +572,7 @@ _COMPLETED_RECORD = {
 class TestStatusFileReadsSurviveConcurrentWrites:
     """A status file mid-write must not turn a poll into a reported failure.
 
-    The collision `TestAppInitializationCompleteWorkerGuard` describes
-    (griptape-ai/griptape-nodes-engine#5373), reached through the reader that guard could not
-    remove: the terminal `"completed"` write holds the lock while the editor polls for
-    progress, so the handler reported `PermissionError: [Errno 13] Permission denied` on the
-    line after "Successfully downloaded model".
+    The terminal `"completed"` write holds the lock while the editor polls for progress.
     """
 
     @pytest.fixture
@@ -597,7 +599,7 @@ class TestStatusFileReadsSurviveConcurrentWrites:
         assert data == _COMPLETED_RECORD
 
     def test_retries_past_a_half_written_file(self, status_file: Path) -> None:
-        # The write truncates before it locks, so a reader can see zero bytes.
+        # Advisory flock does not stop the reader, so it can see the rewrite at zero bytes.
         real_open = Path.open
         attempts = []
 
@@ -615,22 +617,44 @@ class TestStatusFileReadsSurviveConcurrentWrites:
         assert data == _COMPLETED_RECORD
 
     def test_a_file_that_never_frees_up_is_dropped_not_raised(self, status_file: Path) -> None:
-        with patch.object(Path, "open", side_effect=PermissionError(13, "Permission denied")):
+        with patch.object(Path, "open", side_effect=PermissionError(13, "Permission denied")) as locked_open:
             assert _load_status_file(status_file) is None
+
+        assert locked_open.call_count == _STATUS_READ_LOCK_ATTEMPTS
+
+    def test_a_permanently_malformed_file_does_not_pay_the_lock_budget(self, status_file: Path) -> None:
+        # Nothing distinguishes this from a torn read, and a poll cannot afford to wait on
+        # every corrupt file in the directory once per second.
+        status_file.write_text("{ truncated", encoding="utf-8")
+        real_open = Path.open
+        attempts = []
+
+        def count_attempts(self_path: Path, *args: Any, **kwargs: Any) -> Any:
+            attempts.append(self_path)
+            return real_open(self_path, *args, **kwargs)
+
+        with patch.object(Path, "open", count_attempts):
+            assert _load_status_file(status_file) is None
+
+        assert len(attempts) == _STATUS_READ_TORN_ATTEMPTS
 
     def test_missing_file_reads_as_no_status(self, tmp_path: Path) -> None:
         assert _load_status_file(tmp_path / "never-downloaded.json") is None
 
-    @pytest.mark.skipif(sys.platform != "win32", reason="only Windows fails a read inside another handle's lock")
-    def test_a_real_exclusive_lock_is_contained(self, status_file: Path) -> None:
-        # The lock os_manager takes for every status file write.
+    def test_a_real_write_lock_is_contained(self, status_file: Path) -> None:
+        # The lock os_manager takes for every status file write, mode included: `"w"` is what
+        # makes portalocker truncate under the lock, which is the window a POSIX reader sees.
         with portalocker.Lock(
             str(status_file),
-            mode="r+",
+            mode="w",
             timeout=0,
             flags=portalocker.LockFlags.EXCLUSIVE | portalocker.LockFlags.NON_BLOCKING,
         ):
+            # Windows fails the read on the locked range; POSIX reads the truncated file.
             assert _load_status_file(status_file) is None
+
+        status_file.write_text(json.dumps(_COMPLETED_RECORD), encoding="utf-8")
+        assert _load_status_file(status_file) == _COMPLETED_RECORD
 
     @pytest.mark.asyncio
     async def test_list_downloads_still_succeeds_when_a_read_fails(

--- a/tests/unit/retained_mode/managers/test_model_manager.py
+++ b/tests/unit/retained_mode/managers/test_model_manager.py
@@ -5,13 +5,19 @@ Covers:
 - `on_handle_search_models_request` — search result handling
 - `on_handle_declare_model_invocation_request` — clears a declared invocation past the pre-dispatch chain
 - `_download_model_task` — the spawned subprocess targets a runnable module
+- `_load_status_file` — status file reads survive a concurrent status file write
 """
 
 import importlib.util
+import io
+import json
 import sys
+from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
+import portalocker
 import pytest
 
 from griptape_nodes.exe_types.node_types import BaseNode
@@ -25,12 +31,14 @@ from griptape_nodes.retained_mode.events.model_events import (
     GetModelInfoRequest,
     GetModelInfoResultFailure,
     GetModelInfoResultSuccess,
+    ListModelDownloadsRequest,
+    ListModelDownloadsResultSuccess,
     SearchModelsRequest,
     SearchModelsResultFailure,
     SearchModelsResultSuccess,
 )
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
-from griptape_nodes.retained_mode.managers.model_manager import DownloadParams, ModelManager
+from griptape_nodes.retained_mode.managers.model_manager import DownloadParams, ModelManager, _load_status_file
 
 
 @pytest.fixture
@@ -536,6 +544,116 @@ class TestDownloadModelTaskSubprocess:
 
         assert captured_cmd[3] == "download"
         assert "org/model" in captured_cmd
+
+
+# ---------------------------------------------------------------------------
+# _load_status_file — reads that land on a status file being written
+# ---------------------------------------------------------------------------
+
+
+_COMPLETED_RECORD = {
+    "model_id": "depth-anything/DA3-SMALL",
+    "status": "completed",
+    "started_at": "2026-09-03T11:12:30+00:00",
+    "updated_at": "2026-09-03T11:13:02+00:00",
+    "completed_at": "2026-09-03T11:13:02+00:00",
+    "total_bytes": 100,
+    "downloaded_bytes": 100,
+    "progress_percent": 100.0,
+}
+
+
+class TestStatusFileReadsSurviveConcurrentWrites:
+    """A status file mid-write must not turn a poll into a reported failure.
+
+    The collision `TestAppInitializationCompleteWorkerGuard` describes
+    (griptape-ai/griptape-nodes-engine#5373), reached through the reader that guard could not
+    remove: the terminal `"completed"` write holds the lock while the editor polls for
+    progress, so the handler reported `PermissionError: [Errno 13] Permission denied` on the
+    line after "Successfully downloaded model".
+    """
+
+    @pytest.fixture
+    def status_file(self, tmp_path: Path) -> Path:
+        path = tmp_path / "depth-anything--DA3-SMALL.json"
+        path.write_text(json.dumps(_COMPLETED_RECORD), encoding="utf-8")
+        return path
+
+    def test_retries_past_a_locked_file(self, status_file: Path) -> None:
+        real_open = Path.open
+        attempts = []
+
+        def open_locked_once(self_path: Path, *args: Any, **kwargs: Any) -> Any:
+            attempts.append(self_path)
+            if len(attempts) == 1:
+                raise PermissionError(13, "Permission denied")
+            return real_open(self_path, *args, **kwargs)
+
+        with patch.object(Path, "open", open_locked_once):
+            data = _load_status_file(status_file)
+
+        # The failed read plus the retry that got the value.
+        assert attempts == [status_file, status_file]
+        assert data == _COMPLETED_RECORD
+
+    def test_retries_past_a_half_written_file(self, status_file: Path) -> None:
+        # The write truncates before it locks, so a reader can see zero bytes.
+        real_open = Path.open
+        attempts = []
+
+        def open_truncated_once(self_path: Path, *args: Any, **kwargs: Any) -> Any:
+            attempts.append(self_path)
+            if len(attempts) == 1:
+                return io.StringIO("")
+            return real_open(self_path, *args, **kwargs)
+
+        with patch.object(Path, "open", open_truncated_once):
+            data = _load_status_file(status_file)
+
+        # The failed read plus the retry that got the value.
+        assert attempts == [status_file, status_file]
+        assert data == _COMPLETED_RECORD
+
+    def test_a_file_that_never_frees_up_is_dropped_not_raised(self, status_file: Path) -> None:
+        with patch.object(Path, "open", side_effect=PermissionError(13, "Permission denied")):
+            assert _load_status_file(status_file) is None
+
+    def test_missing_file_reads_as_no_status(self, tmp_path: Path) -> None:
+        assert _load_status_file(tmp_path / "never-downloaded.json") is None
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="only Windows fails a read inside another handle's lock")
+    def test_a_real_exclusive_lock_is_contained(self, status_file: Path) -> None:
+        # The lock os_manager takes for every status file write.
+        with portalocker.Lock(
+            str(status_file),
+            mode="r+",
+            timeout=0,
+            flags=portalocker.LockFlags.EXCLUSIVE | portalocker.LockFlags.NON_BLOCKING,
+        ):
+            assert _load_status_file(status_file) is None
+
+    @pytest.mark.asyncio
+    async def test_list_downloads_still_succeeds_when_a_read_fails(
+        self, model_manager: ModelManager, status_file: Path
+    ) -> None:
+        with (
+            patch.object(model_manager, "_get_status_directory", return_value=status_file.parent),
+            patch.object(Path, "open", side_effect=PermissionError(13, "Permission denied")),
+        ):
+            result = await model_manager.on_handle_list_model_downloads_request(ListModelDownloadsRequest())
+
+        # An unreadable record drops out of the list; it does not fail the request.
+        assert isinstance(result, ListModelDownloadsResultSuccess)
+        assert result.downloads == []
+
+    @pytest.mark.asyncio
+    async def test_list_downloads_reads_a_settled_file(self, model_manager: ModelManager, status_file: Path) -> None:
+        with patch.object(model_manager, "_get_status_directory", return_value=status_file.parent):
+            result = await model_manager.on_handle_list_model_downloads_request(ListModelDownloadsRequest())
+
+        assert isinstance(result, ListModelDownloadsResultSuccess)
+        assert [download.model_id for download in result.downloads] == ["depth-anything/DA3-SMALL"]
+        assert result.downloads[0].status == "completed"
 
 
 class TestAppInitializationCompleteWorkerGuard:


### PR DESCRIPTION
A finished model download reports an error on Windows:

```
[11:13:02] INFO     Successfully downloaded model 'depth-anything/DA3-SMALL'
           ERROR    Failed to get download status: [Errno 13] Permission denied
```

Both lines are the same event, and neither the download nor the poll was wrong.

## What was happening

The collision #5373 diagnosed, reached through a different reader. Every status file write takes an exclusive lock (`_write_download_status` -> `File.write_text` -> os_manager's portalocker write) and holds it across the write and the `fsync`. The terminal `"completed"` write lands exactly when the editor's download panel polls `ListModelDownloadsRequest`.

The read side was a plain `open()` + `json.load()` whose only handler was `(json.JSONDecodeError, KeyError)`. Windows byte-range locks are mandatory, so the reader opens the file and then fails on the locked range — `PermissionError` escaped the read, hit the handler's broad `except Exception`, and became an ERROR-level failure payload.

Two details worth having on the record:

- It is not a cross-process problem. The lock is held per handle, so the writing process cannot read the locked region through a second handle either.
- The bare `[Errno 13] Permission denied` with no path in it is the tell that the failure came from `read()`, not `open()` — the same signature as the traceback in #5373. Reproduced directly:

  ```
  reader raised: PermissionError errno= 13 winerror= None
  str(e) = '[Errno 13] Permission denied'
  ```

## Relationship to #5373 and #5374

#5373 answered this for the startup scan by taking the worker's reader away, and that stands — nothing here re-enables it, and its `TestAppInitializationCompleteWorkerGuard` tests are untouched and still pass. #5374 then kept one listener's failure from taking its siblings down.

This is the reader that cannot be taken away: the editor asks what is downloading while something is downloading. So it has to survive the lock rather than avoid it.

## The fix

`_load_status_file` retries five times, 50 ms apart. The lock is held for milliseconds, so the retry reads the value the writer was in the middle of committing. A file that never frees up drops out of the list with a warning instead of failing the request — a status record is progress metadata, and losing one from a poll costs less than turning that poll into an error an artist has to interpret.

The same retry covers a second window: portalocker opens with mode `"w"`, so it truncates before it locks, and a reader can catch the file at zero bytes and conclude there is no such download.

All three readers go through the helper, with record construction factored into `_build_download_status`. That removed a double read in `_list_all_download_statuses`, which opened each file for its `model_id` and then re-opened it through `_read_model_download_status` — two chances to land on the lock per record.

## Testing

- 7 new tests, including one that takes a real portalocker exclusive lock and one asserting `ListModelDownloads` returns success rather than an error when a read fails. Advisory `flock` makes this inert on Linux and macOS, so the real-lock test is Windows-only; the retry and half-written paths are covered portably.
- `tests/unit/retained_mode/managers/test_model_manager.py`: 24 passed, 0 skipped (on Windows), including #5373's worker-guard tests.
- `tests/unit/retained_mode/managers` + `tests/unit/exe_types/param_components`: 2239 passed, 80 skipped.
- `ruff format --check`, `ruff check`, `typos`: clean.
- `pyright` was not run locally (no node on the dev machine), so CI is the check for types.
