### PR TITLE
chore: bump v0.100.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes-engine"
-version = "0.100.2"
+version = "0.100.3"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12.0, <3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "griptape-nodes-engine"
-version = "0.100.2"
+version = "0.100.3"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
Advances `main` past the last release. `v0.100.2` was tagged directly off `main` (via `make version/set`, following #5499) rather than from a `release/vX.Y` branch, so `version-bump-next-on-release.yml` correctly skipped it (it only bumps main for `.0` tags), leaving main's version equal to the latest release and `version-check.yml` failing on every other PR (e.g. #5500).

Same manual fix used previously for this scenario (#4685, #4695, #4699 — the `v0.85.1`-`v0.85.3` sequence): a plain version bump, no tag/release.