### PR TITLE
deps: migrate the skills capability to pydantic-ai-skills 2.x

### DIFF
--- a/docs/guides/agent/skills.md
+++ b/docs/guides/agent/skills.md
@@ -6,21 +6,23 @@ Griptape Nodes ships with a built-in skill for building and running workflows. Y
 
 ## Where to put skills
 
-Create a `.agents/skills/` folder inside your workspace directory and drop skill files in there:
+Create a `.agents/skills/` folder inside your workspace directory and give each skill its own folder with a `SKILL.md` inside:
 
 ```
 <workspace_directory>/
 └── .agents/
     └── skills/
-        ├── my-skill.md
-        └── another-skill.md
+        ├── my-skill/
+        │   └── SKILL.md
+        └── another-skill/
+            └── SKILL.md
 ```
 
 The default workspace directory is `GriptapeNodes/` inside wherever you launched the engine. You can find the exact path in **Settings → File System → Workspace Directory**.
 
 ## Skill file format
 
-Each skill is a markdown file with a YAML frontmatter block:
+Each `SKILL.md` is a markdown file with a YAML frontmatter block:
 
 ```markdown
 ---
@@ -35,7 +37,7 @@ when this skill is relevant. Write in plain English — the agent reads this as
 part of its context.
 ```
 
-The `name` and `description` fields tell the agent what the skill is for and when to use it. The body can be as long or short as you need — code snippets, step-by-step instructions, reference tables, etc.
+The `name` must match the skill's folder name, and `description` tells the agent when to use the skill. The body can be as long or short as you need — code snippets, step-by-step instructions, reference tables, etc.
 
 ## Example: a house style guide
 
@@ -57,7 +59,7 @@ description: Apply our house style when drafting or editing text.
 
 !!! tip
 
-    Skills are picked up automatically — no engine restart needed. Drop a new `.md` file into `.agents/skills/`, and the very next message you send will use it.
+    Skills are picked up automatically — no engine restart needed. Add a new skill folder under `.agents/skills/`, and the very next message you send will use it.
 
 ## Related
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,19 +40,8 @@ dependencies = [
   "truststore>=0.10.1",
   "cattrs>=26.1.0",
   "fileseq>=3.2.0",
-  # Floor at 2.29.0: that release ("Support FastMCP 4 and MCP SDK v2 in `MCPToolset` alongside
-  # FastMCP 3", pydantic/pydantic-ai#6738) is the first where the `[mcp]` extra's `fastmcp-slim`
-  # floor supports the mcp 2.x module layout our own `mcp>=2.0,<3` pin (above) resolves to.
-  # Below this, `pydantic_ai/mcp.py` imports symbols (e.g. `mcp.shared.context.RequestContext`)
-  # that mcp 2.x moved/renamed, so `agent_manager` fails to import at construction time.
-  # PR #5449 raised the `mcp` ceiling without checking this; PR #5493 papered over the fallout
-  # for pydantic-ai-skills but left this one. Lift no lower than this floor.
   "pydantic-ai-slim[mcp,openai]>=2.29.0",
-  # Ceiling below 2.0: that release removes the exclude_tools and auto_reload arguments
-  # agents/pydantic_ai/runner.py passes to SkillsCapability, so an unbounded resolve breaks
-  # the sidebar agent at construction time (see issue 5491). Lift once the call site is
-  # migrated to the 2.x API (see issue 5492).
-  "pydantic-ai-skills>=0.11.0,<2",
+  "pydantic-ai-skills>=2.0",
 ]
 
 [project.optional-dependencies]
@@ -106,7 +95,10 @@ pythonpath = ["libraries/griptape_nodes_library"]
 line-length = 120
 # Engine-generated workflow files. Their formatting is whatever the workflow generator emits, so
 # reformatting them would mean the committed copy no longer matches a real save.
-extend-exclude = ["libraries/**/templates/*.py", "tests/e2e/fixtures/**/*_workflow.py"]
+extend-exclude = [
+  "libraries/**/templates/*.py",
+  "tests/e2e/fixtures/**/*_workflow.py",
+]
 
 
 [tool.ruff.lint]
