### PR TITLE
fix(deps): raise pydantic-ai-slim floor to fix mcp 2.x / RequestContext import break

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,14 @@ dependencies = [
   "truststore>=0.10.1",
   "cattrs>=26.1.0",
   "fileseq>=3.2.0",
-  "pydantic-ai-slim[mcp,openai]>=1.95.1",
+  # Floor at 2.29.0: that release ("Support FastMCP 4 and MCP SDK v2 in `MCPToolset` alongside
+  # FastMCP 3", pydantic/pydantic-ai#6738) is the first where the `[mcp]` extra's `fastmcp-slim`
+  # floor supports the mcp 2.x module layout our own `mcp>=2.0,<3` pin (above) resolves to.
+  # Below this, `pydantic_ai/mcp.py` imports symbols (e.g. `mcp.shared.context.RequestContext`)
+  # that mcp 2.x moved/renamed, so `agent_manager` fails to import at construction time.
+  # PR #5449 raised the `mcp` ceiling without checking this; PR #5493 papered over the fallout
+  # for pydantic-ai-skills but left this one. Lift no lower than this floor.
+  "pydantic-ai-slim[mcp,openai]>=2.29.0",
   # Ceiling below 2.0: that release removes the exclude_tools and auto_reload arguments
   # agents/pydantic_ai/runner.py passes to SkillsCapability, so an unbounded resolve breaks
   # the sidebar agent at construction time (see issue 5491). Lift once the call site is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes-engine"
-version = "0.100.0"
+version = "0.100.2"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12.0, <3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -673,7 +673,7 @@ requires-dist = [
     { name = "portalocker", specifier = ">=2.10.0" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "pydantic-ai-skills", specifier = ">=0.11.0,<2" },
-    { name = "pydantic-ai-slim", extras = ["mcp", "openai"], specifier = ">=1.95.1" },
+    { name = "pydantic-ai-slim", extras = ["mcp", "openai"], specifier = ">=2.29.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "rich", specifier = ">=14.1.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "griptape-nodes-engine"
-version = "0.100.0"
+version = "0.100.2"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## What broke

v0.100.1 shipped two dependency-affecting changes that don't compose:

1. #5449 (\"deps: migrate MCP server to the mcp 2.x API\") raised our own `mcp` pin from `mcp>=1.10.1,<2` to `mcp>=2.0,<3` to migrate `servers/mcp.py` to mcp 2.x's constructor-registered handler API. In doing so it removed a pre-existing comment that flagged exactly this hazard (`pydantic-ai-slim` reaches `mcp` through `fastmcp-slim[client]`, and every `fastmcp-slim` release under its then-cap required `mcp<2.0`) — without checking whether `pydantic-ai-slim` actually supported `mcp>=2.0` yet.
2. #5493 (\"cap pydantic-ai-skills below 2.0\") fixed an unrelated sidebar-agent break, but didn't touch the `mcp`/`pydantic-ai-slim` combination.

Our `pydantic-ai-slim[mcp,openai]` floor was left at `>=1.95.1`. Below `pydantic-ai-slim` 2.29.0, its `[mcp]` extra pulls a `fastmcp-slim` version that only supports the mcp SDK v1 module layout, so `pydantic_ai/mcp.py` imports symbols mcp 2.x moved/renamed (e.g. `from mcp.shared.context import RequestContext`). When a resolve lands on `mcp>=2.0` (our pin) with a `pydantic-ai-slim` below 2.29.0, that import fails:

```
ImportError: cannot import name 'RequestContext' from 'mcp.shared.context'
```

This cascades: `griptape_nodes.agents.pydantic_ai.mcp_servers` and `griptape_nodes.retained_mode.managers.agent_manager` fail to import, so `Engine()` construction blows up. Downstream consumers pinning `griptape-nodes-engine>=0.100.1` (e.g. `griptape-nodes-app`) hit this in unit tests.

I confirmed the incompatibility directly with an isolated resolve:

```
$ uv pip install "mcp>=2.0,<3" "pydantic-ai-slim[mcp,openai]==1.95.1"
  × No solution found when resolving dependencies:
  ╰─▶ Because pydantic-ai-slim[mcp]==1.95.1 depends on mcp>=1.25.0,<2.0 and
      you require mcp>=2.0,<3, we can conclude that your requirements and
      pydantic-ai-slim[mcp]==1.95.1 are incompatible.
```

So the `>=1.95.1` floor never actually described a version that works together with our own `mcp>=2.0,<3` pin — it was stale from before #5449.

## The fix

Raise the `pydantic-ai-slim[mcp,openai]` floor to `>=2.29.0` — the first pydantic-ai release with [\"Support FastMCP 4 and MCP SDK v2 in `MCPToolset` alongside FastMCP 3\"](https://github.com/pydantic/pydantic-ai/pull/6738), i.e. the first version whose `[mcp]` extra's `fastmcp-slim` floor actually supports the mcp 2.x module layout our own pin resolves to.

This is a floor-only change and does not alter what currently resolves: `uv.lock` on `main` already resolves `pydantic-ai-slim` to 2.37.0 / `mcp` to 2.1.1 / `fastmcp-slim` to 4.0.0, all `make check` / unit tests pass with that combination today. This PR just makes that the guaranteed minimum instead of an incidental outcome of "highest wins" resolution, so a downstream resolve (a different resolution strategy, a partially-refreshed lock, `pip`'s `only-if-needed` upgrade strategy, etc.) can't land on the broken combination.

I considered the fallback of re-capping `mcp<2.0` (reverting the dependency-constraint part of #5449), but `servers/mcp.py`'s changes from #5449 use mcp 2.x-only APIs at runtime (`on_list_tools`/`on_call_tool` constructor-registered handlers, `mcp.server.context.ServerRequestContext`), so that isn't a safe option without also reverting the server code — the mcp 2.x pin has to stay, and pydantic-ai-slim has to catch up to it instead.

## Version bump

This repo's `version-check.yml` blocks PRs into `main` unless `main`'s version is strictly ahead of the latest published release. `main` was still at `0.100.0` while `v0.100.1` is already published, and `make version/patch` would collide with that tag, so the second commit sets the version explicitly to `0.100.2` via `make version/set v=0.100.2` (kept separate from the dependency fix commit).

## Validation

- `make check` — format, lint, types, spell all pass.
- `make test/unit` — 5844 passed, 23 skipped, 14 xfailed, 0 failed.
- Targeted: `tests/unit/servers/test_mcp.py` and `tests/unit/agents/**` (84 tests) all pass.
- Confirmed the actual import chain that was broken downstream now works:
  ```
  uv run python -c "
  import griptape_nodes
  from griptape_nodes.agents.pydantic_ai import mcp_servers
  from griptape_nodes.retained_mode.managers.agent_manager import AgentManager
  "
  ```

Refs #5449, #5493.