### PR TITLE
chore: bump v0.101.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "griptape-nodes-engine"
-version = "0.100.3"
+version = "0.101.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12.0, <3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "griptape-nodes-engine"
-version = "0.100.3"
+version = "0.101.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
post-release bumps should always be [a minor version on main](https://github.com/griptape-ai/griptape-nodes-engine/blob/main/CONTRIBUTING.md#regular-releases-from-main)