@@ -161,7 +153,10 @@ ignore = [
 # TID251: node libraries are the intended audience for the GriptapeNodes facade, as the
 # ban message itself says.
 "docs/development/custom_nodes/example_dynamic_library/**" = ["INP001", "N807"]
-"docs/development/custom_nodes/example_request_handler_library/**" = ["INP001", "TID251"]
+"docs/development/custom_nodes/example_request_handler_library/**" = [
+  "INP001",
+  "TID251",
+]
 
 # TID251 allowlist for the GriptapeNodes facade. Two groups, and the difference matters.
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,19 @@ dependencies = [
   "truststore>=0.10.1",
   "cattrs>=26.1.0",
   "fileseq>=3.2.0",
+  # Floor at 2.29.0: that release ("Support FastMCP 4 and MCP SDK v2 in `MCPToolset` alongside
+  # FastMCP 3", pydantic/pydantic-ai#6738) is the first where the `[mcp]` extra's `fastmcp-slim`
+  # floor supports the mcp 2.x module layout our own `mcp>=2.0,<3` pin (above) resolves to.
+  # Below this, `pydantic_ai/mcp.py` imports symbols (e.g. `mcp.shared.context.RequestContext`)
+  # that mcp 2.x moved/renamed, so `agent_manager` fails to import at construction time.
+  # PR #5449 raised the `mcp` ceiling without checking this; PR #5493 papered over the fallout
+  # for pydantic-ai-skills but left this one. Lift no lower than this floor.
   "pydantic-ai-slim[mcp,openai]>=2.29.0",
-  "pydantic-ai-skills>=2.0",
+  # Floor at 2.0: agents/pydantic_ai/runner.py builds a SkillsCapability with the 2.x
+  # arguments (`scripts`, `include`) that replaced 1.x's `exclude_tools`/`auto_reload`.
+  # Ceiling below 3.0 so the next major cannot silently break the sidebar agent at
+  # construction time the way 2.0.0 did (see issue 5491).
+  "pydantic-ai-skills>=2.0,<3",
 ]
 
 [project.optional-dependencies]

--- a/src/griptape_nodes/agents/pydantic_ai/runner.py
+++ b/src/griptape_nodes/agents/pydantic_ai/runner.py
@@ -272,8 +272,9 @@ class PydanticAgentRunner:
         is a frontmatter report and ``OSError`` an unreadable ``SKILL.md``; both cost
         skills rather than the run.
 
-        ``index_resources=False`` skips indexing bundled files, which a probe does not
-        need and which is what makes probing expensive.
+        ``index_resources=False`` skips indexing bundled *resources*, which a probe does
+        not need and which is the bulk of what makes probing expensive. Scripts are still
+        discovered, so a library shipping them pays more per probe than one that does not.
         """
         exclude_resources = None if index_resources else ["*"]
         try:
@@ -300,9 +301,10 @@ class PydanticAgentRunner:
         rejection to the skill that caused it and keeps the others. Returns ``None`` when
         nothing survives.
 
-        Probing costs a construction per skill, and every construction indexes the whole
-        library's bundled files, so probes skip that indexing: a probe only has to answer
-        whether the frontmatter parses, and the survivors are indexed by the build below.
+        Probing costs a construction per skill, and every construction walks the whole
+        library's bundled files, so probes skip indexing its resources: a probe only has
+        to answer whether the frontmatter parses, and the survivors' resources are indexed
+        by the build below.
         """
         try:
             candidates = sorted(entry.name for entry in skills_dir.iterdir() if (entry / "SKILL.md").is_file())

--- a/src/griptape_nodes/agents/pydantic_ai/runner.py
+++ b/src/griptape_nodes/agents/pydantic_ai/runner.py
@@ -258,16 +258,31 @@ class PydanticAgentRunner:
             return []
         return [capability]
 
-    def _load_skills(self, skills_dir: Path, include: list[str] | None = None) -> SkillsCapability | None:
+    def _load_skills(
+        self,
+        skills_dir: Path,
+        include: list[str] | None = None,
+        *,
+        index_resources: bool = True,
+    ) -> SkillsCapability | None:
         """Build a capability over ``skills_dir``, or ``None`` when the loader rejects a skill.
 
         The loader validates every selected skill while constructing and raises on the
         first one it rejects, so this succeeds only when all of them load. ``ValueError``
         is a frontmatter report and ``OSError`` an unreadable ``SKILL.md``; both cost
         skills rather than the run.
+
+        ``index_resources=False`` skips indexing bundled files, which a probe does not
+        need and which is what makes probing expensive.
         """
+        exclude_resources = None if index_resources else ["*"]
         try:
-            return SkillsCapability(directories=[skills_dir], scripts=False, include=include)
+            return SkillsCapability(
+                directories=[skills_dir],
+                scripts=False,
+                include=include,
+                exclude_resources=exclude_resources,
+            )
         except (ValueError, OSError) as e:
             logger.warning(
                 "Attempted to load skills %s from %s. Failed because of: %s",
@@ -284,6 +299,10 @@ class PydanticAgentRunner:
         first: ``include`` filters before the loader parses anything, which pins a
         rejection to the skill that caused it and keeps the others. Returns ``None`` when
         nothing survives.
+
+        Probing costs a construction per skill, and every construction indexes the whole
+        library's bundled files, so probes skip that indexing: a probe only has to answer
+        whether the frontmatter parses, and the survivors are indexed by the build below.
         """
         try:
             candidates = sorted(entry.name for entry in skills_dir.iterdir() if (entry / "SKILL.md").is_file())
@@ -291,7 +310,11 @@ class PydanticAgentRunner:
             logger.warning("Attempted to list the skills in %s. Failed because of: %s", skills_dir, e)
             return None
 
-        usable = [name for name in candidates if self._load_skills(skills_dir, include=[name]) is not None]
+        usable = [
+            name
+            for name in candidates
+            if self._load_skills(skills_dir, include=[name], index_resources=False) is not None
+        ]
         if not usable:
             return None
         return self._load_skills(skills_dir, include=usable)

--- a/src/griptape_nodes/agents/pydantic_ai/runner.py
+++ b/src/griptape_nodes/agents/pydantic_ai/runner.py
@@ -245,18 +245,56 @@ class PydanticAgentRunner:
         gated shell tool and skills here ship no scripts.
 
         Returns an empty list when skills are disabled, the directory is absent,
-        or a skill on disk is unreadable, so the run proceeds without skills
-        instead of failing on one bad ``SKILL.md``.
+        or no skill in it loads, so the run proceeds without skills instead of
+        failing on a bad ``SKILL.md``.
         """
         skills_dir = self._skills_library()
         if skills_dir is None:
             return []
-        try:
-            capability = SkillsCapability(directories=[skills_dir], scripts=False)
-        except ValueError as e:
-            logger.warning("Attempted to load skills from %s. Failed because of: %s", skills_dir, e)
+        capability = self._load_skills(skills_dir)
+        if capability is None:
+            capability = self._load_usable_skills(skills_dir)
+        if capability is None:
             return []
         return [capability]
+
+    def _load_skills(self, skills_dir: Path, include: list[str] | None = None) -> SkillsCapability | None:
+        """Build a capability over ``skills_dir``, or ``None`` when the loader rejects a skill.
+
+        The loader validates every selected skill while constructing and raises on the
+        first one it rejects, so this succeeds only when all of them load. ``ValueError``
+        is a frontmatter report and ``OSError`` an unreadable ``SKILL.md``; both cost
+        skills rather than the run.
+        """
+        try:
+            return SkillsCapability(directories=[skills_dir], scripts=False, include=include)
+        except (ValueError, OSError) as e:
+            logger.warning(
+                "Attempted to load skills %s from %s. Failed because of: %s",
+                include if include is not None else "(all)",
+                skills_dir,
+                e,
+            )
+            return None
+
+    def _load_usable_skills(self, skills_dir: Path) -> SkillsCapability | None:
+        """Build a capability over only the skills in ``skills_dir`` that load on their own.
+
+        One rejected ``SKILL.md`` fails the whole library, so probe each skill by name
+        first: ``include`` filters before the loader parses anything, which pins a
+        rejection to the skill that caused it and keeps the others. Returns ``None`` when
+        nothing survives.
+        """
+        try:
+            candidates = sorted(entry.name for entry in skills_dir.iterdir() if (entry / "SKILL.md").is_file())
+        except OSError as e:
+            logger.warning("Attempted to list the skills in %s. Failed because of: %s", skills_dir, e)
+            return None
+
+        usable = [name for name in candidates if self._load_skills(skills_dir, include=[name]) is not None]
+        if not usable:
+            return None
+        return self._load_skills(skills_dir, include=usable)
 
     @property
     def agent(self) -> Agent[Any, str]:

--- a/src/griptape_nodes/agents/pydantic_ai/runner.py
+++ b/src/griptape_nodes/agents/pydantic_ai/runner.py
@@ -180,11 +180,9 @@ class PydanticAgentRunner:
     def __post_init__(self) -> None:
         toolsets: list[Any] = list(self.mcp_servers)
         instructions = self._build_instructions()
-        capabilities = self._build_skills_capabilities()
         agent_kwargs: dict[str, Any] = {
             "instructions": instructions,
             "toolsets": toolsets or None,
-            "capabilities": capabilities or None,
         }
         if self.system_prompt:
             agent_kwargs["system_prompt"] = self.system_prompt
@@ -206,13 +204,13 @@ class PydanticAgentRunner:
             self._image_toolset = register_image_tools(self._agent, self.image_config, self.static_files_manager)
         resolved_settings = model.settings or {}
         logger.info(
-            "PydanticAgentRunner ready: model=%s workspace=%s mcp_servers=%d image_tool=%s skills=%d "
+            "PydanticAgentRunner ready: model=%s workspace=%s mcp_servers=%d image_tool=%s skills_library=%s "
             "usage_limits=%s max_tokens=%s",
             self.model_name,
             self.workspace_root,
             len(self.mcp_servers),
             self._image_toolset is not None,
-            len(capabilities),
+            self._skills_library(),
             self.usage_limits,
             # "provider default" is the honest description of sending no
             # max_tokens: the ceiling exists, we just don't choose it.
@@ -222,33 +220,43 @@ class PydanticAgentRunner:
     def _build_instructions(self) -> str | None:
         """Compose the instruction string from the user's input.
 
-        Skill guidance is injected separately by :class:`SkillsCapability` via
-        its own ``get_instructions`` hook, so it is not concatenated here.
+        Each skill is its own deferred capability, so its guidance reaches the
+        model through Pydantic AI's ``load_capability`` tool rather than being
+        concatenated here.
         """
         return self.instructions or None
+
+    def _skills_library(self) -> Path | None:
+        """The skills directory to scan, or ``None`` when there is nothing to scan."""
+        if not self.auto_load_skills:
+            return None
+        skills_dir = self.workspace_root / self.skills_directory
+        if not skills_dir.is_dir():
+            return None
+        return skills_dir
 
     def _build_skills_capabilities(self) -> list[SkillsCapability]:
         """Build the skills capability exposing ``.agents/skills`` to the agent.
 
-        Returns an empty list when skills are disabled or the skills directory
-        is absent so the agent is created without a skills capability rather
-        than an empty one. ``run_skill_script`` is excluded because the workspace
-        already exposes a gated shell tool and skills here ship no scripts;
-        ``auto_reload`` re-scans the directory before each run so edits land
-        without restarting the engine.
+        Built per run rather than per runner: discovery is a construction-time
+        snapshot, so rebuilding it each turn is what makes an edited skill land
+        without restarting the engine. ``scripts=False`` leaves
+        ``run_skill_script`` unregistered because the workspace already exposes a
+        gated shell tool and skills here ship no scripts.
+
+        Returns an empty list when skills are disabled, the directory is absent,
+        or a skill on disk is unreadable, so the run proceeds without skills
+        instead of failing on one bad ``SKILL.md``.
         """
-        if not self.auto_load_skills:
+        skills_dir = self._skills_library()
+        if skills_dir is None:
             return []
-        skills_dir = self.workspace_root / self.skills_directory
-        if not skills_dir.is_dir():
+        try:
+            capability = SkillsCapability(directories=[skills_dir], scripts=False)
+        except ValueError as e:
+            logger.warning("Attempted to load skills from %s. Failed because of: %s", skills_dir, e)
             return []
-        return [
-            SkillsCapability(
-                directories=[skills_dir],
-                exclude_tools={"run_skill_script"},
-                auto_reload=True,
-            )
-        ]
+        return [capability]
 
     @property
     def agent(self) -> Agent[Any, str]:
@@ -313,11 +321,15 @@ class PydanticAgentRunner:
             model_history = await history_rehydrator(history)
         run_id = thread_id[:8]
 
+        # Rebuilt every run so skill edits land without an engine restart.
+        capabilities = self._build_skills_capabilities()
+
         logger.info(
-            "[run %s] start: model=%s history_len=%d prompt=%r",
+            "[run %s] start: model=%s history_len=%d skills=%s prompt=%r",
             run_id,
             self.model_name,
             len(history),
+            [name for capability in capabilities for name in capability.skill_names],
             _prompt_preview(prompt),
         )
         started = time.monotonic()
@@ -336,6 +348,7 @@ class PydanticAgentRunner:
                 message_history=model_history,
                 usage_limits=self.usage_limits,
                 event_stream_handler=event_handler,
+                capabilities=capabilities or None,
             )
         )
         try:

--- a/src/griptape_nodes/retained_mode/managers/agent_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/agent_manager.py
@@ -895,14 +895,13 @@ class AgentManager(EngineScoped):
         return runner
 
     def _ensure_skills_directory(self, workspace_root: Path) -> None:
-        """Scaffold `<workspace>/.agents/skills` so the runner always builds a skills capability.
+        """Scaffold `<workspace>/.agents/skills` so the runner always has a library to scan.
 
-        Called before every runner construction: the runner only attaches a
-        `SkillsCapability` when the directory exists at construction time, and
-        runners are cached, so creating the directory here guarantees skills
-        added mid-session are picked up on the next scan. Seeds a README the
-        first time so users discovering the folder know what belongs in it.
-        Failure to scaffold is logged but never blocks building the agent.
+        Called before every runner construction: the runner builds its skills
+        capability from this directory on each run, so creating it here means a
+        skill added mid-session is picked up without an engine restart. Seeds a
+        README the first time so users discovering the folder know what belongs
+        in it. Failure to scaffold is logged but never blocks building the agent.
         """
         skills_dir = workspace_root / DEFAULT_SKILLS_DIRECTORY
         try:

--- a/tests/unit/agents/pydantic_ai/test_runner.py
+++ b/tests/unit/agents/pydantic_ai/test_runner.py
@@ -240,6 +240,33 @@ async def test_tool_call_round_trips_through_runner(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_workspace_skill_reaches_the_model_on_a_run(tmp_path: Path) -> None:
+    """A skill in the workspace is offered to the model, so the run wiring is not silently dropped."""
+    workspace = tmp_path / "ws"
+    skill_dir = workspace / ".agents/skills/demo-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: demo-skill\ndescription: Demo skill description.\n---\n\nGuidance for the task."
+    )
+    threads_dir = tmp_path / "threads"
+
+    offered: list[AgentInfo] = []
+
+    async def stream(_messages: list[ModelMessage], info: AgentInfo) -> AsyncIterator[str]:
+        offered.append(info)
+        yield "Done."
+
+    runner = _runner_with_function_model(workspace, threads_dir, stream)
+    await runner.run("Use the demo skill.")
+
+    assert len(offered) == 1
+    # Each skill is a deferred capability: the model sees it in the catalog instructions
+    # and pulls its guidance in with `load_capability`.
+    assert "load_capability" in {tool.name for tool in offered[0].function_tools}
+    assert "demo-skill" in (offered[0].instructions or "")
+
+
+@pytest.mark.asyncio
 async def test_run_captures_generate_image_urls(tmp_path: Path) -> None:
     """URLs returned by the `generate_image` tool surface on the run result."""
     workspace = tmp_path / "ws"

--- a/tests/unit/agents/pydantic_ai/test_skills.py
+++ b/tests/unit/agents/pydantic_ai/test_skills.py
@@ -89,7 +89,9 @@ def test_excludes_script_tool(workspace: Path, tmp_path: Path) -> None:
 
 def test_broken_skill_costs_only_itself(workspace: Path, tmp_path: Path) -> None:
     """A `SKILL.md` the loader rejects is skipped; the valid skills beside it still load."""
-    _write_skill(workspace, "good-skill")
+    skill_dir = _write_skill(workspace, "good-skill")
+    (skill_dir / "references").mkdir()
+    (skill_dir / "references/notes.md").write_text("Reference material.")
     broken = workspace / ".agents/skills/broken-skill"
     broken.mkdir(parents=True)
     (broken / "SKILL.md").write_text("no frontmatter at all\n")
@@ -99,6 +101,8 @@ def test_broken_skill_costs_only_itself(workspace: Path, tmp_path: Path) -> None
 
     assert len(capabilities) == 1
     assert capabilities[0].skill_names == ["good-skill"]
+    # Probes skip bundled-file indexing; the surviving skill's files must not skip it too.
+    assert [resource.name for resource in capabilities[0].packages["good-skill"].resources] == ["references/notes.md"]
 
 
 def test_unreadable_skill_costs_skills_not_the_run(workspace: Path, tmp_path: Path) -> None:

--- a/tests/unit/agents/pydantic_ai/test_skills.py
+++ b/tests/unit/agents/pydantic_ai/test_skills.py
@@ -3,20 +3,21 @@
 Skill discovery and progressive disclosure are owned by `pydantic-ai-skills`;
 these tests cover only the runner's contract: when a capability is built, what
 it discovers, which tools it exposes, and what a broken skill costs.
+
+The skills reaching the model on a run is covered in `test_runner.py`, which is
+where a `FunctionModel` can observe the offered tools.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from pydantic_ai.toolsets import FunctionToolset
 
 from griptape_nodes.agents.pydantic_ai.runner import PydanticAgentRunner
 from griptape_nodes.drivers.thread_storage.local_thread_storage_driver import LocalThreadStorageDriver
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def _runner(workspace: Path, threads_dir: Path, *, auto_load_skills: bool = True) -> PydanticAgentRunner:
@@ -86,8 +87,31 @@ def test_excludes_script_tool(workspace: Path, tmp_path: Path) -> None:
     assert "run_skill_script" not in toolset.tools
 
 
-def test_broken_skill_costs_skills_not_the_run(workspace: Path, tmp_path: Path) -> None:
-    """A `SKILL.md` the loader rejects yields no capability rather than raising."""
+def test_broken_skill_costs_only_itself(workspace: Path, tmp_path: Path) -> None:
+    """A `SKILL.md` the loader rejects is skipped; the valid skills beside it still load."""
+    _write_skill(workspace, "good-skill")
+    broken = workspace / ".agents/skills/broken-skill"
+    broken.mkdir(parents=True)
+    (broken / "SKILL.md").write_text("no frontmatter at all\n")
+    runner = _runner(workspace, tmp_path / "threads")
+
+    capabilities = runner._build_skills_capabilities()
+
+    assert len(capabilities) == 1
+    assert capabilities[0].skill_names == ["good-skill"]
+
+
+def test_unreadable_skill_costs_skills_not_the_run(workspace: Path, tmp_path: Path) -> None:
+    """A `SKILL.md` that cannot be read yields no capability rather than raising."""
+    skill_dir = _write_skill(workspace, "demo-skill")
+    runner = _runner(workspace, tmp_path / "threads")
+    with patch.object(Path, "read_text", side_effect=PermissionError(13, "Permission denied")):
+        assert runner._build_skills_capabilities() == []
+    assert (skill_dir / "SKILL.md").is_file()
+
+
+def test_no_capability_when_every_skill_is_broken(workspace: Path, tmp_path: Path) -> None:
+    """A library where nothing loads yields no capability rather than an empty one."""
     broken = workspace / ".agents/skills/broken-skill"
     broken.mkdir(parents=True)
     (broken / "SKILL.md").write_text("no frontmatter at all\n")

--- a/tests/unit/agents/pydantic_ai/test_skills.py
+++ b/tests/unit/agents/pydantic_ai/test_skills.py
@@ -2,7 +2,7 @@
 
 Skill discovery and progressive disclosure are owned by `pydantic-ai-skills`;
 these tests cover only the runner's contract: when a capability is built, what
-it discovers, and which tools it exposes.
+it discovers, which tools it exposes, and what a broken skill costs.
 """
 
 from __future__ import annotations
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
+from pydantic_ai.toolsets import FunctionToolset
 
 from griptape_nodes.agents.pydantic_ai.runner import PydanticAgentRunner
 from griptape_nodes.drivers.thread_storage.local_thread_storage_driver import LocalThreadStorageDriver
@@ -30,11 +31,12 @@ def _runner(workspace: Path, threads_dir: Path, *, auto_load_skills: bool = True
     )
 
 
-def _write_skill(workspace: Path, name: str, body: str = "Guidance for the task.") -> None:
+def _write_skill(workspace: Path, name: str, body: str = "Guidance for the task.") -> Path:
     """Create a minimal valid `.agents/skills/<name>/SKILL.md` under `workspace`."""
     skill_dir = workspace / ".agents/skills" / name
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(f"---\nname: {name}\ndescription: {name} description\n---\n\n{body}")
+    return skill_dir
 
 
 @pytest.fixture
@@ -58,15 +60,48 @@ def test_no_capability_when_disabled(workspace: Path, tmp_path: Path) -> None:
     assert runner._build_skills_capabilities() == []
 
 
-def test_discovers_skill_and_excludes_script_tool(workspace: Path, tmp_path: Path) -> None:
-    """A present skill is discovered; `run_skill_script` is excluded from the tools."""
+def test_discovers_skill(workspace: Path, tmp_path: Path) -> None:
+    """A present skill is discovered and exposed to the model by name."""
     _write_skill(workspace, "demo-skill")
     runner = _runner(workspace, tmp_path / "threads")
 
     capabilities = runner._build_skills_capabilities()
     assert len(capabilities) == 1
+    assert capabilities[0].skill_names == ["demo-skill"]
 
-    toolset = capabilities[0].toolset
-    assert "demo-skill" in toolset.skills
+
+def test_excludes_script_tool(workspace: Path, tmp_path: Path) -> None:
+    """A skill shipping both kinds of files gets the resource tool but not the script tool."""
+    skill_dir = _write_skill(workspace, "demo-skill")
+    (skill_dir / "references").mkdir()
+    (skill_dir / "references/notes.md").write_text("Reference material.")
+    (skill_dir / "scripts").mkdir()
+    (skill_dir / "scripts/go.py").write_text("print('hi')\n")
+    runner = _runner(workspace, tmp_path / "threads")
+
+    toolset = runner._build_skills_capabilities()[0].get_toolset()
+
+    assert isinstance(toolset, FunctionToolset)
+    assert "read_skill_resource" in toolset.tools
     assert "run_skill_script" not in toolset.tools
-    assert {"list_skills", "load_skill"} <= set(toolset.tools)
+
+
+def test_broken_skill_costs_skills_not_the_run(workspace: Path, tmp_path: Path) -> None:
+    """A `SKILL.md` the loader rejects yields no capability rather than raising."""
+    broken = workspace / ".agents/skills/broken-skill"
+    broken.mkdir(parents=True)
+    (broken / "SKILL.md").write_text("no frontmatter at all\n")
+    runner = _runner(workspace, tmp_path / "threads")
+
+    assert runner._build_skills_capabilities() == []
+
+
+def test_rebuilds_snapshot_per_call(workspace: Path, tmp_path: Path) -> None:
+    """Discovery is a snapshot, so a skill added after the first build still lands."""
+    _write_skill(workspace, "first-skill")
+    runner = _runner(workspace, tmp_path / "threads")
+    assert runner._build_skills_capabilities()[0].skill_names == ["first-skill"]
+
+    _write_skill(workspace, "second-skill")
+
+    assert runner._build_skills_capabilities()[0].skill_names == ["first-skill", "second-skill"]

--- a/uv.lock
+++ b/uv.lock
@@ -495,15 +495,15 @@ wheels = [
 
 [[package]]
 name = "genai-prices"
-version = "0.1.5"
+version = "0.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx2" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/70/76dcc9c76b416d2df9aa4c65553f88b75d2ba4fbfeb5efb137f078844cc3/genai_prices-0.1.5.tar.gz", hash = "sha256:04c2cbf4444a3b2f5d38c3b6ab8385ea28ab924ac6f9202bde9261f599be8b45", size = 109418, upload-time = "2026-08-31T09:36:22.848Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/16/e5a507d42c0eb629b48ebe6c278f2d8c3f929bb6b28f18108bdd66d8ae12/genai_prices-0.1.6.tar.gz", hash = "sha256:802c1e4cc3ed5e70a09083b83af441a58d91f62e12768f7f1b6b26c98a33fcac", size = 111810, upload-time = "2026-09-02T14:53:54.895Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/14/28f578fa25391bb8983522f3e365e8735310f4b741e54cfed3a614f50384/genai_prices-0.1.5-py3-none-any.whl", hash = "sha256:5215706950decd833ce3527a9e1e745ad0dbdd35ce1b33ac1f7167699640b82a", size = 116330, upload-time = "2026-08-31T09:36:21.364Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a1/43fa2a4c5557cd977e83eecec265b0b77b726b0c7b9f2f180b46c6fdb458/genai_prices-0.1.6-py3-none-any.whl", hash = "sha256:35ac8043dbcf2958488129413bfecba7304fe12a68ad4a78c5b0d15281e82814", size = 118834, upload-time = "2026-09-02T14:53:53.758Z" },
 ]
 
 [[package]]
@@ -672,7 +672,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=11.3.0" },
     { name = "portalocker", specifier = ">=2.10.0" },
     { name = "pydantic", specifier = ">=2.10.6" },
-    { name = "pydantic-ai-skills", specifier = ">=0.11.0,<2" },
+    { name = "pydantic-ai-skills", specifier = ">=2.0" },
     { name = "pydantic-ai-slim", extras = ["mcp", "openai"], specifier = ">=2.29.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "python-multipart", specifier = ">=0.0.20" },
@@ -1526,7 +1526,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "3.6.0"
+version = "3.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1536,9 +1536,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/76/913b755a1a6b54e2d9140eb8d488aa0d47c7359b1d7eac5e864cb7913bbf/openai-3.6.0.tar.gz", hash = "sha256:18fe3f6e96390ef41ee27b152fc9effefca321c33673bd9b956a572493d3ab9b", size = 1455376, upload-time = "2026-08-28T22:29:18.268Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/77/3508ca0f04f42124bb89ab6e3e853c144660b9a680165beb49cd48634bce/openai-3.9.0.tar.gz", hash = "sha256:fea0fe63d04a27e9da588f673e291183fbf4813767e9df743e351bb548afc60b", size = 1481863, upload-time = "2026-09-08T16:43:15.033Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/94/805b87ecc951c49ec8f247f5e8eb324ab064bd2ad73b6a0e704dd49aa073/openai-3.6.0-py3-none-any.whl", hash = "sha256:508e2158bf971687f953b62e44b02f207792c815aac306816386d7ba34d37f5f", size = 1699841, upload-time = "2026-08-28T22:29:16.436Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ec/59307303cdb38d89f73555245cec54ab5fe34628c39b78b24ea48d0bbed8/openai-3.9.0-py3-none-any.whl", hash = "sha256:8e0e9a1abea664507f03fdad204579092d0fdf1aff54e8335c2098041d4c0345", size = 1741583, upload-time = "2026-09-08T16:43:12.369Z" },
 ]
 
 [[package]]
