### PR TITLE
Fix UnicodeEncodeError in gtn config list on cp1252 consoles

### DIFF
--- a/src/griptape_nodes/cli/commands/config.py
+++ b/src/griptape_nodes/cli/commands/config.py
@@ -60,8 +60,10 @@ def _print_user_config(config_path: str | None = None) -> None:
 def _list_user_configs() -> None:
     """Lists user configuration files in ascending precedence."""
     num_config_files = len(config_manager.config_files)
+    # ASCII arrow only: "\u27f6" raises UnicodeEncodeError on consoles whose
+    # stdout encoding is cp1252 (see issue #5470).
     console.print(
-        f"[bold]User Configuration Files (lowest precedence (1.) ⟶ highest precedence ({num_config_files}.)):[/bold]"
+        f"[bold]User Configuration Files (lowest precedence (1.) -> highest precedence ({num_config_files}.)):[/bold]"
     )
     for idx, config in enumerate(config_manager.config_files):
         console.print(f"[green]{idx + 1}. {config}[/green]")

--- a/tests/unit/cli/commands/test_config.py
+++ b/tests/unit/cli/commands/test_config.py
@@ -1,0 +1,29 @@
+"""Unit tests for the config CLI command."""
+
+import io
+
+import pytest
+from rich.console import Console
+
+from griptape_nodes.cli.commands import config as config_command
+
+
+class TestListUserConfigs:
+    def test_lists_user_configs_on_cp1252_stdout(self, monkeypatch):
+        """Regression test for issue #5470.
+
+        `gtn config list` used to raise UnicodeEncodeError on Windows consoles
+        whose stdout encoding is the legacy cp1252 code page, because the
+        header contained the U+27F6 (long rightwards arrow) character.
+        """
+        cp1252_console = Console(
+            file=io.TextIOWrapper(io.BytesIO(), encoding="cp1252", errors="strict"),
+            force_terminal=False,
+        )
+        monkeypatch.setattr(config_command, "console", cp1252_console)
+
+        config_command._list_user_configs()  # must not raise UnicodeEncodeError
+
+        output = cp1252_console.file.buffer.getvalue().decode("cp1252")
+        assert "User Configuration Files" in output
+        assert "highest precedence" in output


### PR DESCRIPTION
## Summary

Fixes #5470.

`gtn config list` printed its header containing U+27F6 (`⟶`, long rightwards
arrow) and then crashed with `UnicodeEncodeError: 'charmap' codec can't encode
character '\u27f6'` on any Windows console/pipe whose stdout encoding is the
legacy cp1252 code page. This replaces that one character with the ASCII arrow
`->`, so the command works on every console.

## Changes

- `src/griptape_nodes/cli/commands/config.py`: `⟶` -> `->` in the
  `_list_user_configs()` header, plus a comment explaining why the character
  must stay ASCII
- `tests/unit/cli/commands/test_config.py` (new): regression test that swaps
  the shared console for one writing through a strict-cp1252 `BytesIO` wrapper
  and asserts `_list_user_configs()` completes without raising

## Test evidence

Windows, Python 3.12.13, pytest 9.1.1.

Before (upstream code with the regression test applied, via `git stash`):

```
C:\...\Lib\encodings\cp1252.py:19: UnicodeEncodeError
FAILED tests/unit/cli/commands/test_config.py::TestListUserConfigs::test_lists_user_configs_on_cp1252_stdout
======================== 1 failed, 1 warning in 13.89s ========================
```

End-to-end repro on upstream code (cp1252 stdout):

```
UnicodeEncodeError: 'charmap' codec can't encode character '\u27f6' in position 1: character maps to <undefined>
```

After:

```
tests/unit/cli/commands/test_config.py::TestListUserConfigs::test_lists_user_configs_on_cp1252_stdout PASSED
======================== 1 passed, 1 warning in 7.25s =========================
```

`pytest tests/unit/cli -q`: main baseline `4 failed, 15 passed` vs this branch
`4 failed, 16 passed` — the 4 failures are pre-existing network-dependent
doctor/websocket tests, unrelated to this change; no regressions.

Note: `src/griptape_nodes/cli/commands/libraries.py` lines 53/56 use `✓`/`→`/`✗`,
which have the same cp1252 failure mode. Left out of this PR to keep it scoped
to the reported command; happy to follow up.