@@ -1732,22 +1732,42 @@ email = [
 ]
 
 [[package]]
+name = "pydantic-ai-harness"
+version = "0.29.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "genai-prices" },
+    { name = "httpx" },
+    { name = "pydantic-ai-slim" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/06/64db2f6a1132e96404e5af877c5570ba0f630ac0011335e5253c1ee7b342/pydantic_ai_harness-0.29.1.tar.gz", hash = "sha256:023066aa00dd75a1b31dde529d01ffdb13c929bcb9bc5d6b803fb5ef131c35f0", size = 2490023, upload-time = "2026-09-08T04:25:32.869Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/d2/9da26f8ab0887c249f230b1c5c6ac68cc58335d249ef10edced4c88a5372/pydantic_ai_harness-0.29.1-py3-none-any.whl", hash = "sha256:d11af43c3b9360547a1e1a9da4fc8feef6f328514f881f44f32ad436dbd2cc65", size = 784763, upload-time = "2026-09-08T04:25:30.772Z" },
+]
+
+[package.optional-dependencies]
+skills = [
+    { name = "pyyaml" },
+]
+
+[[package]]
 name = "pydantic-ai-skills"
-version = "1.4.0"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
+    { name = "pydantic-ai-harness", extra = ["skills"] },
     { name = "pydantic-ai-slim" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/59/65d312c625c546b4754022d0e3e20921f9637f1e87225c0fbcbce09ddb82/pydantic_ai_skills-1.4.0.tar.gz", hash = "sha256:7303e0738a837218415f8b2e7bd5b5cbc0ceeb74850b1902c2d079550e0b9b83", size = 9095029, upload-time = "2026-08-16T13:01:26.999Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/d5/f3059f89077f257e43475ad81878d5ee7e03c501579bf9a7b05166a7e18a/pydantic_ai_skills-2.0.0.tar.gz", hash = "sha256:25fd5f14268f68d25d68e38bc94fb93323092d3b7d96db0b5e499c074e3d40c7", size = 9110556, upload-time = "2026-09-06T01:44:21.651Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/eb/a4bea0c2c97f2351938e0ae2200fb197e4953928337198a17d89f0d0bbbb/pydantic_ai_skills-1.4.0-py3-none-any.whl", hash = "sha256:bce8731a042f50c45965acc520dc883163e511c34b208f720eb62067ef5be686", size = 75744, upload-time = "2026-08-16T13:01:25.501Z" },
+    { url = "https://files.pythonhosted.org/packages/86/8a/b05c3540dfe4e1491aa3f3de06d320bb93b61dbe49b805e2d5c4465c47b5/pydantic_ai_skills-2.0.0-py3-none-any.whl", hash = "sha256:d3bed993fe65a7a4a1c6e37c71914e9594cec86114e446a332f203f2cdc755f2", size = 73558, upload-time = "2026-09-06T01:44:20.268Z" },
 ]
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "2.37.0"
+version = "2.41.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1759,9 +1779,9 @@ dependencies = [
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/29/6204f4a6a90a4741ef80453d65ed22ea953506abecdfd922dccf2ee50119/pydantic_ai_slim-2.37.0.tar.gz", hash = "sha256:c4743bdcd6fd0ea60d82088856f3dfcce93180543b2a66587547034f9dc36e57", size = 1317321, upload-time = "2026-09-01T02:07:39.837Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/f2/2c5eba226a5ca3e12ab143babc90c1e2ced51ea11a243ff3dc6ec67c83f9/pydantic_ai_slim-2.41.0.tar.gz", hash = "sha256:fd2fabd19f9cd0d696ddecdeb26d4c22eb3ba3931fd2ad4b7a48a9f5fe981803", size = 1444949, upload-time = "2026-09-08T04:26:05.684Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/3a/37891340c959c53f71d65eb45de84fccd722749bf8123fcd5a53094cf0c4/pydantic_ai_slim-2.37.0-py3-none-any.whl", hash = "sha256:439973ce2dae1e64631b05b803743fe44b3b1791514b16488c005b1ca4f2b3e7", size = 1552945, upload-time = "2026-09-01T02:07:31.076Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/b7/faa4829fb7f2021a9d7e22494949fb916cdc917a5559a7801632b2003744/pydantic_ai_slim-2.41.0-py3-none-any.whl", hash = "sha256:aedb67910cd0867d4e44f6e4723663ac26a97b979c7995d2cae9aedfee07422b", size = 1703223, upload-time = "2026-09-08T04:25:57.995Z" },
 ]
 
 [package.optional-dependencies]
@@ -1820,7 +1840,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-graph"
-version = "2.37.0"
+version = "2.41.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1828,9 +1848,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/03/d7730770a7a564ec74d49872fde5e2606405c8380bb894dbfc47da36fa7a/pydantic_graph-2.37.0.tar.gz", hash = "sha256:447e4635f781ba525452d793be5935381a5a67aa4c81d0f53095cd8a8b626a94", size = 45188, upload-time = "2026-09-01T02:07:42Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/5f/710c3ef69975031fcd58c74f97b854c61a38940c46e074268d1d60c14c08/pydantic_graph-2.41.0.tar.gz", hash = "sha256:02e3253a3a100f583411065f8da51454cdf4f4d8bfa5d216e1f770c924bf5cc9", size = 45189, upload-time = "2026-09-08T04:26:08.092Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/ad/1cd14e2f39bbee1ad6f511649ccb966d9ad11bcd2433c7377e2305dcecae/pydantic_graph-2.37.0-py3-none-any.whl", hash = "sha256:7b07237264b92f57aa06b1686315005e320099106534fc20da4081873f68c31f", size = 52701, upload-time = "2026-09-01T02:07:34.829Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/39/0752f32d8063131a1f56d34fd2cf215fbea543dbcc5286ec34ac5e22aafd/pydantic_graph-2.41.0-py3-none-any.whl", hash = "sha256:a51bda0e151a18d00a23ec2fd2965350f977337e8754475cab827fb9f636fd7c", size = 52699, upload-time = "2026-09-08T04:26:01.356Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -672,7 +672,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=11.3.0" },
     { name = "portalocker", specifier = ">=2.10.0" },
     { name = "pydantic", specifier = ">=2.10.6" },
-    { name = "pydantic-ai-skills", specifier = ">=2.0" },
+    { name = "pydantic-ai-skills", specifier = ">=2.0,<3" },
     { name = "pydantic-ai-slim", extras = ["mcp", "openai"], specifier = ">=2.29.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "python-multipart", specifier = ">=0.0.20" },


### PR DESCRIPTION
Migrates the sidebar agent's skills capability to the `pydantic-ai-skills` 2.x API, lifting the `<2` cap from #5491.

2.x also removes `auto_reload`, but hot reload is not lost: the capability is now built per run and passed to `agent.run(capabilities=...)`, so a skill added or edited mid-session still lands on the next turn, exactly as before.

Closes #5492

<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--5514.org.readthedocs.build/en/5514/

<!-- readthedocs-preview griptape-nodes end -->