### PR TITLE
feat(budgets): attribution context event + BudgetManager (E1)

### DIFF
--- a/src/griptape_nodes/app/worker_routing.py
+++ b/src/griptape_nodes/app/worker_routing.py
@@ -41,6 +41,9 @@ from griptape_nodes.retained_mode.events.base_events import (
     SkipTheLineMixin,
     WorkflowNotAlteredMixin,
 )
+from griptape_nodes.retained_mode.events.budget_events import (
+    GetAttributionContextRequest,
+)
 from griptape_nodes.retained_mode.events.config_events import (
     ResetConfigRequest,
     SetConfigCategoryRequest,
@@ -104,6 +107,11 @@ HandlerCallback = "Callable[[RequestPayload], ResultPayload | Awaitable[ResultPa
 
 FORWARDED_REQUEST_TYPES: frozenset[type[RequestPayload]] = frozenset(
     {
+        # budget_events
+        # A worker has its own engine id and no workflow context, so answering locally would
+        # report the wrong engine and omit the workflow. The orchestrator holds the
+        # authoritative project chain and workflow name.
+        GetAttributionContextRequest,
         # connection_events
         CreateConnectionRequest,
         DeleteConnectionRequest,

--- a/src/griptape_nodes/app/worker_routing.py
+++ b/src/griptape_nodes/app/worker_routing.py
@@ -108,9 +108,9 @@ HandlerCallback = "Callable[[RequestPayload], ResultPayload | Awaitable[ResultPa
 FORWARDED_REQUEST_TYPES: frozenset[type[RequestPayload]] = frozenset(
     {
         # budget_events
-        # A worker has its own engine id and no workflow context, so answering locally would
-        # report the wrong engine and omit the workflow. The orchestrator holds the
-        # authoritative project chain and workflow name.
+        # A worker's project manager is a replica populated by broadcast, so it can serve a
+        # stale chain. The orchestrator holds the authoritative one, and asking it costs the
+        # orchestrator path -- which is all shipping traffic today -- nothing.
         GetAttributionContextRequest,
         # connection_events
         CreateConnectionRequest,

--- a/src/griptape_nodes/common/project_templates/project.py
+++ b/src/griptape_nodes/common/project_templates/project.py
@@ -43,7 +43,7 @@ def build_project_yaml() -> YAML:
 
 
 class ProjectTemplate(BaseModel):
-    """Complete project template loaded from project.yml."""
+    """Complete project template loaded from a `griptape-nodes-project.yml` file."""
 
     LATEST_SCHEMA_VERSION: ClassVar[str] = "1.0.0"
 

--- a/src/griptape_nodes/common/project_templates/project.py
+++ b/src/griptape_nodes/common/project_templates/project.py
@@ -52,11 +52,16 @@ class ProjectTemplate(BaseModel):
     id: str | None = Field(
         default=None,
         description=(
-            "Opaque identifier for the template, unique per engine. The UI sets a GUID by default, but a "
-            "user may set any unique string. It is the identifier used by project events and referenced by "
-            "external consumers such as policies; consumers must not parse or construct it. Absent on legacy "
-            "projects that predate this field, in which case the engine derives the id from the canonicalized "
-            "project file path. Set once at creation and immutable thereafter."
+            "Opaque identifier for the template, unique per engine. The editor's New Project flow "
+            "proposes a slug of the project name plus a short random suffix (e.g. `season-02-a3f9c1`), "
+            "and the user may override it with any unique string. It is the identifier used by project "
+            "events and referenced by external consumers such as policies; consumers must not parse or "
+            "construct it -- the slug is a convenience for the person picking it, not a parseable "
+            "structure. Absent whenever nothing supplied one: a hand-written project file, a project "
+            "created before this field existed, or one created by an editor talking to an engine older "
+            "than 0.87.0, which dropped the field during validation. In those cases the engine derives "
+            "the id from the canonicalized project file path. Set once at creation and immutable "
+            "thereafter."
         ),
     )
     description: str | None = Field(default=None, description="Description of the project")

--- a/src/griptape_nodes/retained_mode/engine.py
+++ b/src/griptape_nodes/retained_mode/engine.py
@@ -58,6 +58,7 @@ if TYPE_CHECKING:
         ArbitraryCodeExecManager,
     )
     from griptape_nodes.retained_mode.managers.artifact_manager import ArtifactManager
+    from griptape_nodes.retained_mode.managers.budget_manager import BudgetManager
     from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
     from griptape_nodes.retained_mode.managers.context_manager import ContextManager
     from griptape_nodes.retained_mode.managers.engine_identity_manager import EngineIdentityManager
@@ -169,6 +170,7 @@ class Engine:
     _project_manager: ProjectManager
     _artifact_manager: ArtifactManager
     _manifest_manager: ManifestManager
+    _budget_manager: BudgetManager
     _worker_manager: WorkerManager
 
     def __init__(self) -> None:  # noqa: PLR0915
@@ -178,6 +180,7 @@ class Engine:
             ArbitraryCodeExecManager,
         )
         from griptape_nodes.retained_mode.managers.artifact_manager import ArtifactManager
+        from griptape_nodes.retained_mode.managers.budget_manager import BudgetManager
         from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
         from griptape_nodes.retained_mode.managers.context_manager import ContextManager
         from griptape_nodes.retained_mode.managers.engine_identity_manager import EngineIdentityManager
@@ -245,6 +248,9 @@ class Engine:
         )
         self._artifact_manager = ArtifactManager(self._event_manager, engine=self)
         self._manifest_manager = ManifestManager(self._event_manager, engine=self)
+        # Constructed unconditionally, including on workers: register_remote_handlers raises if a
+        # forwarded request type (GetAttributionContextRequest) has no registered owner.
+        self._budget_manager = BudgetManager(self._event_manager, engine=self)
 
         # Assign handlers now that these are created.
         self._event_manager.assign_manager_to_request_type(GetEngineVersionRequest, self.handle_engine_version_request)
@@ -359,6 +365,10 @@ class Engine:
         return self._manifest_manager
 
     @property
+    def budget_manager(self) -> BudgetManager:
+        return self._budget_manager
+
+    @property
     def worker_manager(self) -> WorkerManager:
         return self._worker_manager
 
@@ -447,6 +457,9 @@ class Engine:
 
     def ManifestManager(self) -> ManifestManager:
         return self._manifest_manager
+
+    def BudgetManager(self) -> BudgetManager:
+        return self._budget_manager
 
     def WorkerManager(self) -> WorkerManager:
         return self._worker_manager

--- a/src/griptape_nodes/retained_mode/events/budget_events.py
+++ b/src/griptape_nodes/retained_mode/events/budget_events.py
@@ -30,7 +30,8 @@ class GetAttributionContextRequest(RequestPayload):
 
     Best-effort: nothing here raises, because the caller is about to spend money and an
     unattributed call beats a blocked one. A chain that cannot be read yields a Failure rather
-    than an empty chain -- an empty one would claim no project is open.
+    than an empty chain -- an empty one would assert that no project is open, which is not
+    something the engine knows at that point.
 
     Use when: A node or driver is about to make a credit-consuming call and wants the spend
     attributed to the project the user is working in.

--- a/src/griptape_nodes/retained_mode/events/budget_events.py
+++ b/src/griptape_nodes/retained_mode/events/budget_events.py
@@ -84,7 +84,9 @@ class GetAttributionContextResultSuccess(WorkflowNotAlteredMixin, ResultPayloadS
         workflow_name: The current workflow's registry key, or `<unsaved>`
         node_type: The node type the caller passed back, unchanged
         engine_id: The id of the engine that answered
-        orchestrator_engine_id: The parent engine's id when this engine is a worker
+        orchestrator_engine_id: Reserved; not emitted in practice. Worker requests are
+            forwarded to the orchestrator, which has no parent, so this is always absent
+            today -- do not build a consumer-side join on it
         session_id: The active session id
         chain_truncated: Whether ancestors were dropped from `project_chain`
     """

--- a/src/griptape_nodes/retained_mode/events/budget_events.py
+++ b/src/griptape_nodes/retained_mode/events/budget_events.py
@@ -64,8 +64,9 @@ class GetAttributionContextRequest(RequestPayload):
 class GetAttributionContextResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     """An attribution header value is available; attach it to the outbound request.
 
-    `header_value` is `base64url(utf-8 JSON)` with padding kept. The decoded payload omits any
-    key the engine could not determine, so an absent key means "unknown" and never "none". Two
+    `header_value` is `base64url(utf-8 JSON)` with padding kept. Every dimension sits under a
+    single `tags` object -- the Cloud parser reads no other namespace. The decoded payload omits
+    any key the engine could not determine, so an absent key means "unknown" and never "none". Two
     values are real rather than omissions: `<system-defaults>` in the project chain means no
     project is open, and `<unsaved>` as the workflow means it has never been saved.
 

--- a/src/griptape_nodes/retained_mode/events/budget_events.py
+++ b/src/griptape_nodes/retained_mode/events/budget_events.py
@@ -66,9 +66,10 @@ class GetAttributionContextResultSuccess(WorkflowNotAlteredMixin, ResultPayloadS
 
     `header_value` is `base64url(utf-8 JSON)` with padding kept. Every dimension sits under a
     single `tags` object -- the Cloud parser reads no other namespace. The decoded payload omits
-    any key the engine could not determine, so an absent key means "unknown" and never "none". Two
-    values are real rather than omissions: `<system-defaults>` in the project chain means no
-    project is open, and `<unsaved>` as the workflow means it has never been saved.
+    any key the engine could not determine, so an absent key means "unknown" and never "none".
+    `<unsaved>` as the workflow is a real value rather than an omission: it means the workflow has
+    never been saved. `<system-defaults>` never travels -- the Cloud reserves that string for its
+    own default and rejects a client copy, so an unprojected call simply omits `project`.
 
     The structured fields are populated from the same encoding pass as `header_value`, so a
     consumer reading them and the Cloud reading the header cannot disagree.

--- a/src/griptape_nodes/retained_mode/events/budget_events.py
+++ b/src/griptape_nodes/retained_mode/events/budget_events.py
@@ -58,9 +58,10 @@ class GetAttributionContextResultSuccess(WorkflowNotAlteredMixin, ResultPayloadS
     project is open and `{"v": 1, "tags": {"project": [...]}}` otherwise. `project` is the only
     key the Cloud matches budgets against, and `tags` the only namespace its parser reads.
 
-    A missing `tags` is a signal rather than an absence: it says no project is open on a client
-    that attributes, which the Cloud distinguishes from a client sending no header at all.
-    `<system-defaults>` never travels -- the Cloud reserves that string and rejects a client copy.
+    A missing `tags` reads at the far end exactly as no header at all -- both satisfy
+    `project_chain_absent` and neither emits a metric -- so the bare envelope is sent for
+    forward-compatibility, not because it currently says anything. `<system-defaults>` never
+    travels, in any padding: the Cloud reserves that string and strips before testing it.
 
     Args:
         header_value: The encoded header value to send
@@ -90,7 +91,8 @@ class GetAttributionContextResultFailure(WorkflowNotAlteredMixin, ResultPayloadF
     at all: an id derived from a filesystem path whose bytes are not valid UTF-8 arrives holding
     lone surrogates that the wire cannot carry.
 
-    Sending nothing is the honest answer -- the Cloud reads a missing header as "this client did
-    not attribute", where `{"v": 1}` would assert no project is open. Either way the spend lands
-    in the default budget.
+    Sending nothing rather than `{"v": 1}` is about the engine not asserting a fact it does not
+    have; the far end reads the two identically today, so it changes nothing there. Either way
+    the spend lands in the default budget, and the loss is visible only in the engine's log --
+    see the `reduced` follow-up on the Cloud side.
     """

--- a/src/griptape_nodes/retained_mode/events/budget_events.py
+++ b/src/griptape_nodes/retained_mode/events/budget_events.py
@@ -29,8 +29,11 @@ UNSAVED_WORKFLOW_SENTINEL = "<unsaved>"
 class GetAttributionContextRequest(RequestPayload):
     """Describe the current engine context so an outbound call can be attributed to a project.
 
-    Everything in the result is descriptive rather than secret: project ids, a workflow key,
-    a node type, and engine/session guids. It carries no credential and no user-authored label.
+    Everything in the result is descriptive rather than secret: project names, a workflow key,
+    a node type, and engine/session guids. It carries no credential.
+
+    It does carry user-authored strings. `tags.project` holds project names, and the workflow
+    key is a workspace-relative path. Both are visible to an SSL-inspecting egress proxy.
 
     Attribution is best-effort. Anything the engine cannot determine is omitted rather than
     guessed at or raised, because the caller is about to spend money and a missing dimension
@@ -79,8 +82,8 @@ class GetAttributionContextResultSuccess(WorkflowNotAlteredMixin, ResultPayloadS
         header_name: The header to send it under. Shipped on the result so a rename never has
             to touch a vendored client copy.
         schema_version: The payload schema version encoded in `header_value`
-        project_chain: The project ids the call is attributed to, ordered leaf-first. Ids only;
-            project names are never included.
+        project_chain: The project names the call is attributed to, ordered leaf-first. A
+            project whose template did not load has no name and ends the chain.
         workflow_name: The current workflow's registry key, or `<unsaved>`
         node_type: The node type the caller passed back, unchanged
         engine_id: The id of the engine that answered

--- a/src/griptape_nodes/retained_mode/events/budget_events.py
+++ b/src/griptape_nodes/retained_mode/events/budget_events.py
@@ -19,40 +19,31 @@ from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 ATTRIBUTION_HEADER_NAME = "X-Griptape-Attribution"
 ATTRIBUTION_SCHEMA_VERSION = 1
 
-# Sent as the `workflow` value when the workflow has never been saved. A real value, not an
-# omission: it buckets scratch spend without leaking the per-session `unsaved:<uuid4>` key.
-UNSAVED_WORKFLOW_SENTINEL = "<unsaved>"
-
 
 @dataclass
 @PayloadRegistry.register
 class GetAttributionContextRequest(RequestPayload):
-    """Describe the current engine context so an outbound call can be attributed to a project.
+    """Describe the current project so an outbound call can be attributed to it.
 
-    Everything in the result is descriptive rather than secret: project names, a workflow key,
-    a node type, and engine/session guids. It carries no credential.
+    The result is descriptive rather than secret: it carries project ids and no credential.
 
-    It does carry user-authored strings. `tags.project` holds project names, and the workflow
-    key is a workspace-relative path. Both are visible to an SSL-inspecting egress proxy.
+    It does carry user-authored strings. A project id has no enforced shape -- it is usually a
+    slug of the project name, the user may replace it with any string, and a project created
+    before ids existed carries the canonical path to its file. All of it is visible to an
+    SSL-inspecting egress proxy.
 
-    Attribution is best-effort. Anything the engine cannot determine is omitted rather than
-    guessed at or raised, because the caller is about to spend money and a missing dimension
-    beats a blocked call.
+    Attribution is best-effort. A project chain the engine cannot resolve is omitted rather
+    than guessed at or raised, because the caller is about to spend money and an unattributed
+    call beats a blocked one.
 
     Use when: A node or driver is about to make a credit-consuming call and wants the spend
     attributed to the project the user is working in.
-
-    Args:
-        node_type: The library-declared node type making the call (e.g. "GriptapeProxyImage"),
-            when the caller knows it. The engine cannot read this reliably -- the caller is
-            usually a driver where the node is not on the context stack -- so the caller passes it.
 
     Results: GetAttributionContextResultSuccess (a header value is available) |
         GetAttributionContextResultFailure (none could be produced; the call should still
         proceed, unattributed)
     """
 
-    node_type: str | None = None
     # Per-call and useful only to the direct caller; without this the Success payload would be
     # broadcast on the WebSocket feed once per metered call.
     #
@@ -67,50 +58,34 @@ class GetAttributionContextRequest(RequestPayload):
 class GetAttributionContextResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     """An attribution header value is available; attach it to the outbound request.
 
-    `header_value` is `base64url(utf-8 JSON)` with padding kept. Every dimension sits under a
-    single `tags` object -- the Cloud parser reads no other namespace. The decoded payload omits
-    any key the engine could not determine, so an absent key means "unknown" and never "none".
-    `<unsaved>` as the workflow is a real value rather than an omission: it means the workflow has
-    never been saved. `<system-defaults>` never travels -- the Cloud reserves that string for its
-    own default and rejects a client copy, so an unprojected call simply omits `project`.
+    `header_value` is `base64url(utf-8 JSON)` with padding kept. The decoded payload is
+    `{"v": 1}` when no project is open, and otherwise `{"v": 1, "tags": {"project": [...]}}`.
+    `project` is the only key the engine sends, because it is the only one the Cloud matches
+    budgets against, and `tags` is the only namespace the Cloud parser reads.
 
-    The structured fields are populated from the same encoding pass as `header_value`, so a
-    consumer reading them and the Cloud reading the header cannot disagree.
+    A missing `tags` is a real signal rather than an absence: it says no project is open on a
+    client that speaks attribution, which the Cloud distinguishes from a client that sends no
+    attribution header at all. `<system-defaults>` never travels -- the Cloud reserves that
+    string for its own default and rejects a client copy, so the rest state simply omits it.
+
+    `project_chain` is populated from the same pass that built `header_value`, so a consumer
+    reading it and the Cloud reading the header cannot disagree.
 
     Args:
         header_value: The encoded header value to send
         header_name: The header to send it under. Shipped on the result so a rename never has
             to touch a vendored client copy.
         schema_version: The payload schema version encoded in `header_value`
-        project_chain: The project names the call is attributed to, ordered leaf-first. Never
-            partial and never shortened -- budget paths are root-anchored, so a chain missing a
-            link would present a nested project as a root, and a name cut here would arrive
-            looking intact. Depth and length are the Cloud's to judge, and it reports what it
-            had to repair. Empty whenever the full ancestry cannot be described or sent.
-        workflow_name: The current workflow's registry key, or `<unsaved>`
-        node_type: The node type the caller passed back, unchanged
-        engine_id: The id of the engine that answered
-        orchestrator_engine_id: Reserved; not emitted in practice. Worker requests are
-            forwarded to the orchestrator, which has no parent, so this is always absent
-            today -- do not build a consumer-side join on it
-        session_id: The active session id
-        chain_truncated: Whether a chain the engine had resolved was given up to fit the
-            header. Only ever set with an empty `project_chain`, because the chain is shed
-            whole or not at all -- there is no partial form. Empty and unflagged means either
-            no project is open or the chain could not be described; both send no `project`
-            key, and neither is a size problem.
+        project_chain: The project ids the call is attributed to, ordered leaf-first, each one
+            exactly as the project stores it -- unstripped, uncut, and never repaired. Depth
+            and length are the Cloud's to judge, and it reports what it had to repair. Empty
+            when no project is open or the chain could not be read.
     """
 
     header_value: str
     header_name: str = ATTRIBUTION_HEADER_NAME
     schema_version: int = ATTRIBUTION_SCHEMA_VERSION
     project_chain: list[str] = field(default_factory=list)
-    workflow_name: str | None = None
-    node_type: str | None = None
-    engine_id: str | None = None
-    orchestrator_engine_id: str | None = None
-    session_id: str | None = None
-    chain_truncated: bool = False
 
 
 @dataclass
@@ -118,9 +93,9 @@ class GetAttributionContextResultSuccess(WorkflowNotAlteredMixin, ResultPayloadS
 class GetAttributionContextResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     """No attribution header value could be produced.
 
-    In practice the only cause is a header still over the size the ingress will carry even with
-    the project chain given up; every other degradation returns Success with a key omitted. An
-    unencodable payload lands here too, but every field that could carry one is filtered first,
-    so that path is a backstop. The caller should proceed and send no attribution header -- the
-    spend lands in the default budget.
+    The only cause is a project id the wire cannot carry: an id derived from a filesystem path
+    whose bytes are not valid UTF-8 arrives carrying lone surrogates, which cannot be encoded
+    at all. There is no honest partial form to send instead, so the whole header is given up.
+    The caller should proceed and send no attribution header -- the spend lands in the default
+    budget.
     """

--- a/src/griptape_nodes/retained_mode/events/budget_events.py
+++ b/src/griptape_nodes/retained_mode/events/budget_events.py
@@ -28,8 +28,9 @@ class GetAttributionContextRequest(RequestPayload):
     slug of the project name, replaceable with any string, and a filesystem path on a project
     created before ids existed -- and all of it is visible to an SSL-inspecting egress proxy.
 
-    Best-effort: an unresolvable chain is omitted rather than raised, because the caller is about
-    to spend money and an unattributed call beats a blocked one.
+    Best-effort: nothing here raises, because the caller is about to spend money and an
+    unattributed call beats a blocked one. A chain that cannot be read yields a Failure rather
+    than an empty chain -- an empty one would claim no project is open.
 
     Use when: A node or driver is about to make a credit-consuming call and wants the spend
     attributed to the project the user is working in.
@@ -69,8 +70,8 @@ class GetAttributionContextResultSuccess(WorkflowNotAlteredMixin, ResultPayloadS
         project_chain: The project ids the call is attributed to, leaf-first, each exactly as
             stored -- unstripped, uncut, never repaired, because a repaired value arrives looking
             intact and the Cloud reports what it had to repair itself. Populated from the same
-            pass that built `header_value`, so the two cannot disagree. Empty when no project is
-            open or the chain could not be read.
+            pass that built `header_value`, so the two cannot disagree. Empty only when no
+            project is open; a chain that could not be read yields a Failure instead.
     """
 
     header_value: str
@@ -82,10 +83,14 @@ class GetAttributionContextResultSuccess(WorkflowNotAlteredMixin, ResultPayloadS
 @dataclass
 @PayloadRegistry.register
 class GetAttributionContextResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
-    """No attribution header value could be produced.
+    """No attribution header value could be produced; send no header and make the call anyway.
 
-    The only cause is a project id the wire cannot carry: an id derived from a filesystem path
-    whose bytes are not valid UTF-8 arrives holding lone surrogates, which cannot be encoded at
-    all. There is no honest partial form, so the whole header is given up. The caller should
-    proceed without it -- the spend lands in the default budget.
+    Two causes, and both mean the engine cannot describe the spend truthfully. The project chain
+    could not be read, so whether a project is open is unknown. Or a project id cannot be encoded
+    at all: an id derived from a filesystem path whose bytes are not valid UTF-8 arrives holding
+    lone surrogates that the wire cannot carry.
+
+    Sending nothing is the honest answer -- the Cloud reads a missing header as "this client did
+    not attribute", where `{"v": 1}` would assert no project is open. Either way the spend lands
+    in the default budget.
     """

--- a/src/griptape_nodes/retained_mode/events/budget_events.py
+++ b/src/griptape_nodes/retained_mode/events/budget_events.py
@@ -1,10 +1,9 @@
 """Events for budget attribution.
 
-The engine is the only party that knows which project a credit-consuming call
-belongs to: Griptape Cloud deliberately holds no project model and no hierarchy.
-These events let a node about to spend money ask the engine for one ready-to-send
-header value describing that attribution, and stop there. Nothing here makes a
-network call, holds a credential, or enforces a budget.
+Griptape Cloud holds no project model, so the engine is the only party that can say
+which project a credit-consuming call belongs to. These events hand a caller one
+ready-to-send header value describing that. Nothing here makes a network call, holds
+a credential, or enforces a budget.
 """
 
 from dataclasses import dataclass, field
@@ -20,10 +19,8 @@ from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
 ATTRIBUTION_HEADER_NAME = "X-Griptape-Attribution"
 ATTRIBUTION_SCHEMA_VERSION = 1
 
-# Sent as the `workflow` value when the current workflow has never been saved. A real value,
-# not an omission: it buckets scratch spend without leaking the per-session `unsaved:<uuid4>`
-# registry key. Lives here, beside the header name, because it is part of the wire contract
-# the vendored client helper and the Cloud both read.
+# Sent as the `workflow` value when the workflow has never been saved. A real value, not an
+# omission: it buckets scratch spend without leaking the per-session `unsaved:<uuid4>` key.
 UNSAVED_WORKFLOW_SENTINEL = "<unsaved>"
 
 
@@ -32,39 +29,33 @@ UNSAVED_WORKFLOW_SENTINEL = "<unsaved>"
 class GetAttributionContextRequest(RequestPayload):
     """Describe the current engine context so an outbound call can be attributed to a project.
 
-    The result carries one encoded header value naming the project chain the caller
-    belongs to, plus the same facts as structured fields. Everything in it is
-    descriptive rather than secret: project ids, a workflow key, a node type, and
-    engine/session guids -- identifiers the user already sees in the editor. It
-    carries no credential and no user-authored label.
+    Everything in the result is descriptive rather than secret: project ids, a workflow key,
+    a node type, and engine/session guids. It carries no credential and no user-authored label.
 
-    Attribution is best-effort by design. Anything the engine cannot determine is
-    omitted from the payload rather than guessed at or raised, because the caller is
-    about to spend money and a missing dimension is better than a blocked call.
+    Attribution is best-effort. Anything the engine cannot determine is omitted rather than
+    guessed at or raised, because the caller is about to spend money and a missing dimension
+    beats a blocked call.
 
-    Use when: A node or driver is about to make a credit-consuming call and wants
-    the spend attributed to the project the user is working in.
+    Use when: A node or driver is about to make a credit-consuming call and wants the spend
+    attributed to the project the user is working in.
 
     Args:
-        node_type: The library-declared node type making the call (e.g.
-            "GriptapeProxyImage"), when the caller knows it. The engine cannot read
-            this reliably -- the caller is usually a driver inside process(), where
-            the node is not on the context stack -- so the caller passes it.
+        node_type: The library-declared node type making the call (e.g. "GriptapeProxyImage"),
+            when the caller knows it. The engine cannot read this reliably -- the caller is
+            usually a driver where the node is not on the context stack -- so the caller passes it.
 
     Results: GetAttributionContextResultSuccess (a header value is available) |
-        GetAttributionContextResultFailure (no header value could be produced; the
-        call should still proceed, unattributed)
+        GetAttributionContextResultFailure (none could be produced; the call should still
+        proceed, unattributed)
     """
 
     node_type: str | None = None
-    # Per-call and useful only to the direct caller. Without this the Success payload --
-    # header_value included -- would be queued for broadcast on the WebSocket feed once
-    # per metered call (engine.py handle_request).
+    # Per-call and useful only to the direct caller; without this the Success payload would be
+    # broadcast on the WebSocket feed once per metered call.
     #
-    # `field(default=False, kw_only=True)`, not a bare `= False`: `RequestPayload` is
-    # `kw_only=True` but these subclasses are plain `@dataclass`, so a bare redeclaration
-    # re-registers the field as positional and reorders __init__. Precedent:
-    # `agent_events.py` CancelAgentRequest.
+    # `field(default=False, kw_only=True)` rather than a bare `= False`: `RequestPayload` is
+    # `kw_only=True` but this subclass is a plain `@dataclass`, so a bare redeclaration would
+    # re-register the field as positional and reorder __init__.
     broadcast_result: bool = field(default=False, kw_only=True)
 
 
@@ -73,23 +64,21 @@ class GetAttributionContextRequest(RequestPayload):
 class GetAttributionContextResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     """An attribution header value is available; attach it to the outbound request.
 
-    `header_value` is `base64url(utf-8 JSON)` with padding kept. The decoded payload
-    omits any key the engine could not determine, so an absent key always means
-    "unknown" and never "none". Two values are real rather than omissions:
-    `<system-defaults>` in the project chain means no project is open, and
-    `<unsaved>` as the workflow means the current workflow has never been saved.
+    `header_value` is `base64url(utf-8 JSON)` with padding kept. The decoded payload omits any
+    key the engine could not determine, so an absent key means "unknown" and never "none". Two
+    values are real rather than omissions: `<system-defaults>` in the project chain means no
+    project is open, and `<unsaved>` as the workflow means it has never been saved.
 
-    The structured fields describe exactly what `header_value` encodes -- they are
-    populated from the same encoding pass, so a consumer reading them and the Cloud
-    reading the header cannot disagree.
+    The structured fields are populated from the same encoding pass as `header_value`, so a
+    consumer reading them and the Cloud reading the header cannot disagree.
 
     Args:
         header_value: The encoded header value to send
-        header_name: The header to send it under. Shipped on the result so a rename
-            never has to touch a vendored client copy.
+        header_name: The header to send it under. Shipped on the result so a rename never has
+            to touch a vendored client copy.
         schema_version: The payload schema version encoded in `header_value`
-        project_chain: The project ids the call is attributed to, ordered leaf-first.
-            Ids only; project names are never included.
+        project_chain: The project ids the call is attributed to, ordered leaf-first. Ids only;
+            project names are never included.
         workflow_name: The current workflow's registry key, or `<unsaved>`
         node_type: The node type the caller passed back, unchanged
         engine_id: The id of the engine that answered
@@ -115,10 +104,7 @@ class GetAttributionContextResultSuccess(WorkflowNotAlteredMixin, ResultPayloadS
 class GetAttributionContextResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     """No attribution header value could be produced.
 
-    The only cause is a payload that stays over the header size limit even after
-    being reduced to its smallest form. Every other degradation returns Success with
-    a key omitted, because a partial attribution beats none.
-
-    The caller should proceed with the outbound call and send no attribution header.
-    The spend still happens; it lands in the default budget instead of a project's.
+    The only cause is a payload still over the header size limit after being reduced to its
+    smallest form; every other degradation returns Success with a key omitted. The caller
+    should proceed and send no attribution header -- the spend lands in the default budget.
     """

--- a/src/griptape_nodes/retained_mode/events/budget_events.py
+++ b/src/griptape_nodes/retained_mode/events/budget_events.py
@@ -1,0 +1,124 @@
+"""Events for budget attribution.
+
+The engine is the only party that knows which project a credit-consuming call
+belongs to: Griptape Cloud deliberately holds no project model and no hierarchy.
+These events let a node about to spend money ask the engine for one ready-to-send
+header value describing that attribution, and stop there. Nothing here makes a
+network call, holds a credential, or enforces a budget.
+"""
+
+from dataclasses import dataclass, field
+
+from griptape_nodes.retained_mode.events.base_events import (
+    RequestPayload,
+    ResultPayloadFailure,
+    ResultPayloadSuccess,
+    WorkflowNotAlteredMixin,
+)
+from griptape_nodes.retained_mode.events.payload_registry import PayloadRegistry
+
+ATTRIBUTION_HEADER_NAME = "X-Griptape-Attribution"
+ATTRIBUTION_SCHEMA_VERSION = 1
+
+# Sent as the `workflow` value when the current workflow has never been saved. A real value,
+# not an omission: it buckets scratch spend without leaking the per-session `unsaved:<uuid4>`
+# registry key. Lives here, beside the header name, because it is part of the wire contract
+# the vendored client helper and the Cloud both read.
+UNSAVED_WORKFLOW_SENTINEL = "<unsaved>"
+
+
+@dataclass
+@PayloadRegistry.register
+class GetAttributionContextRequest(RequestPayload):
+    """Describe the current engine context so an outbound call can be attributed to a project.
+
+    The result carries one encoded header value naming the project chain the caller
+    belongs to, plus the same facts as structured fields. Everything in it is
+    descriptive rather than secret: project ids, a workflow key, a node type, and
+    engine/session guids -- identifiers the user already sees in the editor. It
+    carries no credential and no user-authored label.
+
+    Attribution is best-effort by design. Anything the engine cannot determine is
+    omitted from the payload rather than guessed at or raised, because the caller is
+    about to spend money and a missing dimension is better than a blocked call.
+
+    Use when: A node or driver is about to make a credit-consuming call and wants
+    the spend attributed to the project the user is working in.
+
+    Args:
+        node_type: The library-declared node type making the call (e.g.
+            "GriptapeProxyImage"), when the caller knows it. The engine cannot read
+            this reliably -- the caller is usually a driver inside process(), where
+            the node is not on the context stack -- so the caller passes it.
+
+    Results: GetAttributionContextResultSuccess (a header value is available) |
+        GetAttributionContextResultFailure (no header value could be produced; the
+        call should still proceed, unattributed)
+    """
+
+    node_type: str | None = None
+    # Per-call and useful only to the direct caller. Without this the Success payload --
+    # header_value included -- would be queued for broadcast on the WebSocket feed once
+    # per metered call (engine.py handle_request).
+    #
+    # `field(default=False, kw_only=True)`, not a bare `= False`: `RequestPayload` is
+    # `kw_only=True` but these subclasses are plain `@dataclass`, so a bare redeclaration
+    # re-registers the field as positional and reorders __init__. Precedent:
+    # `agent_events.py` CancelAgentRequest.
+    broadcast_result: bool = field(default=False, kw_only=True)
+
+
+@dataclass
+@PayloadRegistry.register
+class GetAttributionContextResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
+    """An attribution header value is available; attach it to the outbound request.
+
+    `header_value` is `base64url(utf-8 JSON)` with padding kept. The decoded payload
+    omits any key the engine could not determine, so an absent key always means
+    "unknown" and never "none". Two values are real rather than omissions:
+    `<system-defaults>` in the project chain means no project is open, and
+    `<unsaved>` as the workflow means the current workflow has never been saved.
+
+    The structured fields describe exactly what `header_value` encodes -- they are
+    populated from the same encoding pass, so a consumer reading them and the Cloud
+    reading the header cannot disagree.
+
+    Args:
+        header_value: The encoded header value to send
+        header_name: The header to send it under. Shipped on the result so a rename
+            never has to touch a vendored client copy.
+        schema_version: The payload schema version encoded in `header_value`
+        project_chain: The project ids the call is attributed to, ordered leaf-first.
+            Ids only; project names are never included.
+        workflow_name: The current workflow's registry key, or `<unsaved>`
+        node_type: The node type the caller passed back, unchanged
+        engine_id: The id of the engine that answered
+        orchestrator_engine_id: The parent engine's id when this engine is a worker
+        session_id: The active session id
+        chain_truncated: Whether ancestors were dropped from `project_chain`
+    """
+
+    header_value: str
+    header_name: str = ATTRIBUTION_HEADER_NAME
+    schema_version: int = ATTRIBUTION_SCHEMA_VERSION
+    project_chain: list[str] = field(default_factory=list)
+    workflow_name: str | None = None
+    node_type: str | None = None
+    engine_id: str | None = None
+    orchestrator_engine_id: str | None = None
+    session_id: str | None = None
+    chain_truncated: bool = False
+
+
+@dataclass
+@PayloadRegistry.register
+class GetAttributionContextResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
+    """No attribution header value could be produced.
+
+    The only cause is a payload that stays over the header size limit even after
+    being reduced to its smallest form. Every other degradation returns Success with
+    a key omitted, because a partial attribution beats none.
+
+    The caller should proceed with the outbound call and send no attribution header.
+    The spend still happens; it lands in the default budget instead of a project's.
+    """

--- a/src/griptape_nodes/retained_mode/events/budget_events.py
+++ b/src/griptape_nodes/retained_mode/events/budget_events.py
@@ -1,9 +1,8 @@
 """Events for budget attribution.
 
-Griptape Cloud holds no project model, so the engine is the only party that can say
-which project a credit-consuming call belongs to. These events hand a caller one
-ready-to-send header value describing that. Nothing here makes a network call, holds
-a credential, or enforces a budget.
+Griptape Cloud holds no project model, so the engine is the only party that can say which
+project a credit-consuming call belongs to. These events hand a caller one ready-to-send header
+value. No network call, no credential, no enforcement.
 """
 
 from dataclasses import dataclass, field
@@ -25,16 +24,12 @@ ATTRIBUTION_SCHEMA_VERSION = 1
 class GetAttributionContextRequest(RequestPayload):
     """Describe the current project so an outbound call can be attributed to it.
 
-    The result is descriptive rather than secret: it carries project ids and no credential.
+    The result carries project ids and no credential. Ids are still user-influenced -- usually a
+    slug of the project name, replaceable with any string, and a filesystem path on a project
+    created before ids existed -- and all of it is visible to an SSL-inspecting egress proxy.
 
-    It does carry user-authored strings. A project id has no enforced shape -- it is usually a
-    slug of the project name, the user may replace it with any string, and a project created
-    before ids existed carries the canonical path to its file. All of it is visible to an
-    SSL-inspecting egress proxy.
-
-    Attribution is best-effort. A project chain the engine cannot resolve is omitted rather
-    than guessed at or raised, because the caller is about to spend money and an unattributed
-    call beats a blocked one.
+    Best-effort: an unresolvable chain is omitted rather than raised, because the caller is about
+    to spend money and an unattributed call beats a blocked one.
 
     Use when: A node or driver is about to make a credit-consuming call and wants the spend
     attributed to the project the user is working in.
@@ -44,8 +39,8 @@ class GetAttributionContextRequest(RequestPayload):
         proceed, unattributed)
     """
 
-    # Per-call and useful only to the direct caller; without this the Success payload would be
-    # broadcast on the WebSocket feed once per metered call.
+    # Per-call and useful only to the direct caller; otherwise the Success payload broadcasts on
+    # the WebSocket feed once per metered call.
     #
     # `field(default=False, kw_only=True)` rather than a bare `= False`: `RequestPayload` is
     # `kw_only=True` but this subclass is a plain `@dataclass`, so a bare redeclaration would
@@ -58,28 +53,24 @@ class GetAttributionContextRequest(RequestPayload):
 class GetAttributionContextResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuccess):
     """An attribution header value is available; attach it to the outbound request.
 
-    `header_value` is `base64url(utf-8 JSON)` with padding kept. The decoded payload is
-    `{"v": 1}` when no project is open, and otherwise `{"v": 1, "tags": {"project": [...]}}`.
-    `project` is the only key the engine sends, because it is the only one the Cloud matches
-    budgets against, and `tags` is the only namespace the Cloud parser reads.
+    `header_value` is `base64url(utf-8 JSON)` with padding kept, decoding to `{"v": 1}` when no
+    project is open and `{"v": 1, "tags": {"project": [...]}}` otherwise. `project` is the only
+    key the Cloud matches budgets against, and `tags` the only namespace its parser reads.
 
-    A missing `tags` is a real signal rather than an absence: it says no project is open on a
-    client that speaks attribution, which the Cloud distinguishes from a client that sends no
-    attribution header at all. `<system-defaults>` never travels -- the Cloud reserves that
-    string for its own default and rejects a client copy, so the rest state simply omits it.
-
-    `project_chain` is populated from the same pass that built `header_value`, so a consumer
-    reading it and the Cloud reading the header cannot disagree.
+    A missing `tags` is a signal rather than an absence: it says no project is open on a client
+    that attributes, which the Cloud distinguishes from a client sending no header at all.
+    `<system-defaults>` never travels -- the Cloud reserves that string and rejects a client copy.
 
     Args:
         header_value: The encoded header value to send
-        header_name: The header to send it under. Shipped on the result so a rename never has
-            to touch a vendored client copy.
+        header_name: The header to send it under. On the result so a rename never has to touch a
+            vendored client copy.
         schema_version: The payload schema version encoded in `header_value`
-        project_chain: The project ids the call is attributed to, ordered leaf-first, each one
-            exactly as the project stores it -- unstripped, uncut, and never repaired. Depth
-            and length are the Cloud's to judge, and it reports what it had to repair. Empty
-            when no project is open or the chain could not be read.
+        project_chain: The project ids the call is attributed to, leaf-first, each exactly as
+            stored -- unstripped, uncut, never repaired, because a repaired value arrives looking
+            intact and the Cloud reports what it had to repair itself. Populated from the same
+            pass that built `header_value`, so the two cannot disagree. Empty when no project is
+            open or the chain could not be read.
     """
 
     header_value: str
@@ -94,8 +85,7 @@ class GetAttributionContextResultFailure(WorkflowNotAlteredMixin, ResultPayloadF
     """No attribution header value could be produced.
 
     The only cause is a project id the wire cannot carry: an id derived from a filesystem path
-    whose bytes are not valid UTF-8 arrives carrying lone surrogates, which cannot be encoded
-    at all. There is no honest partial form to send instead, so the whole header is given up.
-    The caller should proceed and send no attribution header -- the spend lands in the default
-    budget.
+    whose bytes are not valid UTF-8 arrives holding lone surrogates, which cannot be encoded at
+    all. There is no honest partial form, so the whole header is given up. The caller should
+    proceed without it -- the spend lands in the default budget.
     """

--- a/src/griptape_nodes/retained_mode/events/budget_events.py
+++ b/src/griptape_nodes/retained_mode/events/budget_events.py
@@ -82,8 +82,9 @@ class GetAttributionContextResultSuccess(WorkflowNotAlteredMixin, ResultPayloadS
         header_name: The header to send it under. Shipped on the result so a rename never has
             to touch a vendored client copy.
         schema_version: The payload schema version encoded in `header_value`
-        project_chain: The project names the call is attributed to, ordered leaf-first. A
-            project whose template did not load has no name and ends the chain.
+        project_chain: The project names the call is attributed to, ordered leaf-first. Never
+            partial -- budget paths are root-anchored, so a chain missing a link would present
+            a nested project as a root. Empty whenever the full ancestry cannot be described.
         workflow_name: The current workflow's registry key, or `<unsaved>`
         node_type: The node type the caller passed back, unchanged
         engine_id: The id of the engine that answered
@@ -91,7 +92,9 @@ class GetAttributionContextResultSuccess(WorkflowNotAlteredMixin, ResultPayloadS
             forwarded to the orchestrator, which has no parent, so this is always absent
             today -- do not build a consumer-side join on it
         session_id: The active session id
-        chain_truncated: Whether ancestors were dropped from `project_chain`
+        chain_truncated: Whether anything was trimmed off `project_chain` to fit the header.
+            Read with the list: non-empty means ancestors were dropped for size, empty means
+            the whole chain was. Empty and unflagged means there was no chain to begin with.
     """
 
     header_value: str
@@ -111,7 +114,9 @@ class GetAttributionContextResultSuccess(WorkflowNotAlteredMixin, ResultPayloadS
 class GetAttributionContextResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     """No attribution header value could be produced.
 
-    The only cause is a payload still over the header size limit after being reduced to its
-    smallest form; every other degradation returns Success with a key omitted. The caller
-    should proceed and send no attribution header -- the spend lands in the default budget.
+    In practice the only cause is a payload still over the header size limit after being reduced
+    to its smallest form; every other degradation returns Success with a key omitted. An
+    unencodable payload lands here too, but every field that could carry one is filtered first,
+    so that path is a backstop. The caller should proceed and send no attribution header -- the
+    spend lands in the default budget.
     """

--- a/src/griptape_nodes/retained_mode/events/budget_events.py
+++ b/src/griptape_nodes/retained_mode/events/budget_events.py
@@ -83,8 +83,10 @@ class GetAttributionContextResultSuccess(WorkflowNotAlteredMixin, ResultPayloadS
             to touch a vendored client copy.
         schema_version: The payload schema version encoded in `header_value`
         project_chain: The project names the call is attributed to, ordered leaf-first. Never
-            partial -- budget paths are root-anchored, so a chain missing a link would present
-            a nested project as a root. Empty whenever the full ancestry cannot be described.
+            partial and never shortened -- budget paths are root-anchored, so a chain missing a
+            link would present a nested project as a root, and a name cut here would arrive
+            looking intact. Depth and length are the Cloud's to judge, and it reports what it
+            had to repair. Empty whenever the full ancestry cannot be described or sent.
         workflow_name: The current workflow's registry key, or `<unsaved>`
         node_type: The node type the caller passed back, unchanged
         engine_id: The id of the engine that answered
@@ -92,9 +94,11 @@ class GetAttributionContextResultSuccess(WorkflowNotAlteredMixin, ResultPayloadS
             forwarded to the orchestrator, which has no parent, so this is always absent
             today -- do not build a consumer-side join on it
         session_id: The active session id
-        chain_truncated: Whether anything was trimmed off `project_chain` to fit the header.
-            Read with the list: non-empty means ancestors were dropped for size, empty means
-            the whole chain was. Empty and unflagged means there was no chain to begin with.
+        chain_truncated: Whether a chain the engine had resolved was given up to fit the
+            header. Only ever set with an empty `project_chain`, because the chain is shed
+            whole or not at all -- there is no partial form. Empty and unflagged means either
+            no project is open or the chain could not be described; both send no `project`
+            key, and neither is a size problem.
     """
 
     header_value: str
@@ -114,8 +118,8 @@ class GetAttributionContextResultSuccess(WorkflowNotAlteredMixin, ResultPayloadS
 class GetAttributionContextResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     """No attribution header value could be produced.
 
-    In practice the only cause is a payload still over the header size limit after being reduced
-    to its smallest form; every other degradation returns Success with a key omitted. An
+    In practice the only cause is a header still over the size the ingress will carry even with
+    the project chain given up; every other degradation returns Success with a key omitted. An
     unencodable payload lands here too, but every field that could carry one is filtered first,
     so that path is a backstop. The caller should proceed and send no attribution header -- the
     spend lands in the default budget.

--- a/src/griptape_nodes/retained_mode/griptape_nodes.py
+++ b/src/griptape_nodes/retained_mode/griptape_nodes.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
         ArbitraryCodeExecManager,
     )
     from griptape_nodes.retained_mode.managers.artifact_manager import ArtifactManager
+    from griptape_nodes.retained_mode.managers.budget_manager import BudgetManager
     from griptape_nodes.retained_mode.managers.config_manager import ConfigManager
     from griptape_nodes.retained_mode.managers.context_manager import ContextManager
     from griptape_nodes.retained_mode.managers.engine_identity_manager import EngineIdentityManager
@@ -222,6 +223,10 @@ class GriptapeNodes(metaclass=_EngineRootMeta):
     @classmethod
     def ManifestManager(cls) -> ManifestManager:
         return current_engine().manifest_manager
+
+    @classmethod
+    def BudgetManager(cls) -> BudgetManager:
+        return current_engine().budget_manager
 
     @classmethod
     def WorkerManager(cls) -> WorkerManager:

--- a/src/griptape_nodes/retained_mode/managers/budget_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/budget_manager.py
@@ -1,28 +1,20 @@
-"""BudgetManager - Describes the engine context an outbound call should be attributed to.
+"""BudgetManager - Describes which project an outbound call should be attributed to.
 
-The manager owns no state. The project chain is read from a peer manager at request time, so a
-project switch between two calls is reflected on the second one. Nothing here makes a network
-call, holds a credential, or enforces a budget.
+Holds no state: the project chain is read from the project manager per request, so a project
+switch between two calls shows up on the second. No network call, no credential, no enforcement.
 
-**Keeping the header value out of logs and broadcasts is a convention, not an invariant.**
-`broadcast_result` defaults to False but is a per-instance field any caller can flip;
-post-dispatch hooks receive the full result regardless of it; a forwarded worker request
-(`app/worker_routing.FORWARDED_REQUEST_TYPES`) puts the Success payload on the worker
-response topic by construction; and the engine's `omit_from_result` redaction primitive is
-request-side only, so it cannot mark a result field non-broadcastable. What this module can
-do it does: it never interpolates `header_value` or the payload into `result_details`, which
-is logged as well as broadcast. Project ids are descriptive rather than secret, so none of that
-is alarming -- but it is the real state of the mechanism.
+**Nothing here judges a value.** Griptape Cloud's parser reports every degradation it applies
+and marks a chain it repaired `mangled`, which drops it out of budget matching. A value the
+engine repaired instead arrives looking intact -- nothing recorded, and a budget matched against
+a rewritten string. So ids travel exactly as stored and the far end decides.
 
-**Nothing here judges a value.** Griptape Cloud's parser already reports every degradation it
-applies -- a truncated value, a truncated chain, a dropped entry -- and marks a chain it had to
-repair `mangled`, which takes it out of budget matching entirely. Repairing or withholding a
-value here would arrive looking intact instead: no reason recorded, no metric fired, and a
-budget matched against something the engine quietly rewrote. So ids travel exactly as the
-project manager reports them, at whatever length that comes to, and the far end decides.
+Keeping the header out of logs and broadcasts is a convention, not an invariant:
+`broadcast_result` is a field any caller can flip, post-dispatch hooks see the full result, and
+worker forwarding puts the Success payload on the response topic by construction. What this
+module can do it does -- `header_value` never reaches `result_details`, which is logged.
 
-`Engine.handle_request` converts a raised handler exception into a `ResultPayloadFailure`,
-so there is deliberately no blanket try/except here; the resolver guards its own peer read.
+`Engine.handle_request` turns a raised handler exception into a `ResultPayloadFailure`, so there
+is no blanket try/except here; the resolver guards its own peer read.
 """
 
 from __future__ import annotations
@@ -51,13 +43,12 @@ logger = logging.getLogger("griptape_nodes")
 def _build_attribution_payload(project_chain: list[str]) -> dict[str, Any]:
     """Build the decoded payload for a project chain, which may be empty.
 
-    `project` is the only tag key the engine sends, because it is the only one Griptape Cloud
-    matches budgets against. It lives under `tags`; the parser reads no other namespace.
+    `project` is the only key the Cloud matches budgets against, so it is the only one sent, and
+    `tags` is the only namespace the parser reads.
 
-    An empty chain omits `tags` entirely rather than sending it empty, and the bare `{"v": 1}`
-    envelope that leaves is worth sending: the parser reads a missing `tags` as "no project is
-    open on a client that speaks attribution", which is a different and more useful fact than
-    sending no header at all, which it reads as "this client has not adopted attribution".
+    An empty chain omits `tags` rather than sending it empty. The bare `{"v": 1}` still goes out:
+    the parser reads a missing `tags` as "no project open on a client that attributes", which is
+    a different fact from sending no header at all.
     """
     if not project_chain:
         return {"v": ATTRIBUTION_SCHEMA_VERSION}
@@ -67,21 +58,17 @@ def _build_attribution_payload(project_chain: list[str]) -> dict[str, Any]:
 def _encode_attribution_payload(payload: dict[str, Any]) -> str | None:
     """Encode a payload as base64url, or None when it cannot be encoded at all.
 
-    Size is not judged here, or anywhere. A header the Cloud considers oversized is discarded
-    *and reported* as OVERSIZE, so the spend goes unattributed and the platform knows it did --
-    a better outcome than shrinking the header here and having it arrive looking complete.
+    Size is not judged, here or anywhere: an oversized header is discarded *and reported* by the
+    Cloud, which beats shrinking it here and having it arrive looking complete. Padding is kept
+    because the parser re-pads anyway, so both forms arrive intact.
 
-    Padding is kept because the payload is `base64.b64encode`'s natural output and stripping it
-    would buy nothing: the parser re-pads whatever it receives before decoding, so both forms
-    arrive intact.
-
-    The UTF-8 guard is the module's only failure path, and it fires by design rather than as a
-    backstop. A project id derived from a filesystem path whose bytes are not valid UTF-8 comes
-    back from the OS carrying lone surrogates from `surrogateescape`, which `str.encode` refuses.
-    That costs the whole header, deliberately: it is the one thing the wire physically cannot
-    carry, so there is no honest partial form to send instead. Letting `str.encode` raise would
-    escape the handler as a `GenericResultFailure`, which ignores `failure_log_level`
-    (`event_manager.py:1088-1094`) and would log an ERROR with a traceback on every metered call.
+    The UTF-8 guard is the module's only failure path and fires by design. A legacy project's id
+    is the path to its file, and a path whose bytes are not valid UTF-8 carries lone surrogates
+    from `surrogateescape` that `str.encode` refuses. That costs the whole header: it is the one
+    thing the wire cannot carry, so there is no honest partial form. Returning None rather than
+    raising, because a handler exception becomes a `GenericResultFailure`, which ignores
+    `failure_log_level` (`event_manager.py:1088-1094`) and logs an ERROR with a traceback on
+    every metered call.
     """
     try:
         raw = json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
@@ -95,11 +82,7 @@ def _encode_attribution_payload(payload: dict[str, Any]) -> str | None:
 
 
 class BudgetManager(EngineScoped):
-    """Composes the attribution context for a credit-consuming call.
-
-    Holds no state: the project chain is read from the project manager on every request, so the
-    answer always reflects the engine as it is now.
-    """
+    """Composes the attribution context for a credit-consuming call."""
 
     def __init__(self, event_manager: EventManager, *, engine: Engine | None = None) -> None:
         """Initialize the BudgetManager.
@@ -117,11 +100,11 @@ class BudgetManager(EngineScoped):
         self,
         request: GetAttributionContextRequest,  # noqa: ARG002
     ) -> GetAttributionContextResultSuccess | GetAttributionContextResultFailure:
-        """Describe the current engine context as an encoded attribution header.
+        """Describe the current project as an encoded attribution header.
 
-        A project chain the engine cannot resolve degrades to an empty one rather than a
-        failure: the caller is about to spend money, and an unattributed call beats a blocked
-        one. The one failure is an id the wire cannot carry at all.
+        An unresolvable chain degrades to an empty one rather than a failure: the caller is
+        about to spend money, and an unattributed call beats a blocked one. The one failure is
+        an id the wire cannot carry.
         """
         project_chain = self._resolve_project_chain()
         header_value = _encode_attribution_payload(_build_attribution_payload(project_chain))
@@ -146,20 +129,14 @@ class BudgetManager(EngineScoped):
     def _resolve_project_chain(self) -> list[str]:
         """Resolve the current project's ancestry as ids, leaf-first, or [] when unavailable.
 
-        `tags.project` is the only dimension the Cloud matches budgets against, and the project
-        id is what identifies a project across a rename -- the name would silently re-point that
-        project's spend the moment a user edited it.
+        The id rather than the name, because it survives a rename -- a name would re-point that
+        project's spend the moment a user edited it. But an id is not opaque: `ProjectTemplate.id`
+        has no pattern and no length cap, the editor proposes a slug of the name, and a legacy
+        project carries the canonical path to its file. So an id discloses roughly what a name
+        would plus directory layout, in a header egress proxies log. Accepted for a stable key.
 
-        An id is not an opaque GUID. `ProjectTemplate.id` has no pattern and no length cap: the
-        editor proposes a slug of the project name, the user may replace it with anything, and a
-        legacy project without one has the canonical path to its file written in permanently. So
-        an id discloses roughly what a name would, plus directory layout, in a header that
-        SSL-inspecting egress proxies log. That is the accepted cost of a stable identifier.
-
-        Every id travels exactly as it is stored -- unstripped, uncut, unexamined. The one entry
-        skipped is the `<system-defaults>` rest-state sentinel, and that is not a repair: it is
-        the root sentinel rather than an ancestor the Cloud models, and the Cloud reserves that
-        string for its own default and refuses a client copy of it.
+        Ids travel exactly as stored. The one entry skipped is the `<system-defaults>` rest-state
+        sentinel, which is not an ancestor the Cloud models and whose string it reserves anyway.
         """
         try:
             chain = self.engine.project_manager.get_project_chain()

--- a/src/griptape_nodes/retained_mode/managers/budget_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/budget_manager.py
@@ -24,6 +24,7 @@ import base64
 import json
 import logging
 import os
+import re
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
@@ -52,6 +53,11 @@ _MAX_PROJECT_CHAIN_ENTRIES = 32
 # ceiling, itself well under nginx's 8 KB default.
 _MAX_DECODED_PAYLOAD_BYTES = 4096
 
+# C0 and C1 control characters, mirroring the Cloud parser's storability rule. A value
+# containing one is stored nowhere on the far end, so sending it buys nothing and costs
+# something -- see `_is_transmissible`.
+_UNSTORABLE_CHARACTERS = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+
 
 class _AttributionFacts(NamedTuple):
     """The engine facts one outbound call is attributed to.
@@ -74,6 +80,46 @@ class _AttributionEncoding(NamedTuple):
     header_value: str
     facts: _AttributionFacts
     chain_truncated: bool
+
+
+class _ReductionStage(NamedTuple):
+    """One rung of the size-reduction ladder, ordered most informative first."""
+
+    facts: _AttributionFacts
+    # None on the unreduced rung; otherwise what this rung gives up, for the warning log.
+    reduction_note: str | None
+
+
+def _is_transmissible(value: str) -> bool:
+    """Whether a value survives the trip to the Cloud intact.
+
+    Two ways it does not, and both arrive by the same route -- a legacy project's id is its
+    canonical filesystem path (`project_manager.py:795`), and the workflow registry key is
+    derived from one. A path whose bytes are not valid UTF-8 comes back from the OS carrying
+    lone surrogates from `surrogateescape`, which `str.encode` refuses. A directory name may
+    legally contain a control character, which encodes here and is then discarded by the
+    Cloud's storability check.
+    """
+    if _UNSTORABLE_CHARACTERS.search(value):
+        return False
+    try:
+        value.encode("utf-8")
+    except UnicodeEncodeError:
+        return False
+    return True
+
+
+def _transmissible_or_none(value: str | None) -> str | None:
+    """Pass a value through, or None when it cannot reach the Cloud intact.
+
+    Omitting the key says "the engine could not determine this", which is honest: a value
+    the far end would discard is one the engine cannot express.
+    """
+    if value is None:
+        return None
+    if not _is_transmissible(value):
+        return None
+    return value
 
 
 def _build_attribution_payload(facts: _AttributionFacts) -> dict[str, Any]:
@@ -104,54 +150,85 @@ def _build_attribution_payload(facts: _AttributionFacts) -> dict[str, Any]:
 
 
 def _encode_attribution_payload(payload: dict[str, Any]) -> str | None:
-    """Encode a payload as base64url, or None when it exceeds the size cap.
+    """Encode a payload as base64url, or None when it cannot be encoded or exceeds the cap.
 
     Padding is kept so the Cloud can call `urlsafe_b64decode` without re-padding.
+
+    The UTF-8 guard covers the identifier fields, which are not filtered individually the way
+    the chain, workflow, and node type are: `orchestrator_engine_id` is read from the
+    environment, and `os.getenv` decodes with `surrogateescape`, so a non-UTF-8 value reaches
+    here as a lone surrogate. Letting that raise would escape the handler as a
+    `GenericResultFailure`, which ignores `failure_log_level` (`event_manager.py:1088-1094`)
+    and would therefore log an ERROR with a traceback on every metered call. Returning None
+    instead degrades to the documented outcome: no header, and the spend lands in the default
+    budget.
     """
-    raw = json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    try:
+        raw = json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    except UnicodeEncodeError:
+        logger.warning(
+            "Attribution payload could not be encoded as UTF-8; sending no attribution header.",
+            exc_info=True,
+        )
+        return None
     if len(raw) > _MAX_DECODED_PAYLOAD_BYTES:
         return None
     return base64.urlsafe_b64encode(raw).decode("ascii")
 
 
 def _encode_attribution_header(facts: _AttributionFacts) -> _AttributionEncoding | None:
-    """Encode the attribution header, reducing the payload once if it does not fit.
+    """Encode the attribution header, shedding dimensions in stages until it fits.
 
     The chain is always truncated to `_MAX_PROJECT_CHAIN_ENTRIES` from the leaf -- the v1 rule,
-    not a size response. If the result still does not fit, one reduction step drops the workflow
-    and node type and keeps only the leaf project. None means even that did not fit, which needs
-    a single project id larger than the whole cap.
+    not a size response. If the result does not fit, dimensions are shed in order of increasing
+    value: the workflow and node type first, and only then the chain's ancestors.
+
+    The chain goes last because it is the only dimension the Cloud matches budgets against, and
+    budget paths are root-anchored, so a chain reduced to its leaf matches nothing at all.
+    Shedding it first would trade the billable dimension for audit-only labels -- and would do
+    so even when an oversized `workflow` was what pushed the payload over, leaving the chain to
+    pay for room it was not using.
+
+    None means even a leaf-only payload did not fit, which needs a single project id larger
+    than the whole cap.
     """
     chain_truncated = len(facts.project_chain) > _MAX_PROJECT_CHAIN_ENTRIES
     full_facts = facts._replace(project_chain=list(facts.project_chain[:_MAX_PROJECT_CHAIN_ENTRIES]))
+    without_labels = full_facts._replace(workflow_name=None, node_type=None)
+    leaf_only = without_labels._replace(project_chain=without_labels.project_chain[:1])
 
-    full_header_value = _encode_attribution_payload(_build_attribution_payload(full_facts))
-    if full_header_value is not None:
+    stages = (
+        _ReductionStage(facts=full_facts, reduction_note=None),
+        _ReductionStage(
+            facts=without_labels,
+            reduction_note="the workflow and node type will not be attributed for this call",
+        ),
+        _ReductionStage(
+            facts=leaf_only,
+            reduction_note="only the leaf project will be attributed for this call",
+        ),
+    )
+
+    for stage in stages:
+        header_value = _encode_attribution_payload(_build_attribution_payload(stage.facts))
+        if header_value is None:
+            continue
+        if stage.reduction_note is not None:
+            logger.warning(
+                "Attribution payload exceeded %d bytes; reducing it so %s.",
+                _MAX_DECODED_PAYLOAD_BYTES,
+                stage.reduction_note,
+            )
         return _AttributionEncoding(
-            header_value=full_header_value,
-            facts=full_facts,
-            chain_truncated=chain_truncated,
+            header_value=header_value,
+            facts=stage.facts,
+            # Derived, never asserted. `chain_truncated` means ancestors were dropped, so it has
+            # to describe what this stage actually shed: a payload pushed over the cap by an
+            # oversized `node_type` can reach a later stage without the chain losing anything.
+            chain_truncated=chain_truncated or len(stage.facts.project_chain) < len(full_facts.project_chain),
         )
 
-    logger.warning(
-        "Attribution payload exceeded %d bytes; reducing it to the leaf project only. "
-        "The workflow and node type will not be attributed for this call.",
-        _MAX_DECODED_PAYLOAD_BYTES,
-    )
-    reduced_facts = full_facts._replace(
-        project_chain=full_facts.project_chain[:1],
-        workflow_name=None,
-        node_type=None,
-    )
-    reduced_header_value = _encode_attribution_payload(_build_attribution_payload(reduced_facts))
-    if reduced_header_value is None:
-        return None
-
-    return _AttributionEncoding(
-        header_value=reduced_header_value,
-        facts=reduced_facts,
-        chain_truncated=True,
-    )
+    return None
 
 
 class BudgetManager(EngineScoped):
@@ -185,7 +262,7 @@ class BudgetManager(EngineScoped):
         facts = _AttributionFacts(
             project_chain=self._resolve_project_chain(),
             workflow_name=self._resolve_workflow_name(),
-            node_type=request.node_type,
+            node_type=_transmissible_or_none(request.node_type),
             engine_id=self._resolve_engine_id(),
             orchestrator_engine_id=self._resolve_orchestrator_engine_id(),
             session_id=self._resolve_session_id(),
@@ -223,7 +300,19 @@ class BudgetManager(EngineScoped):
         """Resolve the current project's ancestry as ids, leaf-first, or [] when unavailable.
 
         `ProjectChainEntry.name` is dropped here -- the single place the chain is consumed --
-        so no user-authored project label can reach the payload by construction.
+        so a project's *display name* never travels. That is weaker than "no user-authored
+        string travels", and the difference matters: a legacy project predating the explicit
+        `id` field uses its canonical file path as its id (`project_manager.py:795`), and a
+        user may set any unique string as one, so `tags.project` can carry a filesystem path
+        or a chosen label. Ids still go out verbatim, because the Cloud matches them against
+        admin-authored budget paths -- hashing or dropping one would silently unbudget that
+        project rather than protect it. Disclosed on the PR; see the id-space contract at
+        `project_manager.py:163-172`.
+
+        An id the Cloud cannot store costs the *whole* chain, not just its own entry. Budget
+        paths are root-anchored, so a chain missing any link already matches nothing -- and
+        dropping only the offending entry is worse than sending none, because it promotes that
+        entry's parent to leaf and bills a real ancestor project for spend it never incurred.
 
         `<system-defaults>` is dropped with it. The Cloud reserves that exact string as its own
         marker for unattributed spend, so its parser discards a client copy and counts the call
@@ -236,14 +325,25 @@ class BudgetManager(EngineScoped):
         except Exception:
             logger.warning("Could not resolve the project chain for budget attribution.", exc_info=True)
             return []
-        return [entry.id for entry in chain if entry.id != SYSTEM_DEFAULTS_KEY]
+
+        project_ids = [entry.id for entry in chain if entry.id != SYSTEM_DEFAULTS_KEY]
+        untransmissible_count = sum(1 for project_id in project_ids if not _is_transmissible(project_id))
+        if untransmissible_count > 0:
+            logger.warning(
+                "Dropping project attribution for this call: %d project id(s) in the chain cannot be "
+                "transmitted intact. This spend will land in the default budget.",
+                untransmissible_count,
+            )
+            return []
+        return project_ids
 
     def _resolve_workflow_name(self) -> str | None:
         """Resolve the current workflow's registry key, or None when it cannot be determined.
 
         An unsaved workflow is registered under an `unsaved:<uuid4>` key that is fresh every
         session, so the sentinel goes out instead: one low-cardinality bucket for scratch spend,
-        still distinguishable from an absent key.
+        still distinguishable from an absent key. A saved key is workspace-path-derived, so it
+        carries the same transmissibility risk as a project id and gets the same check.
         """
         try:
             if not self.engine.context_manager.has_current_workflow():
@@ -255,7 +355,7 @@ class BudgetManager(EngineScoped):
 
         if registry_key.startswith(WorkflowRegistry.UNSAVED_KEY_PREFIX):
             return UNSAVED_WORKFLOW_SENTINEL
-        return registry_key
+        return _transmissible_or_none(registry_key)
 
     def _resolve_engine_id(self) -> str | None:
         """Resolve this engine's identifier, or None when it cannot be determined."""

--- a/src/griptape_nodes/retained_mode/managers/budget_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/budget_manager.py
@@ -1,0 +1,286 @@
+"""BudgetManager - Describes the engine context an outbound call should be attributed to.
+
+The manager owns no state. Every fact is read from a peer manager at request time, so
+a project switch between two calls is reflected on the second one.
+
+Nothing here makes a network call, holds a credential, or enforces a budget. It composes
+one attribution fact and stops.
+
+**On keeping the header value out of logs and broadcasts.** Three defaults and a
+convention protect it; none of them is an enforced invariant, and each has a bypass worth
+knowing about:
+
+- `GetAttributionContextRequest.broadcast_result` defaults to False, which keeps the
+  Success payload off the WebSocket feed -- but it is a per-instance field any caller can
+  set back to True.
+- Post-dispatch hooks receive the full result object and run regardless of
+  `broadcast_result` or event suppression.
+- `result_details` is logged as well as broadcast, so this module never interpolates
+  `header_value` or the payload into one. That discipline is held by convention: the
+  engine's `omit_from_result` redaction primitive is request-side only and cannot mark a
+  result field non-broadcastable.
+- On a worker, the request is forwarded to the orchestrator (see
+  `app/worker_routing.FORWARDED_REQUEST_TYPES`), so the Success payload crosses the
+  worker response topic by construction, whatever `broadcast_result` says.
+
+None of that is alarming on its own -- the value is descriptive, not secret -- but it is
+the real state of the mechanism rather than a guarantee.
+
+`Engine.handle_request` already converts a raised handler exception into a
+`ResultPayloadFailure`, so this module deliberately has no blanket try/except around the
+handler body; the resolvers guard their own peer reads and nothing else can escape.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+from typing import TYPE_CHECKING, Any, NamedTuple
+
+from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
+from griptape_nodes.retained_mode.engine import EngineScoped
+from griptape_nodes.retained_mode.events.budget_events import (
+    ATTRIBUTION_SCHEMA_VERSION,
+    UNSAVED_WORKFLOW_SENTINEL,
+    GetAttributionContextRequest,
+    GetAttributionContextResultFailure,
+    GetAttributionContextResultSuccess,
+)
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
+    from griptape_nodes.retained_mode.managers.event_manager import EventManager
+
+logger = logging.getLogger("griptape_nodes")
+
+# The Cloud truncates the chain at this depth anyway. Truncating client-side means both
+# ends agree and the oversize path is unreachable in practice.
+_MAX_PROJECT_CHAIN_ENTRIES = 10
+
+# base64 inflates 4:3, so 4096 decoded bytes encode to at most 5464 -- inside the 5.5 KB
+# raw ceiling, which is itself well under nginx's 8 KB default header limit.
+_MAX_DECODED_PAYLOAD_BYTES = 4096
+
+
+class _AttributionFacts(NamedTuple):
+    """The engine facts one outbound call is attributed to, as resolved for a single request.
+
+    A value of None means the engine could not determine that fact; the corresponding payload
+    key is then omitted, which is how "unknown" is expressed on the wire.
+    """
+
+    project_chain: list[str]
+    workflow_name: str | None
+    node_type: str | None
+    engine_id: str | None
+    orchestrator_engine_id: str | None
+    session_id: str | None
+
+
+class _AttributionEncoding(NamedTuple):
+    """What was actually encoded, so the result's structured fields cannot drift from the header."""
+
+    header_value: str
+    facts: _AttributionFacts
+    chain_truncated: bool
+
+
+def _build_attribution_payload(facts: _AttributionFacts) -> dict[str, Any]:
+    """Build the decoded attribution payload, omitting every key the engine could not determine.
+
+    An absent key means "unknown". `tags` is omitted entirely when the chain is empty, because an
+    empty list would assert "belongs to zero projects" -- a claim we cannot make.
+    """
+    payload: dict[str, Any] = {"v": ATTRIBUTION_SCHEMA_VERSION}
+    if facts.project_chain:
+        payload["tags"] = {"project": list(facts.project_chain)}
+    if facts.workflow_name is not None:
+        payload["workflow"] = facts.workflow_name
+    if facts.node_type is not None:
+        payload["node_type"] = facts.node_type
+    if facts.engine_id is not None:
+        payload["engine_id"] = facts.engine_id
+    if facts.orchestrator_engine_id is not None:
+        payload["orchestrator_engine_id"] = facts.orchestrator_engine_id
+    if facts.session_id is not None:
+        payload["session_id"] = facts.session_id
+    return payload
+
+
+def _encode_attribution_payload(payload: dict[str, Any]) -> str | None:
+    """Encode a payload as base64url, or None when it exceeds the size cap.
+
+    Padding is kept so the Cloud can call `urlsafe_b64decode` without re-padding.
+    """
+    raw = json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    if len(raw) > _MAX_DECODED_PAYLOAD_BYTES:
+        return None
+    return base64.urlsafe_b64encode(raw).decode("ascii")
+
+
+def _encode_attribution_header(facts: _AttributionFacts) -> _AttributionEncoding | None:
+    """Encode the attribution header, reducing the payload once if it does not fit.
+
+    The chain is always truncated to `_MAX_PROJECT_CHAIN_ENTRIES` from the leaf: that is the v1
+    rule, not a size response. If the result still does not fit, one reduction step drops the
+    workflow and node type and keeps only the leaf project. Returns None when even that does not
+    fit, which needs a single project id larger than the whole cap.
+    """
+    chain_truncated = len(facts.project_chain) > _MAX_PROJECT_CHAIN_ENTRIES
+    full_facts = facts._replace(project_chain=list(facts.project_chain[:_MAX_PROJECT_CHAIN_ENTRIES]))
+
+    full_header_value = _encode_attribution_payload(_build_attribution_payload(full_facts))
+    if full_header_value is not None:
+        return _AttributionEncoding(
+            header_value=full_header_value,
+            facts=full_facts,
+            chain_truncated=chain_truncated,
+        )
+
+    logger.warning(
+        "Attribution payload exceeded %d bytes; reducing it to the leaf project only. "
+        "The workflow and node type will not be attributed for this call.",
+        _MAX_DECODED_PAYLOAD_BYTES,
+    )
+    reduced_facts = full_facts._replace(
+        project_chain=full_facts.project_chain[:1],
+        workflow_name=None,
+        node_type=None,
+    )
+    reduced_header_value = _encode_attribution_payload(_build_attribution_payload(reduced_facts))
+    if reduced_header_value is None:
+        return None
+
+    return _AttributionEncoding(
+        header_value=reduced_header_value,
+        facts=reduced_facts,
+        chain_truncated=True,
+    )
+
+
+class BudgetManager(EngineScoped):
+    """Composes the attribution context for a credit-consuming call.
+
+    Holds no state: the project chain, workflow, engine, and session are read from peer
+    managers on every request, so the answer always reflects the engine as it is now.
+    """
+
+    def __init__(self, event_manager: EventManager, *, engine: Engine | None = None) -> None:
+        """Initialize the BudgetManager.
+
+        Args:
+            event_manager: The EventManager instance to use for event handling.
+            engine: The owning Engine, used to resolve peer managers.
+        """
+        super().__init__(engine)
+        event_manager.assign_manager_to_request_type(
+            GetAttributionContextRequest, self.on_get_attribution_context_request
+        )
+
+    def on_get_attribution_context_request(
+        self, request: GetAttributionContextRequest
+    ) -> GetAttributionContextResultSuccess | GetAttributionContextResultFailure:
+        """Describe the current engine context as an encoded attribution header.
+
+        Every resolver degrades to a missing key rather than a failure: the caller is
+        about to spend money, and a partial attribution beats none. The one failure is a
+        payload that will not fit in a header even after being reduced.
+        """
+        facts = _AttributionFacts(
+            project_chain=self._resolve_project_chain(),
+            workflow_name=self._resolve_workflow_name(),
+            node_type=request.node_type,
+            engine_id=self._resolve_engine_id(),
+            orchestrator_engine_id=self._resolve_orchestrator_engine_id(),
+            session_id=self._resolve_session_id(),
+        )
+
+        encoding = _encode_attribution_header(facts)
+        if encoding is None:
+            return GetAttributionContextResultFailure(
+                result_details=(
+                    "Attempted to describe an outbound request for budget attribution. Failed because "
+                    "the attribution payload exceeded the maximum header size even after being reduced. "
+                    "The request can proceed, but this spend will not be attributed."
+                )
+            )
+
+        # Every structured field comes from `encoding.facts`, never from `facts`: the reduction
+        # step above can drop values, and a consumer reading these must see exactly what the
+        # header encodes.
+        encoded = encoding.facts
+        return GetAttributionContextResultSuccess(
+            header_value=encoding.header_value,
+            project_chain=list(encoded.project_chain),
+            workflow_name=encoded.workflow_name,
+            node_type=encoded.node_type,
+            engine_id=encoded.engine_id,
+            orchestrator_engine_id=encoded.orchestrator_engine_id,
+            session_id=encoded.session_id,
+            chain_truncated=encoding.chain_truncated,
+            result_details=(
+                f"Successfully described the attribution context for an outbound request "
+                f"({len(encoded.project_chain)} project(s) in the chain)."
+            ),
+        )
+
+    def _resolve_project_chain(self) -> list[str]:
+        """Resolve the current project's ancestry as ids, leaf-first, or [] when unavailable.
+
+        `ProjectChainEntry.name` is dropped here -- the single place the chain is consumed --
+        so no user-authored project label can reach the payload by construction.
+        """
+        try:
+            chain = self.engine.project_manager.get_project_chain()
+        except Exception:
+            logger.warning("Could not resolve the project chain for budget attribution.", exc_info=True)
+            return []
+        return [entry.id for entry in chain]
+
+    def _resolve_workflow_name(self) -> str | None:
+        """Resolve the current workflow's registry key, or None when it cannot be determined.
+
+        A workflow that has never been saved is registered under an `unsaved:<uuid4>` key.
+        That uuid is fresh every session, so sending it would put a never-repeating value in
+        the Cloud's workflow dimension and a per-session identifier in a proxy-logged header.
+        Report the sentinel instead: one low-cardinality bucket for scratch spend, still
+        distinguishable from an absent key, which means the engine could not tell at all.
+        """
+        try:
+            if not self.engine.context_manager.has_current_workflow():
+                return None
+            registry_key = self.engine.context_manager.get_current_workflow_name()
+        except Exception:
+            logger.warning("Could not resolve the current workflow for budget attribution.", exc_info=True)
+            return None
+
+        if registry_key.startswith(WorkflowRegistry.UNSAVED_KEY_PREFIX):
+            return UNSAVED_WORKFLOW_SENTINEL
+        return registry_key
+
+    def _resolve_engine_id(self) -> str | None:
+        """Resolve this engine's identifier, or None when it cannot be determined."""
+        try:
+            return self.engine.engine_identity_manager.engine_id
+        except Exception:
+            logger.warning("Could not resolve the engine id for budget attribution.", exc_info=True)
+            return None
+
+    def _resolve_orchestrator_engine_id(self) -> str | None:
+        """Resolve the parent engine's id, set at spawn on workers and unset on the orchestrator.
+
+        Reading an environment variable cannot raise, so this one needs no guard. In practice
+        the key is always absent from the payload: worker-originated requests are forwarded to
+        the orchestrator, which is not a worker and so has no parent to report.
+        """
+        return os.getenv("GTN_ORCHESTRATOR_ENGINE_ID")
+
+    def _resolve_session_id(self) -> str | None:
+        """Resolve the active session id, or None when it cannot be determined."""
+        try:
+            return self.engine.session_manager.active_session_id
+        except Exception:
+            logger.warning("Could not resolve the session id for budget attribution.", exc_info=True)
+            return None

--- a/src/griptape_nodes/retained_mode/managers/budget_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/budget_manager.py
@@ -160,10 +160,11 @@ class BudgetManager(EngineScoped):
     def _resolve_project_chain(self) -> list[str] | None:
         """Resolve the current project's ancestry as ids, leaf-first, or None when unreadable.
 
-        None and [] are different answers and must not collapse. [] means no project is open,
-        which the Cloud reads off the bare `{"v": 1}` as a positive fact. A peer that raised
-        knows nothing about whether a project is open, so reporting [] would send that fact
-        anyway -- the same arrives-looking-intact failure this module exists to avoid.
+        None and [] are different answers and must not collapse. [] means no project is open;
+        a peer that raised knows nothing of the kind. The far end cannot tell the two apart --
+        a bare `{"v": 1}` and no header at all parse to equal objects -- so this buys nothing
+        on the wire. It buys the engine not asserting a fact it does not have, and a caller
+        that gets a Failure it can act on instead of a Success carrying an empty chain.
 
         The id rather than the name, because it survives a rename -- a name would re-point that
         project's spend the moment a user edited it. But an id is not opaque: `ProjectTemplate.id`

--- a/src/griptape_nodes/retained_mode/managers/budget_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/budget_manager.py
@@ -42,9 +42,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("griptape_nodes")
 
-# The Cloud truncates the chain at this depth anyway; matching it client-side keeps both ends
-# in agreement.
-_MAX_PROJECT_CHAIN_ENTRIES = 10
+# Matches the Cloud parser's MAX_CHAIN_LENGTH (griptape-cloud#2225). Truncating lower would
+# not be conservative: the parser flags a truncated chain as mangled because budget paths are
+# root-anchored, so dropping ancestors client-side costs matches the Cloud would have made.
+_MAX_PROJECT_CHAIN_ENTRIES = 32
 
 # base64 inflates 4:3, so 4096 decoded bytes encode to at most 5464 -- inside the 5.5 KB raw
 # ceiling, itself well under nginx's 8 KB default.
@@ -77,22 +78,27 @@ class _AttributionEncoding(NamedTuple):
 def _build_attribution_payload(facts: _AttributionFacts) -> dict[str, Any]:
     """Build the decoded payload, omitting every key the engine could not determine.
 
-    `tags` is omitted entirely on an empty chain: an empty list would assert "belongs to zero
-    projects", a claim we cannot make.
+    Every dimension lives under `tags`; the Cloud parser reads nothing else, and there is no
+    second namespace beside it (griptape-cloud#2225). `tags` itself is omitted when the engine
+    could determine nothing, rather than sent empty.
     """
-    payload: dict[str, Any] = {"v": ATTRIBUTION_SCHEMA_VERSION}
+    tags: dict[str, Any] = {}
     if facts.project_chain:
-        payload["tags"] = {"project": list(facts.project_chain)}
+        tags["project"] = list(facts.project_chain)
     if facts.workflow_name is not None:
-        payload["workflow"] = facts.workflow_name
+        tags["workflow"] = facts.workflow_name
     if facts.node_type is not None:
-        payload["node_type"] = facts.node_type
+        tags["node_type"] = facts.node_type
     if facts.engine_id is not None:
-        payload["engine_id"] = facts.engine_id
+        tags["engine_id"] = facts.engine_id
     if facts.orchestrator_engine_id is not None:
-        payload["orchestrator_engine_id"] = facts.orchestrator_engine_id
+        tags["orchestrator_engine_id"] = facts.orchestrator_engine_id
     if facts.session_id is not None:
-        payload["session_id"] = facts.session_id
+        tags["session_id"] = facts.session_id
+
+    payload: dict[str, Any] = {"v": ATTRIBUTION_SCHEMA_VERSION}
+    if tags:
+        payload["tags"] = tags
     return payload
 
 

--- a/src/griptape_nodes/retained_mode/managers/budget_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/budget_manager.py
@@ -44,10 +44,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("griptape_nodes")
 
-# The four constants below mirror the Cloud parser, and each was read off it rather than agreed
-# in a doc: `control_plane/api/griptapecloud/components/spend/attribution.py` in the
-# griptape-cloud repo (PR #2225). Diverging from any of them costs attribution silently, so
-# check that file before changing one.
+# The four constants below mirror Griptape Cloud's attribution-header parser, and each was read
+# off that parser rather than agreed in a doc. Diverging from any of them costs attribution
+# silently, so re-check them against it before changing one; the PR description says where it
+# lives.
 
 # The parser's MAX_CHAIN_LENGTH. Truncating lower would not be conservative: it flags a
 # truncated chain as mangled because budget paths are root-anchored, so dropping ancestors
@@ -65,8 +65,8 @@ _MAX_DECODED_PAYLOAD_BYTES = 4096
 _UNSTORABLE_CHARACTERS = re.compile(r"[\x00-\x1f\x7f-\x9f]")
 
 # The parser's MAX_VALUE_LENGTH, and a cap on *characters*: it compares `len(value)` and slices
-# `value[:MAX_VALUE_LENGTH]` on a `str`, never on encoded bytes. Applied to project names only;
-# see `_as_the_cloud_keeps_it`.
+# `value[:MAX_VALUE_LENGTH]` on a `str`, never on encoded bytes. Used to judge project names,
+# not to cut them -- see `_project_name_for_the_wire`.
 _MAX_VALUE_CHARS = 256
 
 
@@ -110,11 +110,37 @@ def _as_the_cloud_keeps_it(name: str) -> str:
     parent-billed-for-its-child failure again. And it has to run before the byte checks, or a
     control character sitting past the cap drops a whole chain the far end would have stored.
 
-    Project names only. The result is what budget rules are written against, so reporting the
-    kept form is the accurate answer; a workflow registry key is an identifier rather than a
-    match key and travels as the engine spells it.
+    For deciding only. What actually travels is `_project_name_for_the_wire`, which is a
+    different string for an over-long name and for a good reason.
     """
     return name.strip()[:_MAX_VALUE_CHARS].strip()
+
+
+def _project_name_for_the_wire(name: str) -> str:
+    """Which form of a project name to send: the full one whenever it can travel.
+
+    Stripping here is free, because the far end strips too and records nothing when it does.
+    Cutting here is not. The parser marks a chain it had to cut as mangled and stops matching
+    it against admin-authored paths -- which is what keeps two sibling projects sharing a
+    256-character prefix from collapsing onto one budget. Handing it a pre-cut name presents
+    that prefix as an intact one: it reports no degradation, emits no metric, and matches. The
+    substitution then goes unrecorded on both sides, since `chain_truncated` on the result is
+    about the length of the chain, not of a name in it.
+
+    Whether a prefix match beats falling to the default budget is the Cloud's call to make on
+    its own data. Sending the full name leaves it able to make it.
+
+    One exception, and it is a real trade rather than a preference: a lone surrogate past the
+    cap survives the strip and makes the payload unencodable, costing the whole header. The cut
+    form drops that byte, so it goes instead -- one name's truncation signal for every other
+    dimension on the call.
+    """
+    stripped = name.strip()
+    try:
+        stripped.encode("utf-8")
+    except UnicodeEncodeError:
+        return _as_the_cloud_keeps_it(name)
+    return stripped
 
 
 def _is_transmissible(value: str) -> bool:
@@ -383,11 +409,11 @@ class BudgetManager(EngineScoped):
                     "attribute its spend."
                 )
                 return []
-            # Reduced to the kept form before anything is decided about it, so every test
-            # below sees the string the far end will see. A project name is a label rather
-            # than a key, so nothing is lost by reporting it the way it is stored.
-            name = _as_the_cloud_keeps_it(entry.name)
-            if not _is_transmissible(name):
+            # Judged on the form the far end keeps, so both tests below see the string it
+            # will see -- not on the form that travels, which for an over-long name is the
+            # uncut one.
+            kept = _as_the_cloud_keeps_it(entry.name)
+            if not _is_transmissible(kept):
                 logger.warning(
                     "Dropping project attribution for this call: a project name in the chain cannot "
                     "be transmitted intact. Rename the project using ordinary text to attribute its "
@@ -396,14 +422,14 @@ class BudgetManager(EngineScoped):
                 return []
             # Separate from the sentinel *id* skipped above -- this is a real project a user
             # named that, whether outright or by padding one out to the cap.
-            if name == SYSTEM_DEFAULTS_KEY:
+            if kept == SYSTEM_DEFAULTS_KEY:
                 logger.warning(
                     "Dropping project attribution for this call: a project is named '%s', which Griptape "
                     "Cloud reserves for its own use. Rename the project to attribute its spend.",
                     SYSTEM_DEFAULTS_KEY,
                 )
                 return []
-            project_names.append(name)
+            project_names.append(_project_name_for_the_wire(entry.name))
 
         return project_names
 

--- a/src/griptape_nodes/retained_mode/managers/budget_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/budget_manager.py
@@ -1,8 +1,8 @@
 """BudgetManager - Describes the engine context an outbound call should be attributed to.
 
-The manager owns no state. Every fact is read from a peer manager at request time, so a
-project switch between two calls is reflected on the second one. Nothing here makes a
-network call, holds a credential, or enforces a budget.
+The manager owns no state. The project chain is read from a peer manager at request time, so a
+project switch between two calls is reflected on the second one. Nothing here makes a network
+call, holds a credential, or enforces a budget.
 
 **Keeping the header value out of logs and broadcasts is a convention, not an invariant.**
 `broadcast_result` defaults to False but is a per-instance field any caller can flip;
@@ -11,11 +11,18 @@ post-dispatch hooks receive the full result regardless of it; a forwarded worker
 response topic by construction; and the engine's `omit_from_result` redaction primitive is
 request-side only, so it cannot mark a result field non-broadcastable. What this module can
 do it does: it never interpolates `header_value` or the payload into `result_details`, which
-is logged as well as broadcast. The value is descriptive rather than secret, so none of that
+is logged as well as broadcast. Project ids are descriptive rather than secret, so none of that
 is alarming -- but it is the real state of the mechanism.
 
+**Nothing here judges a value.** Griptape Cloud's parser already reports every degradation it
+applies -- a truncated value, a truncated chain, a dropped entry -- and marks a chain it had to
+repair `mangled`, which takes it out of budget matching entirely. Repairing or withholding a
+value here would arrive looking intact instead: no reason recorded, no metric fired, and a
+budget matched against something the engine quietly rewrote. So ids travel exactly as the
+project manager reports them, at whatever length that comes to, and the far end decides.
+
 `Engine.handle_request` converts a raised handler exception into a `ResultPayloadFailure`,
-so there is deliberately no blanket try/except here; the resolvers guard their own peer reads.
+so there is deliberately no blanket try/except here; the resolver guards its own peer read.
 """
 
 from __future__ import annotations
@@ -23,15 +30,11 @@ from __future__ import annotations
 import base64
 import json
 import logging
-import os
-import re
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, Any
 
-from griptape_nodes.node_library.workflow_registry import WorkflowRegistry
 from griptape_nodes.retained_mode.engine import EngineScoped
 from griptape_nodes.retained_mode.events.budget_events import (
     ATTRIBUTION_SCHEMA_VERSION,
-    UNSAVED_WORKFLOW_SENTINEL,
     GetAttributionContextRequest,
     GetAttributionContextResultFailure,
     GetAttributionContextResultSuccess,
@@ -44,178 +47,41 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("griptape_nodes")
 
-# The three constants below mirror Griptape Cloud's attribution-header parser, and each was read
-# off that parser rather than agreed in a doc. Diverging from any of them costs attribution
-# silently, so re-check them against it before changing one; the PR description says where it
-# lives.
-#
-# Only the first is enforced. The others describe what the far end will do with a value so the
-# engine can tell a value it would drop from one it would merely repair -- never so the engine
-# can repair it first. See `_encode_attribution_header`.
 
-# The parser's MAX_RAW_HEADER_LENGTH, measured the same way -- on the encoded header, before
-# any decoding. It is the only size this module enforces, and it is an ingress concern rather
-# than an attribution one. Past it the Cloud reports OVERSIZE without decoding, so a larger
-# header buys no further diagnosis while eating into nginx's 8 KB header buffer -- and a header
-# the ingress rejects kills the API call itself, not merely its attribution.
-#
-# Deliberately not the parser's MAX_DECODED_LENGTH of 4096. A payload over that is discarded by
-# the Cloud *and reported* as OVERSIZE; shrinking it here to slip under would trade a spend the
-# platform knows it could not attribute for one it believes it attributed correctly.
-_MAX_ENCODED_HEADER_BYTES = 5632
+def _build_attribution_payload(project_chain: list[str]) -> dict[str, Any]:
+    """Build the decoded payload for a project chain, which may be empty.
 
-# C0 and C1 control characters, the parser's `_is_storable` rule written as a class. A value
-# containing one is stored nowhere on the far end, so sending it buys nothing and costs
-# something -- see `_is_transmissible`.
-_UNSTORABLE_CHARACTERS = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+    `project` is the only tag key the engine sends, because it is the only one Griptape Cloud
+    matches budgets against. It lives under `tags`; the parser reads no other namespace.
 
-# The parser's MAX_VALUE_LENGTH, and a cap on *characters*: it compares `len(value)` and slices
-# `value[:MAX_VALUE_LENGTH]` on a `str`, never on encoded bytes. Used to judge project names
-# (`_is_transmissible`). Only ever used to judge a name, never to cut the one that travels: a
-# name cut here arrives looking intact, which is the one thing the far end cannot detect.
-_MAX_VALUE_CHARS = 256
-
-
-class _AttributionFacts(NamedTuple):
-    """The engine facts one outbound call is attributed to.
-
-    None means the engine could not determine that fact; its payload key is then omitted,
-    which is how "unknown" is expressed on the wire.
+    An empty chain omits `tags` entirely rather than sending it empty, and the bare `{"v": 1}`
+    envelope that leaves is worth sending: the parser reads a missing `tags` as "no project is
+    open on a client that speaks attribution", which is a different and more useful fact than
+    sending no header at all, which it reads as "this client has not adopted attribution".
     """
-
-    project_chain: list[str]
-    workflow_name: str | None
-    node_type: str | None
-    engine_id: str | None
-    orchestrator_engine_id: str | None
-    session_id: str | None
-
-
-class _AttributionEncoding(NamedTuple):
-    """What was actually encoded, so the result's structured fields cannot drift from the header."""
-
-    header_value: str
-    facts: _AttributionFacts
-    chain_truncated: bool
-
-
-def _as_the_cloud_keeps_it(name: str) -> str:
-    """Reduce a project name to the form the Cloud actually stores.
-
-    Strip, cut to the value cap, strip again -- the parser's own order, and the order matters
-    twice. It has to run *before* the reserved-value test, or a name that only becomes
-    `<system-defaults>` after the cut passes here and is refused there, which is the
-    parent-billed-for-its-child failure again. And it has to run before the byte checks, or a
-    control character sitting past the cap drops a whole chain the far end would have stored.
-
-    For deciding only -- nothing here is ever sent. The question it answers is whether the
-    Cloud would store an entry for this name at all: if it would, the whole name travels and
-    the Cloud cuts it itself, flagging the cut; if it would not, the entry would be dropped
-    there and its parent promoted, so the chain goes instead.
-    """
-    return name.strip()[:_MAX_VALUE_CHARS].strip()
-
-
-def _is_encodable(value: str) -> bool:
-    """Whether a string can be put on the wire at all.
-
-    A project name is free text and a workflow registry key is derived from a filesystem path,
-    so either can carry a byte the wire cannot hold: a path whose bytes are not valid UTF-8
-    comes back from the OS carrying lone surrogates from `surrogateescape`, which `str.encode`
-    refuses. Unguarded that raises out of the encoder and costs the whole header, not one key.
-    """
-    try:
-        value.encode("utf-8")
-    except UnicodeEncodeError:
-        return False
-    return True
-
-
-def _is_transmissible(value: str) -> bool:
-    """Whether a value survives the trip to the Cloud intact.
-
-    Judged on the stored form, not the given one: the far end normalizes before it decides
-    storability, so a value that passes here raw and is discarded there costs an entry,
-    promotes its parent to leaf, and bills a real ancestor for spend it never had. Stripping
-    covers that for every dimension. A project name is judged on the cut form as well, since
-    the far end cuts before it decides -- the caller passes `_as_the_cloud_keeps_it(name)`.
-    That is about what to judge, never about what to send; the whole name still travels.
-
-    Three ways a value does not survive. A pasted line break, or a directory name that legally
-    contains a control character, encodes here and is discarded there. A name that is nothing
-    but whitespace strips to empty, which the far end will not store. And the value may not be
-    encodable at all -- see `_is_encodable`.
-    """
-    stripped = value.strip()
-    if not stripped:
-        return False
-    if _UNSTORABLE_CHARACTERS.search(stripped):
-        return False
-    return _is_encodable(stripped)
-
-
-def _transmissible_or_none(value: str | None) -> str | None:
-    """Pass a value through, or None when it cannot reach the Cloud intact.
-
-    Passed through verbatim, never stripped. Transmissibility is judged on the stripped form
-    because that is what the far end tests, but normalizing is a *project name* rule and this
-    helper runs over every dimension. A workflow registry key is an identifier the engine can
-    be asked to look up again, so trimming it here would hand a consumer a string that no
-    longer names the workflow it came from. `_resolve_project_chain` normalizes its own names,
-    where the reason to is written down.
-
-    Omitting the key says "the engine could not determine this", which is honest: a value the
-    far end would discard is one the engine cannot express.
-    """
-    if value is None:
-        return None
-    if not _is_transmissible(value):
-        return None
-    return value
-
-
-def _build_attribution_payload(facts: _AttributionFacts) -> dict[str, Any]:
-    """Build the decoded payload, omitting every key the engine could not determine.
-
-    Every dimension lives under `tags`; the Cloud parser reads nothing else, and there is no
-    second namespace beside it. `tags` itself is omitted when the engine could determine
-    nothing, rather than sent empty.
-    """
-    tags: dict[str, Any] = {}
-    if facts.project_chain:
-        tags["project"] = list(facts.project_chain)
-    if facts.workflow_name is not None:
-        tags["workflow"] = facts.workflow_name
-    if facts.node_type is not None:
-        tags["node_type"] = facts.node_type
-    if facts.engine_id is not None:
-        tags["engine_id"] = facts.engine_id
-    if facts.orchestrator_engine_id is not None:
-        tags["orchestrator_engine_id"] = facts.orchestrator_engine_id
-    if facts.session_id is not None:
-        tags["session_id"] = facts.session_id
-
-    payload: dict[str, Any] = {"v": ATTRIBUTION_SCHEMA_VERSION}
-    if tags:
-        payload["tags"] = tags
-    return payload
+    if not project_chain:
+        return {"v": ATTRIBUTION_SCHEMA_VERSION}
+    return {"v": ATTRIBUTION_SCHEMA_VERSION, "tags": {"project": list(project_chain)}}
 
 
 def _encode_attribution_payload(payload: dict[str, Any]) -> str | None:
     """Encode a payload as base64url, or None when it cannot be encoded at all.
 
-    Size is not judged here. What has to fit is the header, not the payload, and the caller is
-    the only one that knows what it is willing to give up to make it fit.
+    Size is not judged here, or anywhere. A header the Cloud considers oversized is discarded
+    *and reported* as OVERSIZE, so the spend goes unattributed and the platform knows it did --
+    a better outcome than shrinking the header here and having it arrive looking complete.
 
     Padding is kept because the payload is `base64.b64encode`'s natural output and stripping it
     would buy nothing: the parser re-pads whatever it receives before decoding, so both forms
     arrive intact.
 
-    The UTF-8 guard is a backstop -- every dimension is filtered through `_transmissible_or_none`
-    upstream, which costs one key where returning None here costs the whole header. It stays
-    because letting `str.encode` raise would escape the handler as a `GenericResultFailure`,
-    which ignores `failure_log_level` (`event_manager.py:1088-1094`) and would log an ERROR with
-    a traceback on every metered call.
+    The UTF-8 guard is the module's only failure path, and it fires by design rather than as a
+    backstop. A project id derived from a filesystem path whose bytes are not valid UTF-8 comes
+    back from the OS carrying lone surrogates from `surrogateescape`, which `str.encode` refuses.
+    That costs the whole header, deliberately: it is the one thing the wire physically cannot
+    carry, so there is no honest partial form to send instead. Letting `str.encode` raise would
+    escape the handler as a `GenericResultFailure`, which ignores `failure_log_level`
+    (`event_manager.py:1088-1094`) and would log an ERROR with a traceback on every metered call.
     """
     try:
         raw = json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
@@ -228,66 +94,11 @@ def _encode_attribution_payload(payload: dict[str, Any]) -> str | None:
     return base64.urlsafe_b64encode(raw).decode("ascii")
 
 
-def _encode_attribution_header(facts: _AttributionFacts) -> _AttributionEncoding | None:
-    """Encode the attribution header, shedding the project chain only if the ingress demands it.
-
-    Nothing here repairs a tag. The engine cannot tell a name that is too long from one that is
-    wrong, and Griptape Cloud can: it truncates an over-long name, truncates an over-deep chain,
-    reports each as a degradation metric, and -- the part that decides this function -- marks a
-    chain it had to repair `mangled`, which takes it out of budget matching entirely. Damage the
-    far end can see is damage it refuses to bill against. So facts travel as the engine found
-    them, and judging them is the Cloud's job.
-
-    Repairing them here would invert that. A chain cut to `MAX_CHAIN_LENGTH` before sending, or a
-    name cut to `MAX_VALUE_LENGTH`, arrives looking intact: no reason is recorded, no metric
-    fires, `mangled` stays false, and the Cloud matches a budget against a chain missing its root
-    or a name sharing a prefix with its siblings. That bills the wrong project silently, and it is strictly
-    worse than the loud non-billing the Cloud would have produced on its own.
-
-    The one size this enforces is `_MAX_ENCODED_HEADER_BYTES`, and it is not an attribution rule.
-    A payload past the Cloud's own decode cap is discarded *and reported* as OVERSIZE, which is a
-    fine outcome -- the spend goes unattributed and the platform knows it did. A header past the
-    ingress buffer is not: it fails the whole request with a 4xx, and the artist loses the call
-    rather than its attribution. So the header is bounded where the ingress bounds it, and the
-    only thing given up to get under that bound is the chain.
-
-    When the chain goes, all of it goes -- never a prefix, never cut entries. Budget paths are
-    root-anchored, so a partial chain matches nothing at best and an unrelated top-level project
-    of the same name at worst. Same rule `_resolve_project_chain` applies to a name it cannot
-    describe, and for the same reason: an incomplete claim is worse than no claim.
-
-    None means even the chainless envelope does not fit, or does not encode -- the first
-    unreachable short of a header bound under a hundred bytes, the second a backstop for a
-    payload every dimension of which was already filtered.
-    """
-    with_chain = _encode_attribution_payload(_build_attribution_payload(facts))
-    if with_chain is not None and len(with_chain) <= _MAX_ENCODED_HEADER_BYTES:
-        return _AttributionEncoding(header_value=with_chain, facts=facts, chain_truncated=False)
-
-    if not facts.project_chain:
-        return None
-
-    chainless_facts = facts._replace(project_chain=[])
-    chainless = _encode_attribution_payload(_build_attribution_payload(chainless_facts))
-    if chainless is None:
-        return None
-    if len(chainless) > _MAX_ENCODED_HEADER_BYTES:
-        return None
-
-    logger.warning(
-        "The attribution header would exceed %d bytes, so no project is attributed for this call "
-        "and Griptape Cloud will bill the spend to the default budget. This needs a project chain "
-        "thousands of characters long; shorten the project names to attribute their spend.",
-        _MAX_ENCODED_HEADER_BYTES,
-    )
-    return _AttributionEncoding(header_value=chainless, facts=chainless_facts, chain_truncated=True)
-
-
 class BudgetManager(EngineScoped):
     """Composes the attribution context for a credit-consuming call.
 
-    Holds no state: the project chain, workflow, engine, and session are read from peer
-    managers on every request, so the answer always reflects the engine as it is now.
+    Holds no state: the project chain is read from the project manager on every request, so the
+    answer always reflects the engine as it is now.
     """
 
     def __init__(self, event_manager: EventManager, *, engine: Engine | None = None) -> None:
@@ -303,75 +114,52 @@ class BudgetManager(EngineScoped):
         )
 
     def on_get_attribution_context_request(
-        self, request: GetAttributionContextRequest
+        self,
+        request: GetAttributionContextRequest,  # noqa: ARG002
     ) -> GetAttributionContextResultSuccess | GetAttributionContextResultFailure:
         """Describe the current engine context as an encoded attribution header.
 
-        Every resolver degrades to a missing key rather than a failure: the caller is about to
-        spend money, and a partial attribution beats none. The one failure is a header still
-        too large for the ingress even with the project chain given up.
+        A project chain the engine cannot resolve degrades to an empty one rather than a
+        failure: the caller is about to spend money, and an unattributed call beats a blocked
+        one. The one failure is an id the wire cannot carry at all.
         """
-        facts = _AttributionFacts(
-            project_chain=self._resolve_project_chain(),
-            workflow_name=self._resolve_workflow_name(),
-            node_type=_transmissible_or_none(request.node_type),
-            engine_id=_transmissible_or_none(self._resolve_engine_id()),
-            orchestrator_engine_id=_transmissible_or_none(self._resolve_orchestrator_engine_id()),
-            session_id=_transmissible_or_none(self._resolve_session_id()),
-        )
-
-        encoding = _encode_attribution_header(facts)
-        if encoding is None:
+        project_chain = self._resolve_project_chain()
+        header_value = _encode_attribution_payload(_build_attribution_payload(project_chain))
+        if header_value is None:
             return GetAttributionContextResultFailure(
                 result_details=(
-                    "Attempted to describe an outbound request for budget attribution. Failed because "
-                    "the description could not be fitted into a request header, even with the project left "
-                    "out of it. The request can proceed, but this spend will not be attributed."
+                    "Attempted to describe an outbound request for budget attribution. Failed because a "
+                    "project id contains characters that cannot be sent in a request header. The request "
+                    "can proceed, but this spend will not be attributed."
                 )
             )
 
-        # From `encoding.facts`, never `facts`: the encoder may have given up the chain, and
-        # these fields must describe exactly what the header encodes.
-        encoded = encoding.facts
         return GetAttributionContextResultSuccess(
-            header_value=encoding.header_value,
-            project_chain=list(encoded.project_chain),
-            workflow_name=encoded.workflow_name,
-            node_type=encoded.node_type,
-            engine_id=encoded.engine_id,
-            orchestrator_engine_id=encoded.orchestrator_engine_id,
-            session_id=encoded.session_id,
-            chain_truncated=encoding.chain_truncated,
+            header_value=header_value,
+            project_chain=list(project_chain),
             result_details=(
                 f"Successfully described the attribution context for an outbound request "
-                f"({len(encoded.project_chain)} project(s) in the chain)."
+                f"({len(project_chain)} project(s) in the chain)."
             ),
         )
 
     def _resolve_project_chain(self) -> list[str]:
-        """Resolve the current project's ancestry as names, leaf-first, or [] when unavailable.
+        """Resolve the current project's ancestry as ids, leaf-first, or [] when unavailable.
 
-        `tags.project` is the only dimension the Cloud matches budgets against, so whatever
-        goes here has to be something a budget admin can author into a rule. The project name
-        is that: required by the schema, so always present, and the same string on every
-        machine that opens the project.
+        `tags.project` is the only dimension the Cloud matches budgets against, and the project
+        id is what identifies a project across a rename -- the name would silently re-point that
+        project's spend the moment a user edited it.
 
-        Two costs come with it, both accepted deliberately. A user-authored string rides in a
-        header that SSL-inspecting egress proxies log, so a project name discloses whatever the
-        user put in it -- a client name, typically. And a rename silently re-points that
-        project's spend, because the Cloud matches on the string alone and has no way to know
-        the two names are the same project.
+        An id is not an opaque GUID. `ProjectTemplate.id` has no pattern and no length cap: the
+        editor proposes a slug of the project name, the user may replace it with anything, and a
+        legacy project without one has the canonical path to its file written in permanently. So
+        an id discloses roughly what a name would, plus directory layout, in a header that
+        SSL-inspecting egress proxies log. That is the accepted cost of a stable identifier.
 
-        Any link the Cloud cannot match costs the *whole* chain, not just its own entry --
-        whether it is nameless, reserved, or untransmissible. Budget paths are root-anchored,
-        so a chain missing a link already matches nothing, and dropping just the offender is
-        worse than sending none: it promotes that entry's parent to leaf and bills a real
-        ancestor for spend it never incurred. A nameless entry can sit anywhere, since
-        `get_project_chain` maps any falsy name to None and the schema permits `name: ""`.
-
-        The `<system-defaults>` rest state is the one exception, skipped by *id* before its
-        name is read. It is the root sentinel rather than an ancestor the Cloud models, so
-        skipping it leaves a matchable chain instead of a truncated one.
+        Every id travels exactly as it is stored -- unstripped, uncut, unexamined. The one entry
+        skipped is the `<system-defaults>` rest-state sentinel, and that is not a repair: it is
+        the root sentinel rather than an ancestor the Cloud models, and the Cloud reserves that
+        string for its own default and refuses a client copy of it.
         """
         try:
             chain = self.engine.project_manager.get_project_chain()
@@ -379,92 +167,4 @@ class BudgetManager(EngineScoped):
             logger.warning("Could not resolve the project chain for budget attribution.", exc_info=True)
             return []
 
-        project_names: list[str] = []
-        for entry in chain:
-            if entry.id == SYSTEM_DEFAULTS_KEY:
-                continue
-            if entry.name is None:
-                logger.warning(
-                    "Dropping project attribution for this call: a project in the chain has no "
-                    "usable name, so the chain cannot be described. Give every project a name to "
-                    "attribute its spend."
-                )
-                return []
-            # Judged on the form the far end keeps, so both tests below see the string it
-            # will see. That is deliberately more forgiving than judging the whole name: a
-            # control character past the value cap is one the Cloud's own truncation removes
-            # before it decides storability, so it costs a truncation flag over there rather
-            # than a chain over here.
-            #
-            # Encodability is the exception, and is judged on the whole name, because it is
-            # the one property of a name that is ours rather than the Cloud's -- a name the
-            # cut form could encode and the whole one cannot has no honest wire form. Sending
-            # the cut form would be a repair arriving intact.
-            kept = _as_the_cloud_keeps_it(entry.name)
-            if not _is_transmissible(kept) or not _is_encodable(entry.name):
-                logger.warning(
-                    "Dropping project attribution for this call: a project name in the chain cannot "
-                    "be transmitted intact. Rename the project using ordinary text to attribute its "
-                    "spend."
-                )
-                return []
-            # Separate from the sentinel *id* skipped above -- this is a real project a user
-            # named that, whether outright or by padding one out to the cap.
-            if kept == SYSTEM_DEFAULTS_KEY:
-                logger.warning(
-                    "Dropping project attribution for this call: a project is named '%s', which Griptape "
-                    "Cloud reserves for its own use. Rename the project to attribute its spend.",
-                    SYSTEM_DEFAULTS_KEY,
-                )
-                return []
-            # Stripped, never cut. Stripping is free -- the far end strips too and records
-            # nothing when it does -- while cutting is the repair this module refuses to make.
-            project_names.append(entry.name.strip())
-
-        return project_names
-
-    def _resolve_workflow_name(self) -> str | None:
-        """Resolve the current workflow's registry key, or None when it cannot be determined.
-
-        An unsaved workflow is registered under an `unsaved:<uuid4>` key that is fresh every
-        session, so the sentinel goes out instead: one low-cardinality bucket for scratch spend,
-        still distinguishable from an absent key. A saved key is workspace-path-derived, so it
-        carries the same transmissibility risk as a project name and gets the same check --
-        but not the same normalizing. A key is how the engine names the workflow, and a path
-        segment may legally begin or end with a space, so it travels exactly as
-        `get_current_workflow_name` returns it.
-        """
-        try:
-            if not self.engine.context_manager.has_current_workflow():
-                return None
-            registry_key = self.engine.context_manager.get_current_workflow_name()
-        except Exception:
-            logger.warning("Could not resolve the current workflow for budget attribution.", exc_info=True)
-            return None
-
-        if registry_key.startswith(WorkflowRegistry.UNSAVED_KEY_PREFIX):
-            return UNSAVED_WORKFLOW_SENTINEL
-        return _transmissible_or_none(registry_key)
-
-    def _resolve_engine_id(self) -> str | None:
-        """Resolve this engine's identifier, or None when it cannot be determined."""
-        try:
-            return self.engine.engine_identity_manager.engine_id
-        except Exception:
-            logger.warning("Could not resolve the engine id for budget attribution.", exc_info=True)
-            return None
-
-    def _resolve_orchestrator_engine_id(self) -> str | None:
-        """Resolve the parent engine's id, set at spawn on workers, unset on the orchestrator.
-
-        Unguarded because `os.getenv` cannot raise.
-        """
-        return os.getenv("GTN_ORCHESTRATOR_ENGINE_ID")
-
-    def _resolve_session_id(self) -> str | None:
-        """Resolve the active session id, or None when it cannot be determined."""
-        try:
-            return self.engine.session_manager.active_session_id
-        except Exception:
-            logger.warning("Could not resolve the session id for budget attribution.", exc_info=True)
-            return None
+        return [entry.id for entry in chain if entry.id != SYSTEM_DEFAULTS_KEY]

--- a/src/griptape_nodes/retained_mode/managers/budget_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/budget_manager.py
@@ -35,6 +35,7 @@ from griptape_nodes.retained_mode.events.budget_events import (
     GetAttributionContextResultFailure,
     GetAttributionContextResultSuccess,
 )
+from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY
 
 if TYPE_CHECKING:
     from griptape_nodes.retained_mode.engine import Engine
@@ -223,13 +224,19 @@ class BudgetManager(EngineScoped):
 
         `ProjectChainEntry.name` is dropped here -- the single place the chain is consumed --
         so no user-authored project label can reach the payload by construction.
+
+        `<system-defaults>` is dropped with it. The Cloud reserves that exact string as its own
+        marker for unattributed spend, so its parser discards a client copy and counts the call
+        as degraded. Working outside a project is ordinary rather than exceptional, so sending it
+        would put a permanent noise floor under the platform's client-health metric for no gain:
+        omitting the key lands the spend in the same default bucket, silently.
         """
         try:
             chain = self.engine.project_manager.get_project_chain()
         except Exception:
             logger.warning("Could not resolve the project chain for budget attribution.", exc_info=True)
             return []
-        return [entry.id for entry in chain]
+        return [entry.id for entry in chain if entry.id != SYSTEM_DEFAULTS_KEY]
 
     def _resolve_workflow_name(self) -> str | None:
         """Resolve the current workflow's registry key, or None when it cannot be determined.

--- a/src/griptape_nodes/retained_mode/managers/budget_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/budget_manager.py
@@ -14,7 +14,8 @@ worker forwarding puts the Success payload on the response topic by construction
 module can do it does -- `header_value` never reaches `result_details`, which is logged.
 
 `Engine.handle_request` turns a raised handler exception into a `ResultPayloadFailure`, so there
-is no blanket try/except here; the resolver guards its own peer read.
+is no blanket try/except here; the resolver guards its own peer read and reports the failure
+rather than swallowing it.
 """
 
 from __future__ import annotations
@@ -25,6 +26,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from griptape_nodes.retained_mode.engine import EngineScoped
+from griptape_nodes.retained_mode.events.base_events import ResultDetails
 from griptape_nodes.retained_mode.events.budget_events import (
     ATTRIBUTION_SCHEMA_VERSION,
     GetAttributionContextRequest,
@@ -62,13 +64,16 @@ def _encode_attribution_payload(payload: dict[str, Any]) -> str | None:
     Cloud, which beats shrinking it here and having it arrive looking complete. Padding is kept
     because the parser re-pads anyway, so both forms arrive intact.
 
-    The UTF-8 guard is the module's only failure path and fires by design. A legacy project's id
-    is the path to its file, and a path whose bytes are not valid UTF-8 carries lone surrogates
-    from `surrogateescape` that `str.encode` refuses. That costs the whole header: it is the one
-    thing the wire cannot carry, so there is no honest partial form. Returning None rather than
-    raising, because a handler exception becomes a `GenericResultFailure`, which ignores
-    `failure_log_level` (`event_manager.py:1088-1094`) and logs an ERROR with a traceback on
-    every metered call.
+    A legacy project's id is the path to its file, and a path whose bytes are not valid UTF-8
+    carries lone surrogates from `surrogateescape` that `str.encode` refuses. That costs the whole
+    header: it is the one thing the wire cannot carry, so there is no honest partial form.
+
+    Returning None rather than raising, because a handler exception becomes a
+    `GenericResultFailure`, which ignores `failure_log_level` (`event_manager.py:1088-1094`).
+
+    This warning is the engineer-facing half of the pair and the artist-facing message is the
+    other; the traceback stays because `UnicodeEncodeError` names the offending codepoint and its
+    position, which is the only pointer to which entry of a deep chain is the bad one.
     """
     try:
         raw = json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
@@ -102,18 +107,39 @@ class BudgetManager(EngineScoped):
     ) -> GetAttributionContextResultSuccess | GetAttributionContextResultFailure:
         """Describe the current project as an encoded attribution header.
 
-        An unresolvable chain degrades to an empty one rather than a failure: the caller is
-        about to spend money, and an unattributed call beats a blocked one. The one failure is
-        an id the wire cannot carry.
+        Both failures send no header at all, which the Cloud reads as "this client did not
+        attribute" -- the honest answer, and distinct from the `{"v": 1}` a client sends to say
+        no project is open. Neither blocks the caller: it is about to spend money, and an
+        unattributed call beats a blocked one.
+
+        Both are logged at WARNING rather than the ERROR a bare `result_details` string would
+        default to. Neither condition clears on its own -- a legacy project keeps its unencodable
+        id -- so an ERROR would repeat once per metered call for something the artist cannot act
+        on and that did not stop the work.
         """
         project_chain = self._resolve_project_chain()
+        if project_chain is None:
+            return GetAttributionContextResultFailure(
+                result_details=ResultDetails(
+                    message=(
+                        "Attempted to describe an outbound request for budget attribution. Failed because the "
+                        "current project's ancestry could not be read. The request can proceed, but this spend "
+                        "will not be attributed."
+                    ),
+                    level=logging.WARNING,
+                )
+            )
+
         header_value = _encode_attribution_payload(_build_attribution_payload(project_chain))
         if header_value is None:
             return GetAttributionContextResultFailure(
-                result_details=(
-                    "Attempted to describe an outbound request for budget attribution. Failed because a "
-                    "project id contains characters that cannot be sent in a request header. The request "
-                    "can proceed, but this spend will not be attributed."
+                result_details=ResultDetails(
+                    message=(
+                        "Attempted to describe an outbound request for budget attribution. Failed because a "
+                        "project id contains characters that cannot be sent in a request header. The request "
+                        "can proceed, but this spend will not be attributed."
+                    ),
+                    level=logging.WARNING,
                 )
             )
 
@@ -126,8 +152,13 @@ class BudgetManager(EngineScoped):
             ),
         )
 
-    def _resolve_project_chain(self) -> list[str]:
-        """Resolve the current project's ancestry as ids, leaf-first, or [] when unavailable.
+    def _resolve_project_chain(self) -> list[str] | None:
+        """Resolve the current project's ancestry as ids, leaf-first, or None when unreadable.
+
+        None and [] are different answers and must not collapse. [] means no project is open,
+        which the Cloud reads off the bare `{"v": 1}` as a positive fact. A peer that raised
+        knows nothing about whether a project is open, so reporting [] would send that fact
+        anyway -- the same arrives-looking-intact failure this module exists to avoid.
 
         The id rather than the name, because it survives a rename -- a name would re-point that
         project's spend the moment a user edited it. But an id is not opaque: `ProjectTemplate.id`
@@ -142,6 +173,6 @@ class BudgetManager(EngineScoped):
             chain = self.engine.project_manager.get_project_chain()
         except Exception:
             logger.warning("Could not resolve the project chain for budget attribution.", exc_info=True)
-            return []
+            return None
 
         return [entry.id for entry in chain if entry.id != SYSTEM_DEFAULTS_KEY]

--- a/src/griptape_nodes/retained_mode/managers/budget_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/budget_manager.py
@@ -48,9 +48,12 @@ def _build_attribution_payload(project_chain: list[str]) -> dict[str, Any]:
     `project` is the only key the Cloud matches budgets against, so it is the only one sent, and
     `tags` is the only namespace the parser reads.
 
-    An empty chain omits `tags` rather than sending it empty. The bare `{"v": 1}` still goes out:
-    the parser reads a missing `tags` as "no project open on a client that attributes", which is
-    a different fact from sending no header at all.
+    An empty chain omits `tags` rather than sending it empty, and the bare `{"v": 1}` still goes
+    out -- but only because it is harmless and forward-compatible, not because the far end can
+    read anything off it. `Attribution()` defaults `tags_read` and `interpreted` to True, so an
+    absent header satisfies every conjunct of `project_chain_absent` exactly as this envelope
+    does; the two parse to equal objects and neither emits a metric. If the Cloud ever adds a
+    `client_attributed` flag this becomes a real signal without a client release.
     """
     if not project_chain:
         return {"v": ATTRIBUTION_SCHEMA_VERSION}
@@ -107,10 +110,12 @@ class BudgetManager(EngineScoped):
     ) -> GetAttributionContextResultSuccess | GetAttributionContextResultFailure:
         """Describe the current project as an encoded attribution header.
 
-        Both failures send no header at all, which the Cloud reads as "this client did not
-        attribute" -- the honest answer, and distinct from the `{"v": 1}` a client sends to say
-        no project is open. Neither blocks the caller: it is about to spend money, and an
-        unattributed call beats a blocked one.
+        Both failures send no header at all rather than the `{"v": 1}` they used to. The far end
+        cannot tell those apart -- an absent header and a bare envelope parse to equal objects --
+        so this buys nothing on the wire. It is about the engine not asserting a fact it does not
+        have, and about the caller getting a Failure it can act on instead of a Success carrying
+        an empty chain. Neither blocks the call: it is about to spend money, and an unattributed
+        call beats a blocked one.
 
         Both are logged at WARNING rather than the ERROR a bare `result_details` string would
         default to. Neither condition clears on its own -- a legacy project keeps its unencodable
@@ -168,6 +173,18 @@ class BudgetManager(EngineScoped):
 
         Ids travel exactly as stored. The one entry skipped is the `<system-defaults>` rest-state
         sentinel, which is not an ancestor the Cloud models and whose string it reserves anyway.
+
+        Matched on the stripped id, because that is the form the far end matches on: it strips
+        each entry before testing the reserved value, so a padded copy is the same claim to it.
+        Left whole, such an entry is dropped there rather than here -- and a dropped entry
+        promotes its parent to leaf while `ENTRY_DROPPED` stays out of `mangled`, so the short
+        chain still matches a budget and bills a real ancestor. Skipping an entry is not the
+        value-repair the verbatim rule forbids; every id that does travel still travels untouched.
+
+        Not covered: an id long enough that the far end's 256-character cut leaves exactly the
+        reserved string. Catching that means mirroring `MAX_VALUE_LENGTH` here, which is the
+        constant-mirroring this module deleted on purpose. The real fix is on the far end --
+        `ENTRY_DROPPED` belongs in `mangled`.
         """
         try:
             chain = self.engine.project_manager.get_project_chain()
@@ -175,4 +192,4 @@ class BudgetManager(EngineScoped):
             logger.warning("Could not resolve the project chain for budget attribution.", exc_info=True)
             return None
 
-        return [entry.id for entry in chain if entry.id != SYSTEM_DEFAULTS_KEY]
+        return [entry.id for entry in chain if entry.id.strip() != SYSTEM_DEFAULTS_KEY]

--- a/src/griptape_nodes/retained_mode/managers/budget_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/budget_manager.py
@@ -153,14 +153,11 @@ def _encode_attribution_payload(payload: dict[str, Any]) -> str | None:
 
     Padding is kept so the Cloud can call `urlsafe_b64decode` without re-padding.
 
-    The UTF-8 guard covers the identifier fields, which are not filtered individually the way
-    the chain, workflow, and node type are: `orchestrator_engine_id` is read from the
-    environment, and `os.getenv` decodes with `surrogateescape`, so a non-UTF-8 value reaches
-    here as a lone surrogate. Letting that raise would escape the handler as a
-    `GenericResultFailure`, which ignores `failure_log_level` (`event_manager.py:1088-1094`)
-    and would therefore log an ERROR with a traceback on every metered call. Returning None
-    instead degrades to the documented outcome: no header, and the spend lands in the default
-    budget.
+    The UTF-8 guard is a backstop -- every dimension is filtered through `_transmissible_or_none`
+    upstream, which costs one key where returning None here costs the whole header. It stays
+    because letting `str.encode` raise would escape the handler as a `GenericResultFailure`,
+    which ignores `failure_log_level` (`event_manager.py:1088-1094`) and would log an ERROR with
+    a traceback on every metered call.
     """
     try:
         raw = json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
@@ -182,19 +179,22 @@ def _encode_attribution_header(facts: _AttributionFacts) -> _AttributionEncoding
     rule, not a size response. If the result does not fit, dimensions are shed in order of increasing
     value: the workflow and node type first, and only then the chain's ancestors.
 
-    The chain goes last because it is the only dimension the Cloud matches budgets against, and
-    budget paths are root-anchored, so a chain reduced to its leaf matches nothing at all.
-    Shedding it first would trade the billable dimension for audit-only labels -- and would do
-    so even when an oversized `workflow` was what pushed the payload over, leaving the chain to
-    pay for room it was not using.
+    The chain goes last because it is the only dimension the Cloud matches budgets against.
+    Shedding it first would trade the billable dimension for audit-only labels, even when an
+    oversized `workflow` was what pushed the payload over.
 
-    None means even a leaf-only payload did not fit, which needs a single project name larger
-    than the whole cap.
+    When it does go, all of it goes. Budget paths are root-anchored, so keeping the leaf buys
+    no narrower match; it presents a nested project as a root, which matches nothing at best
+    and bills an unrelated top-level project of the same name at worst. Same rule
+    `_resolve_project_chain` applies to a name it cannot describe.
+
+    None means the payload did not fit even with no chain and no labels, leaving only the
+    schema version and a few guids -- unreachable short of a cap under a hundred bytes.
     """
     chain_truncated = len(facts.project_chain) > _MAX_PROJECT_CHAIN_ENTRIES
     full_facts = facts._replace(project_chain=list(facts.project_chain[:_MAX_PROJECT_CHAIN_ENTRIES]))
     without_labels = full_facts._replace(workflow_name=None, node_type=None)
-    leaf_only = without_labels._replace(project_chain=without_labels.project_chain[:1])
+    no_chain = without_labels._replace(project_chain=[])
 
     stages = (
         _ReductionStage(facts=full_facts, reduction_note=None),
@@ -203,8 +203,8 @@ def _encode_attribution_header(facts: _AttributionFacts) -> _AttributionEncoding
             reduction_note="the workflow and node type will not be attributed for this call",
         ),
         _ReductionStage(
-            facts=leaf_only,
-            reduction_note="only the leaf project will be attributed for this call",
+            facts=no_chain,
+            reduction_note="no project will be attributed for this call",
         ),
     )
 
@@ -262,9 +262,9 @@ class BudgetManager(EngineScoped):
             project_chain=self._resolve_project_chain(),
             workflow_name=self._resolve_workflow_name(),
             node_type=_transmissible_or_none(request.node_type),
-            engine_id=self._resolve_engine_id(),
-            orchestrator_engine_id=self._resolve_orchestrator_engine_id(),
-            session_id=self._resolve_session_id(),
+            engine_id=_transmissible_or_none(self._resolve_engine_id()),
+            orchestrator_engine_id=_transmissible_or_none(self._resolve_orchestrator_engine_id()),
+            session_id=_transmissible_or_none(self._resolve_session_id()),
         )
 
         encoding = _encode_attribution_header(facts)
@@ -272,8 +272,8 @@ class BudgetManager(EngineScoped):
             return GetAttributionContextResultFailure(
                 result_details=(
                     "Attempted to describe an outbound request for budget attribution. Failed because "
-                    "the attribution payload exceeded the maximum header size even after being reduced. "
-                    "The request can proceed, but this spend will not be attributed."
+                    "the attribution payload could not be encoded into a header, even after being reduced "
+                    "to its smallest form. The request can proceed, but this spend will not be attributed."
                 )
             )
 
@@ -309,10 +309,11 @@ class BudgetManager(EngineScoped):
         project's spend, because the Cloud matches on the string alone and has no way to know
         the two names are the same project.
 
-        A nameless entry ends the chain rather than contributing anything in its place. There is
-        nothing to put there that a budget rule could match, and it costs nothing to stop:
-        `get_project_chain` breaks its walk at the first entry whose template did not load, so a
-        nameless entry is always the last one -- an unregistered ancestor.
+        A nameless entry costs the whole chain, wherever it sits. `get_project_chain` maps any
+        falsy name to None, so an entry is nameless either because its template did not load or
+        because it loaded with an empty `name` -- nothing in the schema forbids the empty
+        string. The two are indistinguishable here and need not be distinguished: both leave a
+        link no budget rule can name.
 
         The synthetic `<system-defaults>` rest state is skipped by *id*, before its name is
         read. It does have a template -- the shipped default one -- so it does have a name,
@@ -337,7 +338,12 @@ class BudgetManager(EngineScoped):
             if entry.id == SYSTEM_DEFAULTS_KEY:
                 continue
             if entry.name is None:
-                break
+                logger.warning(
+                    "Dropping project attribution for this call: a project in the chain has no "
+                    "usable name, so the chain cannot be described. Give every project a name to "
+                    "attribute its spend."
+                )
+                return []
             project_names.append(entry.name)
 
         # A real project *named* `<system-defaults>`, separate from the sentinel id skipped

--- a/src/griptape_nodes/retained_mode/managers/budget_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/budget_manager.py
@@ -44,20 +44,25 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("griptape_nodes")
 
-# The four constants below mirror Griptape Cloud's attribution-header parser, and each was read
+# The three constants below mirror Griptape Cloud's attribution-header parser, and each was read
 # off that parser rather than agreed in a doc. Diverging from any of them costs attribution
 # silently, so re-check them against it before changing one; the PR description says where it
 # lives.
+#
+# Only the first is enforced. The others describe what the far end will do with a value so the
+# engine can tell a value it would drop from one it would merely repair -- never so the engine
+# can repair it first. See `_encode_attribution_header`.
 
-# The parser's MAX_CHAIN_LENGTH. Truncating lower would not be conservative: it flags a
-# truncated chain as mangled because budget paths are root-anchored, so dropping ancestors
-# client-side costs matches the Cloud would have made.
-_MAX_PROJECT_CHAIN_ENTRIES = 32
-
-# The parser's MAX_DECODED_LENGTH, measured the same way -- on the decoded bytes. base64
-# inflates 4:3, so 4096 decoded bytes encode to at most 5464, inside its MAX_RAW_HEADER_LENGTH
-# of 5632 and well under nginx's 8 KB default.
-_MAX_DECODED_PAYLOAD_BYTES = 4096
+# The parser's MAX_RAW_HEADER_LENGTH, measured the same way -- on the encoded header, before
+# any decoding. It is the only size this module enforces, and it is an ingress concern rather
+# than an attribution one. Past it the Cloud reports OVERSIZE without decoding, so a larger
+# header buys no further diagnosis while eating into nginx's 8 KB header buffer -- and a header
+# the ingress rejects kills the API call itself, not merely its attribution.
+#
+# Deliberately not the parser's MAX_DECODED_LENGTH of 4096. A payload over that is discarded by
+# the Cloud *and reported* as OVERSIZE; shrinking it here to slip under would trade a spend the
+# platform knows it could not attribute for one it believes it attributed correctly.
+_MAX_ENCODED_HEADER_BYTES = 5632
 
 # C0 and C1 control characters, the parser's `_is_storable` rule written as a class. A value
 # containing one is stored nowhere on the far end, so sending it buys nothing and costs
@@ -66,9 +71,8 @@ _UNSTORABLE_CHARACTERS = re.compile(r"[\x00-\x1f\x7f-\x9f]")
 
 # The parser's MAX_VALUE_LENGTH, and a cap on *characters*: it compares `len(value)` and slices
 # `value[:MAX_VALUE_LENGTH]` on a `str`, never on encoded bytes. Used to judge project names
-# (`_is_transmissible`), and to cut them only on the rungs between shedding the labels and
-# shedding the chain (`_encode_attribution_header`) -- never on the ordinary path, which sends
-# them whole.
+# (`_is_transmissible`). Only ever used to judge a name, never to cut the one that travels: a
+# name cut here arrives looking intact, which is the one thing the far end cannot detect.
 _MAX_VALUE_CHARS = 256
 
 
@@ -95,14 +99,6 @@ class _AttributionEncoding(NamedTuple):
     chain_truncated: bool
 
 
-class _ReductionStage(NamedTuple):
-    """One rung of the size-reduction ladder, ordered most informative first."""
-
-    facts: _AttributionFacts
-    # None on the unreduced rung; otherwise what this rung gives up, for the warning log.
-    reduction_note: str | None
-
-
 def _as_the_cloud_keeps_it(name: str) -> str:
     """Reduce a project name to the form the Cloud actually stores.
 
@@ -112,43 +108,27 @@ def _as_the_cloud_keeps_it(name: str) -> str:
     parent-billed-for-its-child failure again. And it has to run before the byte checks, or a
     control character sitting past the cap drops a whole chain the far end would have stored.
 
-    For deciding only. What actually travels is `_project_name_for_the_wire`, which is a
-    different string for an over-long name and for a good reason.
+    For deciding only -- nothing here is ever sent. The question it answers is whether the
+    Cloud would store an entry for this name at all: if it would, the whole name travels and
+    the Cloud cuts it itself, flagging the cut; if it would not, the entry would be dropped
+    there and its parent promoted, so the chain goes instead.
     """
     return name.strip()[:_MAX_VALUE_CHARS].strip()
 
 
-def _project_name_for_the_wire(name: str) -> str:
-    """Which form of a project name to send: the full one whenever it can travel.
+def _is_encodable(value: str) -> bool:
+    """Whether a string can be put on the wire at all.
 
-    Stripping here is free, because the far end strips too and records nothing when it does.
-    Cutting here is not. The parser marks a chain it had to cut as mangled and stops matching
-    it against admin-authored paths -- which is what keeps two sibling projects sharing a
-    256-character prefix from collapsing onto one budget. Handing it a pre-cut name presents
-    that prefix as an intact one: it reports no degradation, emits no metric, and matches. The
-    substitution then goes unrecorded on both sides, since `chain_truncated` on the result is
-    about the length of the chain, not of a name in it.
-
-    Whether a prefix match beats falling to the default budget is the Cloud's call to make on
-    its own data. Sending the full name leaves it able to make it.
-
-    One exception, and it is a real trade rather than a preference: a lone surrogate past the
-    cap survives the strip and makes the payload unencodable, costing the whole header. The cut
-    form drops that byte, so it goes instead -- one name's truncation signal for every other
-    dimension on the call.
-
-    The size ladder holds the other exception, and it is not this function's call to make: names
-    long enough to push the payload past the cap never reach the far end at all, so
-    `_encode_attribution_header` cuts them there rather than shed the chain. That costs nothing
-    this function was protecting -- a chain shed client-side arrives as no chain, and no chain
-    carries no truncation signal either.
+    A project name is free text and a workflow registry key is derived from a filesystem path,
+    so either can carry a byte the wire cannot hold: a path whose bytes are not valid UTF-8
+    comes back from the OS carrying lone surrogates from `surrogateescape`, which `str.encode`
+    refuses. Unguarded that raises out of the encoder and costs the whole header, not one key.
     """
-    stripped = name.strip()
     try:
-        stripped.encode("utf-8")
+        value.encode("utf-8")
     except UnicodeEncodeError:
-        return _as_the_cloud_keeps_it(name)
-    return stripped
+        return False
+    return True
 
 
 def _is_transmissible(value: str) -> bool:
@@ -157,26 +137,21 @@ def _is_transmissible(value: str) -> bool:
     Judged on the stored form, not the given one: the far end normalizes before it decides
     storability, so a value that passes here raw and is discarded there costs an entry,
     promotes its parent to leaf, and bills a real ancestor for spend it never had. Stripping
-    covers that for every dimension. Project names are cut to length as well, and arrive
-    already normalized by `_as_the_cloud_keeps_it`.
+    covers that for every dimension. A project name is judged on the cut form as well, since
+    the far end cuts before it decides -- the caller passes `_as_the_cloud_keeps_it(name)`.
+    That is about what to judge, never about what to send; the whole name still travels.
 
-    Three ways a value does not survive. A project name is free text and a workflow registry
-    key is derived from a filesystem path, so either can carry a byte the wire cannot hold: a
-    path whose bytes are not valid UTF-8 comes back from the OS carrying lone surrogates from
-    `surrogateescape`, which `str.encode` refuses. A pasted line break, or a directory name
-    that legally contains a control character, encodes here and is discarded there. And a name
-    that is nothing but whitespace strips to empty, which the far end will not store.
+    Three ways a value does not survive. A pasted line break, or a directory name that legally
+    contains a control character, encodes here and is discarded there. A name that is nothing
+    but whitespace strips to empty, which the far end will not store. And the value may not be
+    encodable at all -- see `_is_encodable`.
     """
     stripped = value.strip()
     if not stripped:
         return False
     if _UNSTORABLE_CHARACTERS.search(stripped):
         return False
-    try:
-        stripped.encode("utf-8")
-    except UnicodeEncodeError:
-        return False
-    return True
+    return _is_encodable(stripped)
 
 
 def _transmissible_or_none(value: str | None) -> str | None:
@@ -227,7 +202,10 @@ def _build_attribution_payload(facts: _AttributionFacts) -> dict[str, Any]:
 
 
 def _encode_attribution_payload(payload: dict[str, Any]) -> str | None:
-    """Encode a payload as base64url, or None when it cannot be encoded or exceeds the cap.
+    """Encode a payload as base64url, or None when it cannot be encoded at all.
+
+    Size is not judged here. What has to fit is the header, not the payload, and the caller is
+    the only one that knows what it is willing to give up to make it fit.
 
     Padding is kept because the payload is `base64.b64encode`'s natural output and stripping it
     would buy nothing: the parser re-pads whatever it receives before decoding, so both forms
@@ -247,126 +225,62 @@ def _encode_attribution_payload(payload: dict[str, Any]) -> str | None:
             exc_info=True,
         )
         return None
-    if len(raw) > _MAX_DECODED_PAYLOAD_BYTES:
-        return None
     return base64.urlsafe_b64encode(raw).decode("ascii")
 
 
-def _reduce(
-    facts: _AttributionFacts,
-    *,
-    cut_names: bool = False,
-    drop_labels: bool = False,
-    drop_chain: bool = False,
-) -> _AttributionFacts:
-    """Apply one rung's own set of reductions to the unreduced facts.
-
-    Every rung is built from the full facts and names what it gives up, so no rung inherits its
-    neighbour's reductions. That is not tidiness: deriving a rung from the one above it is how
-    this ladder twice ended up shedding the labels to pay for an overage the rung's own reduction
-    already covered.
-
-    `drop_chain` subsumes `cut_names` -- there is nothing left to cut -- so no rung passes both.
-    """
-    project_chain = list(facts.project_chain)
-    if drop_chain:
-        project_chain = []
-    elif cut_names:
-        project_chain = [_as_the_cloud_keeps_it(name) for name in project_chain]
-
-    workflow_name = facts.workflow_name
-    node_type = facts.node_type
-    if drop_labels:
-        workflow_name = None
-        node_type = None
-
-    return facts._replace(project_chain=project_chain, workflow_name=workflow_name, node_type=node_type)
-
-
 def _encode_attribution_header(facts: _AttributionFacts) -> _AttributionEncoding | None:
-    """Encode the attribution header, shedding dimensions in stages until it fits.
+    """Encode the attribution header, shedding the project chain only if the ingress demands it.
 
-    The chain is always truncated to `_MAX_PROJECT_CHAIN_ENTRIES` from the leaf -- a standing
-    rule, not a size response. If the result does not fit, six rungs are tried in order of what
-    each gives up and the first that fits is sent: nothing, the labels, cut project names, both of
-    those, the chain, then the chain and the labels together.
+    Nothing here repairs a tag. The engine cannot tell a name that is too long from one that is
+    wrong, and Griptape Cloud can: it truncates an over-long name, truncates an over-deep chain,
+    reports each as a degradation metric, and -- the part that decides this function -- marks a
+    chain it had to repair `mangled`, which takes it out of budget matching entirely. Damage the
+    far end can see is damage it refuses to bill against. So facts travel as the engine found
+    them, and judging them is the Cloud's job.
 
-    Ordered by cost, not by being successively smaller -- rung three puts back the labels rung two
-    shed. Each rung states its own reductions against the full facts rather than trimming the rung
-    above it, so none gives up more than its own overage needs. Shedding the chain frees thousands
-    of bytes and the labels are worth tens, so a rung that bundled them would cost a dashboard row
-    for nothing. `_reduce` is what keeps that structural rather than remembered.
+    Repairing them here would invert that. A chain cut to `MAX_CHAIN_LENGTH` before sending, or a
+    name cut to `MAX_VALUE_LENGTH`, arrives looking intact: no reason is recorded, no metric
+    fires, `mangled` stays false, and the Cloud matches a budget against a chain missing its root
+    or a name sharing a prefix with its siblings. That bills the wrong project silently, and it is strictly
+    worse than the loud non-billing the Cloud would have produced on its own.
 
-    The chain goes last because it is the only dimension the Cloud matches budgets against.
-    Shedding it first would trade the billable dimension for audit-only labels, even when an
-    oversized `workflow` was what pushed the payload over. The labels go before any cutting
-    because sending a name whole is what buys a truncation signal on the far end, and that signal
-    is what keeps two siblings sharing a 256-character prefix off one budget -- worth more than an
-    audit-only dimension.
+    The one size this enforces is `_MAX_ENCODED_HEADER_BYTES`, and it is not an attribution rule.
+    A payload past the Cloud's own decode cap is discarded *and reported* as OVERSIZE, which is a
+    fine outcome -- the spend goes unattributed and the platform knows it did. A header past the
+    ingress buffer is not: it fails the whole request with a 4xx, and the artist loses the call
+    rather than its attribution. So the header is bounded where the ingress bounds it, and the
+    only thing given up to get under that bound is the chain.
 
-    Cutting is worth reaching at all because a payload over the cap never arrives to carry that
-    signal. Shedding the chain instead lands the spend in the default bucket with `reasons` empty:
-    no metric fires, and it reads as an engine that never attributed anything. Cutting keeps the
-    match, and gives up the signal only where the signal was already gone.
+    When the chain goes, all of it goes -- never a prefix, never cut entries. Budget paths are
+    root-anchored, so a partial chain matches nothing at best and an unrelated top-level project
+    of the same name at worst. Same rule `_resolve_project_chain` applies to a name it cannot
+    describe, and for the same reason: an incomplete claim is worse than no claim.
 
-    When the chain does go, all of it goes. Budget paths are root-anchored, so keeping the leaf buys
-    no narrower match; it presents a nested project as a root, which matches nothing at best
-    and bills an unrelated top-level project of the same name at worst. Same rule
-    `_resolve_project_chain` applies to a name it cannot describe.
-
-    None means the payload did not fit even with no chain and no labels, leaving only the
-    schema version and a few guids -- unreachable short of a cap under a hundred bytes.
+    None means even the chainless envelope does not fit, or does not encode -- the first
+    unreachable short of a header bound under a hundred bytes, the second a backstop for a
+    payload every dimension of which was already filtered.
     """
-    chain_truncated = len(facts.project_chain) > _MAX_PROJECT_CHAIN_ENTRIES
-    full_facts = facts._replace(project_chain=list(facts.project_chain[:_MAX_PROJECT_CHAIN_ENTRIES]))
+    with_chain = _encode_attribution_payload(_build_attribution_payload(facts))
+    if with_chain is not None and len(with_chain) <= _MAX_ENCODED_HEADER_BYTES:
+        return _AttributionEncoding(header_value=with_chain, facts=facts, chain_truncated=False)
 
-    stages = (
-        _ReductionStage(facts=full_facts, reduction_note=None),
-        _ReductionStage(
-            facts=_reduce(full_facts, drop_labels=True),
-            reduction_note="the workflow and node type will not be attributed for this call",
-        ),
-        _ReductionStage(
-            facts=_reduce(full_facts, cut_names=True),
-            reduction_note="long project names will be attributed cut to the form the Cloud stores",
-        ),
-        _ReductionStage(
-            facts=_reduce(full_facts, cut_names=True, drop_labels=True),
-            reduction_note=(
-                "long project names will be attributed cut to the form the Cloud stores, and the "
-                "workflow and node type not at all"
-            ),
-        ),
-        _ReductionStage(
-            facts=_reduce(full_facts, drop_chain=True),
-            reduction_note="no project will be attributed for this call",
-        ),
-        _ReductionStage(
-            facts=_reduce(full_facts, drop_chain=True, drop_labels=True),
-            reduction_note="no project, workflow, or node type will be attributed for this call",
-        ),
+    if not facts.project_chain:
+        return None
+
+    chainless_facts = facts._replace(project_chain=[])
+    chainless = _encode_attribution_payload(_build_attribution_payload(chainless_facts))
+    if chainless is None:
+        return None
+    if len(chainless) > _MAX_ENCODED_HEADER_BYTES:
+        return None
+
+    logger.warning(
+        "The attribution header would exceed %d bytes, so no project is attributed for this call "
+        "and Griptape Cloud will bill the spend to the default budget. This needs a project chain "
+        "thousands of characters long; shorten the project names to attribute their spend.",
+        _MAX_ENCODED_HEADER_BYTES,
     )
-
-    for stage in stages:
-        header_value = _encode_attribution_payload(_build_attribution_payload(stage.facts))
-        if header_value is None:
-            continue
-        if stage.reduction_note is not None:
-            logger.warning(
-                "Attribution payload exceeded %d bytes; reducing it so %s.",
-                _MAX_DECODED_PAYLOAD_BYTES,
-                stage.reduction_note,
-            )
-        return _AttributionEncoding(
-            header_value=header_value,
-            facts=stage.facts,
-            # Derived, never asserted. `chain_truncated` means ancestors were dropped, so it has
-            # to describe what this stage actually shed: a payload pushed over the cap by an
-            # oversized `node_type` can reach a later stage without the chain losing anything.
-            chain_truncated=chain_truncated or len(stage.facts.project_chain) < len(full_facts.project_chain),
-        )
-
-    return None
+    return _AttributionEncoding(header_value=chainless, facts=chainless_facts, chain_truncated=True)
 
 
 class BudgetManager(EngineScoped):
@@ -394,8 +308,8 @@ class BudgetManager(EngineScoped):
         """Describe the current engine context as an encoded attribution header.
 
         Every resolver degrades to a missing key rather than a failure: the caller is about to
-        spend money, and a partial attribution beats none. The one failure is a payload that
-        will not fit in a header even after being reduced.
+        spend money, and a partial attribution beats none. The one failure is a header still
+        too large for the ingress even with the project chain given up.
         """
         facts = _AttributionFacts(
             project_chain=self._resolve_project_chain(),
@@ -411,13 +325,13 @@ class BudgetManager(EngineScoped):
             return GetAttributionContextResultFailure(
                 result_details=(
                     "Attempted to describe an outbound request for budget attribution. Failed because "
-                    "the attribution payload could not be encoded into a header, even after being reduced "
-                    "to its smallest form. The request can proceed, but this spend will not be attributed."
+                    "the description could not be fitted into a request header, even with the project left "
+                    "out of it. The request can proceed, but this spend will not be attributed."
                 )
             )
 
-        # From `encoding.facts`, never `facts`: the reduction step can drop values, and these
-        # fields must describe exactly what the header encodes.
+        # From `encoding.facts`, never `facts`: the encoder may have given up the chain, and
+        # these fields must describe exactly what the header encodes.
         encoded = encoding.facts
         return GetAttributionContextResultSuccess(
             header_value=encoding.header_value,
@@ -477,10 +391,17 @@ class BudgetManager(EngineScoped):
                 )
                 return []
             # Judged on the form the far end keeps, so both tests below see the string it
-            # will see -- not on the form that travels, which for an over-long name is the
-            # uncut one.
+            # will see. That is deliberately more forgiving than judging the whole name: a
+            # control character past the value cap is one the Cloud's own truncation removes
+            # before it decides storability, so it costs a truncation flag over there rather
+            # than a chain over here.
+            #
+            # Encodability is the exception, and is judged on the whole name, because it is
+            # the one property of a name that is ours rather than the Cloud's -- a name the
+            # cut form could encode and the whole one cannot has no honest wire form. Sending
+            # the cut form would be a repair arriving intact.
             kept = _as_the_cloud_keeps_it(entry.name)
-            if not _is_transmissible(kept):
+            if not _is_transmissible(kept) or not _is_encodable(entry.name):
                 logger.warning(
                     "Dropping project attribution for this call: a project name in the chain cannot "
                     "be transmitted intact. Rename the project using ordinary text to attribute its "
@@ -496,7 +417,9 @@ class BudgetManager(EngineScoped):
                     SYSTEM_DEFAULTS_KEY,
                 )
                 return []
-            project_names.append(_project_name_for_the_wire(entry.name))
+            # Stripped, never cut. Stripping is free -- the far end strips too and records
+            # nothing when it does -- while cutting is the repair this module refuses to make.
+            project_names.append(entry.name.strip())
 
         return project_names
 

--- a/src/griptape_nodes/retained_mode/managers/budget_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/budget_manager.py
@@ -1,34 +1,21 @@
 """BudgetManager - Describes the engine context an outbound call should be attributed to.
 
-The manager owns no state. Every fact is read from a peer manager at request time, so
-a project switch between two calls is reflected on the second one.
+The manager owns no state. Every fact is read from a peer manager at request time, so a
+project switch between two calls is reflected on the second one. Nothing here makes a
+network call, holds a credential, or enforces a budget.
 
-Nothing here makes a network call, holds a credential, or enforces a budget. It composes
-one attribution fact and stops.
+**Keeping the header value out of logs and broadcasts is a convention, not an invariant.**
+`broadcast_result` defaults to False but is a per-instance field any caller can flip;
+post-dispatch hooks receive the full result regardless of it; a forwarded worker request
+(`app/worker_routing.FORWARDED_REQUEST_TYPES`) puts the Success payload on the worker
+response topic by construction; and the engine's `omit_from_result` redaction primitive is
+request-side only, so it cannot mark a result field non-broadcastable. What this module can
+do it does: it never interpolates `header_value` or the payload into `result_details`, which
+is logged as well as broadcast. The value is descriptive rather than secret, so none of that
+is alarming -- but it is the real state of the mechanism.
 
-**On keeping the header value out of logs and broadcasts.** Three defaults and a
-convention protect it; none of them is an enforced invariant, and each has a bypass worth
-knowing about:
-
-- `GetAttributionContextRequest.broadcast_result` defaults to False, which keeps the
-  Success payload off the WebSocket feed -- but it is a per-instance field any caller can
-  set back to True.
-- Post-dispatch hooks receive the full result object and run regardless of
-  `broadcast_result` or event suppression.
-- `result_details` is logged as well as broadcast, so this module never interpolates
-  `header_value` or the payload into one. That discipline is held by convention: the
-  engine's `omit_from_result` redaction primitive is request-side only and cannot mark a
-  result field non-broadcastable.
-- On a worker, the request is forwarded to the orchestrator (see
-  `app/worker_routing.FORWARDED_REQUEST_TYPES`), so the Success payload crosses the
-  worker response topic by construction, whatever `broadcast_result` says.
-
-None of that is alarming on its own -- the value is descriptive, not secret -- but it is
-the real state of the mechanism rather than a guarantee.
-
-`Engine.handle_request` already converts a raised handler exception into a
-`ResultPayloadFailure`, so this module deliberately has no blanket try/except around the
-handler body; the resolvers guard their own peer reads and nothing else can escape.
+`Engine.handle_request` converts a raised handler exception into a `ResultPayloadFailure`,
+so there is deliberately no blanket try/except here; the resolvers guard their own peer reads.
 """
 
 from __future__ import annotations
@@ -55,20 +42,20 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("griptape_nodes")
 
-# The Cloud truncates the chain at this depth anyway. Truncating client-side means both
-# ends agree and the oversize path is unreachable in practice.
+# The Cloud truncates the chain at this depth anyway; matching it client-side keeps both ends
+# in agreement.
 _MAX_PROJECT_CHAIN_ENTRIES = 10
 
-# base64 inflates 4:3, so 4096 decoded bytes encode to at most 5464 -- inside the 5.5 KB
-# raw ceiling, which is itself well under nginx's 8 KB default header limit.
+# base64 inflates 4:3, so 4096 decoded bytes encode to at most 5464 -- inside the 5.5 KB raw
+# ceiling, itself well under nginx's 8 KB default.
 _MAX_DECODED_PAYLOAD_BYTES = 4096
 
 
 class _AttributionFacts(NamedTuple):
-    """The engine facts one outbound call is attributed to, as resolved for a single request.
+    """The engine facts one outbound call is attributed to.
 
-    A value of None means the engine could not determine that fact; the corresponding payload
-    key is then omitted, which is how "unknown" is expressed on the wire.
+    None means the engine could not determine that fact; its payload key is then omitted,
+    which is how "unknown" is expressed on the wire.
     """
 
     project_chain: list[str]
@@ -88,10 +75,10 @@ class _AttributionEncoding(NamedTuple):
 
 
 def _build_attribution_payload(facts: _AttributionFacts) -> dict[str, Any]:
-    """Build the decoded attribution payload, omitting every key the engine could not determine.
+    """Build the decoded payload, omitting every key the engine could not determine.
 
-    An absent key means "unknown". `tags` is omitted entirely when the chain is empty, because an
-    empty list would assert "belongs to zero projects" -- a claim we cannot make.
+    `tags` is omitted entirely on an empty chain: an empty list would assert "belongs to zero
+    projects", a claim we cannot make.
     """
     payload: dict[str, Any] = {"v": ATTRIBUTION_SCHEMA_VERSION}
     if facts.project_chain:
@@ -123,10 +110,10 @@ def _encode_attribution_payload(payload: dict[str, Any]) -> str | None:
 def _encode_attribution_header(facts: _AttributionFacts) -> _AttributionEncoding | None:
     """Encode the attribution header, reducing the payload once if it does not fit.
 
-    The chain is always truncated to `_MAX_PROJECT_CHAIN_ENTRIES` from the leaf: that is the v1
-    rule, not a size response. If the result still does not fit, one reduction step drops the
-    workflow and node type and keeps only the leaf project. Returns None when even that does not
-    fit, which needs a single project id larger than the whole cap.
+    The chain is always truncated to `_MAX_PROJECT_CHAIN_ENTRIES` from the leaf -- the v1 rule,
+    not a size response. If the result still does not fit, one reduction step drops the workflow
+    and node type and keeps only the leaf project. None means even that did not fit, which needs
+    a single project id larger than the whole cap.
     """
     chain_truncated = len(facts.project_chain) > _MAX_PROJECT_CHAIN_ENTRIES
     full_facts = facts._replace(project_chain=list(facts.project_chain[:_MAX_PROJECT_CHAIN_ENTRIES]))
@@ -184,9 +171,9 @@ class BudgetManager(EngineScoped):
     ) -> GetAttributionContextResultSuccess | GetAttributionContextResultFailure:
         """Describe the current engine context as an encoded attribution header.
 
-        Every resolver degrades to a missing key rather than a failure: the caller is
-        about to spend money, and a partial attribution beats none. The one failure is a
-        payload that will not fit in a header even after being reduced.
+        Every resolver degrades to a missing key rather than a failure: the caller is about to
+        spend money, and a partial attribution beats none. The one failure is a payload that
+        will not fit in a header even after being reduced.
         """
         facts = _AttributionFacts(
             project_chain=self._resolve_project_chain(),
@@ -207,9 +194,8 @@ class BudgetManager(EngineScoped):
                 )
             )
 
-        # Every structured field comes from `encoding.facts`, never from `facts`: the reduction
-        # step above can drop values, and a consumer reading these must see exactly what the
-        # header encodes.
+        # From `encoding.facts`, never `facts`: the reduction step can drop values, and these
+        # fields must describe exactly what the header encodes.
         encoded = encoding.facts
         return GetAttributionContextResultSuccess(
             header_value=encoding.header_value,
@@ -242,11 +228,9 @@ class BudgetManager(EngineScoped):
     def _resolve_workflow_name(self) -> str | None:
         """Resolve the current workflow's registry key, or None when it cannot be determined.
 
-        A workflow that has never been saved is registered under an `unsaved:<uuid4>` key.
-        That uuid is fresh every session, so sending it would put a never-repeating value in
-        the Cloud's workflow dimension and a per-session identifier in a proxy-logged header.
-        Report the sentinel instead: one low-cardinality bucket for scratch spend, still
-        distinguishable from an absent key, which means the engine could not tell at all.
+        An unsaved workflow is registered under an `unsaved:<uuid4>` key that is fresh every
+        session, so the sentinel goes out instead: one low-cardinality bucket for scratch spend,
+        still distinguishable from an absent key.
         """
         try:
             if not self.engine.context_manager.has_current_workflow():
@@ -271,9 +255,8 @@ class BudgetManager(EngineScoped):
     def _resolve_orchestrator_engine_id(self) -> str | None:
         """Resolve the parent engine's id, set at spawn on workers and unset on the orchestrator.
 
-        Reading an environment variable cannot raise, so this one needs no guard. In practice
-        the key is always absent from the payload: worker-originated requests are forwarded to
-        the orchestrator, which is not a worker and so has no parent to report.
+        No guard: reading an environment variable cannot raise. In practice the key is always
+        absent, since worker requests are forwarded to the orchestrator, which has no parent.
         """
         return os.getenv("GTN_ORCHESTRATOR_ENGINE_ID")
 

--- a/src/griptape_nodes/retained_mode/managers/budget_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/budget_manager.py
@@ -93,32 +93,43 @@ class _ReductionStage(NamedTuple):
 def _is_transmissible(value: str) -> bool:
     """Whether a value survives the trip to the Cloud intact.
 
-    Two ways it does not. A project name is free text and a workflow registry key is derived
-    from a filesystem path, so either can carry a byte the wire cannot hold. A path whose bytes
-    are not valid UTF-8 comes back from the OS carrying lone surrogates from `surrogateescape`,
-    which `str.encode` refuses. A pasted line break, or a directory name that legally contains
-    a control character, encodes here and is then discarded by the Cloud's storability check.
+    Judged on `value.strip()`, because that is what the Cloud decides on: it strips before
+    testing storability, so a value this passes unstripped and the far end then discards costs
+    an entry, promotes its parent to leaf, and bills a real ancestor for spend it never had.
+
+    Three ways a value does not survive. A project name is free text and a workflow registry
+    key is derived from a filesystem path, so either can carry a byte the wire cannot hold: a
+    path whose bytes are not valid UTF-8 comes back from the OS carrying lone surrogates from
+    `surrogateescape`, which `str.encode` refuses. A pasted line break, or a directory name
+    that legally contains a control character, encodes here and is discarded there. And a name
+    that is nothing but whitespace strips to empty, which the far end will not store.
     """
-    if _UNSTORABLE_CHARACTERS.search(value):
+    stripped = value.strip()
+    if not stripped:
+        return False
+    if _UNSTORABLE_CHARACTERS.search(stripped):
         return False
     try:
-        value.encode("utf-8")
+        stripped.encode("utf-8")
     except UnicodeEncodeError:
         return False
     return True
 
 
 def _transmissible_or_none(value: str | None) -> str | None:
-    """Pass a value through, or None when it cannot reach the Cloud intact.
+    """Normalize a value the way the Cloud will, or None when it cannot reach it intact.
 
-    Omitting the key says "the engine could not determine this", which is honest: a value
-    the far end would discard is one the engine cannot express.
+    Returns the stripped form rather than the original, because the far end strips what it
+    stores -- sending the stripped value keeps the result's structured fields describing what
+    budgets actually match against. Omitting the key instead says "the engine could not
+    determine this", which is honest: a value the far end would discard is one the engine
+    cannot express.
     """
     if value is None:
         return None
     if not _is_transmissible(value):
         return None
-    return value
+    return value.strip()
 
 
 def _build_attribution_payload(facts: _AttributionFacts) -> dict[str, Any]:
@@ -309,23 +320,16 @@ class BudgetManager(EngineScoped):
         project's spend, because the Cloud matches on the string alone and has no way to know
         the two names are the same project.
 
-        A nameless entry costs the whole chain, wherever it sits. `get_project_chain` maps any
-        falsy name to None, so an entry is nameless either because its template did not load or
-        because it loaded with an empty `name` -- nothing in the schema forbids the empty
-        string. The two are indistinguishable here and need not be distinguished: both leave a
-        link no budget rule can name.
+        Any link the Cloud cannot match costs the *whole* chain, not just its own entry --
+        whether it is nameless, reserved, or untransmissible. Budget paths are root-anchored,
+        so a chain missing a link already matches nothing, and dropping just the offender is
+        worse than sending none: it promotes that entry's parent to leaf and bills a real
+        ancestor for spend it never incurred. A nameless entry can sit anywhere, since
+        `get_project_chain` maps any falsy name to None and the schema permits `name: ""`.
 
-        The synthetic `<system-defaults>` rest state is skipped by *id*, before its name is
-        read. It does have a template -- the shipped default one -- so it does have a name,
-        and that name is "Default Project", which is exactly the kind of generic string that
-        would collide across every user in an org. It is also not a project the Cloud models
-        at all: it is the root sentinel, never a real ancestor, so skipping it leaves a chain
-        the Cloud can still match rather than a truncated one.
-
-        A name the Cloud cannot store costs the *whole* chain, not just its own entry. Budget
-        paths are root-anchored, so a chain missing any link already matches nothing -- and
-        dropping only the offending entry is worse than sending none, because it promotes that
-        entry's parent to leaf and bills a real ancestor project for spend it never incurred.
+        The `<system-defaults>` rest state is the one exception, skipped by *id* before its
+        name is read. It is the root sentinel rather than an ancestor the Cloud models, so
+        skipping it leaves a matchable chain instead of a truncated one.
         """
         try:
             chain = self.engine.project_manager.get_project_chain()
@@ -344,28 +348,26 @@ class BudgetManager(EngineScoped):
                     "attribute its spend."
                 )
                 return []
-            project_names.append(entry.name)
+            name = _transmissible_or_none(entry.name)
+            if name is None:
+                logger.warning(
+                    "Dropping project attribution for this call: a project name in the chain cannot "
+                    "be transmitted intact. Rename the project using ordinary text to attribute its "
+                    "spend."
+                )
+                return []
+            # Compared after normalizing, because the Cloud strips before testing the reserved
+            # value: `" <system-defaults> "` is the same claim as the bare string. Separate from
+            # the sentinel *id* skipped above -- this is a real project a user named that.
+            if name == SYSTEM_DEFAULTS_KEY:
+                logger.warning(
+                    "Dropping project attribution for this call: a project is named '%s', which Griptape "
+                    "Cloud reserves for its own use. Rename the project to attribute its spend.",
+                    SYSTEM_DEFAULTS_KEY,
+                )
+                return []
+            project_names.append(name)
 
-        # A real project *named* `<system-defaults>`, separate from the sentinel id skipped
-        # above. Nothing stops a user typing the reserved string into `name:`. The Cloud
-        # reserves it and discards a client copy, which would drop that entry and bill its
-        # parent for spend it never incurred, so the chain goes nowhere instead.
-        if SYSTEM_DEFAULTS_KEY in project_names:
-            logger.warning(
-                "Dropping project attribution for this call: a project is named '%s', which Griptape "
-                "Cloud reserves for its own use. Rename the project to attribute its spend.",
-                SYSTEM_DEFAULTS_KEY,
-            )
-            return []
-
-        untransmissible_count = sum(1 for name in project_names if not _is_transmissible(name))
-        if untransmissible_count > 0:
-            logger.warning(
-                "Dropping project attribution for this call: %d project name(s) in the chain cannot be "
-                "transmitted intact. This spend will land in the default budget.",
-                untransmissible_count,
-            )
-            return []
         return project_names
 
     def _resolve_workflow_name(self) -> str | None:
@@ -397,10 +399,9 @@ class BudgetManager(EngineScoped):
             return None
 
     def _resolve_orchestrator_engine_id(self) -> str | None:
-        """Resolve the parent engine's id, set at spawn on workers and unset on the orchestrator.
+        """Resolve the parent engine's id, set at spawn on workers, unset on the orchestrator.
 
-        No guard: reading an environment variable cannot raise. In practice the key is always
-        absent, since worker requests are forwarded to the orchestrator, which has no parent.
+        Unguarded because `os.getenv` cannot raise.
         """
         return os.getenv("GTN_ORCHESTRATOR_ENGINE_ID")
 

--- a/src/griptape_nodes/retained_mode/managers/budget_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/budget_manager.py
@@ -43,9 +43,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("griptape_nodes")
 
-# Matches the Cloud parser's MAX_CHAIN_LENGTH (griptape-cloud#2225). Truncating lower would
-# not be conservative: the parser flags a truncated chain as mangled because budget paths are
-# root-anchored, so dropping ancestors client-side costs matches the Cloud would have made.
+# Matches the Cloud parser's MAX_CHAIN_LENGTH. Truncating lower would not be conservative: the
+# parser flags a truncated chain as mangled because budget paths are root-anchored, so dropping
+# ancestors client-side costs matches the Cloud would have made.
 _MAX_PROJECT_CHAIN_ENTRIES = 32
 
 # base64 inflates 4:3, so 4096 decoded bytes encode to at most 5464 -- inside the 5.5 KB raw
@@ -80,8 +80,8 @@ def _build_attribution_payload(facts: _AttributionFacts) -> dict[str, Any]:
     """Build the decoded payload, omitting every key the engine could not determine.
 
     Every dimension lives under `tags`; the Cloud parser reads nothing else, and there is no
-    second namespace beside it (griptape-cloud#2225). `tags` itself is omitted when the engine
-    could determine nothing, rather than sent empty.
+    second namespace beside it. `tags` itself is omitted when the engine could determine
+    nothing, rather than sent empty.
     """
     tags: dict[str, Any] = {}
     if facts.project_chain:

--- a/src/griptape_nodes/retained_mode/managers/budget_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/budget_manager.py
@@ -44,22 +44,29 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("griptape_nodes")
 
-# Matches the Cloud parser's MAX_CHAIN_LENGTH. Truncating lower would not be conservative: the
-# parser flags a truncated chain as mangled because budget paths are root-anchored, so dropping
-# ancestors client-side costs matches the Cloud would have made.
+# The four constants below mirror the Cloud parser, and each was read off it rather than agreed
+# in a doc: `control_plane/api/griptapecloud/components/spend/attribution.py` in the
+# griptape-cloud repo (PR #2225). Diverging from any of them costs attribution silently, so
+# check that file before changing one.
+
+# The parser's MAX_CHAIN_LENGTH. Truncating lower would not be conservative: it flags a
+# truncated chain as mangled because budget paths are root-anchored, so dropping ancestors
+# client-side costs matches the Cloud would have made.
 _MAX_PROJECT_CHAIN_ENTRIES = 32
 
-# base64 inflates 4:3, so 4096 decoded bytes encode to at most 5464 -- inside the 5.5 KB raw
-# ceiling, itself well under nginx's 8 KB default.
+# The parser's MAX_DECODED_LENGTH, measured the same way -- on the decoded bytes. base64
+# inflates 4:3, so 4096 decoded bytes encode to at most 5464, inside its MAX_RAW_HEADER_LENGTH
+# of 5632 and well under nginx's 8 KB default.
 _MAX_DECODED_PAYLOAD_BYTES = 4096
 
-# C0 and C1 control characters, mirroring the Cloud parser's storability rule. A value
+# C0 and C1 control characters, the parser's `_is_storable` rule written as a class. A value
 # containing one is stored nowhere on the far end, so sending it buys nothing and costs
 # something -- see `_is_transmissible`.
 _UNSTORABLE_CHARACTERS = re.compile(r"[\x00-\x1f\x7f-\x9f]")
 
-# Matches the Cloud parser's MAX_VALUE_LENGTH -- the length it cuts a tag value down to before
-# it decides anything about that value. Applied to project names only; see `_as_the_cloud_keeps_it`.
+# The parser's MAX_VALUE_LENGTH, and a cap on *characters*: it compares `len(value)` and slices
+# `value[:MAX_VALUE_LENGTH]` on a `str`, never on encoded bytes. Applied to project names only;
+# see `_as_the_cloud_keeps_it`.
 _MAX_VALUE_CHARS = 256
 
 
@@ -188,7 +195,9 @@ def _build_attribution_payload(facts: _AttributionFacts) -> dict[str, Any]:
 def _encode_attribution_payload(payload: dict[str, Any]) -> str | None:
     """Encode a payload as base64url, or None when it cannot be encoded or exceeds the cap.
 
-    Padding is kept so the Cloud can call `urlsafe_b64decode` without re-padding.
+    Padding is kept because the payload is `base64.b64encode`'s natural output and stripping it
+    would buy nothing: the parser re-pads whatever it receives before decoding, so both forms
+    arrive intact.
 
     The UTF-8 guard is a backstop -- every dimension is filtered through `_transmissible_or_none`
     upstream, which costs one key where returning None here costs the whole header. It stays

--- a/src/griptape_nodes/retained_mode/managers/budget_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/budget_manager.py
@@ -66,8 +66,9 @@ _UNSTORABLE_CHARACTERS = re.compile(r"[\x00-\x1f\x7f-\x9f]")
 
 # The parser's MAX_VALUE_LENGTH, and a cap on *characters*: it compares `len(value)` and slices
 # `value[:MAX_VALUE_LENGTH]` on a `str`, never on encoded bytes. Used to judge project names
-# (`_is_transmissible`), and to cut them only on the last rung before the chain is shed
-# (`_encode_attribution_header`) -- never on the ordinary path, which sends them whole.
+# (`_is_transmissible`), and to cut them only on the rungs between shedding the labels and
+# shedding the chain (`_encode_attribution_header`) -- never on the ordinary path, which sends
+# them whole.
 _MAX_VALUE_CHARS = 256
 
 
@@ -255,20 +256,26 @@ def _encode_attribution_header(facts: _AttributionFacts) -> _AttributionEncoding
     """Encode the attribution header, shedding dimensions in stages until it fits.
 
     The chain is always truncated to `_MAX_PROJECT_CHAIN_ENTRIES` from the leaf -- a standing
-    rule, not a size response. If the result does not fit, dimensions are shed in order of increasing
-    value: the workflow and node type first, and only then the chain's ancestors.
+    rule, not a size response. If the result does not fit, five rungs are tried in order of what
+    each gives up and the first that fits is sent: nothing, the labels, cut project names, both,
+    the chain.
+
+    Ordered by cost, not by being successively smaller -- rung three puts back the labels rung two
+    shed. Each rung is its own set of reductions rather than a further trim of the one above, so
+    none gives up more than its own overage needs. Cutting one long name frees thousands of bytes
+    where the labels are worth tens, and bundling the two would cost a dashboard row for nothing.
 
     The chain goes last because it is the only dimension the Cloud matches budgets against.
     Shedding it first would trade the billable dimension for audit-only labels, even when an
-    oversized `workflow` was what pushed the payload over.
+    oversized `workflow` was what pushed the payload over. The labels go before any cutting
+    because sending a name whole is what buys a truncation signal on the far end, and that signal
+    is what keeps two siblings sharing a 256-character prefix off one budget -- worth more than an
+    audit-only dimension.
 
-    One rung rewrites rather than sheds, and sits just above that: project names cut to the form
-    the Cloud stores. Sending them whole is the rule and `_project_name_for_the_wire` says why,
-    but what that rule buys is a truncation signal on the far end, and a payload over the cap
-    never gets there to carry one. Shedding the chain instead lands the spend in the default
-    bucket with `reasons` empty -- indistinguishable from an engine that never attributed
-    anything. Cutting keeps the match. It gives up the signal only where the signal was already
-    lost.
+    Cutting is worth reaching at all because a payload over the cap never arrives to carry that
+    signal. Shedding the chain instead lands the spend in the default bucket with `reasons` empty:
+    no metric fires, and it reads as an engine that never attributed anything. Cutting keeps the
+    match, and gives up the signal only where the signal was already gone.
 
     When the chain does go, all of it goes. Budget paths are root-anchored, so keeping the leaf buys
     no narrower match; it presents a nested project as a root, which matches nothing at best
@@ -281,9 +288,8 @@ def _encode_attribution_header(facts: _AttributionFacts) -> _AttributionEncoding
     chain_truncated = len(facts.project_chain) > _MAX_PROJECT_CHAIN_ENTRIES
     full_facts = facts._replace(project_chain=list(facts.project_chain[:_MAX_PROJECT_CHAIN_ENTRIES]))
     without_labels = full_facts._replace(workflow_name=None, node_type=None)
-    cut_names = without_labels._replace(
-        project_chain=[_as_the_cloud_keeps_it(name) for name in without_labels.project_chain]
-    )
+    cut_names = full_facts._replace(project_chain=[_as_the_cloud_keeps_it(name) for name in full_facts.project_chain])
+    cut_names_without_labels = cut_names._replace(workflow_name=None, node_type=None)
     no_chain = without_labels._replace(project_chain=[])
 
     stages = (
@@ -295,6 +301,13 @@ def _encode_attribution_header(facts: _AttributionFacts) -> _AttributionEncoding
         _ReductionStage(
             facts=cut_names,
             reduction_note="long project names will be attributed cut to the form the Cloud stores",
+        ),
+        _ReductionStage(
+            facts=cut_names_without_labels,
+            reduction_note=(
+                "long project names will be attributed cut to the form the Cloud stores, and the "
+                "workflow and node type not at all"
+            ),
         ),
         _ReductionStage(
             facts=no_chain,

--- a/src/griptape_nodes/retained_mode/managers/budget_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/budget_manager.py
@@ -93,12 +93,11 @@ class _ReductionStage(NamedTuple):
 def _is_transmissible(value: str) -> bool:
     """Whether a value survives the trip to the Cloud intact.
 
-    Two ways it does not, and both arrive by the same route -- a legacy project's id is its
-    canonical filesystem path (`project_manager.py:795`), and the workflow registry key is
-    derived from one. A path whose bytes are not valid UTF-8 comes back from the OS carrying
-    lone surrogates from `surrogateescape`, which `str.encode` refuses. A directory name may
-    legally contain a control character, which encodes here and is then discarded by the
-    Cloud's storability check.
+    Two ways it does not. A project name is free text and a workflow registry key is derived
+    from a filesystem path, so either can carry a byte the wire cannot hold. A path whose bytes
+    are not valid UTF-8 comes back from the OS carrying lone surrogates from `surrogateescape`,
+    which `str.encode` refuses. A pasted line break, or a directory name that legally contains
+    a control character, encodes here and is then discarded by the Cloud's storability check.
     """
     if _UNSTORABLE_CHARACTERS.search(value):
         return False
@@ -179,8 +178,8 @@ def _encode_attribution_payload(payload: dict[str, Any]) -> str | None:
 def _encode_attribution_header(facts: _AttributionFacts) -> _AttributionEncoding | None:
     """Encode the attribution header, shedding dimensions in stages until it fits.
 
-    The chain is always truncated to `_MAX_PROJECT_CHAIN_ENTRIES` from the leaf -- the v1 rule,
-    not a size response. If the result does not fit, dimensions are shed in order of increasing
+    The chain is always truncated to `_MAX_PROJECT_CHAIN_ENTRIES` from the leaf -- a standing
+    rule, not a size response. If the result does not fit, dimensions are shed in order of increasing
     value: the workflow and node type first, and only then the chain's ancestors.
 
     The chain goes last because it is the only dimension the Cloud matches budgets against, and
@@ -189,7 +188,7 @@ def _encode_attribution_header(facts: _AttributionFacts) -> _AttributionEncoding
     so even when an oversized `workflow` was what pushed the payload over, leaving the chain to
     pay for room it was not using.
 
-    None means even a leaf-only payload did not fit, which needs a single project id larger
+    None means even a leaf-only payload did not fit, which needs a single project name larger
     than the whole cap.
     """
     chain_truncated = len(facts.project_chain) > _MAX_PROJECT_CHAIN_ENTRIES
@@ -297,28 +296,35 @@ class BudgetManager(EngineScoped):
         )
 
     def _resolve_project_chain(self) -> list[str]:
-        """Resolve the current project's ancestry as ids, leaf-first, or [] when unavailable.
+        """Resolve the current project's ancestry as names, leaf-first, or [] when unavailable.
 
-        `ProjectChainEntry.name` is dropped here -- the single place the chain is consumed --
-        so a project's *display name* never travels. That is weaker than "no user-authored
-        string travels", and the difference matters: a legacy project predating the explicit
-        `id` field uses its canonical file path as its id (`project_manager.py:795`), and a
-        user may set any unique string as one, so `tags.project` can carry a filesystem path
-        or a chosen label. Ids still go out verbatim, because the Cloud matches them against
-        admin-authored budget paths -- hashing or dropping one would silently unbudget that
-        project rather than protect it. Disclosed on the PR; see the id-space contract at
-        `project_manager.py:163-172`.
+        `tags.project` is the only dimension the Cloud matches budgets against, so whatever
+        goes here has to be something a budget admin can author into a rule. The project name
+        is that: required by the schema, so always present, and the same string on every
+        machine that opens the project.
 
-        An id the Cloud cannot store costs the *whole* chain, not just its own entry. Budget
+        Two costs come with it, both accepted deliberately. A user-authored string rides in a
+        header that SSL-inspecting egress proxies log, so a project name discloses whatever the
+        user put in it -- a client name, typically. And a rename silently re-points that
+        project's spend, because the Cloud matches on the string alone and has no way to know
+        the two names are the same project.
+
+        A nameless entry ends the chain rather than contributing anything in its place. There is
+        nothing to put there that a budget rule could match, and it costs nothing to stop:
+        `get_project_chain` breaks its walk at the first entry whose template did not load, so a
+        nameless entry is always the last one -- an unregistered ancestor.
+
+        The synthetic `<system-defaults>` rest state is skipped by *id*, before its name is
+        read. It does have a template -- the shipped default one -- so it does have a name,
+        and that name is "Default Project", which is exactly the kind of generic string that
+        would collide across every user in an org. It is also not a project the Cloud models
+        at all: it is the root sentinel, never a real ancestor, so skipping it leaves a chain
+        the Cloud can still match rather than a truncated one.
+
+        A name the Cloud cannot store costs the *whole* chain, not just its own entry. Budget
         paths are root-anchored, so a chain missing any link already matches nothing -- and
         dropping only the offending entry is worse than sending none, because it promotes that
         entry's parent to leaf and bills a real ancestor project for spend it never incurred.
-
-        `<system-defaults>` is dropped with it. The Cloud reserves that exact string as its own
-        marker for unattributed spend, so its parser discards a client copy and counts the call
-        as degraded. Working outside a project is ordinary rather than exceptional, so sending it
-        would put a permanent noise floor under the platform's client-health metric for no gain:
-        omitting the key lands the spend in the same default bucket, silently.
         """
         try:
             chain = self.engine.project_manager.get_project_chain()
@@ -326,16 +332,35 @@ class BudgetManager(EngineScoped):
             logger.warning("Could not resolve the project chain for budget attribution.", exc_info=True)
             return []
 
-        project_ids = [entry.id for entry in chain if entry.id != SYSTEM_DEFAULTS_KEY]
-        untransmissible_count = sum(1 for project_id in project_ids if not _is_transmissible(project_id))
+        project_names: list[str] = []
+        for entry in chain:
+            if entry.id == SYSTEM_DEFAULTS_KEY:
+                continue
+            if entry.name is None:
+                break
+            project_names.append(entry.name)
+
+        # A real project *named* `<system-defaults>`, separate from the sentinel id skipped
+        # above. Nothing stops a user typing the reserved string into `name:`. The Cloud
+        # reserves it and discards a client copy, which would drop that entry and bill its
+        # parent for spend it never incurred, so the chain goes nowhere instead.
+        if SYSTEM_DEFAULTS_KEY in project_names:
+            logger.warning(
+                "Dropping project attribution for this call: a project is named '%s', which Griptape "
+                "Cloud reserves for its own use. Rename the project to attribute its spend.",
+                SYSTEM_DEFAULTS_KEY,
+            )
+            return []
+
+        untransmissible_count = sum(1 for name in project_names if not _is_transmissible(name))
         if untransmissible_count > 0:
             logger.warning(
-                "Dropping project attribution for this call: %d project id(s) in the chain cannot be "
+                "Dropping project attribution for this call: %d project name(s) in the chain cannot be "
                 "transmitted intact. This spend will land in the default budget.",
                 untransmissible_count,
             )
             return []
-        return project_ids
+        return project_names
 
     def _resolve_workflow_name(self) -> str | None:
         """Resolve the current workflow's registry key, or None when it cannot be determined.
@@ -343,7 +368,7 @@ class BudgetManager(EngineScoped):
         An unsaved workflow is registered under an `unsaved:<uuid4>` key that is fresh every
         session, so the sentinel goes out instead: one low-cardinality bucket for scratch spend,
         still distinguishable from an absent key. A saved key is workspace-path-derived, so it
-        carries the same transmissibility risk as a project id and gets the same check.
+        carries the same transmissibility risk as a project name and gets the same check.
         """
         try:
             if not self.engine.context_manager.has_current_workflow():

--- a/src/griptape_nodes/retained_mode/managers/budget_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/budget_manager.py
@@ -58,6 +58,10 @@ _MAX_DECODED_PAYLOAD_BYTES = 4096
 # something -- see `_is_transmissible`.
 _UNSTORABLE_CHARACTERS = re.compile(r"[\x00-\x1f\x7f-\x9f]")
 
+# Matches the Cloud parser's MAX_VALUE_LENGTH -- the length it cuts a tag value down to before
+# it decides anything about that value. Applied to project names only; see `_as_the_cloud_keeps_it`.
+_MAX_VALUE_CHARS = 256
+
 
 class _AttributionFacts(NamedTuple):
     """The engine facts one outbound call is attributed to.
@@ -90,12 +94,30 @@ class _ReductionStage(NamedTuple):
     reduction_note: str | None
 
 
+def _as_the_cloud_keeps_it(name: str) -> str:
+    """Reduce a project name to the form the Cloud actually stores.
+
+    Strip, cut to the value cap, strip again -- the parser's own order, and the order matters
+    twice. It has to run *before* the reserved-value test, or a name that only becomes
+    `<system-defaults>` after the cut passes here and is refused there, which is the
+    parent-billed-for-its-child failure again. And it has to run before the byte checks, or a
+    control character sitting past the cap drops a whole chain the far end would have stored.
+
+    Project names only. The result is what budget rules are written against, so reporting the
+    kept form is the accurate answer; a workflow registry key is an identifier rather than a
+    match key and travels as the engine spells it.
+    """
+    return name.strip()[:_MAX_VALUE_CHARS].strip()
+
+
 def _is_transmissible(value: str) -> bool:
     """Whether a value survives the trip to the Cloud intact.
 
-    Judged on `value.strip()`, because that is what the Cloud decides on: it strips before
-    testing storability, so a value this passes unstripped and the far end then discards costs
-    an entry, promotes its parent to leaf, and bills a real ancestor for spend it never had.
+    Judged on the stored form, not the given one: the far end normalizes before it decides
+    storability, so a value that passes here raw and is discarded there costs an entry,
+    promotes its parent to leaf, and bills a real ancestor for spend it never had. Stripping
+    covers that for every dimension. Project names are cut to length as well, and arrive
+    already normalized by `_as_the_cloud_keeps_it`.
 
     Three ways a value does not survive. A project name is free text and a workflow registry
     key is derived from a filesystem path, so either can carry a byte the wire cannot hold: a
@@ -117,19 +139,23 @@ def _is_transmissible(value: str) -> bool:
 
 
 def _transmissible_or_none(value: str | None) -> str | None:
-    """Normalize a value the way the Cloud will, or None when it cannot reach it intact.
+    """Pass a value through, or None when it cannot reach the Cloud intact.
 
-    Returns the stripped form rather than the original, because the far end strips what it
-    stores -- sending the stripped value keeps the result's structured fields describing what
-    budgets actually match against. Omitting the key instead says "the engine could not
-    determine this", which is honest: a value the far end would discard is one the engine
-    cannot express.
+    Passed through verbatim, never stripped. Transmissibility is judged on the stripped form
+    because that is what the far end tests, but normalizing is a *project name* rule and this
+    helper runs over every dimension. A workflow registry key is an identifier the engine can
+    be asked to look up again, so trimming it here would hand a consumer a string that no
+    longer names the workflow it came from. `_resolve_project_chain` normalizes its own names,
+    where the reason to is written down.
+
+    Omitting the key says "the engine could not determine this", which is honest: a value the
+    far end would discard is one the engine cannot express.
     """
     if value is None:
         return None
     if not _is_transmissible(value):
         return None
-    return value.strip()
+    return value
 
 
 def _build_attribution_payload(facts: _AttributionFacts) -> dict[str, Any]:
@@ -348,17 +374,19 @@ class BudgetManager(EngineScoped):
                     "attribute its spend."
                 )
                 return []
-            name = _transmissible_or_none(entry.name)
-            if name is None:
+            # Reduced to the kept form before anything is decided about it, so every test
+            # below sees the string the far end will see. A project name is a label rather
+            # than a key, so nothing is lost by reporting it the way it is stored.
+            name = _as_the_cloud_keeps_it(entry.name)
+            if not _is_transmissible(name):
                 logger.warning(
                     "Dropping project attribution for this call: a project name in the chain cannot "
                     "be transmitted intact. Rename the project using ordinary text to attribute its "
                     "spend."
                 )
                 return []
-            # Compared after normalizing, because the Cloud strips before testing the reserved
-            # value: `" <system-defaults> "` is the same claim as the bare string. Separate from
-            # the sentinel *id* skipped above -- this is a real project a user named that.
+            # Separate from the sentinel *id* skipped above -- this is a real project a user
+            # named that, whether outright or by padding one out to the cap.
             if name == SYSTEM_DEFAULTS_KEY:
                 logger.warning(
                     "Dropping project attribution for this call: a project is named '%s', which Griptape "
@@ -376,7 +404,10 @@ class BudgetManager(EngineScoped):
         An unsaved workflow is registered under an `unsaved:<uuid4>` key that is fresh every
         session, so the sentinel goes out instead: one low-cardinality bucket for scratch spend,
         still distinguishable from an absent key. A saved key is workspace-path-derived, so it
-        carries the same transmissibility risk as a project name and gets the same check.
+        carries the same transmissibility risk as a project name and gets the same check --
+        but not the same normalizing. A key is how the engine names the workflow, and a path
+        segment may legally begin or end with a space, so it travels exactly as
+        `get_current_workflow_name` returns it.
         """
         try:
             if not self.engine.context_manager.has_current_workflow():

--- a/src/griptape_nodes/retained_mode/managers/budget_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/budget_manager.py
@@ -252,18 +252,50 @@ def _encode_attribution_payload(payload: dict[str, Any]) -> str | None:
     return base64.urlsafe_b64encode(raw).decode("ascii")
 
 
+def _reduce(
+    facts: _AttributionFacts,
+    *,
+    cut_names: bool = False,
+    drop_labels: bool = False,
+    drop_chain: bool = False,
+) -> _AttributionFacts:
+    """Apply one rung's own set of reductions to the unreduced facts.
+
+    Every rung is built from the full facts and names what it gives up, so no rung inherits its
+    neighbour's reductions. That is not tidiness: deriving a rung from the one above it is how
+    this ladder twice ended up shedding the labels to pay for an overage the rung's own reduction
+    already covered.
+
+    `drop_chain` subsumes `cut_names` -- there is nothing left to cut -- so no rung passes both.
+    """
+    project_chain = list(facts.project_chain)
+    if drop_chain:
+        project_chain = []
+    elif cut_names:
+        project_chain = [_as_the_cloud_keeps_it(name) for name in project_chain]
+
+    workflow_name = facts.workflow_name
+    node_type = facts.node_type
+    if drop_labels:
+        workflow_name = None
+        node_type = None
+
+    return facts._replace(project_chain=project_chain, workflow_name=workflow_name, node_type=node_type)
+
+
 def _encode_attribution_header(facts: _AttributionFacts) -> _AttributionEncoding | None:
     """Encode the attribution header, shedding dimensions in stages until it fits.
 
     The chain is always truncated to `_MAX_PROJECT_CHAIN_ENTRIES` from the leaf -- a standing
-    rule, not a size response. If the result does not fit, five rungs are tried in order of what
-    each gives up and the first that fits is sent: nothing, the labels, cut project names, both,
-    the chain.
+    rule, not a size response. If the result does not fit, six rungs are tried in order of what
+    each gives up and the first that fits is sent: nothing, the labels, cut project names, both of
+    those, the chain, then the chain and the labels together.
 
     Ordered by cost, not by being successively smaller -- rung three puts back the labels rung two
-    shed. Each rung is its own set of reductions rather than a further trim of the one above, so
-    none gives up more than its own overage needs. Cutting one long name frees thousands of bytes
-    where the labels are worth tens, and bundling the two would cost a dashboard row for nothing.
+    shed. Each rung states its own reductions against the full facts rather than trimming the rung
+    above it, so none gives up more than its own overage needs. Shedding the chain frees thousands
+    of bytes and the labels are worth tens, so a rung that bundled them would cost a dashboard row
+    for nothing. `_reduce` is what keeps that structural rather than remembered.
 
     The chain goes last because it is the only dimension the Cloud matches budgets against.
     Shedding it first would trade the billable dimension for audit-only labels, even when an
@@ -287,31 +319,31 @@ def _encode_attribution_header(facts: _AttributionFacts) -> _AttributionEncoding
     """
     chain_truncated = len(facts.project_chain) > _MAX_PROJECT_CHAIN_ENTRIES
     full_facts = facts._replace(project_chain=list(facts.project_chain[:_MAX_PROJECT_CHAIN_ENTRIES]))
-    without_labels = full_facts._replace(workflow_name=None, node_type=None)
-    cut_names = full_facts._replace(project_chain=[_as_the_cloud_keeps_it(name) for name in full_facts.project_chain])
-    cut_names_without_labels = cut_names._replace(workflow_name=None, node_type=None)
-    no_chain = without_labels._replace(project_chain=[])
 
     stages = (
         _ReductionStage(facts=full_facts, reduction_note=None),
         _ReductionStage(
-            facts=without_labels,
+            facts=_reduce(full_facts, drop_labels=True),
             reduction_note="the workflow and node type will not be attributed for this call",
         ),
         _ReductionStage(
-            facts=cut_names,
+            facts=_reduce(full_facts, cut_names=True),
             reduction_note="long project names will be attributed cut to the form the Cloud stores",
         ),
         _ReductionStage(
-            facts=cut_names_without_labels,
+            facts=_reduce(full_facts, cut_names=True, drop_labels=True),
             reduction_note=(
                 "long project names will be attributed cut to the form the Cloud stores, and the "
                 "workflow and node type not at all"
             ),
         ),
         _ReductionStage(
-            facts=no_chain,
+            facts=_reduce(full_facts, drop_chain=True),
             reduction_note="no project will be attributed for this call",
+        ),
+        _ReductionStage(
+            facts=_reduce(full_facts, drop_chain=True, drop_labels=True),
+            reduction_note="no project, workflow, or node type will be attributed for this call",
         ),
     )
 

--- a/src/griptape_nodes/retained_mode/managers/budget_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/budget_manager.py
@@ -65,8 +65,9 @@ _MAX_DECODED_PAYLOAD_BYTES = 4096
 _UNSTORABLE_CHARACTERS = re.compile(r"[\x00-\x1f\x7f-\x9f]")
 
 # The parser's MAX_VALUE_LENGTH, and a cap on *characters*: it compares `len(value)` and slices
-# `value[:MAX_VALUE_LENGTH]` on a `str`, never on encoded bytes. Used to judge project names,
-# not to cut them -- see `_project_name_for_the_wire`.
+# `value[:MAX_VALUE_LENGTH]` on a `str`, never on encoded bytes. Used to judge project names
+# (`_is_transmissible`), and to cut them only on the last rung before the chain is shed
+# (`_encode_attribution_header`) -- never on the ordinary path, which sends them whole.
 _MAX_VALUE_CHARS = 256
 
 
@@ -134,6 +135,12 @@ def _project_name_for_the_wire(name: str) -> str:
     cap survives the strip and makes the payload unencodable, costing the whole header. The cut
     form drops that byte, so it goes instead -- one name's truncation signal for every other
     dimension on the call.
+
+    The size ladder holds the other exception, and it is not this function's call to make: names
+    long enough to push the payload past the cap never reach the far end at all, so
+    `_encode_attribution_header` cuts them there rather than shed the chain. That costs nothing
+    this function was protecting -- a chain shed client-side arrives as no chain, and no chain
+    carries no truncation signal either.
     """
     stripped = name.strip()
     try:
@@ -255,7 +262,15 @@ def _encode_attribution_header(facts: _AttributionFacts) -> _AttributionEncoding
     Shedding it first would trade the billable dimension for audit-only labels, even when an
     oversized `workflow` was what pushed the payload over.
 
-    When it does go, all of it goes. Budget paths are root-anchored, so keeping the leaf buys
+    One rung rewrites rather than sheds, and sits just above that: project names cut to the form
+    the Cloud stores. Sending them whole is the rule and `_project_name_for_the_wire` says why,
+    but what that rule buys is a truncation signal on the far end, and a payload over the cap
+    never gets there to carry one. Shedding the chain instead lands the spend in the default
+    bucket with `reasons` empty -- indistinguishable from an engine that never attributed
+    anything. Cutting keeps the match. It gives up the signal only where the signal was already
+    lost.
+
+    When the chain does go, all of it goes. Budget paths are root-anchored, so keeping the leaf buys
     no narrower match; it presents a nested project as a root, which matches nothing at best
     and bills an unrelated top-level project of the same name at worst. Same rule
     `_resolve_project_chain` applies to a name it cannot describe.
@@ -266,6 +281,9 @@ def _encode_attribution_header(facts: _AttributionFacts) -> _AttributionEncoding
     chain_truncated = len(facts.project_chain) > _MAX_PROJECT_CHAIN_ENTRIES
     full_facts = facts._replace(project_chain=list(facts.project_chain[:_MAX_PROJECT_CHAIN_ENTRIES]))
     without_labels = full_facts._replace(workflow_name=None, node_type=None)
+    cut_names = without_labels._replace(
+        project_chain=[_as_the_cloud_keeps_it(name) for name in without_labels.project_chain]
+    )
     no_chain = without_labels._replace(project_chain=[])
 
     stages = (
@@ -273,6 +291,10 @@ def _encode_attribution_header(facts: _AttributionFacts) -> _AttributionEncoding
         _ReductionStage(
             facts=without_labels,
             reduction_note="the workflow and node type will not be attributed for this call",
+        ),
+        _ReductionStage(
+            facts=cut_names,
+            reduction_note="long project names will be attributed cut to the form the Cloud stores",
         ),
         _ReductionStage(
             facts=no_chain,

--- a/tests/unit/retained_mode/managers/test_budget_manager.py
+++ b/tests/unit/retained_mode/managers/test_budget_manager.py
@@ -1,0 +1,478 @@
+"""Tests for BudgetManager.on_get_attribution_context_request.
+
+The attribution header is the one thing E1 produces, so most of these assert on the
+*decoded* payload rather than on the manager's internals: that dict is the contract the
+Cloud reads, and the Success payload's structured fields have to agree with it.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import MagicMock, Mock, PropertyMock, patch
+
+import pytest
+
+from griptape_nodes.retained_mode.events.budget_events import (
+    ATTRIBUTION_HEADER_NAME,
+    ATTRIBUTION_SCHEMA_VERSION,
+    UNSAVED_WORKFLOW_SENTINEL,
+    GetAttributionContextRequest,
+    GetAttributionContextResultFailure,
+    GetAttributionContextResultSuccess,
+)
+from griptape_nodes.retained_mode.events.context_events import (
+    SetWorkflowContextRequest,
+)
+from griptape_nodes.retained_mode.managers import budget_manager as budget_manager_module
+from griptape_nodes.retained_mode.managers.budget_manager import BudgetManager
+from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY, ProjectManager
+
+if TYPE_CHECKING:
+    from griptape_nodes.retained_mode.engine import Engine
+    from griptape_nodes.retained_mode.events.base_events import ResultPayload
+
+# The complete set of keys v1 is allowed to put on the wire. A new field must consciously
+# update this list, which is the point: `node_id` is absent by decision, and `BaseNode.name`
+# must never appear under any key.
+ALLOWED_PAYLOAD_KEYS = {
+    "v",
+    "tags",
+    "workflow",
+    "node_type",
+    "engine_id",
+    "orchestrator_engine_id",
+    "session_id",
+}
+
+
+def _decode(result: GetAttributionContextResultSuccess) -> dict[str, Any]:
+    """Decode a Success payload's header value back into the dict the Cloud will read."""
+    return json.loads(base64.urlsafe_b64decode(result.header_value))
+
+
+def _dispatch(manager: BudgetManager, **kwargs: Any) -> ResultPayload:
+    """Invoke the handler directly, bypassing the event bus."""
+    return manager.on_get_attribution_context_request(GetAttributionContextRequest(**kwargs))
+
+
+def _succeed(manager: BudgetManager, **kwargs: Any) -> GetAttributionContextResultSuccess:
+    """Invoke the handler and assert it succeeded."""
+    result = _dispatch(manager, **kwargs)
+    assert isinstance(result, GetAttributionContextResultSuccess)
+    return result
+
+
+def _mock_engine() -> MagicMock:
+    """A stand-in engine whose peers answer with JSON-encodable values.
+
+    A bare MagicMock hands back MagicMocks, which `json.dumps` cannot encode -- so every
+    peer a resolver reads is given a real value here and overridden per test.
+    """
+    mock_engine = MagicMock()
+    mock_engine.project_manager.get_project_chain.return_value = []
+    mock_engine.context_manager.has_current_workflow.return_value = False
+    mock_engine.engine_identity_manager.engine_id = "eng-1"
+    mock_engine.session_manager.active_session_id = "sess-1"
+    return mock_engine
+
+
+def _register_project(
+    project_manager: ProjectManager,
+    project_id: str,
+    *,
+    name: str | None = None,
+    parent_id: str | None = None,
+) -> None:
+    """Register an id-linked project directly in the in-memory registry.
+
+    Mirrors the helper at `test_project_manager.py:11588`: an explicit `parent_project_id`
+    so the chain walk resolves through the registry without touching disk, and a distinct
+    `name` on each template so the ids-only assertions have something to catch.
+    """
+    from griptape_nodes.common.project_templates import ProjectValidationInfo, ProjectValidationStatus
+    from griptape_nodes.common.project_templates.default_project_template import DEFAULT_PROJECT_TEMPLATE
+    from griptape_nodes.retained_mode.managers.project_manager import ProjectInfo
+
+    update: dict[str, Any] = {"id": project_id, "parent_project_id": parent_id}
+    if name is not None:
+        update["name"] = name
+    project_manager._successfully_loaded_project_templates[project_id] = ProjectInfo(
+        project_id=project_id,
+        project_file_path=None,
+        project_base_dir=Path("/"),
+        template=DEFAULT_PROJECT_TEMPLATE.model_copy(update=update),
+        validation=ProjectValidationInfo(status=ProjectValidationStatus.GOOD),
+        parsed_situation_schemas={},
+        parsed_directory_schemas={},
+    )
+
+
+class TestAttributionPayloadShape:
+    """The decoded header is the contract; these pin its shape."""
+
+    @pytest.fixture
+    def budget_manager(self) -> BudgetManager:
+        return BudgetManager(MagicMock(), engine=_mock_engine())
+
+    def test_request_dispatches_through_the_engine(self, engine: Engine) -> None:
+        """The request reaches BudgetManager over the real bus and comes back usable."""
+        result = engine.handle_request(GetAttributionContextRequest(node_type="GriptapeProxyImage"))
+
+        assert isinstance(result, GetAttributionContextResultSuccess)
+        assert result.header_value
+        assert result.header_name == ATTRIBUTION_HEADER_NAME
+        assert result.schema_version == ATTRIBUTION_SCHEMA_VERSION
+
+    def test_header_value_decodes_to_documented_payload(self, engine: Engine) -> None:
+        """base64url of compact UTF-8 JSON, leaf-first chain, schema version 1."""
+        result = engine.handle_request(GetAttributionContextRequest(node_type="GriptapeProxyImage"))
+        assert isinstance(result, GetAttributionContextResultSuccess)
+
+        decoded = _decode(result)
+        assert decoded["v"] == ATTRIBUTION_SCHEMA_VERSION
+        assert decoded["node_type"] == "GriptapeProxyImage"
+        assert decoded["tags"]["project"] == result.project_chain
+
+    def test_padding_round_trips(self, engine: Engine) -> None:
+        """Padding is kept so the Cloud can decode without re-padding."""
+        result = engine.handle_request(GetAttributionContextRequest())
+        assert isinstance(result, GetAttributionContextResultSuccess)
+
+        # Would raise binascii.Error on a stripped-padding value.
+        base64.urlsafe_b64decode(result.header_value)
+        assert len(result.header_value) % 4 == 0
+
+    def test_payload_key_allowlist(self, engine: Engine) -> None:
+        """No key ships that has not been consciously added, and `node_id` is not one of them."""
+        result = engine.handle_request(GetAttributionContextRequest(node_type="Anything"))
+        assert isinstance(result, GetAttributionContextResultSuccess)
+
+        decoded = _decode(result)
+        assert set(decoded) <= ALLOWED_PAYLOAD_KEYS
+        assert "node_id" not in decoded
+
+    def test_structured_fields_agree_with_the_header(self, budget_manager: BudgetManager) -> None:
+        """A consumer reading the result must see exactly what the header encodes."""
+        mock_engine = cast("MagicMock", budget_manager.engine)
+        mock_engine.project_manager.get_project_chain.return_value = []
+        mock_engine.context_manager.has_current_workflow.return_value = False
+        mock_engine.engine_identity_manager.engine_id = "eng-1"
+        mock_engine.session_manager.active_session_id = "sess-1"
+
+        result = _succeed(budget_manager, node_type="NodeT")
+        decoded = _decode(result)
+
+        assert decoded.get("workflow") == result.workflow_name
+        assert decoded["node_type"] == result.node_type
+        assert decoded["engine_id"] == result.engine_id
+        assert decoded["session_id"] == result.session_id
+
+
+class TestProjectChain:
+    """`tags.project` is ordered leaf-first and carries ids only."""
+
+    def _manager_on(self, project_manager: ProjectManager) -> BudgetManager:
+        mock_engine = _mock_engine()
+        mock_engine.project_manager = project_manager
+        return BudgetManager(MagicMock(), engine=mock_engine)
+
+    def test_chain_is_system_defaults_when_no_project_selected(self) -> None:
+        """The `<system-defaults>` sentinel passes through verbatim, like any other id."""
+        project_manager = ProjectManager(Mock(), Mock(), Mock())
+        result = _succeed(self._manager_on(project_manager))
+
+        assert _decode(result)["tags"]["project"] == [SYSTEM_DEFAULTS_KEY]
+
+    def test_nested_chain_is_ids_only(self) -> None:
+        """Project display names must not reach the payload by any route."""
+        project_manager = ProjectManager(Mock(), Mock(), Mock())
+        _register_project(project_manager, "grandparent", name="Acme Studios")
+        _register_project(project_manager, "parent", name="Feature Film", parent_id="grandparent")
+        _register_project(project_manager, "leaf", name="Shot 020", parent_id="parent")
+        project_manager._current_project_id = "leaf"
+
+        result = _succeed(self._manager_on(project_manager))
+        decoded = _decode(result)
+
+        assert decoded["tags"]["project"] == ["leaf", "parent", "grandparent"]
+        serialized = json.dumps(decoded)
+        for name in ("Acme Studios", "Feature Film", "Shot 020"):
+            assert name not in serialized
+            assert name not in result.header_value
+
+    def test_chain_deeper_than_ten_truncates_from_the_leaf(self) -> None:
+        """v1 caps the chain at 10 entries, keeping the leaf end, and says that it did."""
+        project_manager = ProjectManager(Mock(), Mock(), Mock())
+        ids = [f"p{index:02d}" for index in range(15)]
+        # ids[0] is the leaf; each entry's parent is the next one along.
+        for index, project_id in enumerate(ids):
+            parent = ids[index + 1] if index + 1 < len(ids) else None
+            _register_project(project_manager, project_id, name=f"Name {project_id}", parent_id=parent)
+        project_manager._current_project_id = ids[0]
+
+        result = _succeed(self._manager_on(project_manager))
+
+        assert _decode(result)["tags"]["project"] == ids[:10]
+        assert result.project_chain == ids[:10]
+        assert result.chain_truncated is True
+
+    def test_unregistered_parent_id_is_still_surfaced(self) -> None:
+        """An unresolvable parent ends the chain, and E1 serializes whatever the chain says."""
+        project_manager = ProjectManager(Mock(), Mock(), Mock())
+        _register_project(project_manager, "shot-6", name="Shot 6", parent_id="swx")
+        project_manager._current_project_id = "shot-6"
+
+        result = _succeed(self._manager_on(project_manager))
+
+        assert _decode(result)["tags"]["project"] == ["shot-6", "swx"]
+
+    def test_second_dispatch_reflects_a_project_switch(self) -> None:
+        """The chain is read per invocation, never cached at workflow open."""
+        project_manager = ProjectManager(Mock(), Mock(), Mock())
+        _register_project(project_manager, "before", name="Before")
+        _register_project(project_manager, "after", name="After")
+        manager = self._manager_on(project_manager)
+
+        project_manager._current_project_id = "before"
+        first = _succeed(manager)
+        project_manager._current_project_id = "after"
+        second = _succeed(manager)
+
+        assert _decode(first)["tags"]["project"] == ["before"]
+        assert _decode(second)["tags"]["project"] == ["after"]
+
+    def test_empty_chain_omits_tags_entirely(self) -> None:
+        """`[]` would assert 'belongs to zero projects', which is a claim we cannot make."""
+        manager = BudgetManager(MagicMock(), engine=_mock_engine())
+
+        assert "tags" not in _decode(_succeed(manager))
+
+
+class TestWorkflowName:
+    """An absent `workflow` means unknown; `<unsaved>` means scratch. They differ."""
+
+    def test_unsaved_workflow_reports_the_sentinel(self, engine: Engine) -> None:
+        """Never the per-session `unsaved:<uuid4>` key, which has unbounded cardinality."""
+        set_result = engine.handle_request(SetWorkflowContextRequest(display_name="Untitled"))
+        assert set_result.succeeded()
+        try:
+            result = engine.handle_request(GetAttributionContextRequest())
+            assert isinstance(result, GetAttributionContextResultSuccess)
+
+            decoded = _decode(result)
+            assert decoded["workflow"] == UNSAVED_WORKFLOW_SENTINEL
+            assert result.workflow_name == UNSAVED_WORKFLOW_SENTINEL
+            # The uuid must not leak by any other route, encoded or decoded.
+            assert "unsaved:" not in json.dumps(decoded)
+            assert "unsaved:" not in base64.urlsafe_b64decode(result.header_value).decode("utf-8")
+        finally:
+            while engine.context_manager.has_current_workflow():
+                engine.context_manager.pop_workflow()
+
+    def test_saved_workflow_reports_its_registry_key(self, engine: Engine) -> None:
+        """A saved workflow's key is the workspace-relative path minus extension."""
+        engine.context_manager.push_workflow("shots/sh020/lighting")
+        try:
+            result = engine.handle_request(GetAttributionContextRequest())
+            assert isinstance(result, GetAttributionContextResultSuccess)
+
+            decoded = _decode(result)
+            assert decoded["workflow"] == "shots/sh020/lighting"
+            assert not decoded["workflow"].startswith("unsaved:")
+        finally:
+            engine.context_manager.pop_workflow()
+
+    def test_missing_workflow_context_omits_workflow(self, engine: Engine) -> None:
+        """No workflow pushed -> the key is absent, which is distinct from the scratch bucket."""
+        assert not engine.context_manager.has_current_workflow()
+
+        result = engine.handle_request(GetAttributionContextRequest())
+        assert isinstance(result, GetAttributionContextResultSuccess)
+
+        assert "workflow" not in _decode(result)
+        assert result.workflow_name is None
+
+
+class TestOrchestratorEngineId:
+    """Pins the resolver, NOT a shipping behavior.
+
+    Under the forwarding design the orchestrator answers every attribution request, and the
+    orchestrator has no parent, so production never populates this key. Nobody should later
+    read these tests as evidence that worker spend is joinable to its orchestrator: it is
+    not, and it does not need to be, because budgets match on the project chain alone.
+    """
+
+    @pytest.fixture
+    def budget_manager(self) -> BudgetManager:
+        return BudgetManager(MagicMock(), engine=_mock_engine())
+
+    def test_orchestrator_engine_id_present_when_the_env_var_is_set(
+        self, budget_manager: BudgetManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GTN_ORCHESTRATOR_ENGINE_ID", "eng-orch")
+
+        result = _succeed(budget_manager)
+
+        assert _decode(result)["orchestrator_engine_id"] == "eng-orch"
+        assert result.orchestrator_engine_id == "eng-orch"
+
+    def test_orchestrator_engine_id_absent_on_the_orchestrator(
+        self, budget_manager: BudgetManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("GTN_ORCHESTRATOR_ENGINE_ID", raising=False)
+
+        result = _succeed(budget_manager)
+
+        assert "orchestrator_engine_id" not in _decode(result)
+        assert result.orchestrator_engine_id is None
+
+
+class TestDegradation:
+    """The caller is about to spend money: degrade to a missing key, never raise."""
+
+    def _manager(self) -> BudgetManager:
+        mock_engine = _mock_engine()
+        mock_engine.project_manager.get_project_chain.return_value = [Mock(id="leaf")]
+        mock_engine.context_manager.has_current_workflow.return_value = True
+        mock_engine.context_manager.get_current_workflow_name.return_value = "shots/sh020"
+        return BudgetManager(MagicMock(), engine=mock_engine)
+
+    @pytest.mark.parametrize(
+        ("break_field", "absent_key"),
+        [
+            ("project_chain", "tags"),
+            ("workflow", "workflow"),
+            ("engine_id", "engine_id"),
+            ("session_id", "session_id"),
+        ],
+    )
+    def test_peer_failure_degrades_one_field_not_the_header(
+        self, break_field: str, absent_key: str, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """One unhappy peer costs one key, not the whole attribution."""
+        manager = self._manager()
+        mock_engine = cast("MagicMock", manager.engine)
+        boom = RuntimeError("peer exploded")
+
+        if break_field == "project_chain":
+            mock_engine.project_manager.get_project_chain.side_effect = boom
+        elif break_field == "workflow":
+            mock_engine.context_manager.get_current_workflow_name.side_effect = boom
+        elif break_field == "engine_id":
+            type(mock_engine.engine_identity_manager).engine_id = PropertyMock(side_effect=boom)
+        elif break_field == "session_id":
+            type(mock_engine.session_manager).active_session_id = PropertyMock(side_effect=boom)
+
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+            result = _succeed(manager)
+
+        assert absent_key not in _decode(result)
+        assert any(record.levelno == logging.WARNING for record in caplog.records)
+
+    def test_no_workflow_context_is_not_an_error(self) -> None:
+        """`has_current_workflow()` returning False is an ordinary state, not a degradation."""
+        manager = self._manager()
+        cast("MagicMock", manager.engine).context_manager.has_current_workflow.return_value = False
+
+        result = _succeed(manager)
+
+        assert "workflow" not in _decode(result)
+
+
+class TestSizeCap:
+    """One reduction step and a floor, not a ladder."""
+
+    def _manager(self) -> BudgetManager:
+        mock_engine = _mock_engine()
+        mock_engine.project_manager.get_project_chain.return_value = [Mock(id="leaf"), Mock(id="parent")]
+        mock_engine.context_manager.has_current_workflow.return_value = True
+        mock_engine.context_manager.get_current_workflow_name.return_value = "shots/sh020/lighting"
+        return BudgetManager(MagicMock(), engine=mock_engine)
+
+    def test_oversized_payload_reduces_to_minimum(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Over the cap: drop workflow and node type, keep the leaf, still succeed."""
+        manager = self._manager()
+
+        with (
+            patch.object(budget_manager_module, "_MAX_DECODED_PAYLOAD_BYTES", 80),
+            caplog.at_level(logging.WARNING, logger="griptape_nodes"),
+        ):
+            result = _succeed(manager, node_type="GriptapeProxyImage")
+
+        decoded = _decode(result)
+        assert decoded["tags"]["project"] == ["leaf"]
+        assert "workflow" not in decoded
+        assert "node_type" not in decoded
+        # The structured fields have to agree with the reduced header, not the pre-encode values.
+        assert result.workflow_name is None
+        assert result.node_type is None
+        assert result.project_chain == ["leaf"]
+        assert result.chain_truncated is True
+        assert any(record.levelno == logging.WARNING for record in caplog.records)
+
+    def test_unencodable_payload_fails_without_raising(self) -> None:
+        """The floor: no usable header value exists, so Success would be a lie."""
+        manager = self._manager()
+
+        with patch.object(budget_manager_module, "_MAX_DECODED_PAYLOAD_BYTES", 1):
+            result = _dispatch(manager)
+
+        assert isinstance(result, GetAttributionContextResultFailure)
+        assert "attribution" in str(result.result_details).lower()
+
+
+class TestConfidentiality:
+    """The header value is descriptive, not secret -- but it still stays out of the logs."""
+
+    def test_request_does_not_broadcast(self) -> None:
+        """`broadcast_result=False` keeps the Success payload off the WebSocket feed."""
+        assert GetAttributionContextRequest().broadcast_result is False
+
+    def test_broadcast_result_stays_keyword_only(self) -> None:
+        """Pins `field(..., kw_only=True)` against a future bare redeclaration.
+
+        The base payload is `kw_only=True` but this subclass is a plain `@dataclass`, so a
+        bare `broadcast_result = False` would re-register it as the second positional
+        parameter -- and a caller passing `node_type` positionally could then flip
+        broadcasting back on by accident.
+        """
+        assert GetAttributionContextRequest("GriptapeProxyImage").node_type == "GriptapeProxyImage"
+        with pytest.raises(TypeError):
+            GetAttributionContextRequest("GriptapeProxyImage", True)  # type: ignore[misc]
+
+    def test_header_value_is_never_logged(self, engine: Engine, caplog: pytest.LogCaptureFixture) -> None:
+        """Neither the log stream nor `result_details`, which is logged as well as broadcast."""
+        with caplog.at_level(logging.DEBUG, logger="griptape_nodes"):
+            result = engine.handle_request(GetAttributionContextRequest(node_type="GriptapeProxyImage"))
+        assert isinstance(result, GetAttributionContextResultSuccess)
+
+        assert result.header_value not in caplog.text
+        assert result.header_value not in str(result.result_details)
+
+    def test_node_label_never_appears(self, engine: Engine) -> None:
+        """`BaseNode.name` is user-authored and forbidden; no key named `name` at any depth."""
+        result = engine.handle_request(GetAttributionContextRequest(node_type="GriptapeProxyImage"))
+        assert isinstance(result, GetAttributionContextResultSuccess)
+
+        def walk(value: Any) -> None:
+            if isinstance(value, dict):
+                for key, child in value.items():
+                    assert key != "name"
+                    walk(child)
+            elif isinstance(value, list):
+                for child in value:
+                    walk(child)
+
+        walk(_decode(result))
+
+
+class TestWiring:
+    """The manager exists on every engine. Worker forwarding is covered in tests/unit/worker/."""
+
+    def test_engine_exposes_the_budget_manager(self, engine: Engine) -> None:
+        assert isinstance(engine.budget_manager, BudgetManager)
+        assert engine.BudgetManager() is engine.budget_manager

--- a/tests/unit/retained_mode/managers/test_budget_manager.py
+++ b/tests/unit/retained_mode/managers/test_budget_manager.py
@@ -190,10 +190,11 @@ class TestAttributionPayloadShape:
         assert _tags(result)["project"] == result.project_chain
 
     def test_a_chainless_envelope_is_still_sent(self, budget_manager: BudgetManager) -> None:
-        """`{"v": 1}` says "no project open"; sending nothing says "client does not attribute".
+        """An empty chain is never a reason to withhold the header.
 
-        The Cloud parser distinguishes the two, so the bare envelope carries a real fact and
-        an empty chain is never a reason to withhold the header.
+        The envelope says nothing the far end can read today -- a bare `{"v": 1}` and an absent
+        header parse to equal objects -- so this pins the shape, not a signal. It is sent for
+        forward-compatibility: a `client_attributed` flag would make it one without a release.
         """
         result = _succeed(budget_manager)
 
@@ -466,11 +467,10 @@ class TestDegradation:
     ) -> None:
         """An unreadable chain is not the same fact as an empty one, and must not borrow it.
 
-        `{"v": 1}` is a positive claim -- the Cloud reads a missing `tags` as "no project open
-        on a client that attributes". A project manager that raised knows nothing about whether
-        a project is open, so sending that envelope would attribute an artist's spend to the
-        default budget while recording no degradation on either side. No header at all reads as
-        "this client did not attribute", which is true.
+        `{"v": 1}` asserts that no project is open. A project manager that raised knows nothing
+        about whether one is. The far end reads the envelope and an absent header identically,
+        so nothing downstream moves either way -- what this pins is that the engine stops short
+        of the claim, and that the caller gets a Failure rather than an empty-chain Success.
         """
         mock_engine = _mock_engine()
         mock_engine.project_manager.get_project_chain.side_effect = RuntimeError("peer exploded")

--- a/tests/unit/retained_mode/managers/test_budget_manager.py
+++ b/tests/unit/retained_mode/managers/test_budget_manager.py
@@ -36,11 +36,11 @@ if TYPE_CHECKING:
     from griptape_nodes.retained_mode.events.base_events import ResultPayload
 
 # The complete set of keys v1 is allowed to put on the wire. A new field must consciously
-# update this list, which is the point: `node_id` is absent by decision, and `BaseNode.name`
+# update these, which is the point: `node_id` is absent by decision, and `BaseNode.name`
 # must never appear under any key.
-ALLOWED_PAYLOAD_KEYS = {
-    "v",
-    "tags",
+ALLOWED_ENVELOPE_KEYS = {"v", "tags"}
+ALLOWED_TAG_KEYS = {
+    "project",
     "workflow",
     "node_type",
     "engine_id",
@@ -52,6 +52,11 @@ ALLOWED_PAYLOAD_KEYS = {
 def _decode(result: GetAttributionContextResultSuccess) -> dict[str, Any]:
     """Decode a Success payload's header value back into the dict the Cloud will read."""
     return json.loads(base64.urlsafe_b64decode(result.header_value))
+
+
+def _tags(result: GetAttributionContextResultSuccess) -> dict[str, Any]:
+    """The `tags` object the Cloud reads every dimension out of, or {} when none was sent."""
+    return _decode(result).get("tags", {})
 
 
 def _dispatch(manager: BudgetManager, **kwargs: Any) -> ResultPayload:
@@ -132,10 +137,10 @@ class TestAttributionPayloadShape:
         result = engine.handle_request(GetAttributionContextRequest(node_type="GriptapeProxyImage"))
         assert isinstance(result, GetAttributionContextResultSuccess)
 
-        decoded = _decode(result)
-        assert decoded["v"] == ATTRIBUTION_SCHEMA_VERSION
-        assert decoded["node_type"] == "GriptapeProxyImage"
-        assert decoded["tags"]["project"] == result.project_chain
+        assert _decode(result)["v"] == ATTRIBUTION_SCHEMA_VERSION
+        tags = _tags(result)
+        assert tags["node_type"] == "GriptapeProxyImage"
+        assert tags["project"] == result.project_chain
 
     def test_padding_round_trips(self, engine: Engine) -> None:
         """Padding is kept so the Cloud can decode without re-padding."""
@@ -152,8 +157,9 @@ class TestAttributionPayloadShape:
         assert isinstance(result, GetAttributionContextResultSuccess)
 
         decoded = _decode(result)
-        assert set(decoded) <= ALLOWED_PAYLOAD_KEYS
-        assert "node_id" not in decoded
+        assert set(decoded) <= ALLOWED_ENVELOPE_KEYS
+        assert set(decoded["tags"]) <= ALLOWED_TAG_KEYS
+        assert "node_id" not in decoded["tags"]
 
     def test_structured_fields_agree_with_the_header(self, budget_manager: BudgetManager) -> None:
         """A consumer reading the result must see exactly what the header encodes."""
@@ -164,12 +170,12 @@ class TestAttributionPayloadShape:
         mock_engine.session_manager.active_session_id = "sess-1"
 
         result = _succeed(budget_manager, node_type="NodeT")
-        decoded = _decode(result)
+        tags = _tags(result)
 
-        assert decoded.get("workflow") == result.workflow_name
-        assert decoded["node_type"] == result.node_type
-        assert decoded["engine_id"] == result.engine_id
-        assert decoded["session_id"] == result.session_id
+        assert tags.get("workflow") == result.workflow_name
+        assert tags["node_type"] == result.node_type
+        assert tags["engine_id"] == result.engine_id
+        assert tags["session_id"] == result.session_id
 
 
 class TestProjectChain:
@@ -185,7 +191,7 @@ class TestProjectChain:
         project_manager = ProjectManager(Mock(), Mock(), Mock())
         result = _succeed(self._manager_on(project_manager))
 
-        assert _decode(result)["tags"]["project"] == [SYSTEM_DEFAULTS_KEY]
+        assert _tags(result)["project"] == [SYSTEM_DEFAULTS_KEY]
 
     def test_nested_chain_is_ids_only(self) -> None:
         """Project display names must not reach the payload by any route."""
@@ -204,10 +210,10 @@ class TestProjectChain:
             assert name not in serialized
             assert name not in result.header_value
 
-    def test_chain_deeper_than_ten_truncates_from_the_leaf(self) -> None:
-        """v1 caps the chain at 10 entries, keeping the leaf end, and says that it did."""
+    def test_chain_deeper_than_the_cap_truncates_from_the_leaf(self) -> None:
+        """The chain is capped at the Cloud's own MAX_CHAIN_LENGTH, keeping the leaf end."""
         project_manager = ProjectManager(Mock(), Mock(), Mock())
-        ids = [f"p{index:02d}" for index in range(15)]
+        ids = [f"p{index:02d}" for index in range(40)]
         # ids[0] is the leaf; each entry's parent is the next one along.
         for index, project_id in enumerate(ids):
             parent = ids[index + 1] if index + 1 < len(ids) else None
@@ -216,8 +222,8 @@ class TestProjectChain:
 
         result = _succeed(self._manager_on(project_manager))
 
-        assert _decode(result)["tags"]["project"] == ids[:10]
-        assert result.project_chain == ids[:10]
+        assert _tags(result)["project"] == ids[:32]
+        assert result.project_chain == ids[:32]
         assert result.chain_truncated is True
 
     def test_unregistered_parent_id_is_still_surfaced(self) -> None:
@@ -228,7 +234,7 @@ class TestProjectChain:
 
         result = _succeed(self._manager_on(project_manager))
 
-        assert _decode(result)["tags"]["project"] == ["shot-6", "swx"]
+        assert _tags(result)["project"] == ["shot-6", "swx"]
 
     def test_second_dispatch_reflects_a_project_switch(self) -> None:
         """The chain is read per invocation, never cached at workflow open."""
@@ -242,14 +248,17 @@ class TestProjectChain:
         project_manager._current_project_id = "after"
         second = _succeed(manager)
 
-        assert _decode(first)["tags"]["project"] == ["before"]
-        assert _decode(second)["tags"]["project"] == ["after"]
+        assert _tags(first)["project"] == ["before"]
+        assert _tags(second)["project"] == ["after"]
 
-    def test_empty_chain_omits_tags_entirely(self) -> None:
+    def test_empty_chain_omits_the_project_key(self) -> None:
         """`[]` would assert 'belongs to zero projects', which is a claim we cannot make."""
         manager = BudgetManager(MagicMock(), engine=_mock_engine())
+        result = _succeed(manager)
 
-        assert "tags" not in _decode(_succeed(manager))
+        assert "project" not in _tags(result)
+        # The other dimensions still ship; only the chain is unknown.
+        assert "engine_id" in _tags(result)
 
 
 class TestWorkflowName:
@@ -264,7 +273,7 @@ class TestWorkflowName:
             assert isinstance(result, GetAttributionContextResultSuccess)
 
             decoded = _decode(result)
-            assert decoded["workflow"] == UNSAVED_WORKFLOW_SENTINEL
+            assert decoded["tags"]["workflow"] == UNSAVED_WORKFLOW_SENTINEL
             assert result.workflow_name == UNSAVED_WORKFLOW_SENTINEL
             # The uuid must not leak by any other route, encoded or decoded.
             assert "unsaved:" not in json.dumps(decoded)
@@ -280,9 +289,9 @@ class TestWorkflowName:
             result = engine.handle_request(GetAttributionContextRequest())
             assert isinstance(result, GetAttributionContextResultSuccess)
 
-            decoded = _decode(result)
-            assert decoded["workflow"] == "shots/sh020/lighting"
-            assert not decoded["workflow"].startswith("unsaved:")
+            workflow = _tags(result)["workflow"]
+            assert workflow == "shots/sh020/lighting"
+            assert not workflow.startswith("unsaved:")
         finally:
             engine.context_manager.pop_workflow()
 
@@ -293,7 +302,7 @@ class TestWorkflowName:
         result = engine.handle_request(GetAttributionContextRequest())
         assert isinstance(result, GetAttributionContextResultSuccess)
 
-        assert "workflow" not in _decode(result)
+        assert "workflow" not in _tags(result)
         assert result.workflow_name is None
 
 
@@ -317,7 +326,7 @@ class TestOrchestratorEngineId:
 
         result = _succeed(budget_manager)
 
-        assert _decode(result)["orchestrator_engine_id"] == "eng-orch"
+        assert _tags(result)["orchestrator_engine_id"] == "eng-orch"
         assert result.orchestrator_engine_id == "eng-orch"
 
     def test_orchestrator_engine_id_absent_on_the_orchestrator(
@@ -327,7 +336,7 @@ class TestOrchestratorEngineId:
 
         result = _succeed(budget_manager)
 
-        assert "orchestrator_engine_id" not in _decode(result)
+        assert "orchestrator_engine_id" not in _tags(result)
         assert result.orchestrator_engine_id is None
 
 
@@ -344,7 +353,7 @@ class TestDegradation:
     @pytest.mark.parametrize(
         ("break_field", "absent_key"),
         [
-            ("project_chain", "tags"),
+            ("project_chain", "project"),
             ("workflow", "workflow"),
             ("engine_id", "engine_id"),
             ("session_id", "session_id"),
@@ -370,7 +379,7 @@ class TestDegradation:
         with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
             result = _succeed(manager)
 
-        assert absent_key not in _decode(result)
+        assert absent_key not in _tags(result)
         assert any(record.levelno == logging.WARNING for record in caplog.records)
 
     def test_no_workflow_context_is_not_an_error(self) -> None:
@@ -380,7 +389,7 @@ class TestDegradation:
 
         result = _succeed(manager)
 
-        assert "workflow" not in _decode(result)
+        assert "workflow" not in _tags(result)
 
 
 class TestSizeCap:
@@ -403,10 +412,10 @@ class TestSizeCap:
         ):
             result = _succeed(manager, node_type="GriptapeProxyImage")
 
-        decoded = _decode(result)
-        assert decoded["tags"]["project"] == ["leaf"]
-        assert "workflow" not in decoded
-        assert "node_type" not in decoded
+        tags = _tags(result)
+        assert tags["project"] == ["leaf"]
+        assert "workflow" not in tags
+        assert "node_type" not in tags
         # The structured fields have to agree with the reduced header, not the pre-encode values.
         assert result.workflow_name is None
         assert result.node_type is None

--- a/tests/unit/retained_mode/managers/test_budget_manager.py
+++ b/tests/unit/retained_mode/managers/test_budget_manager.py
@@ -643,12 +643,41 @@ class TestSizeCap:
         mock_engine.project_manager.get_project_chain.return_value = [
             _entry(f"p{index}", "N" * 300) for index in range(budget_manager_module._MAX_PROJECT_CHAIN_ENTRIES)
         ]
+        mock_engine.context_manager.has_current_workflow.return_value = True
+        mock_engine.context_manager.get_current_workflow_name.return_value = "shots/sh020/lighting"
         manager = BudgetManager(MagicMock(), engine=mock_engine)
 
-        result = _succeed(manager)
+        result = _succeed(manager, node_type="GriptapeProxyImage")
 
-        assert "project" not in _tags(result)
+        tags = _tags(result)
+        assert "project" not in tags
         assert result.project_chain == []
+        assert result.chain_truncated is True
+        # Losing the chain does not cost the labels. Shedding it frees thousands of bytes; the
+        # labels are worth tens, and the audit row is all that is left to say who spent this.
+        assert tags["workflow"] == "shots/sh020/lighting"
+        assert tags["node_type"] == "GriptapeProxyImage"
+
+    def test_the_floor_sheds_the_labels_only_when_losing_the_chain_is_not_enough(self) -> None:
+        """The sixth rung, and the only shape that reaches it without a patched cap.
+
+        An oversized workflow key is itself what pushed the payload over, so shedding the chain
+        leaves it still over and the labels have to go too. Anything short of that keeps them.
+        """
+        mock_engine = _mock_engine()
+        mock_engine.project_manager.get_project_chain.return_value = [
+            _entry(f"p{index}", "N" * 300) for index in range(budget_manager_module._MAX_PROJECT_CHAIN_ENTRIES)
+        ]
+        mock_engine.context_manager.has_current_workflow.return_value = True
+        mock_engine.context_manager.get_current_workflow_name.return_value = "w" * 4000
+        manager = BudgetManager(MagicMock(), engine=mock_engine)
+
+        result = _succeed(manager, node_type="GriptapeProxyImage")
+
+        tags = _tags(result)
+        assert "project" not in tags
+        assert "workflow" not in tags
+        assert "node_type" not in tags
         assert result.chain_truncated is True
 
     def test_reduction_of_a_single_entry_chain_does_not_claim_truncation(self) -> None:

--- a/tests/unit/retained_mode/managers/test_budget_manager.py
+++ b/tests/unit/retained_mode/managers/test_budget_manager.py
@@ -696,27 +696,52 @@ class TestTransmissibility:
         assert _tags(result)["workflow"] == "shots/sh020 /lighting"
         assert result.workflow_name == "shots/sh020 /lighting"
 
-    def test_a_name_longer_than_the_value_cap_travels_cut_to_it(self) -> None:
-        """The far end keeps 256 characters, so that is what the chain reports."""
+    def test_a_name_longer_than_the_value_cap_travels_uncut(self) -> None:
+        """Cutting is the far end's job, and doing it here would hide that it happened.
+
+        The Cloud truncates an over-long name rather than dropping it, then marks the chain
+        mangled and stops matching it against admin-authored paths. Pre-cutting hands it a
+        prefix that looks intact, so it matches -- and two sibling projects sharing their
+        first 256 characters silently collapse onto one budget with nothing recorded.
+        Stripping stays, because the far end strips too and flags nothing when it does.
+        """
         mock_engine = _mock_engine()
-        mock_engine.project_manager.get_project_chain.return_value = [_entry("leaf", "S" * 300)]
+        mock_engine.project_manager.get_project_chain.return_value = [_entry("leaf", "  " + "S" * 300 + "  ")]
         manager = BudgetManager(MagicMock(), engine=mock_engine)
 
         result = _succeed(manager)
 
-        assert _tags(result)["project"] == ["S" * 256]
-        assert result.project_chain == ["S" * 256]
+        assert _tags(result)["project"] == ["S" * 300]
+        assert result.project_chain == ["S" * 300]
 
     def test_an_unstorable_byte_past_the_value_cap_does_not_cost_the_chain(self) -> None:
         """Judge the kept form, or the engine refuses a name the far end would have stored.
 
         The cut happens before the storability test on the far end, so a control character
         sitting past the cap is gone by the time anything looks at it. Testing the whole
-        string here would drop a chain over a byte that never arrives.
+        string here would drop a chain over a byte that never arrives -- and the name still
+        travels uncut, because the far end is the one that should decide it was too long.
         """
         mock_engine = _mock_engine()
         mock_engine.project_manager.get_project_chain.return_value = [
-            _entry("leaf", "S" * 300 + "\n"),
+            _entry("leaf", "S" * 300 + "\n" + "S" * 20),
+            _entry("root", "Acme Studios"),
+        ]
+        manager = BudgetManager(MagicMock(), engine=mock_engine)
+
+        result = _succeed(manager)
+
+        assert _tags(result)["project"] == ["S" * 300 + "\n" + "S" * 20, "Acme Studios"]
+
+    def test_a_surrogate_past_the_value_cap_falls_back_to_the_cut_form(self) -> None:
+        """One name's truncation signal is worth less than every other dimension on the call.
+
+        A lone surrogate survives the strip and cannot be UTF-8 encoded, so sending the uncut
+        name would cost the entire header. The cut form drops the byte, which is the trade.
+        """
+        mock_engine = _mock_engine()
+        mock_engine.project_manager.get_project_chain.return_value = [
+            _entry("leaf", "S" * 300 + "\udce9"),
             _entry("root", "Acme Studios"),
         ]
         manager = BudgetManager(MagicMock(), engine=mock_engine)

--- a/tests/unit/retained_mode/managers/test_budget_manager.py
+++ b/tests/unit/retained_mode/managers/test_budget_manager.py
@@ -243,7 +243,15 @@ class TestProjectChain:
 
         assert _tags(result)["project"] == ["Shot 020"]
 
-    @pytest.mark.parametrize("reserved_name", [SYSTEM_DEFAULTS_KEY, f" {SYSTEM_DEFAULTS_KEY} "])
+    @pytest.mark.parametrize(
+        "reserved_name",
+        [
+            SYSTEM_DEFAULTS_KEY,
+            f" {SYSTEM_DEFAULTS_KEY} ",
+            # Only becomes the reserved value once cut to the 256-char cap.
+            SYSTEM_DEFAULTS_KEY + " " * 239 + "x",
+        ],
+    )
     def test_a_project_actually_named_system_defaults_drops_the_chain(
         self, reserved_name: str, caplog: pytest.LogCaptureFixture
     ) -> None:
@@ -251,8 +259,9 @@ class TestProjectChain:
 
         Nothing stops a user typing the reserved string into `name:`. The Cloud discards a
         client copy, which would drop that entry and promote its parent to leaf -- billing a
-        real project for spend it never incurred. Padding does not disguise it: the far end
-        strips before it tests the reserved value, so the comparison here has to strip too.
+        real project for spend it never incurred. Neither padding nor length disguises it: the
+        far end strips, cuts to its value cap, and strips again before it tests the reserved
+        value, so the comparison here runs on that same form.
         """
         project_manager = ProjectManager(Mock(), Mock(), Mock())
         _register_project(project_manager, "grandparent", name="Acme Studios")
@@ -667,6 +676,54 @@ class TestTransmissibility:
 
         assert _tags(result)["project"] == ["Acme Studios"]
         assert result.project_chain == ["Acme Studios"]
+
+    def test_a_padded_workflow_key_travels_unstripped(self) -> None:
+        """A registry key is an identifier, so it goes out as the engine spells it.
+
+        `derive_registry_key` builds the key from a workspace-relative path, and a directory
+        or filename may legally begin or end with a space on macOS and Linux. Trimming it
+        would report a string that no longer names any workflow the engine can look up --
+        the opposite of the project-name case, where normalizing is what makes the value
+        matchable.
+        """
+        mock_engine = _mock_engine()
+        mock_engine.context_manager.has_current_workflow.return_value = True
+        mock_engine.context_manager.get_current_workflow_name.return_value = "shots/sh020 /lighting"
+        manager = BudgetManager(MagicMock(), engine=mock_engine)
+
+        result = _succeed(manager)
+
+        assert _tags(result)["workflow"] == "shots/sh020 /lighting"
+        assert result.workflow_name == "shots/sh020 /lighting"
+
+    def test_a_name_longer_than_the_value_cap_travels_cut_to_it(self) -> None:
+        """The far end keeps 256 characters, so that is what the chain reports."""
+        mock_engine = _mock_engine()
+        mock_engine.project_manager.get_project_chain.return_value = [_entry("leaf", "S" * 300)]
+        manager = BudgetManager(MagicMock(), engine=mock_engine)
+
+        result = _succeed(manager)
+
+        assert _tags(result)["project"] == ["S" * 256]
+        assert result.project_chain == ["S" * 256]
+
+    def test_an_unstorable_byte_past_the_value_cap_does_not_cost_the_chain(self) -> None:
+        """Judge the kept form, or the engine refuses a name the far end would have stored.
+
+        The cut happens before the storability test on the far end, so a control character
+        sitting past the cap is gone by the time anything looks at it. Testing the whole
+        string here would drop a chain over a byte that never arrives.
+        """
+        mock_engine = _mock_engine()
+        mock_engine.project_manager.get_project_chain.return_value = [
+            _entry("leaf", "S" * 300 + "\n"),
+            _entry("root", "Acme Studios"),
+        ]
+        manager = BudgetManager(MagicMock(), engine=mock_engine)
+
+        result = _succeed(manager)
+
+        assert _tags(result)["project"] == ["S" * 256, "Acme Studios"]
 
     def test_an_untransmissible_workflow_key_is_omitted_without_touching_the_chain(self) -> None:
         """One unusable dimension costs its own key and nothing else."""

--- a/tests/unit/retained_mode/managers/test_budget_manager.py
+++ b/tests/unit/retained_mode/managers/test_budget_manager.py
@@ -18,6 +18,7 @@ import pytest
 
 from griptape_nodes.common.project_templates import ProjectValidationInfo, ProjectValidationStatus
 from griptape_nodes.common.project_templates.default_project_template import DEFAULT_PROJECT_TEMPLATE
+from griptape_nodes.retained_mode.events.base_events import ResultDetails
 from griptape_nodes.retained_mode.events.budget_events import (
     ATTRIBUTION_HEADER_NAME,
     ATTRIBUTION_SCHEMA_VERSION,
@@ -113,6 +114,16 @@ def _register_project(
         parsed_situation_schemas={},
         parsed_directory_schemas={},
     )
+
+
+def _assert_warns_not_errors(manager: BudgetManager) -> None:
+    """Assert a dispatch fails, and that its details are logged at WARNING rather than ERROR."""
+    result = _dispatch(manager)
+
+    assert isinstance(result, GetAttributionContextResultFailure)
+    details = result.result_details
+    assert isinstance(details, ResultDetails)
+    assert [detail.level for detail in details.result_details] == [logging.WARNING]
 
 
 class TestAttributionPayloadShape:
@@ -328,7 +339,11 @@ class TestProjectChain:
         assert _tags(second)["project"] == ["after"]
 
     def test_empty_chain_omits_the_project_key(self) -> None:
-        """`[]` would assert 'belongs to zero projects', which is a claim we cannot make."""
+        """`[]` would assert 'belongs to zero projects', which is a claim we cannot make.
+
+        The envelope still goes out: no project open is a fact. An unreadable chain is not,
+        and takes the Failure path instead -- see `TestDegradation`.
+        """
         manager = BudgetManager(MagicMock(), engine=_mock_engine())
         result = _succeed(manager)
 
@@ -410,9 +425,8 @@ class TestValuesTravelVerbatim:
     def test_the_encoder_returns_none_instead_of_raising(self) -> None:
         """Pinned on the module function, because the cost of raising is paid per metered call.
 
-        A handler exception becomes a `GenericResultFailure`, which ignores `failure_log_level`
-        and logs an ERROR with a traceback -- once for every credit-consuming call the artist
-        makes.
+        A handler exception becomes a `GenericResultFailure`, which ignores `failure_log_level`;
+        the explicit Failure returned instead can be quieted by a caller making many of these.
         """
         payload = {"v": 1, "tags": {"project": ["\udce9"]}}
 
@@ -423,20 +437,49 @@ class TestValuesTravelVerbatim:
 
 
 class TestDegradation:
-    """The caller is about to spend money: degrade to a missing key, never raise."""
+    """The caller is about to spend money: never raise, and never guess on its behalf."""
 
-    def test_peer_failure_degrades_the_key_not_the_header(self, caplog: pytest.LogCaptureFixture) -> None:
-        """An unhappy project manager costs the project key, not the whole attribution."""
+    def test_peer_failure_sends_no_header_rather_than_claiming_no_project(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An unreadable chain is not the same fact as an empty one, and must not borrow it.
+
+        `{"v": 1}` is a positive claim -- the Cloud reads a missing `tags` as "no project open
+        on a client that attributes". A project manager that raised knows nothing about whether
+        a project is open, so sending that envelope would attribute an artist's spend to the
+        default budget while recording no degradation on either side. No header at all reads as
+        "this client did not attribute", which is true.
+        """
         mock_engine = _mock_engine()
         mock_engine.project_manager.get_project_chain.side_effect = RuntimeError("peer exploded")
         manager = BudgetManager(MagicMock(), engine=mock_engine)
 
         with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
-            result = _succeed(manager)
+            result = _dispatch(manager)
 
-        assert "project" not in _tags(result)
-        assert _decode(result) == {"v": ATTRIBUTION_SCHEMA_VERSION}
+        assert isinstance(result, GetAttributionContextResultFailure)
+        assert "attribution" in str(result.result_details).lower()
         assert any(record.levelno == logging.WARNING for record in caplog.records)
+
+    def test_an_unreadable_chain_does_not_log_at_error(self) -> None:
+        """A bare `result_details` string defaults to ERROR; both sites pass ResultDetails instead.
+
+        Neither failure condition clears on its own -- a legacy project keeps its unencodable id,
+        an unhappy peer stays unhappy -- so an ERROR would repeat once per metered call for
+        something the artist cannot act on and that did not stop the work. Pinned on both paths
+        because the ERROR default is silent.
+        """
+        mock_engine = _mock_engine()
+        mock_engine.project_manager.get_project_chain.side_effect = RuntimeError("peer exploded")
+
+        _assert_warns_not_errors(BudgetManager(MagicMock(), engine=mock_engine))
+
+    def test_an_unencodable_id_does_not_log_at_error(self) -> None:
+        """The other failure path, same reason."""
+        mock_engine = _mock_engine()
+        mock_engine.project_manager.get_project_chain.return_value = [_entry("renders-\udce9", "leaf")]
+
+        _assert_warns_not_errors(BudgetManager(MagicMock(), engine=mock_engine))
 
 
 class TestConfidentiality:

--- a/tests/unit/retained_mode/managers/test_budget_manager.py
+++ b/tests/unit/retained_mode/managers/test_budget_manager.py
@@ -591,16 +591,47 @@ class TestSizeCap:
             _entry("leaf", "S" * 4200),
             _entry("root", "Acme Studios"),
         ]
+        mock_engine.context_manager.has_current_workflow.return_value = True
+        mock_engine.context_manager.get_current_workflow_name.return_value = "shots/sh020/lighting"
         manager = BudgetManager(MagicMock(), engine=mock_engine)
 
         with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
-            result = _succeed(manager)
+            result = _succeed(manager, node_type="GriptapeProxyImage")
 
-        assert _tags(result)["project"] == ["S" * 256, "Acme Studios"]
+        tags = _tags(result)
+        assert tags["project"] == ["S" * 256, "Acme Studios"]
         assert result.project_chain == ["S" * 256, "Acme Studios"]
         # Names were cut, not ancestors dropped. The flag says the latter.
         assert result.chain_truncated is False
+        # The rung that cuts keeps the labels. Cutting this name frees thousands of bytes and
+        # the labels are worth tens, so shedding them alongside would cost a dashboard row for
+        # an overage the cut already covered.
+        assert tags["workflow"] == "shots/sh020/lighting"
+        assert tags["node_type"] == "GriptapeProxyImage"
         assert any("cut" in record.getMessage() for record in caplog.records)
+
+    def test_labels_are_shed_alongside_a_cut_only_when_cutting_alone_is_not_enough(self) -> None:
+        """The fourth rung exists, and nothing reaches it that the third could have served.
+
+        A long project name and an oversized workflow key together stay over the cap even with
+        every name cut, so this is the one shape that legitimately loses both.
+        """
+        mock_engine = _mock_engine()
+        mock_engine.project_manager.get_project_chain.return_value = [
+            _entry("leaf", "S" * 4200),
+            _entry("root", "Acme Studios"),
+        ]
+        mock_engine.context_manager.has_current_workflow.return_value = True
+        mock_engine.context_manager.get_current_workflow_name.return_value = "w" * 4000
+        manager = BudgetManager(MagicMock(), engine=mock_engine)
+
+        result = _succeed(manager, node_type="GriptapeProxyImage")
+
+        tags = _tags(result)
+        assert tags["project"] == ["S" * 256, "Acme Studios"]
+        assert "workflow" not in tags
+        assert "node_type" not in tags
+        assert result.chain_truncated is False
 
     def test_a_chain_too_long_even_cut_is_still_shed_whole(self) -> None:
         """The new rung is a rung, not a floor: it does not rescue every oversized chain.

--- a/tests/unit/retained_mode/managers/test_budget_manager.py
+++ b/tests/unit/retained_mode/managers/test_budget_manager.py
@@ -17,6 +17,8 @@ from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
 import pytest
 
+from griptape_nodes.common.project_templates import ProjectValidationInfo, ProjectValidationStatus
+from griptape_nodes.common.project_templates.default_project_template import DEFAULT_PROJECT_TEMPLATE
 from griptape_nodes.retained_mode.events.budget_events import (
     ATTRIBUTION_HEADER_NAME,
     ATTRIBUTION_SCHEMA_VERSION,
@@ -30,13 +32,18 @@ from griptape_nodes.retained_mode.events.context_events import (
 )
 from griptape_nodes.retained_mode.managers import budget_manager as budget_manager_module
 from griptape_nodes.retained_mode.managers.budget_manager import BudgetManager
-from griptape_nodes.retained_mode.managers.project_manager import SYSTEM_DEFAULTS_KEY, ProjectManager
+from griptape_nodes.retained_mode.managers.project_manager import (
+    SYSTEM_DEFAULTS_KEY,
+    ProjectChainEntry,
+    ProjectInfo,
+    ProjectManager,
+)
 
 if TYPE_CHECKING:
     from griptape_nodes.retained_mode.engine import Engine
     from griptape_nodes.retained_mode.events.base_events import ResultPayload
 
-# The complete set of keys v1 is allowed to put on the wire. A new field must consciously
+# The complete set of keys allowed on the wire. A new field must consciously
 # update these, which is the point: `node_id` is absent by decision, and `BaseNode.name`
 # must never appear under any key.
 ALLOWED_ENVELOPE_KEYS = {"v", "tags"}
@@ -86,6 +93,16 @@ def _mock_engine() -> MagicMock:
     return mock_engine
 
 
+def _entry(project_id: str, name: str | None) -> ProjectChainEntry:
+    """A chain entry whose id and name never match, so an assertion cannot pass on the wrong one.
+
+    The real type rather than a Mock: `name` is reserved on `Mock`, so `Mock(name="x").name`
+    is a Mock rather than a string, and a mocked chain would answer the nameless branch with
+    something that is neither a name nor `None`.
+    """
+    return ProjectChainEntry(id=project_id, name=name)
+
+
 def _register_project(
     project_manager: ProjectManager,
     project_id: str,
@@ -96,13 +113,9 @@ def _register_project(
     """Register an id-linked project directly in the in-memory registry.
 
     Mirrors the helper at `test_project_manager.py:11588`: an explicit `parent_project_id`
-    so the chain walk resolves through the registry without touching disk, and a distinct
-    `name` on each template so the ids-only assertions have something to catch.
+    so the chain walk resolves through the registry without touching disk, and a `name` that
+    never matches its id, so an assertion cannot pass on the wrong one.
     """
-    from griptape_nodes.common.project_templates import ProjectValidationInfo, ProjectValidationStatus
-    from griptape_nodes.common.project_templates.default_project_template import DEFAULT_PROJECT_TEMPLATE
-    from griptape_nodes.retained_mode.managers.project_manager import ProjectInfo
-
     update: dict[str, Any] = {"id": project_id, "parent_project_id": parent_id}
     if name is not None:
         update["name"] = name
@@ -181,7 +194,11 @@ class TestAttributionPayloadShape:
 
 
 class TestProjectChain:
-    """`tags.project` is ordered leaf-first and carries ids only."""
+    """`tags.project` carries project names, ordered leaf-first.
+
+    The name is the wire value because `tags.project` is the only dimension the Cloud
+    matches budgets against, and a budget admin has to be able to author it into a rule.
+    """
 
     def _manager_on(self, project_manager: ProjectManager) -> BudgetManager:
         mock_engine = _mock_engine()
@@ -189,13 +206,32 @@ class TestProjectChain:
         return BudgetManager(MagicMock(), engine=mock_engine)
 
     def test_system_defaults_never_reaches_the_wire(self) -> None:
-        """The Cloud reserves `<system-defaults>` and counts a client copy as degraded."""
+        """The Cloud reserves `<system-defaults>` and counts a client copy as degraded.
+
+        Nor does its *name* travel in the sentinel's place -- see the next test.
+        """
         project_manager = ProjectManager(Mock(), Mock(), Mock())
         result = _succeed(self._manager_on(project_manager))
 
         assert "project" not in _tags(result)
         assert result.project_chain == []
         assert SYSTEM_DEFAULTS_KEY not in json.dumps(_decode(result))
+
+    def test_the_default_templates_name_never_stands_in_for_the_sentinel(self) -> None:
+        """Skipping `<system-defaults>` is keyed on its id, because it does have a name.
+
+        The rest state is registered with the shipped `DEFAULT_PROJECT_TEMPLATE`, whose name
+        is "Default Project" -- a generic string that would collide across every user in an
+        org and match any budget rule unlucky enough to be written against it. Filtering on
+        the name alone would let it through.
+        """
+        project_manager = ProjectManager(Mock(), Mock(), Mock())
+        project_manager._load_system_defaults()
+
+        result = _succeed(self._manager_on(project_manager))
+
+        assert "project" not in _tags(result)
+        assert DEFAULT_PROJECT_TEMPLATE.name not in result.header_value
 
     def test_system_defaults_is_dropped_from_a_real_chain(self) -> None:
         """Filtered wherever it appears, not only when it is the whole chain."""
@@ -205,10 +241,30 @@ class TestProjectChain:
 
         result = _succeed(self._manager_on(project_manager))
 
-        assert _tags(result)["project"] == ["leaf"]
+        assert _tags(result)["project"] == ["Shot 020"]
 
-    def test_nested_chain_is_ids_only(self) -> None:
-        """Project display names must not reach the payload by any route."""
+    def test_a_project_actually_named_system_defaults_drops_the_chain(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A name collision with the Cloud's reserved value costs the whole chain.
+
+        Nothing stops a user typing the reserved string into `name:`. The Cloud discards a
+        client copy, which would drop that entry and promote its parent to leaf -- billing a
+        real project for spend it never incurred.
+        """
+        project_manager = ProjectManager(Mock(), Mock(), Mock())
+        _register_project(project_manager, "grandparent", name="Acme Studios")
+        _register_project(project_manager, "leaf", name=SYSTEM_DEFAULTS_KEY, parent_id="grandparent")
+        project_manager._current_project_id = "leaf"
+
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+            result = _succeed(self._manager_on(project_manager))
+
+        assert "project" not in _tags(result)
+        assert result.project_chain == []
+        assert "Acme Studios" not in result.header_value
+        assert any(record.levelno == logging.WARNING for record in caplog.records)
+
+    def test_nested_chain_carries_every_name_leaf_first(self) -> None:
+        """The whole ancestry travels, and nothing but names does."""
         project_manager = ProjectManager(Mock(), Mock(), Mock())
         _register_project(project_manager, "grandparent", name="Acme Studios")
         _register_project(project_manager, "parent", name="Feature Film", parent_id="grandparent")
@@ -218,11 +274,11 @@ class TestProjectChain:
         result = _succeed(self._manager_on(project_manager))
         decoded = _decode(result)
 
-        assert decoded["tags"]["project"] == ["leaf", "parent", "grandparent"]
+        assert decoded["tags"]["project"] == ["Shot 020", "Feature Film", "Acme Studios"]
         serialized = json.dumps(decoded)
-        for name in ("Acme Studios", "Feature Film", "Shot 020"):
-            assert name not in serialized
-            assert name not in result.header_value
+        for project_id in ("grandparent", "parent", "leaf"):
+            assert project_id not in serialized
+            assert project_id not in result.header_value
 
     def test_chain_deeper_than_the_cap_truncates_from_the_leaf(self) -> None:
         """The chain is capped at the Cloud's own MAX_CHAIN_LENGTH, keeping the leaf end."""
@@ -234,21 +290,29 @@ class TestProjectChain:
             _register_project(project_manager, project_id, name=f"Name {project_id}", parent_id=parent)
         project_manager._current_project_id = ids[0]
 
+        names = [f"Name {project_id}" for project_id in ids]
         result = _succeed(self._manager_on(project_manager))
 
-        assert _tags(result)["project"] == ids[:32]
-        assert result.project_chain == ids[:32]
+        assert _tags(result)["project"] == names[:32]
+        assert result.project_chain == names[:32]
         assert result.chain_truncated is True
 
-    def test_unregistered_parent_id_is_still_surfaced(self) -> None:
-        """An unresolvable parent ends the chain, and E1 serializes whatever the chain says."""
+    def test_an_unregistered_parent_ends_the_chain_without_falling_back_to_its_id(self) -> None:
+        """A nameless ancestor is dropped, not swapped for its id.
+
+        `get_project_chain` still surfaces an unresolvable parent, but with no template it
+        has no name -- and its registry key is not something a budget rule mentions. Emitting
+        that would put one unmatchable string in the list; the leaf alone at least matches a
+        rule written against the leaf.
+        """
         project_manager = ProjectManager(Mock(), Mock(), Mock())
         _register_project(project_manager, "shot-6", name="Shot 6", parent_id="swx")
         project_manager._current_project_id = "shot-6"
 
         result = _succeed(self._manager_on(project_manager))
 
-        assert _tags(result)["project"] == ["shot-6", "swx"]
+        assert _tags(result)["project"] == ["Shot 6"]
+        assert "swx" not in result.header_value
 
     def test_second_dispatch_reflects_a_project_switch(self) -> None:
         """The chain is read per invocation, never cached at workflow open."""
@@ -262,8 +326,8 @@ class TestProjectChain:
         project_manager._current_project_id = "after"
         second = _succeed(manager)
 
-        assert _tags(first)["project"] == ["before"]
-        assert _tags(second)["project"] == ["after"]
+        assert _tags(first)["project"] == ["Before"]
+        assert _tags(second)["project"] == ["After"]
 
     def test_empty_chain_omits_the_project_key(self) -> None:
         """`[]` would assert 'belongs to zero projects', which is a claim we cannot make."""
@@ -359,7 +423,7 @@ class TestDegradation:
 
     def _manager(self) -> BudgetManager:
         mock_engine = _mock_engine()
-        mock_engine.project_manager.get_project_chain.return_value = [Mock(id="leaf")]
+        mock_engine.project_manager.get_project_chain.return_value = [_entry("leaf", "Leaf")]
         mock_engine.context_manager.has_current_workflow.return_value = True
         mock_engine.context_manager.get_current_workflow_name.return_value = "shots/sh020"
         return BudgetManager(MagicMock(), engine=mock_engine)
@@ -410,8 +474,12 @@ class TestSizeCap:
     """Reduction sheds the cheapest dimensions first, then the chain, then fails."""
 
     def _manager(self) -> BudgetManager:
+        """Short names, so the byte caps in each test below bracket the reduction rung it means to exercise."""
         mock_engine = _mock_engine()
-        mock_engine.project_manager.get_project_chain.return_value = [Mock(id="leaf"), Mock(id="parent")]
+        mock_engine.project_manager.get_project_chain.return_value = [
+            _entry("leaf", "Leaf"),
+            _entry("parent", "Parent"),
+        ]
         mock_engine.context_manager.has_current_workflow.return_value = True
         mock_engine.context_manager.get_current_workflow_name.return_value = "shots/sh020/lighting"
         return BudgetManager(MagicMock(), engine=mock_engine)
@@ -427,13 +495,13 @@ class TestSizeCap:
             result = _succeed(manager, node_type="GriptapeProxyImage")
 
         tags = _tags(result)
-        assert tags["project"] == ["leaf"]
+        assert tags["project"] == ["Leaf"]
         assert "workflow" not in tags
         assert "node_type" not in tags
         # The structured fields have to agree with the reduced header, not the pre-encode values.
         assert result.workflow_name is None
         assert result.node_type is None
-        assert result.project_chain == ["leaf"]
+        assert result.project_chain == ["Leaf"]
         assert result.chain_truncated is True
         assert any(record.levelno == logging.WARNING for record in caplog.records)
 
@@ -454,10 +522,10 @@ class TestSizeCap:
             result = _succeed(manager, node_type="GriptapeProxyImage")
 
         tags = _tags(result)
-        assert tags["project"] == ["leaf", "parent"]
+        assert tags["project"] == ["Leaf", "Parent"]
         assert "workflow" not in tags
         assert "node_type" not in tags
-        assert result.project_chain == ["leaf", "parent"]
+        assert result.project_chain == ["Leaf", "Parent"]
         assert result.chain_truncated is False
         assert any(record.levelno == logging.WARNING for record in caplog.records)
 
@@ -470,7 +538,7 @@ class TestSizeCap:
         would otherwise get a false positive.
         """
         mock_engine = _mock_engine()
-        mock_engine.project_manager.get_project_chain.return_value = [Mock(id="only")]
+        mock_engine.project_manager.get_project_chain.return_value = [_entry("only", "Only")]
         mock_engine.context_manager.has_current_workflow.return_value = True
         mock_engine.context_manager.get_current_workflow_name.return_value = "shots/sh020"
         manager = BudgetManager(MagicMock(), engine=mock_engine)
@@ -478,8 +546,8 @@ class TestSizeCap:
         with patch.object(budget_manager_module, "_MAX_DECODED_PAYLOAD_BYTES", 80):
             result = _succeed(manager, node_type="GriptapeProxyImage")
 
-        assert _tags(result)["project"] == ["only"]
-        assert result.project_chain == ["only"]
+        assert _tags(result)["project"] == ["Only"]
+        assert result.project_chain == ["Only"]
         assert result.chain_truncated is False
 
     def test_unencodable_payload_fails_without_raising(self) -> None:
@@ -496,19 +564,23 @@ class TestSizeCap:
 class TestTransmissibility:
     """A value the Cloud cannot store is dropped here rather than sent and discarded there.
 
-    Both shapes arrive the same way: a legacy project id is a canonical filesystem path
-    (`project_manager.py:795`) and the saved workflow key is derived from one. A path whose
-    bytes are not valid UTF-8 carries lone surrogates from `surrogateescape`; a directory name
-    may legally contain a control character.
+    Now that the chain carries names, the plausible offender is a user typing or pasting one:
+    a project name is free text from a YAML file, and a pasted newline survives the schema.
+    The surrogate case belongs to the path-derived values -- the workflow key, and identifiers
+    `os.getenv` decodes with `surrogateescape` -- but a name read off disk can carry one too,
+    so both shapes are parametrized against the same filter.
     """
 
-    # A path-shaped legacy project id holding a byte that is not valid UTF-8.
-    SURROGATE_ID = "/Users/alice/renders\udce9/project.yml"
-    # Legal on Linux, encodes fine here, and dropped by the Cloud's storability check.
-    CONTROL_CHAR_ID = "/Users/alice/two\nlines/project.yml"
+    # A pasted line break in a project name. Legal in YAML, encodes fine here, and dropped
+    # by the Cloud's storability check.
+    CONTROL_CHAR_NAME = "Acme\nStudios"
+    # A name read from a file whose bytes are not valid UTF-8 carries a lone surrogate.
+    SURROGATE_NAME = "Renders \udce9"
 
-    @pytest.mark.parametrize("bad_id", [SURROGATE_ID, CONTROL_CHAR_ID])
-    def test_an_untransmissible_id_drops_the_whole_chain(self, bad_id: str, caplog: pytest.LogCaptureFixture) -> None:
+    @pytest.mark.parametrize("bad_name", [CONTROL_CHAR_NAME, SURROGATE_NAME])
+    def test_an_untransmissible_name_drops_the_whole_chain(
+        self, bad_name: str, caplog: pytest.LogCaptureFixture
+    ) -> None:
         """The chain goes as a unit: a partial chain bills an ancestor for the leaf's spend.
 
         Budget paths are root-anchored, so a chain missing a link matches nothing either way.
@@ -516,7 +588,10 @@ class TestTransmissibility:
         project for spend it never incurred, which is worse than no attribution at all.
         """
         mock_engine = _mock_engine()
-        mock_engine.project_manager.get_project_chain.return_value = [Mock(id="leaf"), Mock(id=bad_id)]
+        mock_engine.project_manager.get_project_chain.return_value = [
+            _entry("leaf", "Leaf"),
+            _entry("parent", bad_name),
+        ]
         manager = BudgetManager(MagicMock(), engine=mock_engine)
 
         with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
@@ -526,18 +601,18 @@ class TestTransmissibility:
         assert result.project_chain == []
         assert any(record.levelno == logging.WARNING for record in caplog.records)
 
-    def test_a_transmissible_path_shaped_id_still_travels(self) -> None:
-        """The filter targets unstorable bytes, not paths -- a legacy id is still an id."""
+    def test_an_ordinary_human_name_still_travels(self) -> None:
+        """The filter targets unstorable bytes, not punctuation -- names are meant to read like names."""
         mock_engine = _mock_engine()
-        mock_engine.project_manager.get_project_chain.return_value = [Mock(id="/Users/alice/acme/project.yml")]
+        mock_engine.project_manager.get_project_chain.return_value = [_entry("leaf", "Acme Studios / S02 \u2014 v3")]
         manager = BudgetManager(MagicMock(), engine=mock_engine)
 
-        assert _tags(_succeed(manager))["project"] == ["/Users/alice/acme/project.yml"]
+        assert _tags(_succeed(manager))["project"] == ["Acme Studios / S02 \u2014 v3"]
 
     def test_an_untransmissible_workflow_key_is_omitted_without_touching_the_chain(self) -> None:
         """One unusable dimension costs its own key and nothing else."""
         mock_engine = _mock_engine()
-        mock_engine.project_manager.get_project_chain.return_value = [Mock(id="leaf")]
+        mock_engine.project_manager.get_project_chain.return_value = [_entry("leaf", "Leaf")]
         mock_engine.context_manager.has_current_workflow.return_value = True
         mock_engine.context_manager.get_current_workflow_name.return_value = "shots/sh020\udce9/lighting"
         manager = BudgetManager(MagicMock(), engine=mock_engine)
@@ -546,7 +621,7 @@ class TestTransmissibility:
 
         tags = _tags(result)
         assert "workflow" not in tags
-        assert tags["project"] == ["leaf"]
+        assert tags["project"] == ["Leaf"]
         assert result.workflow_name is None
 
     def test_an_untransmissible_node_type_is_omitted(self) -> None:

--- a/tests/unit/retained_mode/managers/test_budget_manager.py
+++ b/tests/unit/retained_mode/managers/test_budget_manager.py
@@ -672,6 +672,23 @@ class TestSizeCap:
         assert result.project_chain == ["Only"]
         assert result.chain_truncated is False
 
+    def test_the_utf8_backstop_returns_none_instead_of_raising(self) -> None:
+        """The one path no dispatch can reach, tested directly because it still has to hold.
+
+        Every dimension is filtered through `_transmissible_or_none` before it gets here, so
+        the encoder should never see an unencodable payload -- but if one ever slips past, the
+        cost of letting `str.encode` raise is an ERROR with a traceback on every metered call,
+        because a handler exception becomes a `GenericResultFailure` that ignores
+        `failure_log_level`. Called on the module function, since the guard is unreachable
+        through the manager by construction.
+        """
+        payload = {"v": 1, "tags": {"project": ["\udce9"]}}
+
+        with pytest.raises(UnicodeEncodeError):
+            json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+        assert budget_manager_module._encode_attribution_payload(payload) is None
+
     def test_unencodable_payload_fails_without_raising(self) -> None:
         """The floor: no usable header value exists, so Success would be a lie."""
         manager = self._manager()

--- a/tests/unit/retained_mode/managers/test_budget_manager.py
+++ b/tests/unit/retained_mode/managers/test_budget_manager.py
@@ -140,7 +140,8 @@ class TestAttributionPayloadShape:
         assert _decode(result)["v"] == ATTRIBUTION_SCHEMA_VERSION
         tags = _tags(result)
         assert tags["node_type"] == "GriptapeProxyImage"
-        assert tags["project"] == result.project_chain
+        # No project is selected on a bare engine, so the key is absent rather than empty.
+        assert tags.get("project", []) == result.project_chain
 
     def test_padding_round_trips(self, engine: Engine) -> None:
         """Padding is kept so the Cloud can decode without re-padding."""
@@ -186,12 +187,24 @@ class TestProjectChain:
         mock_engine.project_manager = project_manager
         return BudgetManager(MagicMock(), engine=mock_engine)
 
-    def test_chain_is_system_defaults_when_no_project_selected(self) -> None:
-        """The `<system-defaults>` sentinel passes through verbatim, like any other id."""
+    def test_system_defaults_never_reaches_the_wire(self) -> None:
+        """The Cloud reserves `<system-defaults>` and counts a client copy as degraded."""
         project_manager = ProjectManager(Mock(), Mock(), Mock())
         result = _succeed(self._manager_on(project_manager))
 
-        assert _tags(result)["project"] == [SYSTEM_DEFAULTS_KEY]
+        assert "project" not in _tags(result)
+        assert result.project_chain == []
+        assert SYSTEM_DEFAULTS_KEY not in json.dumps(_decode(result))
+
+    def test_system_defaults_is_dropped_from_a_real_chain(self) -> None:
+        """Filtered wherever it appears, not only when it is the whole chain."""
+        project_manager = ProjectManager(Mock(), Mock(), Mock())
+        _register_project(project_manager, "leaf", name="Shot 020", parent_id=SYSTEM_DEFAULTS_KEY)
+        project_manager._current_project_id = "leaf"
+
+        result = _succeed(self._manager_on(project_manager))
+
+        assert _tags(result)["project"] == ["leaf"]
 
     def test_nested_chain_is_ids_only(self) -> None:
         """Project display names must not reach the payload by any route."""

--- a/tests/unit/retained_mode/managers/test_budget_manager.py
+++ b/tests/unit/retained_mode/managers/test_budget_manager.py
@@ -577,6 +577,49 @@ class TestSizeCap:
         assert result.chain_truncated is False
         assert any(record.levelno == logging.WARNING for record in caplog.records)
 
+    def test_names_are_cut_before_the_chain_is_shed(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Past the cap, cutting a name costs a signal that was already gone.
+
+        Sending names whole buys one thing: the far end sees it had to truncate and stops
+        matching the chain. A payload over the cap never reaches the far end to carry that,
+        so shedding the chain here lands the spend in the default bucket with nothing recorded
+        on either side. The cut form matches instead. Run against the real cap, because the
+        band this rung exists for starts near 3948 characters and nowhere else.
+        """
+        mock_engine = _mock_engine()
+        mock_engine.project_manager.get_project_chain.return_value = [
+            _entry("leaf", "S" * 4200),
+            _entry("root", "Acme Studios"),
+        ]
+        manager = BudgetManager(MagicMock(), engine=mock_engine)
+
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+            result = _succeed(manager)
+
+        assert _tags(result)["project"] == ["S" * 256, "Acme Studios"]
+        assert result.project_chain == ["S" * 256, "Acme Studios"]
+        # Names were cut, not ancestors dropped. The flag says the latter.
+        assert result.chain_truncated is False
+        assert any("cut" in record.getMessage() for record in caplog.records)
+
+    def test_a_chain_too_long_even_cut_is_still_shed_whole(self) -> None:
+        """The new rung is a rung, not a floor: it does not rescue every oversized chain.
+
+        Thirty-two entries at the value cap encode past 4096 bytes even after cutting, so the
+        ladder still falls through to no chain rather than sending a partial one.
+        """
+        mock_engine = _mock_engine()
+        mock_engine.project_manager.get_project_chain.return_value = [
+            _entry(f"p{index}", "N" * 300) for index in range(budget_manager_module._MAX_PROJECT_CHAIN_ENTRIES)
+        ]
+        manager = BudgetManager(MagicMock(), engine=mock_engine)
+
+        result = _succeed(manager)
+
+        assert "project" not in _tags(result)
+        assert result.project_chain == []
+        assert result.chain_truncated is True
+
     def test_reduction_of_a_single_entry_chain_does_not_claim_truncation(self) -> None:
         """Reducing an oversized payload cuts nothing when the chain is already one deep.
 

--- a/tests/unit/retained_mode/managers/test_budget_manager.py
+++ b/tests/unit/retained_mode/managers/test_budget_manager.py
@@ -2,7 +2,7 @@
 
 The attribution header is the one thing E1 produces, so most of these assert on the
 *decoded* payload rather than on the manager's internals: that dict is the contract the
-Cloud reads, and the Success payload's structured fields have to agree with it.
+Cloud reads, and the Success payload's `project_chain` has to agree with it.
 """
 
 from __future__ import annotations
@@ -10,10 +10,9 @@ from __future__ import annotations
 import base64
 import json
 import logging
-import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
-from unittest.mock import MagicMock, Mock, PropertyMock, patch
+from unittest.mock import MagicMock, Mock
 
 import pytest
 
@@ -22,13 +21,9 @@ from griptape_nodes.common.project_templates.default_project_template import DEF
 from griptape_nodes.retained_mode.events.budget_events import (
     ATTRIBUTION_HEADER_NAME,
     ATTRIBUTION_SCHEMA_VERSION,
-    UNSAVED_WORKFLOW_SENTINEL,
     GetAttributionContextRequest,
     GetAttributionContextResultFailure,
     GetAttributionContextResultSuccess,
-)
-from griptape_nodes.retained_mode.events.context_events import (
-    SetWorkflowContextRequest,
 )
 from griptape_nodes.retained_mode.managers import budget_manager as budget_manager_module
 from griptape_nodes.retained_mode.managers.budget_manager import BudgetManager
@@ -43,18 +38,11 @@ if TYPE_CHECKING:
     from griptape_nodes.retained_mode.engine import Engine
     from griptape_nodes.retained_mode.events.base_events import ResultPayload
 
-# The complete set of keys allowed on the wire. A new field must consciously
-# update these, which is the point: `node_id` is absent by decision, and `BaseNode.name`
-# must never appear under any key.
+# The complete set of keys allowed on the wire. A new field must consciously update these,
+# which is the point: `project` is the only dimension Griptape Cloud matches budgets against,
+# so it is the only one the engine sends, and `BaseNode.name` must never appear under any key.
 ALLOWED_ENVELOPE_KEYS = {"v", "tags"}
-ALLOWED_TAG_KEYS = {
-    "project",
-    "workflow",
-    "node_type",
-    "engine_id",
-    "orchestrator_engine_id",
-    "session_id",
-}
+ALLOWED_TAG_KEYS = {"project"}
 
 
 def _decode(result: GetAttributionContextResultSuccess) -> dict[str, Any]:
@@ -63,7 +51,7 @@ def _decode(result: GetAttributionContextResultSuccess) -> dict[str, Any]:
 
 
 def _tags(result: GetAttributionContextResultSuccess) -> dict[str, Any]:
-    """The `tags` object the Cloud reads every dimension out of, or {} when none was sent."""
+    """The `tags` object the Cloud reads the project chain out of, or {} when none was sent."""
     return _decode(result).get("tags", {})
 
 
@@ -80,16 +68,13 @@ def _succeed(manager: BudgetManager, **kwargs: Any) -> GetAttributionContextResu
 
 
 def _mock_engine() -> MagicMock:
-    """A stand-in engine whose peers answer with JSON-encodable values.
+    """A stand-in engine whose project manager answers with a JSON-encodable value.
 
-    A bare MagicMock hands back MagicMocks, which `json.dumps` cannot encode -- so every
-    peer a resolver reads is given a real value here and overridden per test.
+    A bare MagicMock hands back MagicMocks, which `json.dumps` cannot encode -- so the one
+    peer the resolver reads is given a real value here and overridden per test.
     """
     mock_engine = MagicMock()
     mock_engine.project_manager.get_project_chain.return_value = []
-    mock_engine.context_manager.has_current_workflow.return_value = False
-    mock_engine.engine_identity_manager.engine_id = "eng-1"
-    mock_engine.session_manager.active_session_id = "sess-1"
     return mock_engine
 
 
@@ -97,8 +82,8 @@ def _entry(project_id: str, name: str | None) -> ProjectChainEntry:
     """A chain entry whose id and name never match, so an assertion cannot pass on the wrong one.
 
     The real type rather than a Mock: `name` is reserved on `Mock`, so `Mock(name="x").name`
-    is a Mock rather than a string, and a mocked chain would answer the nameless branch with
-    something that is neither a name nor `None`.
+    is a Mock rather than a string, and a mocked chain would answer with something that is
+    neither a name nor `None`.
     """
     return ProjectChainEntry(id=project_id, name=name)
 
@@ -139,7 +124,7 @@ class TestAttributionPayloadShape:
 
     def test_request_dispatches_through_the_engine(self, engine: Engine) -> None:
         """The request reaches BudgetManager over the real bus and comes back usable."""
-        result = engine.handle_request(GetAttributionContextRequest(node_type="GriptapeProxyImage"))
+        result = engine.handle_request(GetAttributionContextRequest())
 
         assert isinstance(result, GetAttributionContextResultSuccess)
         assert result.header_value
@@ -148,14 +133,12 @@ class TestAttributionPayloadShape:
 
     def test_header_value_decodes_to_documented_payload(self, engine: Engine) -> None:
         """base64url of compact UTF-8 JSON, leaf-first chain, schema version 1."""
-        result = engine.handle_request(GetAttributionContextRequest(node_type="GriptapeProxyImage"))
+        result = engine.handle_request(GetAttributionContextRequest())
         assert isinstance(result, GetAttributionContextResultSuccess)
 
         assert _decode(result)["v"] == ATTRIBUTION_SCHEMA_VERSION
-        tags = _tags(result)
-        assert tags["node_type"] == "GriptapeProxyImage"
         # No project is selected on a bare engine, so the key is absent rather than empty.
-        assert tags.get("project", []) == result.project_chain
+        assert _tags(result).get("project", []) == result.project_chain
 
     def test_padding_round_trips(self, engine: Engine) -> None:
         """Padding is kept so the Cloud can decode without re-padding."""
@@ -166,38 +149,52 @@ class TestAttributionPayloadShape:
         base64.urlsafe_b64decode(result.header_value)
         assert len(result.header_value) % 4 == 0
 
-    def test_payload_key_allowlist(self, engine: Engine) -> None:
-        """No key ships that has not been consciously added, and `node_id` is not one of them."""
-        result = engine.handle_request(GetAttributionContextRequest(node_type="Anything"))
-        assert isinstance(result, GetAttributionContextResultSuccess)
+    def test_payload_key_allowlist(self, engine: Engine, budget_manager: BudgetManager) -> None:
+        """No key ships that has not been consciously added, chain or no chain.
 
-        decoded = _decode(result)
-        assert set(decoded) <= ALLOWED_ENVELOPE_KEYS
-        assert set(decoded["tags"]) <= ALLOWED_TAG_KEYS
-        assert "node_id" not in decoded["tags"]
+        Both shapes are checked because they exercise different halves of the builder: the
+        real engine has no project open and emits a bare envelope, while the mocked one emits
+        the `tags` object that a new dimension would be smuggled into.
+        """
+        cast("MagicMock", budget_manager.engine).project_manager.get_project_chain.return_value = [
+            _entry("leaf", "Leaf")
+        ]
+
+        for result in (engine.handle_request(GetAttributionContextRequest()), _succeed(budget_manager)):
+            assert isinstance(result, GetAttributionContextResultSuccess)
+            assert set(_decode(result)) <= ALLOWED_ENVELOPE_KEYS
+            assert set(_tags(result)) <= ALLOWED_TAG_KEYS
+
+        assert _tags(_succeed(budget_manager)) == {"project": ["leaf"]}
 
     def test_structured_fields_agree_with_the_header(self, budget_manager: BudgetManager) -> None:
         """A consumer reading the result must see exactly what the header encodes."""
-        mock_engine = cast("MagicMock", budget_manager.engine)
-        mock_engine.project_manager.get_project_chain.return_value = []
-        mock_engine.context_manager.has_current_workflow.return_value = False
-        mock_engine.engine_identity_manager.engine_id = "eng-1"
-        mock_engine.session_manager.active_session_id = "sess-1"
+        cast("MagicMock", budget_manager.engine).project_manager.get_project_chain.return_value = [
+            _entry("leaf", "Leaf"),
+            _entry("root", "Root"),
+        ]
 
-        result = _succeed(budget_manager, node_type="NodeT")
-        tags = _tags(result)
+        result = _succeed(budget_manager)
 
-        assert tags.get("workflow") == result.workflow_name
-        assert tags["node_type"] == result.node_type
-        assert tags["engine_id"] == result.engine_id
-        assert tags["session_id"] == result.session_id
+        assert _tags(result)["project"] == result.project_chain
+
+    def test_a_chainless_envelope_is_still_sent(self, budget_manager: BudgetManager) -> None:
+        """`{"v": 1}` says "no project open"; sending nothing says "client does not attribute".
+
+        The Cloud parser distinguishes the two, so the bare envelope carries a real fact and
+        an empty chain is never a reason to withhold the header.
+        """
+        result = _succeed(budget_manager)
+
+        assert _decode(result) == {"v": ATTRIBUTION_SCHEMA_VERSION}
+        assert result.header_value
 
 
 class TestProjectChain:
-    """`tags.project` carries project names, ordered leaf-first.
+    """`tags.project` carries project ids, ordered leaf-first.
 
-    The name is the wire value because `tags.project` is the only dimension the Cloud
-    matches budgets against, and a budget admin has to be able to author it into a rule.
+    The id is the wire value because it is what identifies a project across a rename -- the
+    name would silently re-point that project's spend the moment a user edited it.
     """
 
     def _manager_on(self, project_manager: ProjectManager) -> BudgetManager:
@@ -206,10 +203,7 @@ class TestProjectChain:
         return BudgetManager(MagicMock(), engine=mock_engine)
 
     def test_system_defaults_never_reaches_the_wire(self) -> None:
-        """The Cloud reserves `<system-defaults>` and counts a client copy as degraded.
-
-        Nor does its *name* travel in the sentinel's place -- see the next test.
-        """
+        """The Cloud reserves `<system-defaults>` and counts a client copy as degraded."""
         project_manager = ProjectManager(Mock(), Mock(), Mock())
         result = _succeed(self._manager_on(project_manager))
 
@@ -218,12 +212,11 @@ class TestProjectChain:
         assert SYSTEM_DEFAULTS_KEY not in json.dumps(_decode(result))
 
     def test_the_default_templates_name_never_stands_in_for_the_sentinel(self) -> None:
-        """Skipping `<system-defaults>` is keyed on its id, because it does have a name.
+        """Skipping `<system-defaults>` is keyed on its id, and its name is not sent either.
 
         The rest state is registered with the shipped `DEFAULT_PROJECT_TEMPLATE`, whose name
         is "Default Project" -- a generic string that would collide across every user in an
-        org and match any budget rule unlucky enough to be written against it. Filtering on
-        the name alone would let it through.
+        org and match any budget rule unlucky enough to be written against it.
         """
         project_manager = ProjectManager(Mock(), Mock(), Mock())
         project_manager._load_system_defaults()
@@ -241,43 +234,10 @@ class TestProjectChain:
 
         result = _succeed(self._manager_on(project_manager))
 
-        assert _tags(result)["project"] == ["Shot 020"]
+        assert _tags(result)["project"] == ["leaf"]
 
-    @pytest.mark.parametrize(
-        "reserved_name",
-        [
-            SYSTEM_DEFAULTS_KEY,
-            f" {SYSTEM_DEFAULTS_KEY} ",
-            # Only becomes the reserved value once cut to the 256-char cap.
-            SYSTEM_DEFAULTS_KEY + " " * 239 + "x",
-        ],
-    )
-    def test_a_project_actually_named_system_defaults_drops_the_chain(
-        self, reserved_name: str, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """A name collision with the Cloud's reserved value costs the whole chain.
-
-        Nothing stops a user typing the reserved string into `name:`. The Cloud discards a
-        client copy, which would drop that entry and promote its parent to leaf -- billing a
-        real project for spend it never incurred. Neither padding nor length disguises it: the
-        far end strips, cuts to its value cap, and strips again before it tests the reserved
-        value, so the comparison here runs on that same form.
-        """
-        project_manager = ProjectManager(Mock(), Mock(), Mock())
-        _register_project(project_manager, "grandparent", name="Acme Studios")
-        _register_project(project_manager, "leaf", name=reserved_name, parent_id="grandparent")
-        project_manager._current_project_id = "leaf"
-
-        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
-            result = _succeed(self._manager_on(project_manager))
-
-        assert "project" not in _tags(result)
-        assert result.project_chain == []
-        assert "Acme Studios" not in result.header_value
-        assert any(record.levelno == logging.WARNING for record in caplog.records)
-
-    def test_nested_chain_carries_every_name_leaf_first(self) -> None:
-        """The whole ancestry travels, and nothing but names does."""
+    def test_nested_chain_carries_every_id_leaf_first(self) -> None:
+        """The whole ancestry travels, and nothing but ids does."""
         project_manager = ProjectManager(Mock(), Mock(), Mock())
         _register_project(project_manager, "grandparent", name="Acme Studios")
         _register_project(project_manager, "parent", name="Feature Film", parent_id="grandparent")
@@ -287,11 +247,11 @@ class TestProjectChain:
         result = _succeed(self._manager_on(project_manager))
         decoded = _decode(result)
 
-        assert decoded["tags"]["project"] == ["Shot 020", "Feature Film", "Acme Studios"]
+        assert decoded["tags"]["project"] == ["leaf", "parent", "grandparent"]
         serialized = json.dumps(decoded)
-        for project_id in ("grandparent", "parent", "leaf"):
-            assert project_id not in serialized
-            assert project_id not in result.header_value
+        for name in ("Acme Studios", "Feature Film", "Shot 020"):
+            assert name not in serialized
+            assert name not in result.header_value
 
     def test_a_chain_deeper_than_the_cloud_keeps_still_travels_whole(self) -> None:
         """Depth is the Cloud's to judge, not ours -- and judging it here is what hides it.
@@ -309,60 +269,48 @@ class TestProjectChain:
             _register_project(project_manager, project_id, name=f"Name {project_id}", parent_id=parent)
         project_manager._current_project_id = ids[0]
 
-        names = [f"Name {project_id}" for project_id in ids]
         result = _succeed(self._manager_on(project_manager))
 
-        assert _tags(result)["project"] == names
-        assert result.project_chain == names
-        assert result.chain_truncated is False
+        assert _tags(result)["project"] == ids
+        assert result.project_chain == ids
 
-    def test_an_unregistered_parent_drops_the_chain_and_never_falls_back_to_its_id(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """A nameless ancestor is neither swapped for its id nor quietly cut away.
+    def test_a_chain_of_path_shaped_ids_travels_whole(self) -> None:
+        """The realistic worst case for size, and it is not close to a problem.
 
-        Its registry key is not something a budget rule mentions, so emitting it adds one
-        unmatchable string. Keeping just the leaf is worse: paths are root-anchored, so
-        `["Shot 6"]` presents a nested project as a root and bills an unrelated top-level
-        "Shot 6" if the org has one.
+        A project created before ids existed has the canonical path to its file written in as
+        its id, so a deep chain of legacy projects is the longest header the engine can
+        plausibly produce. Thirty-two of them encode to roughly 4 KB -- inside the Cloud's own
+        raw-header cap and half of a default nginx header buffer -- so there is nothing here
+        worth shortening, and shortening it would arrive looking intact anyway.
+        """
+        project_manager = ProjectManager(Mock(), Mock(), Mock())
+        ids = [f"/Users/alice/Documents/projects/acme/season-02/shot-{index:03d}/project.yml" for index in range(32)]
+        for index, project_id in enumerate(ids):
+            parent = ids[index + 1] if index + 1 < len(ids) else None
+            _register_project(project_manager, project_id, name=f"Shot {index}", parent_id=parent)
+        project_manager._current_project_id = ids[0]
+
+        result = _succeed(self._manager_on(project_manager))
+
+        assert _tags(result)["project"] == ids
+        assert len(result.header_value) < 5632  # noqa: PLR2004 -- the Cloud's MAX_RAW_HEADER_LENGTH
+
+    def test_an_unregistered_parent_still_contributes_its_id(self) -> None:
+        """The walk ends at an unregistered ancestor, but its id is a fact and travels.
+
+        `get_project_chain` surfaces the id it could not resolve a template for and stops
+        there. That id is what the parent is called everywhere else in the engine, so sending
+        it is honest; deciding it is unmatchable and dropping the chain over it would be the
+        engine judging on the Cloud's behalf.
         """
         project_manager = ProjectManager(Mock(), Mock(), Mock())
         _register_project(project_manager, "shot-6", name="Shot 6", parent_id="swx")
         project_manager._current_project_id = "shot-6"
 
-        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
-            result = _succeed(self._manager_on(project_manager))
+        result = _succeed(self._manager_on(project_manager))
 
-        assert "project" not in _tags(result)
-        assert "swx" not in result.header_value
+        assert _tags(result)["project"] == ["shot-6", "swx"]
         assert "Shot 6" not in result.header_value
-        assert any(record.levelno == logging.WARNING for record in caplog.records)
-
-    @pytest.mark.parametrize("blank_at", ["root", "middle"])
-    def test_a_blank_name_drops_the_chain_wherever_it_sits(
-        self, blank_at: str, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """A blank name reads as nameless, and position cannot tell it from a failed load.
-
-        `ProjectTemplate.name` has no `min_length` and `get_project_chain` maps any falsy name
-        to None, so a loaded blank-named template is indistinguishable from an unresolvable
-        one -- including at the root, where it is nameless *and* last. Hence both ends: a rule
-        reading "nameless and last means the walk ended" returns `["Shot 020"]` for a project
-        three deep and presents it to the Cloud as a root.
-        """
-        names = {"root": {"acme": "", "mid": "Mid"}, "middle": {"acme": "Acme Studios", "mid": ""}}[blank_at]
-        project_manager = ProjectManager(Mock(), Mock(), Mock())
-        _register_project(project_manager, "acme", name=names["acme"])
-        _register_project(project_manager, "mid", name=names["mid"], parent_id="acme")
-        _register_project(project_manager, "shot-020", name="Shot 020", parent_id="mid")
-        project_manager._current_project_id = "shot-020"
-
-        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
-            result = _succeed(self._manager_on(project_manager))
-
-        assert "project" not in _tags(result)
-        assert "Shot 020" not in result.header_value
-        assert any(record.levelno == logging.WARNING for record in caplog.records)
 
     def test_second_dispatch_reflects_a_project_switch(self) -> None:
         """The chain is read per invocation, never cached at workflow open."""
@@ -376,8 +324,8 @@ class TestProjectChain:
         project_manager._current_project_id = "after"
         second = _succeed(manager)
 
-        assert _tags(first)["project"] == ["Before"]
-        assert _tags(second)["project"] == ["After"]
+        assert _tags(first)["project"] == ["before"]
+        assert _tags(second)["project"] == ["after"]
 
     def test_empty_chain_omits_the_project_key(self) -> None:
         """`[]` would assert 'belongs to zero projects', which is a claim we cannot make."""
@@ -385,221 +333,86 @@ class TestProjectChain:
         result = _succeed(manager)
 
         assert "project" not in _tags(result)
-        # The other dimensions still ship; only the chain is unknown.
-        assert "engine_id" in _tags(result)
+        assert result.project_chain == []
 
 
-class TestWorkflowName:
-    """An absent `workflow` means unknown; `<unsaved>` means scratch. They differ."""
+class TestValuesTravelVerbatim:
+    """Nothing here repairs an id. The Cloud reports what it had to repair; the engine does not.
 
-    def test_unsaved_workflow_reports_the_sentinel(self, engine: Engine) -> None:
-        """Never the per-session `unsaved:<uuid4>` key, which has unbounded cardinality."""
-        set_result = engine.handle_request(SetWorkflowContextRequest(display_name="Untitled"))
-        assert set_result.succeeded()
-        try:
-            result = engine.handle_request(GetAttributionContextRequest())
-            assert isinstance(result, GetAttributionContextResultSuccess)
-
-            decoded = _decode(result)
-            assert decoded["tags"]["workflow"] == UNSAVED_WORKFLOW_SENTINEL
-            assert result.workflow_name == UNSAVED_WORKFLOW_SENTINEL
-            # The uuid must not leak by any other route, encoded or decoded.
-            assert "unsaved:" not in json.dumps(decoded)
-            assert "unsaved:" not in base64.urlsafe_b64decode(result.header_value).decode("utf-8")
-        finally:
-            while engine.context_manager.has_current_workflow():
-                engine.context_manager.pop_workflow()
-
-    def test_saved_workflow_reports_its_registry_key(self, engine: Engine) -> None:
-        """A saved workflow's key is the workspace-relative path minus extension."""
-        engine.context_manager.push_workflow("shots/sh020/lighting")
-        try:
-            result = engine.handle_request(GetAttributionContextRequest())
-            assert isinstance(result, GetAttributionContextResultSuccess)
-
-            workflow = _tags(result)["workflow"]
-            assert workflow == "shots/sh020/lighting"
-            assert not workflow.startswith("unsaved:")
-        finally:
-            engine.context_manager.pop_workflow()
-
-    def test_missing_workflow_context_omits_workflow(self, engine: Engine) -> None:
-        """No workflow pushed -> the key is absent, which is distinct from the scratch bucket."""
-        assert not engine.context_manager.has_current_workflow()
-
-        result = engine.handle_request(GetAttributionContextRequest())
-        assert isinstance(result, GetAttributionContextResultSuccess)
-
-        assert "workflow" not in _tags(result)
-        assert result.workflow_name is None
-
-
-class TestOrchestratorEngineId:
-    """Pins the resolver, not a shipping behavior.
-
-    The orchestrator answers every attribution request and has no parent, so production never
-    populates this key. It is not evidence that worker spend is joinable to its orchestrator.
+    An id has no enforced shape -- no pattern, no length cap -- so it can carry anything a user
+    typed or a filesystem produced. Every shape below is one the Cloud would strip, cut, or
+    refuse to store, and every one of them still goes out exactly as the project stores it:
+    a value repaired here arrives looking intact, which is the one thing the far end cannot
+    detect and the one outcome worse than no attribution.
     """
 
-    @pytest.fixture
-    def budget_manager(self) -> BudgetManager:
-        return BudgetManager(MagicMock(), engine=_mock_engine())
-
-    def test_orchestrator_engine_id_present_when_the_env_var_is_set(
-        self, budget_manager: BudgetManager, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv("GTN_ORCHESTRATOR_ENGINE_ID", "eng-orch")
-
-        result = _succeed(budget_manager)
-
-        assert _tags(result)["orchestrator_engine_id"] == "eng-orch"
-        assert result.orchestrator_engine_id == "eng-orch"
-
-    def test_orchestrator_engine_id_absent_on_the_orchestrator(
-        self, budget_manager: BudgetManager, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.delenv("GTN_ORCHESTRATOR_ENGINE_ID", raising=False)
-
-        result = _succeed(budget_manager)
-
-        assert "orchestrator_engine_id" not in _tags(result)
-        assert result.orchestrator_engine_id is None
-
-
-class TestDegradation:
-    """The caller is about to spend money: degrade to a missing key, never raise."""
-
-    def _manager(self) -> BudgetManager:
+    def _manager_with(self, *ids: str) -> BudgetManager:
         mock_engine = _mock_engine()
-        mock_engine.project_manager.get_project_chain.return_value = [_entry("leaf", "Leaf")]
-        mock_engine.context_manager.has_current_workflow.return_value = True
-        mock_engine.context_manager.get_current_workflow_name.return_value = "shots/sh020"
+        mock_engine.project_manager.get_project_chain.return_value = [
+            _entry(project_id, f"Name {index}") for index, project_id in enumerate(ids)
+        ]
         return BudgetManager(MagicMock(), engine=mock_engine)
 
-    @pytest.mark.parametrize(
-        ("break_field", "absent_key"),
-        [
-            ("project_chain", "project"),
-            ("workflow", "workflow"),
-            ("engine_id", "engine_id"),
-            ("session_id", "session_id"),
-        ],
-    )
-    def test_peer_failure_degrades_one_field_not_the_header(
-        self, break_field: str, absent_key: str, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """One unhappy peer costs one key, not the whole attribution."""
-        manager = self._manager()
-        mock_engine = cast("MagicMock", manager.engine)
-        boom = RuntimeError("peer exploded")
+    def test_a_control_character_travels_unfiltered(self) -> None:
+        """The Cloud drops an entry it cannot store, promotes its parent to leaf, and reports it.
 
-        if break_field == "project_chain":
-            mock_engine.project_manager.get_project_chain.side_effect = boom
-        elif break_field == "workflow":
-            mock_engine.context_manager.get_current_workflow_name.side_effect = boom
-        elif break_field == "engine_id":
-            type(mock_engine.engine_identity_manager).engine_id = PropertyMock(side_effect=boom)
-        elif break_field == "session_id":
-            type(mock_engine.session_manager).active_session_id = PropertyMock(side_effect=boom)
+        Withholding the chain here would trade that reported drop for a silent absence, and
+        the engine cannot tell an id a user meant to type from one they pasted a newline into.
+        """
+        result = _succeed(self._manager_with("acme\nstudios", "root"))
+
+        assert _tags(result)["project"] == ["acme\nstudios", "root"]
+
+    def test_a_padded_id_travels_unstripped(self) -> None:
+        """An id is an identifier, so it goes out as the project spells it.
+
+        Stripping would be cheap and invisible, which is exactly the problem: `project_chain`
+        would then report a string the engine cannot look the project up by.
+        """
+        result = _succeed(self._manager_with("  season-02-a3f9c1  "))
+
+        assert _tags(result)["project"] == ["  season-02-a3f9c1  "]
+        assert result.project_chain == ["  season-02-a3f9c1  "]
+
+    def test_an_id_past_the_clouds_value_cap_travels_uncut(self) -> None:
+        """Cutting is the far end's job, and doing it here would hide that it happened.
+
+        The Cloud truncates a value past its 256-character cap, marks the chain mangled, and
+        stops matching it against admin-authored paths. Pre-cutting hands it a prefix that
+        looks intact, so it matches -- and two sibling projects sharing their first 256
+        characters silently collapse onto one budget with nothing recorded.
+        """
+        long_id = "s" * 300
+        result = _succeed(self._manager_with(long_id, "root"))
+
+        assert _tags(result)["project"] == [long_id, "root"]
+        assert result.project_chain == [long_id, "root"]
+
+    def test_an_unencodable_id_costs_the_whole_header(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The one thing the wire physically cannot carry, and the module's only failure.
+
+        A project created before ids existed carries the canonical path to its file as its id,
+        so a path whose bytes are not valid UTF-8 arrives holding lone surrogates from
+        `surrogateescape` -- and `str.encode` refuses them. There is no honest partial form to
+        send instead: dropping just that entry would promote its parent to leaf and bill a
+        real ancestor for spend it never incurred. So the header is given up and the call goes
+        out unattributed.
+        """
+        manager = self._manager_with("renders-\udce9", "root")
 
         with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
-            result = _succeed(manager)
+            result = _dispatch(manager)
 
-        assert absent_key not in _tags(result)
+        assert isinstance(result, GetAttributionContextResultFailure)
+        assert "attribution" in str(result.result_details).lower()
         assert any(record.levelno == logging.WARNING for record in caplog.records)
 
-    def test_no_workflow_context_is_not_an_error(self) -> None:
-        """`has_current_workflow()` returning False is an ordinary state, not a degradation."""
-        manager = self._manager()
-        cast("MagicMock", manager.engine).context_manager.has_current_workflow.return_value = False
+    def test_the_encoder_returns_none_instead_of_raising(self) -> None:
+        """Pinned on the module function, because the cost of raising is paid per metered call.
 
-        result = _succeed(manager)
-
-        assert "workflow" not in _tags(result)
-
-
-class TestSizeCap:
-    """Reduction sheds the cheapest dimensions first, then the chain, then fails."""
-
-    def _manager(self) -> BudgetManager:
-        """Short names, so the byte caps in each test below bracket the reduction rung it means to exercise."""
-        mock_engine = _mock_engine()
-        mock_engine.project_manager.get_project_chain.return_value = [
-            _entry("leaf", "Leaf"),
-            _entry("parent", "Parent"),
-        ]
-        mock_engine.context_manager.has_current_workflow.return_value = True
-        mock_engine.context_manager.get_current_workflow_name.return_value = "shots/sh020/lighting"
-        return BudgetManager(MagicMock(), engine=mock_engine)
-
-    def test_a_header_too_large_for_the_ingress_sheds_the_chain(self, caplog: pytest.LogCaptureFixture) -> None:
-        """The only reduction left, run against the real bound rather than a patched one.
-
-        A 4200-character name encodes to 5888 bytes with its parent, past the 5632 the ingress
-        will carry. Nothing is repaired to get under that -- the name is not cut and the chain
-        is not shortened, because either would arrive looking intact. The chain goes whole and
-        the spend lands in the default budget, which is the same place the Cloud would have put
-        it once it saw a mangled chain.
-        """
-        mock_engine = _mock_engine()
-        mock_engine.project_manager.get_project_chain.return_value = [
-            _entry("leaf", "S" * 4200),
-            _entry("root", "Acme Studios"),
-        ]
-        mock_engine.context_manager.has_current_workflow.return_value = True
-        mock_engine.context_manager.get_current_workflow_name.return_value = "shots/sh020/lighting"
-        manager = BudgetManager(MagicMock(), engine=mock_engine)
-
-        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
-            result = _succeed(manager, node_type="GriptapeProxyImage")
-
-        tags = _tags(result)
-        assert "project" not in tags
-        assert result.project_chain == []
-        # Empty *and* flagged: the chain was shed. Empty and unflagged means no project open.
-        assert result.chain_truncated is True
-        # Only the chain is given up. The labels run tens of bytes against a 5632-byte bound,
-        # so shedding them alongside would cost a dashboard row and buy nothing.
-        assert tags["workflow"] == "shots/sh020/lighting"
-        assert tags["node_type"] == "GriptapeProxyImage"
-        # The structured fields have to agree with the reduced header, not the pre-encode values.
-        assert result.workflow_name == "shots/sh020/lighting"
-        assert any(record.levelno == logging.WARNING for record in caplog.records)
-
-    def test_an_enormous_chain_is_shed_whole_rather_than_in_part(self) -> None:
-        """There is no partial rung between the whole chain and none of it.
-
-        Thirty-two names at 300 characters encode to 13192 bytes, twice the bound and past
-        nginx's own header buffer, so this is the shape that most tempts a prefix. Sending one
-        would present a nested project as a root: budget paths are root-anchored, so a partial
-        chain matches an unrelated top-level project of the same name at worst and nothing at
-        best, and neither end records that it happened.
-        """
-        mock_engine = _mock_engine()
-        mock_engine.project_manager.get_project_chain.return_value = [
-            _entry(f"p{index}", "N" * 300) for index in range(32)
-        ]
-        mock_engine.context_manager.has_current_workflow.return_value = True
-        mock_engine.context_manager.get_current_workflow_name.return_value = "shots/sh020/lighting"
-        manager = BudgetManager(MagicMock(), engine=mock_engine)
-
-        result = _succeed(manager, node_type="GriptapeProxyImage")
-
-        tags = _tags(result)
-        assert "project" not in tags
-        assert result.project_chain == []
-        assert result.chain_truncated is True
-        assert tags["workflow"] == "shots/sh020/lighting"
-
-    def test_the_utf8_backstop_returns_none_instead_of_raising(self) -> None:
-        """The one path no dispatch can reach, tested directly because it still has to hold.
-
-        Every dimension is filtered through `_transmissible_or_none` before it gets here, so
-        the encoder should never see an unencodable payload -- but if one ever slips past, the
-        cost of letting `str.encode` raise is an ERROR with a traceback on every metered call,
-        because a handler exception becomes a `GenericResultFailure` that ignores
-        `failure_log_level`. Called on the module function, since the guard is unreachable
-        through the manager by construction.
+        A handler exception becomes a `GenericResultFailure`, which ignores `failure_log_level`
+        and logs an ERROR with a traceback -- once for every credit-consuming call the artist
+        makes.
         """
         payload = {"v": 1, "tags": {"project": ["\udce9"]}}
 
@@ -608,244 +421,22 @@ class TestSizeCap:
 
         assert budget_manager_module._encode_attribution_payload(payload) is None
 
-    def test_a_header_that_does_not_fit_even_chainless_fails(self) -> None:
-        """The floor: no usable header value exists, so Success would be a lie."""
-        manager = self._manager()
 
-        with patch.object(budget_manager_module, "_MAX_ENCODED_HEADER_BYTES", 1):
-            result = _dispatch(manager)
+class TestDegradation:
+    """The caller is about to spend money: degrade to a missing key, never raise."""
 
-        assert isinstance(result, GetAttributionContextResultFailure)
-        assert "attribution" in str(result.result_details).lower()
-
-    def test_an_unencodable_envelope_fails_rather_than_raising(self) -> None:
-        """The second backstop, tested directly for the same reason as the first.
-
-        Every dimension outside the chain is filtered through `_transmissible_or_none` and every
-        name through `_resolve_project_chain`, so the chainless envelope is unencodable only if
-        one of those filters has been broken. If that ever happens the cost of raising here is
-        an ERROR with a traceback on every metered call, so it returns None and the handler
-        answers Failure.
-        """
-        facts = budget_manager_module._AttributionFacts(
-            project_chain=["Leaf"],
-            workflow_name=None,
-            node_type=None,
-            engine_id=None,
-            orchestrator_engine_id=None,
-            session_id=None,
-        )
-
-        with patch.object(budget_manager_module, "_encode_attribution_payload", return_value=None):
-            assert budget_manager_module._encode_attribution_header(facts) is None
-
-    def test_a_chainless_payload_over_the_bound_fails_without_retrying_itself(self) -> None:
-        """With no chain there is nothing to give up, so the second attempt is not made.
-
-        Same Failure either way; the point is that the reduction path does not re-encode an
-        identical payload and log a warning about shedding a chain that was never there.
-        """
+    def test_peer_failure_degrades_the_key_not_the_header(self, caplog: pytest.LogCaptureFixture) -> None:
+        """An unhappy project manager costs the project key, not the whole attribution."""
         mock_engine = _mock_engine()
-        mock_engine.project_manager.get_project_chain.return_value = []
-        manager = BudgetManager(MagicMock(), engine=mock_engine)
-
-        with patch.object(budget_manager_module, "_MAX_ENCODED_HEADER_BYTES", 1):
-            result = _dispatch(manager)
-
-        assert isinstance(result, GetAttributionContextResultFailure)
-
-
-class TestTransmissibility:
-    """A value the Cloud cannot store is dropped here rather than sent and discarded there.
-
-    Now that the chain carries names, the plausible offender is a user typing or pasting one:
-    a project name is free text from a YAML file, and a pasted newline survives the schema.
-    The surrogate case belongs to the path-derived values -- the workflow key, and identifiers
-    `os.getenv` decodes with `surrogateescape` -- but a name read off disk can carry one too,
-    so both shapes are parametrized against the same filter.
-    """
-
-    # A pasted line break in a project name. Legal in YAML, encodes fine here, and dropped
-    # by the Cloud's storability check.
-    CONTROL_CHAR_NAME = "Acme\nStudios"
-    # A name read from a file whose bytes are not valid UTF-8 carries a lone surrogate.
-    SURROGATE_NAME = "Renders \udce9"
-    # Truthy here, so `get_project_chain` hands it over as a name, but it strips to empty at
-    # the far end -- which drops the entry and promotes its parent to leaf.
-    WHITESPACE_NAME = "  "
-    NBSP_NAME = "\u00a0"
-
-    @pytest.mark.parametrize("bad_name", [CONTROL_CHAR_NAME, SURROGATE_NAME, WHITESPACE_NAME, NBSP_NAME])
-    def test_an_untransmissible_name_drops_the_whole_chain(
-        self, bad_name: str, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """The chain goes as a unit: a partial chain bills an ancestor for the leaf's spend.
-
-        Budget paths are root-anchored, so a chain missing a link matches nothing either way.
-        Dropping only the offending entry would promote its parent to leaf and charge a real
-        project for spend it never incurred, which is worse than no attribution at all.
-        """
-        mock_engine = _mock_engine()
-        mock_engine.project_manager.get_project_chain.return_value = [
-            _entry("leaf", "Leaf"),
-            _entry("parent", bad_name),
-        ]
+        mock_engine.project_manager.get_project_chain.side_effect = RuntimeError("peer exploded")
         manager = BudgetManager(MagicMock(), engine=mock_engine)
 
         with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
             result = _succeed(manager)
 
         assert "project" not in _tags(result)
-        assert result.project_chain == []
+        assert _decode(result) == {"v": ATTRIBUTION_SCHEMA_VERSION}
         assert any(record.levelno == logging.WARNING for record in caplog.records)
-
-    def test_an_ordinary_human_name_still_travels(self) -> None:
-        """The filter targets unstorable bytes, not punctuation -- names are meant to read like names."""
-        mock_engine = _mock_engine()
-        mock_engine.project_manager.get_project_chain.return_value = [_entry("leaf", "Acme Studios / S02 \u2014 v3")]
-        manager = BudgetManager(MagicMock(), engine=mock_engine)
-
-        assert _tags(_succeed(manager))["project"] == ["Acme Studios / S02 \u2014 v3"]
-
-    def test_a_padded_name_travels_in_the_form_the_far_end_stores(self) -> None:
-        """Normalize here or the result describes a string budgets never match.
-
-        The Cloud strips what it keeps, so `" Acme Studios "` is stored as `"Acme Studios"`.
-        Sending the padded form would leave `project_chain` reporting a value that no budget
-        rule can be written against.
-        """
-        mock_engine = _mock_engine()
-        mock_engine.project_manager.get_project_chain.return_value = [_entry("leaf", "  Acme Studios  ")]
-        manager = BudgetManager(MagicMock(), engine=mock_engine)
-
-        result = _succeed(manager)
-
-        assert _tags(result)["project"] == ["Acme Studios"]
-        assert result.project_chain == ["Acme Studios"]
-
-    def test_a_padded_workflow_key_travels_unstripped(self) -> None:
-        """A registry key is an identifier, so it goes out as the engine spells it.
-
-        `derive_registry_key` builds the key from a workspace-relative path, and a directory
-        or filename may legally begin or end with a space on macOS and Linux. Trimming it
-        would report a string that no longer names any workflow the engine can look up --
-        the opposite of the project-name case, where normalizing is what makes the value
-        matchable.
-        """
-        mock_engine = _mock_engine()
-        mock_engine.context_manager.has_current_workflow.return_value = True
-        mock_engine.context_manager.get_current_workflow_name.return_value = "shots/sh020 /lighting"
-        manager = BudgetManager(MagicMock(), engine=mock_engine)
-
-        result = _succeed(manager)
-
-        assert _tags(result)["workflow"] == "shots/sh020 /lighting"
-        assert result.workflow_name == "shots/sh020 /lighting"
-
-    def test_a_name_longer_than_the_value_cap_travels_uncut(self) -> None:
-        """Cutting is the far end's job, and doing it here would hide that it happened.
-
-        The Cloud truncates an over-long name rather than dropping it, then marks the chain
-        mangled and stops matching it against admin-authored paths. Pre-cutting hands it a
-        prefix that looks intact, so it matches -- and two sibling projects sharing their
-        first 256 characters silently collapse onto one budget with nothing recorded.
-        Stripping stays, because the far end strips too and flags nothing when it does.
-        """
-        mock_engine = _mock_engine()
-        mock_engine.project_manager.get_project_chain.return_value = [_entry("leaf", "  " + "S" * 300 + "  ")]
-        manager = BudgetManager(MagicMock(), engine=mock_engine)
-
-        result = _succeed(manager)
-
-        assert _tags(result)["project"] == ["S" * 300]
-        assert result.project_chain == ["S" * 300]
-
-    def test_an_unstorable_byte_past_the_value_cap_does_not_cost_the_chain(self) -> None:
-        """Judge the kept form, or the engine refuses a name the far end would have stored.
-
-        The cut happens before the storability test on the far end, so a control character
-        sitting past the cap is gone by the time anything looks at it. Testing the whole
-        string here would drop a chain over a byte that never arrives -- and the name still
-        travels uncut, because the far end is the one that should decide it was too long.
-        """
-        mock_engine = _mock_engine()
-        mock_engine.project_manager.get_project_chain.return_value = [
-            _entry("leaf", "S" * 300 + "\n" + "S" * 20),
-            _entry("root", "Acme Studios"),
-        ]
-        manager = BudgetManager(MagicMock(), engine=mock_engine)
-
-        result = _succeed(manager)
-
-        assert _tags(result)["project"] == ["S" * 300 + "\n" + "S" * 20, "Acme Studios"]
-
-    def test_a_surrogate_past_the_value_cap_drops_the_chain(self, caplog: pytest.LogCaptureFixture) -> None:
-        """Encodability is the one property judged on the whole name rather than the kept form.
-
-        A lone surrogate past the cap is invisible to the Cloud -- its own truncation removes
-        the byte before it decides storability -- so the kept form passes every other test. But
-        the name that would travel cannot be encoded, and the cut form that could is a repair
-        arriving intact. The chain is dropped instead, which is the same abstention any other
-        unsendable name earns.
-        """
-        mock_engine = _mock_engine()
-        mock_engine.project_manager.get_project_chain.return_value = [
-            _entry("leaf", "S" * 300 + "\udce9"),
-            _entry("root", "Acme Studios"),
-        ]
-        manager = BudgetManager(MagicMock(), engine=mock_engine)
-
-        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
-            result = _succeed(manager)
-
-        assert "project" not in _tags(result)
-        assert result.project_chain == []
-        # Not the size path: nothing was shed to fit, so the flag stays down.
-        assert result.chain_truncated is False
-        assert any(record.levelno == logging.WARNING for record in caplog.records)
-
-    def test_an_untransmissible_workflow_key_is_omitted_without_touching_the_chain(self) -> None:
-        """One unusable dimension costs its own key and nothing else."""
-        mock_engine = _mock_engine()
-        mock_engine.project_manager.get_project_chain.return_value = [_entry("leaf", "Leaf")]
-        mock_engine.context_manager.has_current_workflow.return_value = True
-        mock_engine.context_manager.get_current_workflow_name.return_value = "shots/sh020\udce9/lighting"
-        manager = BudgetManager(MagicMock(), engine=mock_engine)
-
-        result = _succeed(manager)
-
-        tags = _tags(result)
-        assert "workflow" not in tags
-        assert tags["project"] == ["Leaf"]
-        assert result.workflow_name is None
-
-    def test_an_untransmissible_node_type_is_omitted(self) -> None:
-        """`node_type` is caller-supplied, so it gets the same check as the engine's own facts."""
-        manager = BudgetManager(MagicMock(), engine=_mock_engine())
-
-        result = _succeed(manager, node_type="Griptape\udce9Image")
-
-        assert "node_type" not in _tags(result)
-        assert result.node_type is None
-
-    def test_an_unencodable_identifier_costs_its_own_key_and_nothing_else(self) -> None:
-        """An identifier gets the same per-field filter every other dimension gets.
-
-        `os.getenv` decodes with `surrogateescape`, so `orchestrator_engine_id` can arrive
-        holding a lone surrogate that `str.encode` refuses. Filtering at the read spends one
-        key on the documented "could not determine this" degradation; letting it reach the
-        encoder costs the whole header, and blames size for a problem that is not size.
-        """
-        mock_engine = _mock_engine()
-        manager = BudgetManager(MagicMock(), engine=mock_engine)
-
-        with patch.dict(os.environ, {"GTN_ORCHESTRATOR_ENGINE_ID": "eng-orch\udce9"}):
-            result = _succeed(manager)
-
-        tags = _tags(result)
-        assert "orchestrator_engine_id" not in tags
-        assert result.orchestrator_engine_id is None
-        assert tags["engine_id"] == mock_engine.engine_identity_manager.engine_id
 
 
 class TestConfidentiality:
@@ -859,26 +450,30 @@ class TestConfidentiality:
         """Pins `field(..., kw_only=True)` against a future bare redeclaration.
 
         The base payload is `kw_only=True` but this subclass is a plain `@dataclass`, so a
-        bare `broadcast_result = False` would re-register it as the second positional
-        parameter -- and a caller passing `node_type` positionally could then flip
-        broadcasting back on by accident.
+        bare `broadcast_result = False` would re-register it as the first positional
+        parameter -- and broadcasting the header on every metered call is not something a
+        stray positional argument should be able to turn on.
         """
-        assert GetAttributionContextRequest("GriptapeProxyImage").node_type == "GriptapeProxyImage"
         with pytest.raises(TypeError):
-            GetAttributionContextRequest("GriptapeProxyImage", True)  # type: ignore[misc]
+            GetAttributionContextRequest(True)  # type: ignore[misc]
 
     def test_header_value_is_never_logged(self, engine: Engine, caplog: pytest.LogCaptureFixture) -> None:
         """Neither the log stream nor `result_details`, which is logged as well as broadcast."""
         with caplog.at_level(logging.DEBUG, logger="griptape_nodes"):
-            result = engine.handle_request(GetAttributionContextRequest(node_type="GriptapeProxyImage"))
+            result = engine.handle_request(GetAttributionContextRequest())
         assert isinstance(result, GetAttributionContextResultSuccess)
 
         assert result.header_value not in caplog.text
         assert result.header_value not in str(result.result_details)
 
-    def test_node_label_never_appears(self, engine: Engine) -> None:
-        """`BaseNode.name` is user-authored and forbidden; no key named `name` at any depth."""
-        result = engine.handle_request(GetAttributionContextRequest(node_type="GriptapeProxyImage"))
+    def test_no_user_authored_label_appears(self, engine: Engine) -> None:
+        """`BaseNode.name` and `ProjectTemplate.name` are user-authored and never travel.
+
+        Ids are the only strings the payload carries now, so no key named `name` at any depth
+        -- and the guard stays even though the builder makes it near-tautological, because it
+        is what a future dimension would trip over.
+        """
+        result = engine.handle_request(GetAttributionContextRequest())
         assert isinstance(result, GetAttributionContextResultSuccess)
 
         def walk(value: Any) -> None:
@@ -891,6 +486,22 @@ class TestConfidentiality:
                     walk(child)
 
         walk(_decode(result))
+
+    def test_a_project_name_never_reaches_the_payload(self) -> None:
+        """Every chain entry carries a name; none of them is ever sent."""
+        mock_engine = _mock_engine()
+        mock_engine.project_manager.get_project_chain.return_value = [
+            _entry("leaf", "Acme Studios"),
+            _entry("root", "Feature Film"),
+        ]
+        manager = BudgetManager(MagicMock(), engine=mock_engine)
+
+        result = _succeed(manager)
+
+        assert _tags(result)["project"] == ["leaf", "root"]
+        for name in ("Acme Studios", "Feature Film"):
+            assert name not in json.dumps(_decode(result))
+            assert name not in result.header_value
 
 
 class TestWiring:

--- a/tests/unit/retained_mode/managers/test_budget_manager.py
+++ b/tests/unit/retained_mode/managers/test_budget_manager.py
@@ -297,22 +297,53 @@ class TestProjectChain:
         assert result.project_chain == names[:32]
         assert result.chain_truncated is True
 
-    def test_an_unregistered_parent_ends_the_chain_without_falling_back_to_its_id(self) -> None:
-        """A nameless ancestor is dropped, not swapped for its id.
+    def test_an_unregistered_parent_drops_the_chain_and_never_falls_back_to_its_id(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A nameless ancestor is neither swapped for its id nor quietly cut away.
 
-        `get_project_chain` still surfaces an unresolvable parent, but with no template it
-        has no name -- and its registry key is not something a budget rule mentions. Emitting
-        that would put one unmatchable string in the list; the leaf alone at least matches a
-        rule written against the leaf.
+        Its registry key is not something a budget rule mentions, so emitting it adds one
+        unmatchable string. Keeping just the leaf is worse: paths are root-anchored, so
+        `["Shot 6"]` presents a nested project as a root and bills an unrelated top-level
+        "Shot 6" if the org has one.
         """
         project_manager = ProjectManager(Mock(), Mock(), Mock())
         _register_project(project_manager, "shot-6", name="Shot 6", parent_id="swx")
         project_manager._current_project_id = "shot-6"
 
-        result = _succeed(self._manager_on(project_manager))
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+            result = _succeed(self._manager_on(project_manager))
 
-        assert _tags(result)["project"] == ["Shot 6"]
+        assert "project" not in _tags(result)
         assert "swx" not in result.header_value
+        assert "Shot 6" not in result.header_value
+        assert any(record.levelno == logging.WARNING for record in caplog.records)
+
+    @pytest.mark.parametrize("blank_at", ["root", "middle"])
+    def test_a_blank_name_drops_the_chain_wherever_it_sits(
+        self, blank_at: str, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A blank name reads as nameless, and position cannot tell it from a failed load.
+
+        `ProjectTemplate.name` has no `min_length` and `get_project_chain` maps any falsy name
+        to None, so a loaded blank-named template is indistinguishable from an unresolvable
+        one -- including at the root, where it is nameless *and* last. Hence both ends: a rule
+        reading "nameless and last means the walk ended" returns `["Shot 020"]` for a project
+        three deep and presents it to the Cloud as a root.
+        """
+        names = {"root": {"acme": "", "mid": "Mid"}, "middle": {"acme": "Acme Studios", "mid": ""}}[blank_at]
+        project_manager = ProjectManager(Mock(), Mock(), Mock())
+        _register_project(project_manager, "acme", name=names["acme"])
+        _register_project(project_manager, "mid", name=names["mid"], parent_id="acme")
+        _register_project(project_manager, "shot-020", name="Shot 020", parent_id="mid")
+        project_manager._current_project_id = "shot-020"
+
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+            result = _succeed(self._manager_on(project_manager))
+
+        assert "project" not in _tags(result)
+        assert "Shot 020" not in result.header_value
+        assert any(record.levelno == logging.WARNING for record in caplog.records)
 
     def test_second_dispatch_reflects_a_project_switch(self) -> None:
         """The chain is read per invocation, never cached at workflow open."""
@@ -485,7 +516,12 @@ class TestSizeCap:
         return BudgetManager(MagicMock(), engine=mock_engine)
 
     def test_oversized_payload_reduces_to_minimum(self, caplog: pytest.LogCaptureFixture) -> None:
-        """Over the cap: drop workflow and node type, keep the leaf, still succeed."""
+        """Over the cap even without labels: the chain goes whole, and the call still succeeds.
+
+        Not down to the leaf -- paths are root-anchored, so `["Leaf"]` for a nested project
+        buys no narrower match than sending nothing and risks billing an unrelated top-level
+        "Leaf".
+        """
         manager = self._manager()
 
         with (
@@ -495,13 +531,14 @@ class TestSizeCap:
             result = _succeed(manager, node_type="GriptapeProxyImage")
 
         tags = _tags(result)
-        assert tags["project"] == ["Leaf"]
+        assert "project" not in tags
         assert "workflow" not in tags
         assert "node_type" not in tags
         # The structured fields have to agree with the reduced header, not the pre-encode values.
         assert result.workflow_name is None
         assert result.node_type is None
-        assert result.project_chain == ["Leaf"]
+        assert result.project_chain == []
+        # Empty *and* flagged: the chain was shed. Empty and unflagged means no project open.
         assert result.chain_truncated is True
         assert any(record.levelno == logging.WARNING for record in caplog.records)
 
@@ -633,22 +670,24 @@ class TestTransmissibility:
         assert "node_type" not in _tags(result)
         assert result.node_type is None
 
-    def test_an_unencodable_identifier_degrades_instead_of_raising(self) -> None:
-        """The encoder floor: identifiers are not filtered individually, so it must not raise.
+    def test_an_unencodable_identifier_costs_its_own_key_and_nothing_else(self) -> None:
+        """An identifier gets the same per-field filter every other dimension gets.
 
         `os.getenv` decodes with `surrogateescape`, so `orchestrator_engine_id` can arrive
-        holding a lone surrogate. Raising out of the handler would return `GenericResultFailure`,
-        which ignores `failure_log_level` and would log an ERROR with a traceback on every
-        metered call rather than degrading quietly.
+        holding a lone surrogate that `str.encode` refuses. Filtering at the read spends one
+        key on the documented "could not determine this" degradation; letting it reach the
+        encoder costs the whole header, and blames size for a problem that is not size.
         """
         mock_engine = _mock_engine()
         manager = BudgetManager(MagicMock(), engine=mock_engine)
 
         with patch.dict(os.environ, {"GTN_ORCHESTRATOR_ENGINE_ID": "eng-orch\udce9"}):
-            result = _dispatch(manager)
+            result = _succeed(manager)
 
-        assert isinstance(result, GetAttributionContextResultFailure)
-        assert "attribution" in str(result.result_details).lower()
+        tags = _tags(result)
+        assert "orchestrator_engine_id" not in tags
+        assert result.orchestrator_engine_id is None
+        assert tags["engine_id"] == mock_engine.engine_identity_manager.engine_id
 
 
 class TestConfidentiality:

--- a/tests/unit/retained_mode/managers/test_budget_manager.py
+++ b/tests/unit/retained_mode/managers/test_budget_manager.py
@@ -243,16 +243,20 @@ class TestProjectChain:
 
         assert _tags(result)["project"] == ["Shot 020"]
 
-    def test_a_project_actually_named_system_defaults_drops_the_chain(self, caplog: pytest.LogCaptureFixture) -> None:
+    @pytest.mark.parametrize("reserved_name", [SYSTEM_DEFAULTS_KEY, f" {SYSTEM_DEFAULTS_KEY} "])
+    def test_a_project_actually_named_system_defaults_drops_the_chain(
+        self, reserved_name: str, caplog: pytest.LogCaptureFixture
+    ) -> None:
         """A name collision with the Cloud's reserved value costs the whole chain.
 
         Nothing stops a user typing the reserved string into `name:`. The Cloud discards a
         client copy, which would drop that entry and promote its parent to leaf -- billing a
-        real project for spend it never incurred.
+        real project for spend it never incurred. Padding does not disguise it: the far end
+        strips before it tests the reserved value, so the comparison here has to strip too.
         """
         project_manager = ProjectManager(Mock(), Mock(), Mock())
         _register_project(project_manager, "grandparent", name="Acme Studios")
-        _register_project(project_manager, "leaf", name=SYSTEM_DEFAULTS_KEY, parent_id="grandparent")
+        _register_project(project_manager, "leaf", name=reserved_name, parent_id="grandparent")
         project_manager._current_project_id = "leaf"
 
         with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
@@ -416,12 +420,10 @@ class TestWorkflowName:
 
 
 class TestOrchestratorEngineId:
-    """Pins the resolver, NOT a shipping behavior.
+    """Pins the resolver, not a shipping behavior.
 
-    Under the forwarding design the orchestrator answers every attribution request, and the
-    orchestrator has no parent, so production never populates this key. Nobody should later
-    read these tests as evidence that worker spend is joinable to its orchestrator: it is
-    not, and it does not need to be, because budgets match on the project chain alone.
+    The orchestrator answers every attribution request and has no parent, so production never
+    populates this key. It is not evidence that worker spend is joinable to its orchestrator.
     """
 
     @pytest.fixture
@@ -613,8 +615,12 @@ class TestTransmissibility:
     CONTROL_CHAR_NAME = "Acme\nStudios"
     # A name read from a file whose bytes are not valid UTF-8 carries a lone surrogate.
     SURROGATE_NAME = "Renders \udce9"
+    # Truthy here, so `get_project_chain` hands it over as a name, but it strips to empty at
+    # the far end -- which drops the entry and promotes its parent to leaf.
+    WHITESPACE_NAME = "  "
+    NBSP_NAME = "\u00a0"
 
-    @pytest.mark.parametrize("bad_name", [CONTROL_CHAR_NAME, SURROGATE_NAME])
+    @pytest.mark.parametrize("bad_name", [CONTROL_CHAR_NAME, SURROGATE_NAME, WHITESPACE_NAME, NBSP_NAME])
     def test_an_untransmissible_name_drops_the_whole_chain(
         self, bad_name: str, caplog: pytest.LogCaptureFixture
     ) -> None:
@@ -645,6 +651,22 @@ class TestTransmissibility:
         manager = BudgetManager(MagicMock(), engine=mock_engine)
 
         assert _tags(_succeed(manager))["project"] == ["Acme Studios / S02 \u2014 v3"]
+
+    def test_a_padded_name_travels_in_the_form_the_far_end_stores(self) -> None:
+        """Normalize here or the result describes a string budgets never match.
+
+        The Cloud strips what it keeps, so `" Acme Studios "` is stored as `"Acme Studios"`.
+        Sending the padded form would leave `project_chain` reporting a value that no budget
+        rule can be written against.
+        """
+        mock_engine = _mock_engine()
+        mock_engine.project_manager.get_project_chain.return_value = [_entry("leaf", "  Acme Studios  ")]
+        manager = BudgetManager(MagicMock(), engine=mock_engine)
+
+        result = _succeed(manager)
+
+        assert _tags(result)["project"] == ["Acme Studios"]
+        assert result.project_chain == ["Acme Studios"]
 
     def test_an_untransmissible_workflow_key_is_omitted_without_touching_the_chain(self) -> None:
         """One unusable dimension costs its own key and nothing else."""

--- a/tests/unit/retained_mode/managers/test_budget_manager.py
+++ b/tests/unit/retained_mode/managers/test_budget_manager.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import base64
 import json
 import logging
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import MagicMock, Mock, PropertyMock, patch
@@ -406,7 +407,7 @@ class TestDegradation:
 
 
 class TestSizeCap:
-    """One reduction step and a floor, not a ladder."""
+    """Reduction sheds the cheapest dimensions first, then the chain, then fails."""
 
     def _manager(self) -> BudgetManager:
         mock_engine = _mock_engine()
@@ -436,11 +437,139 @@ class TestSizeCap:
         assert result.chain_truncated is True
         assert any(record.levelno == logging.WARNING for record in caplog.records)
 
+    def test_labels_are_shed_before_the_chain(self, caplog: pytest.LogCaptureFixture) -> None:
+        """An oversized payload gives up the workflow and node type before any ancestor.
+
+        The chain is the only dimension the Cloud matches budgets against, and its paths are
+        root-anchored, so an ancestor dropped to make room for an audit-only label costs every
+        match the Cloud would have made. Sized so the full payload is over the cap but the
+        chain survives without the labels: shedding the chain here would be pure loss.
+        """
+        manager = self._manager()
+
+        with (
+            patch.object(budget_manager_module, "_MAX_DECODED_PAYLOAD_BYTES", 100),
+            caplog.at_level(logging.WARNING, logger="griptape_nodes"),
+        ):
+            result = _succeed(manager, node_type="GriptapeProxyImage")
+
+        tags = _tags(result)
+        assert tags["project"] == ["leaf", "parent"]
+        assert "workflow" not in tags
+        assert "node_type" not in tags
+        assert result.project_chain == ["leaf", "parent"]
+        assert result.chain_truncated is False
+        assert any(record.levelno == logging.WARNING for record in caplog.records)
+
+    def test_reduction_of_a_single_entry_chain_does_not_claim_truncation(self) -> None:
+        """Reducing an oversized payload cuts nothing when the chain is already one deep.
+
+        `chain_truncated` says ancestors were dropped. A caller passing a huge `node_type`
+        can force the reduction step without the chain having anything to lose, and a
+        consumer reading the flag to decide whether project attribution is incomplete
+        would otherwise get a false positive.
+        """
+        mock_engine = _mock_engine()
+        mock_engine.project_manager.get_project_chain.return_value = [Mock(id="only")]
+        mock_engine.context_manager.has_current_workflow.return_value = True
+        mock_engine.context_manager.get_current_workflow_name.return_value = "shots/sh020"
+        manager = BudgetManager(MagicMock(), engine=mock_engine)
+
+        with patch.object(budget_manager_module, "_MAX_DECODED_PAYLOAD_BYTES", 80):
+            result = _succeed(manager, node_type="GriptapeProxyImage")
+
+        assert _tags(result)["project"] == ["only"]
+        assert result.project_chain == ["only"]
+        assert result.chain_truncated is False
+
     def test_unencodable_payload_fails_without_raising(self) -> None:
         """The floor: no usable header value exists, so Success would be a lie."""
         manager = self._manager()
 
         with patch.object(budget_manager_module, "_MAX_DECODED_PAYLOAD_BYTES", 1):
+            result = _dispatch(manager)
+
+        assert isinstance(result, GetAttributionContextResultFailure)
+        assert "attribution" in str(result.result_details).lower()
+
+
+class TestTransmissibility:
+    """A value the Cloud cannot store is dropped here rather than sent and discarded there.
+
+    Both shapes arrive the same way: a legacy project id is a canonical filesystem path
+    (`project_manager.py:795`) and the saved workflow key is derived from one. A path whose
+    bytes are not valid UTF-8 carries lone surrogates from `surrogateescape`; a directory name
+    may legally contain a control character.
+    """
+
+    # A path-shaped legacy project id holding a byte that is not valid UTF-8.
+    SURROGATE_ID = "/Users/alice/renders\udce9/project.yml"
+    # Legal on Linux, encodes fine here, and dropped by the Cloud's storability check.
+    CONTROL_CHAR_ID = "/Users/alice/two\nlines/project.yml"
+
+    @pytest.mark.parametrize("bad_id", [SURROGATE_ID, CONTROL_CHAR_ID])
+    def test_an_untransmissible_id_drops_the_whole_chain(self, bad_id: str, caplog: pytest.LogCaptureFixture) -> None:
+        """The chain goes as a unit: a partial chain bills an ancestor for the leaf's spend.
+
+        Budget paths are root-anchored, so a chain missing a link matches nothing either way.
+        Dropping only the offending entry would promote its parent to leaf and charge a real
+        project for spend it never incurred, which is worse than no attribution at all.
+        """
+        mock_engine = _mock_engine()
+        mock_engine.project_manager.get_project_chain.return_value = [Mock(id="leaf"), Mock(id=bad_id)]
+        manager = BudgetManager(MagicMock(), engine=mock_engine)
+
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+            result = _succeed(manager)
+
+        assert "project" not in _tags(result)
+        assert result.project_chain == []
+        assert any(record.levelno == logging.WARNING for record in caplog.records)
+
+    def test_a_transmissible_path_shaped_id_still_travels(self) -> None:
+        """The filter targets unstorable bytes, not paths -- a legacy id is still an id."""
+        mock_engine = _mock_engine()
+        mock_engine.project_manager.get_project_chain.return_value = [Mock(id="/Users/alice/acme/project.yml")]
+        manager = BudgetManager(MagicMock(), engine=mock_engine)
+
+        assert _tags(_succeed(manager))["project"] == ["/Users/alice/acme/project.yml"]
+
+    def test_an_untransmissible_workflow_key_is_omitted_without_touching_the_chain(self) -> None:
+        """One unusable dimension costs its own key and nothing else."""
+        mock_engine = _mock_engine()
+        mock_engine.project_manager.get_project_chain.return_value = [Mock(id="leaf")]
+        mock_engine.context_manager.has_current_workflow.return_value = True
+        mock_engine.context_manager.get_current_workflow_name.return_value = "shots/sh020\udce9/lighting"
+        manager = BudgetManager(MagicMock(), engine=mock_engine)
+
+        result = _succeed(manager)
+
+        tags = _tags(result)
+        assert "workflow" not in tags
+        assert tags["project"] == ["leaf"]
+        assert result.workflow_name is None
+
+    def test_an_untransmissible_node_type_is_omitted(self) -> None:
+        """`node_type` is caller-supplied, so it gets the same check as the engine's own facts."""
+        manager = BudgetManager(MagicMock(), engine=_mock_engine())
+
+        result = _succeed(manager, node_type="Griptape\udce9Image")
+
+        assert "node_type" not in _tags(result)
+        assert result.node_type is None
+
+    def test_an_unencodable_identifier_degrades_instead_of_raising(self) -> None:
+        """The encoder floor: identifiers are not filtered individually, so it must not raise.
+
+        `os.getenv` decodes with `surrogateescape`, so `orchestrator_engine_id` can arrive
+        holding a lone surrogate. Raising out of the handler would return `GenericResultFailure`,
+        which ignores `failure_log_level` and would log an ERROR with a traceback on every
+        metered call rather than degrading quietly.
+        """
+        mock_engine = _mock_engine()
+        manager = BudgetManager(MagicMock(), engine=mock_engine)
+
+        with patch.dict(os.environ, {"GTN_ORCHESTRATOR_ENGINE_ID": "eng-orch\udce9"}):
             result = _dispatch(manager)
 
         assert isinstance(result, GetAttributionContextResultFailure)

--- a/tests/unit/retained_mode/managers/test_budget_manager.py
+++ b/tests/unit/retained_mode/managers/test_budget_manager.py
@@ -293,8 +293,14 @@ class TestProjectChain:
             assert project_id not in serialized
             assert project_id not in result.header_value
 
-    def test_chain_deeper_than_the_cap_truncates_from_the_leaf(self) -> None:
-        """The chain is capped at the Cloud's own MAX_CHAIN_LENGTH, keeping the leaf end."""
+    def test_a_chain_deeper_than_the_cloud_keeps_still_travels_whole(self) -> None:
+        """Depth is the Cloud's to judge, not ours -- and judging it here is what hides it.
+
+        Forty entries is past the parser's MAX_CHAIN_LENGTH of 32, so the Cloud truncates,
+        records CHAIN_TRUNCATED, and marks the chain mangled, which takes it out of budget
+        matching entirely. Cutting to 32 before sending would suppress all three: the chain
+        arrives looking intact and matches a budget written against the wrong root.
+        """
         project_manager = ProjectManager(Mock(), Mock(), Mock())
         ids = [f"p{index:02d}" for index in range(40)]
         # ids[0] is the leaf; each entry's parent is the next one along.
@@ -306,9 +312,9 @@ class TestProjectChain:
         names = [f"Name {project_id}" for project_id in ids]
         result = _succeed(self._manager_on(project_manager))
 
-        assert _tags(result)["project"] == names[:32]
-        assert result.project_chain == names[:32]
-        assert result.chain_truncated is True
+        assert _tags(result)["project"] == names
+        assert result.project_chain == names
+        assert result.chain_truncated is False
 
     def test_an_unregistered_parent_drops_the_chain_and_never_falls_back_to_its_id(
         self, caplog: pytest.LogCaptureFixture
@@ -526,65 +532,14 @@ class TestSizeCap:
         mock_engine.context_manager.get_current_workflow_name.return_value = "shots/sh020/lighting"
         return BudgetManager(MagicMock(), engine=mock_engine)
 
-    def test_oversized_payload_reduces_to_minimum(self, caplog: pytest.LogCaptureFixture) -> None:
-        """Over the cap even without labels: the chain goes whole, and the call still succeeds.
+    def test_a_header_too_large_for_the_ingress_sheds_the_chain(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The only reduction left, run against the real bound rather than a patched one.
 
-        Not down to the leaf -- paths are root-anchored, so `["Leaf"]` for a nested project
-        buys no narrower match than sending nothing and risks billing an unrelated top-level
-        "Leaf".
-        """
-        manager = self._manager()
-
-        with (
-            patch.object(budget_manager_module, "_MAX_DECODED_PAYLOAD_BYTES", 80),
-            caplog.at_level(logging.WARNING, logger="griptape_nodes"),
-        ):
-            result = _succeed(manager, node_type="GriptapeProxyImage")
-
-        tags = _tags(result)
-        assert "project" not in tags
-        assert "workflow" not in tags
-        assert "node_type" not in tags
-        # The structured fields have to agree with the reduced header, not the pre-encode values.
-        assert result.workflow_name is None
-        assert result.node_type is None
-        assert result.project_chain == []
-        # Empty *and* flagged: the chain was shed. Empty and unflagged means no project open.
-        assert result.chain_truncated is True
-        assert any(record.levelno == logging.WARNING for record in caplog.records)
-
-    def test_labels_are_shed_before_the_chain(self, caplog: pytest.LogCaptureFixture) -> None:
-        """An oversized payload gives up the workflow and node type before any ancestor.
-
-        The chain is the only dimension the Cloud matches budgets against, and its paths are
-        root-anchored, so an ancestor dropped to make room for an audit-only label costs every
-        match the Cloud would have made. Sized so the full payload is over the cap but the
-        chain survives without the labels: shedding the chain here would be pure loss.
-        """
-        manager = self._manager()
-
-        with (
-            patch.object(budget_manager_module, "_MAX_DECODED_PAYLOAD_BYTES", 100),
-            caplog.at_level(logging.WARNING, logger="griptape_nodes"),
-        ):
-            result = _succeed(manager, node_type="GriptapeProxyImage")
-
-        tags = _tags(result)
-        assert tags["project"] == ["Leaf", "Parent"]
-        assert "workflow" not in tags
-        assert "node_type" not in tags
-        assert result.project_chain == ["Leaf", "Parent"]
-        assert result.chain_truncated is False
-        assert any(record.levelno == logging.WARNING for record in caplog.records)
-
-    def test_names_are_cut_before_the_chain_is_shed(self, caplog: pytest.LogCaptureFixture) -> None:
-        """Past the cap, cutting a name costs a signal that was already gone.
-
-        Sending names whole buys one thing: the far end sees it had to truncate and stops
-        matching the chain. A payload over the cap never reaches the far end to carry that,
-        so shedding the chain here lands the spend in the default bucket with nothing recorded
-        on either side. The cut form matches instead. Run against the real cap, because the
-        band this rung exists for starts near 3948 characters and nowhere else.
+        A 4200-character name encodes to 5888 bytes with its parent, past the 5632 the ingress
+        will carry. Nothing is repaired to get under that -- the name is not cut and the chain
+        is not shortened, because either would arrive looking intact. The chain goes whole and
+        the spend lands in the default budget, which is the same place the Cloud would have put
+        it once it saw a mangled chain.
         """
         mock_engine = _mock_engine()
         mock_engine.project_manager.get_project_chain.return_value = [
@@ -599,49 +554,30 @@ class TestSizeCap:
             result = _succeed(manager, node_type="GriptapeProxyImage")
 
         tags = _tags(result)
-        assert tags["project"] == ["S" * 256, "Acme Studios"]
-        assert result.project_chain == ["S" * 256, "Acme Studios"]
-        # Names were cut, not ancestors dropped. The flag says the latter.
-        assert result.chain_truncated is False
-        # The rung that cuts keeps the labels. Cutting this name frees thousands of bytes and
-        # the labels are worth tens, so shedding them alongside would cost a dashboard row for
-        # an overage the cut already covered.
+        assert "project" not in tags
+        assert result.project_chain == []
+        # Empty *and* flagged: the chain was shed. Empty and unflagged means no project open.
+        assert result.chain_truncated is True
+        # Only the chain is given up. The labels run tens of bytes against a 5632-byte bound,
+        # so shedding them alongside would cost a dashboard row and buy nothing.
         assert tags["workflow"] == "shots/sh020/lighting"
         assert tags["node_type"] == "GriptapeProxyImage"
-        assert any("cut" in record.getMessage() for record in caplog.records)
+        # The structured fields have to agree with the reduced header, not the pre-encode values.
+        assert result.workflow_name == "shots/sh020/lighting"
+        assert any(record.levelno == logging.WARNING for record in caplog.records)
 
-    def test_labels_are_shed_alongside_a_cut_only_when_cutting_alone_is_not_enough(self) -> None:
-        """The fourth rung exists, and nothing reaches it that the third could have served.
+    def test_an_enormous_chain_is_shed_whole_rather_than_in_part(self) -> None:
+        """There is no partial rung between the whole chain and none of it.
 
-        A long project name and an oversized workflow key together stay over the cap even with
-        every name cut, so this is the one shape that legitimately loses both.
+        Thirty-two names at 300 characters encode to 13192 bytes, twice the bound and past
+        nginx's own header buffer, so this is the shape that most tempts a prefix. Sending one
+        would present a nested project as a root: budget paths are root-anchored, so a partial
+        chain matches an unrelated top-level project of the same name at worst and nothing at
+        best, and neither end records that it happened.
         """
         mock_engine = _mock_engine()
         mock_engine.project_manager.get_project_chain.return_value = [
-            _entry("leaf", "S" * 4200),
-            _entry("root", "Acme Studios"),
-        ]
-        mock_engine.context_manager.has_current_workflow.return_value = True
-        mock_engine.context_manager.get_current_workflow_name.return_value = "w" * 4000
-        manager = BudgetManager(MagicMock(), engine=mock_engine)
-
-        result = _succeed(manager, node_type="GriptapeProxyImage")
-
-        tags = _tags(result)
-        assert tags["project"] == ["S" * 256, "Acme Studios"]
-        assert "workflow" not in tags
-        assert "node_type" not in tags
-        assert result.chain_truncated is False
-
-    def test_a_chain_too_long_even_cut_is_still_shed_whole(self) -> None:
-        """The new rung is a rung, not a floor: it does not rescue every oversized chain.
-
-        Thirty-two entries at the value cap encode past 4096 bytes even after cutting, so the
-        ladder still falls through to no chain rather than sending a partial one.
-        """
-        mock_engine = _mock_engine()
-        mock_engine.project_manager.get_project_chain.return_value = [
-            _entry(f"p{index}", "N" * 300) for index in range(budget_manager_module._MAX_PROJECT_CHAIN_ENTRIES)
+            _entry(f"p{index}", "N" * 300) for index in range(32)
         ]
         mock_engine.context_manager.has_current_workflow.return_value = True
         mock_engine.context_manager.get_current_workflow_name.return_value = "shots/sh020/lighting"
@@ -653,53 +589,7 @@ class TestSizeCap:
         assert "project" not in tags
         assert result.project_chain == []
         assert result.chain_truncated is True
-        # Losing the chain does not cost the labels. Shedding it frees thousands of bytes; the
-        # labels are worth tens, and the audit row is all that is left to say who spent this.
         assert tags["workflow"] == "shots/sh020/lighting"
-        assert tags["node_type"] == "GriptapeProxyImage"
-
-    def test_the_floor_sheds_the_labels_only_when_losing_the_chain_is_not_enough(self) -> None:
-        """The sixth rung, and the only shape that reaches it without a patched cap.
-
-        An oversized workflow key is itself what pushed the payload over, so shedding the chain
-        leaves it still over and the labels have to go too. Anything short of that keeps them.
-        """
-        mock_engine = _mock_engine()
-        mock_engine.project_manager.get_project_chain.return_value = [
-            _entry(f"p{index}", "N" * 300) for index in range(budget_manager_module._MAX_PROJECT_CHAIN_ENTRIES)
-        ]
-        mock_engine.context_manager.has_current_workflow.return_value = True
-        mock_engine.context_manager.get_current_workflow_name.return_value = "w" * 4000
-        manager = BudgetManager(MagicMock(), engine=mock_engine)
-
-        result = _succeed(manager, node_type="GriptapeProxyImage")
-
-        tags = _tags(result)
-        assert "project" not in tags
-        assert "workflow" not in tags
-        assert "node_type" not in tags
-        assert result.chain_truncated is True
-
-    def test_reduction_of_a_single_entry_chain_does_not_claim_truncation(self) -> None:
-        """Reducing an oversized payload cuts nothing when the chain is already one deep.
-
-        `chain_truncated` says ancestors were dropped. A caller passing a huge `node_type`
-        can force the reduction step without the chain having anything to lose, and a
-        consumer reading the flag to decide whether project attribution is incomplete
-        would otherwise get a false positive.
-        """
-        mock_engine = _mock_engine()
-        mock_engine.project_manager.get_project_chain.return_value = [_entry("only", "Only")]
-        mock_engine.context_manager.has_current_workflow.return_value = True
-        mock_engine.context_manager.get_current_workflow_name.return_value = "shots/sh020"
-        manager = BudgetManager(MagicMock(), engine=mock_engine)
-
-        with patch.object(budget_manager_module, "_MAX_DECODED_PAYLOAD_BYTES", 80):
-            result = _succeed(manager, node_type="GriptapeProxyImage")
-
-        assert _tags(result)["project"] == ["Only"]
-        assert result.project_chain == ["Only"]
-        assert result.chain_truncated is False
 
     def test_the_utf8_backstop_returns_none_instead_of_raising(self) -> None:
         """The one path no dispatch can reach, tested directly because it still has to hold.
@@ -718,15 +608,51 @@ class TestSizeCap:
 
         assert budget_manager_module._encode_attribution_payload(payload) is None
 
-    def test_unencodable_payload_fails_without_raising(self) -> None:
+    def test_a_header_that_does_not_fit_even_chainless_fails(self) -> None:
         """The floor: no usable header value exists, so Success would be a lie."""
         manager = self._manager()
 
-        with patch.object(budget_manager_module, "_MAX_DECODED_PAYLOAD_BYTES", 1):
+        with patch.object(budget_manager_module, "_MAX_ENCODED_HEADER_BYTES", 1):
             result = _dispatch(manager)
 
         assert isinstance(result, GetAttributionContextResultFailure)
         assert "attribution" in str(result.result_details).lower()
+
+    def test_an_unencodable_envelope_fails_rather_than_raising(self) -> None:
+        """The second backstop, tested directly for the same reason as the first.
+
+        Every dimension outside the chain is filtered through `_transmissible_or_none` and every
+        name through `_resolve_project_chain`, so the chainless envelope is unencodable only if
+        one of those filters has been broken. If that ever happens the cost of raising here is
+        an ERROR with a traceback on every metered call, so it returns None and the handler
+        answers Failure.
+        """
+        facts = budget_manager_module._AttributionFacts(
+            project_chain=["Leaf"],
+            workflow_name=None,
+            node_type=None,
+            engine_id=None,
+            orchestrator_engine_id=None,
+            session_id=None,
+        )
+
+        with patch.object(budget_manager_module, "_encode_attribution_payload", return_value=None):
+            assert budget_manager_module._encode_attribution_header(facts) is None
+
+    def test_a_chainless_payload_over_the_bound_fails_without_retrying_itself(self) -> None:
+        """With no chain there is nothing to give up, so the second attempt is not made.
+
+        Same Failure either way; the point is that the reduction path does not re-encode an
+        identical payload and log a warning about shedding a chain that was never there.
+        """
+        mock_engine = _mock_engine()
+        mock_engine.project_manager.get_project_chain.return_value = []
+        manager = BudgetManager(MagicMock(), engine=mock_engine)
+
+        with patch.object(budget_manager_module, "_MAX_ENCODED_HEADER_BYTES", 1):
+            result = _dispatch(manager)
+
+        assert isinstance(result, GetAttributionContextResultFailure)
 
 
 class TestTransmissibility:
@@ -853,11 +779,14 @@ class TestTransmissibility:
 
         assert _tags(result)["project"] == ["S" * 300 + "\n" + "S" * 20, "Acme Studios"]
 
-    def test_a_surrogate_past_the_value_cap_falls_back_to_the_cut_form(self) -> None:
-        """One name's truncation signal is worth less than every other dimension on the call.
+    def test_a_surrogate_past_the_value_cap_drops_the_chain(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Encodability is the one property judged on the whole name rather than the kept form.
 
-        A lone surrogate survives the strip and cannot be UTF-8 encoded, so sending the uncut
-        name would cost the entire header. The cut form drops the byte, which is the trade.
+        A lone surrogate past the cap is invisible to the Cloud -- its own truncation removes
+        the byte before it decides storability -- so the kept form passes every other test. But
+        the name that would travel cannot be encoded, and the cut form that could is a repair
+        arriving intact. The chain is dropped instead, which is the same abstention any other
+        unsendable name earns.
         """
         mock_engine = _mock_engine()
         mock_engine.project_manager.get_project_chain.return_value = [
@@ -866,9 +795,14 @@ class TestTransmissibility:
         ]
         manager = BudgetManager(MagicMock(), engine=mock_engine)
 
-        result = _succeed(manager)
+        with caplog.at_level(logging.WARNING, logger="griptape_nodes"):
+            result = _succeed(manager)
 
-        assert _tags(result)["project"] == ["S" * 256, "Acme Studios"]
+        assert "project" not in _tags(result)
+        assert result.project_chain == []
+        # Not the size path: nothing was shed to fit, so the flag stays down.
+        assert result.chain_truncated is False
+        assert any(record.levelno == logging.WARNING for record in caplog.records)
 
     def test_an_untransmissible_workflow_key_is_omitted_without_touching_the_chain(self) -> None:
         """One unusable dimension costs its own key and nothing else."""

--- a/tests/unit/retained_mode/managers/test_budget_manager.py
+++ b/tests/unit/retained_mode/managers/test_budget_manager.py
@@ -213,6 +213,28 @@ class TestProjectChain:
         mock_engine.project_manager = project_manager
         return BudgetManager(MagicMock(), engine=mock_engine)
 
+    @pytest.mark.parametrize(
+        "padded",
+        ["  <system-defaults>  ", "\t<system-defaults>", "<system-defaults>\n", " <system-defaults>"],
+    )
+    def test_a_padded_sentinel_copy_never_reaches_the_wire(self, padded: str) -> None:
+        """The far end strips before testing the reserved value, so a padded copy is the same claim.
+
+        Left whole it is dropped there rather than here, and a dropped entry promotes its parent
+        to leaf while `ENTRY_DROPPED` stays out of `mangled` -- so the short chain still matches
+        a budget and bills a real ancestor. The exact string cannot get this far (it is the
+        registry key for the rest state), but a padded one loads fine.
+        """
+        mock_engine = _mock_engine()
+        mock_engine.project_manager.get_project_chain.return_value = [
+            _entry(padded, "leaf"),
+            _entry("acme-studios-0b12d8", "root"),
+        ]
+        result = _succeed(BudgetManager(MagicMock(), engine=mock_engine))
+
+        assert _tags(result)["project"] == ["acme-studios-0b12d8"]
+        assert result.project_chain == ["acme-studios-0b12d8"]
+
     def test_system_defaults_never_reaches_the_wire(self) -> None:
         """The Cloud reserves `<system-defaults>` and counts a client copy as degraded."""
         project_manager = ProjectManager(Mock(), Mock(), Mock())

--- a/tests/unit/retained_mode/managers/test_manifest_manager.py
+++ b/tests/unit/retained_mode/managers/test_manifest_manager.py
@@ -38,12 +38,18 @@ def _library_metadata() -> LibraryMetadata:
     )
 
 
-def _project_info() -> ProjectTemplateInfo:
+def _project_info(
+    project_id: str = "/workspace/projectA/griptape-nodes-project.yml",
+    *,
+    name: str = "Project A",
+    parent_project_id: str | None = None,
+    project_file_path: str | None = "/workspace/projectA/griptape-nodes-project.yml",
+) -> ProjectTemplateInfo:
     info = MagicMock(spec=ProjectTemplateInfo)
-    info.project_id = "/workspace/projectA/griptape-nodes-project.yml"
-    info.name = "Project A"
-    info.project_file_path = "/workspace/projectA/griptape-nodes-project.yml"
-    info.parent_project_id = None
+    info.project_id = project_id
+    info.name = name
+    info.project_file_path = project_file_path
+    info.parent_project_id = parent_project_id
     return info
 
 
@@ -111,6 +117,45 @@ class TestManifestManager:
         assert project.name == "Project A"
         assert project.parent_project_id is None
         assert project.path == "/workspace/projectA/griptape-nodes-project.yml"
+
+    @pytest.mark.asyncio
+    async def test_manifest_exposes_id_keyed_parent_for_a_nested_template(
+        self, manifest_manager: ManifestManager
+    ) -> None:
+        """A child's `parent_project_id` joins to a parent entry's `project_id` within the manifest.
+
+        `parent_project_id` is carried so a consumer can rebuild the project hierarchy from the
+        manifest alone -- the engine is the only party that knows it. The existing tests only
+        assert the None case, so this pins the populated one.
+        """
+        parent = _project_info("p-1", name="Parent", project_file_path="/workspace/parent/project.yml")
+        child = _project_info(
+            "c-1", name="Child", parent_project_id="p-1", project_file_path="/workspace/parent/child/project.yml"
+        )
+
+        mock_engine = cast("MagicMock", manifest_manager.engine)
+        mock_engine.engine_identity_manager.engine_id = "engine-uuid-1"
+        mock_engine.ahandle_request = AsyncMock(
+            side_effect=[
+                ListProjectTemplatesResultSuccess(
+                    successfully_loaded=[parent, child],
+                    failed_to_load=[],
+                    result_details="ok",
+                ),
+                GetEngineVersionResultSuccess(major=1, minor=2, patch=3, result_details="ok"),
+            ]
+        )
+
+        result = await manifest_manager.on_generate_manifest_request(
+            GenerateManifestRequest(include_libraries=False, include_model_catalog=False)
+        )
+
+        assert isinstance(result, GenerateManifestResultSuccess)
+        entries = {entry.project_id: entry for entry in result.manifest.project_templates}
+        assert entries["p-1"].parent_project_id is None
+        assert entries["c-1"].parent_project_id == "p-1"
+        # The join has to resolve inside the manifest, which is the whole point of the field.
+        assert entries["c-1"].parent_project_id in entries
 
     @pytest.mark.asyncio
     async def test_generate_manifest_fails_when_library_listing_fails(self, manifest_manager: ManifestManager) -> None:

--- a/tests/unit/retained_mode/test_engine.py
+++ b/tests/unit/retained_mode/test_engine.py
@@ -184,6 +184,7 @@ class TestEngineScope:
             assert GriptapeNodes.get_instance() is scoped
             assert GriptapeNodes.FlowManager() is scoped.flow_manager
             assert GriptapeNodes.ObjectManager() is scoped.object_manager
+            assert GriptapeNodes.BudgetManager() is scoped.budget_manager
 
     @pytest.mark.asyncio
     async def test_task_created_inside_the_scope_inherits_the_binding(self) -> None:

--- a/tests/unit/worker/test_attribution_forwarding.py
+++ b/tests/unit/worker/test_attribution_forwarding.py
@@ -1,11 +1,9 @@
 """Worker-side attribution is answered by the orchestrator, not locally.
 
-A worker process has its own engine id and no workflow context, so composing the
-attribution header there would report the wrong engine and omit the workflow. The
-orchestrator holds the authoritative project chain and workflow name, so
-`GetAttributionContextRequest` joins `FORWARDED_REQUEST_TYPES` and a worker-side
-`RemoteHandler` forwards it -- but only inside a `worker_node_execution_scope`, which is
-the only time a node spends credits.
+A worker's project manager is a replica populated by broadcast, so it can serve a stale
+chain; the orchestrator holds the authoritative one. So `GetAttributionContextRequest`
+joins `FORWARDED_REQUEST_TYPES` and a worker-side `RemoteHandler` forwards it -- but only
+inside a `worker_node_execution_scope`, which is the only time a node spends credits.
 
 No shipping library runs worker-hosted today; a `worker_mode_override` config entry can
 flip one, which is why this is wired now rather than deferred.

--- a/tests/unit/worker/test_attribution_forwarding.py
+++ b/tests/unit/worker/test_attribution_forwarding.py
@@ -36,8 +36,7 @@ def _orchestrator_answer() -> GetAttributionContextResultSuccess:
     """A result only the orchestrator could have produced, so its origin is unambiguous."""
     return GetAttributionContextResultSuccess(
         header_value="from-the-orchestrator",
-        workflow_name="shots/sh020/lighting",
-        engine_id="orchestrator-engine",
+        project_chain=["orchestrator-project"],
         result_details="ok",
     )
 
@@ -65,7 +64,7 @@ class TestAttributionIsForwardedFromWorkers:
         assert result_event.succeeded()
         assert isinstance(result_event.result, GetAttributionContextResultSuccess)
         assert result_event.result.header_value == "from-the-orchestrator"
-        assert result_event.result.workflow_name == "shots/sh020/lighting"
+        assert result_event.result.project_chain == ["orchestrator-project"]
 
     @pytest.mark.asyncio
     async def test_attribution_is_local_outside_node_execution(self) -> None:

--- a/tests/unit/worker/test_attribution_forwarding.py
+++ b/tests/unit/worker/test_attribution_forwarding.py
@@ -1,0 +1,143 @@
+"""Worker-side attribution is answered by the orchestrator, not locally.
+
+A worker process has its own engine id and no workflow context, so composing the
+attribution header there would report the wrong engine and omit the workflow. The
+orchestrator holds the authoritative project chain and workflow name, so
+`GetAttributionContextRequest` joins `FORWARDED_REQUEST_TYPES` and a worker-side
+`RemoteHandler` forwards it -- but only inside a `worker_node_execution_scope`, which is
+the only time a node spends credits.
+
+No shipping library runs worker-hosted today; a `worker_mode_override` config entry can
+flip one, which is why this is wired now rather than deferred.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+
+from griptape_nodes.app.worker_routing import (
+    FORWARDED_REQUEST_TYPES,
+    RemoteHandler,
+    register_remote_handlers,
+)
+from griptape_nodes.retained_mode.engine import Engine
+from griptape_nodes.retained_mode.events.base_events import EventResultSuccess
+from griptape_nodes.retained_mode.events.budget_events import (
+    GetAttributionContextRequest,
+    GetAttributionContextResultSuccess,
+)
+from tests.unit.worker.harness import InProcessWorkerHarness
+
+
+def _orchestrator_answer() -> GetAttributionContextResultSuccess:
+    """A result only the orchestrator could have produced, so its origin is unambiguous."""
+    return GetAttributionContextResultSuccess(
+        header_value="from-the-orchestrator",
+        workflow_name="shots/sh020/lighting",
+        engine_id="orchestrator-engine",
+        result_details="ok",
+    )
+
+
+class TestAttributionIsForwardedFromWorkers:
+    """Inside node execution the orchestrator answers; outside it the worker does."""
+
+    @pytest.mark.asyncio
+    async def test_attribution_forwards_from_a_worker_in_node_execution(self) -> None:
+        harness = InProcessWorkerHarness()
+
+        async def orchestrator_handler(request: GetAttributionContextRequest) -> GetAttributionContextResultSuccess:  # noqa: ARG001
+            return _orchestrator_answer()
+
+        async def worker_local_handler(request: GetAttributionContextRequest) -> GetAttributionContextResultSuccess:  # noqa: ARG001
+            return GetAttributionContextResultSuccess(header_value="from-the-worker", result_details="ok")
+
+        harness.orchestrator.assign_manager_to_request_type(GetAttributionContextRequest, orchestrator_handler)
+        harness.worker.assign_manager_to_request_type(GetAttributionContextRequest, worker_local_handler)
+        harness.install_remote_handler(GetAttributionContextRequest)
+
+        with harness.worker.worker_node_execution_scope():
+            result_event = await harness.worker.ahandle_request(GetAttributionContextRequest())
+
+        assert result_event.succeeded()
+        assert isinstance(result_event.result, GetAttributionContextResultSuccess)
+        assert result_event.result.header_value == "from-the-orchestrator"
+        assert result_event.result.workflow_name == "shots/sh020/lighting"
+
+    @pytest.mark.asyncio
+    async def test_attribution_is_local_outside_node_execution(self) -> None:
+        """Worker bootstrap makes no metered calls, so answering locally there is correct."""
+        harness = InProcessWorkerHarness()
+
+        async def orchestrator_handler(request: GetAttributionContextRequest) -> GetAttributionContextResultSuccess:  # noqa: ARG001
+            return _orchestrator_answer()
+
+        async def worker_local_handler(request: GetAttributionContextRequest) -> GetAttributionContextResultSuccess:  # noqa: ARG001
+            return GetAttributionContextResultSuccess(header_value="from-the-worker", result_details="ok")
+
+        harness.orchestrator.assign_manager_to_request_type(GetAttributionContextRequest, orchestrator_handler)
+        harness.worker.assign_manager_to_request_type(GetAttributionContextRequest, worker_local_handler)
+        harness.install_remote_handler(GetAttributionContextRequest)
+
+        result_event = await harness.worker.ahandle_request(GetAttributionContextRequest())
+
+        assert result_event.succeeded()
+        assert isinstance(result_event.result, GetAttributionContextResultSuccess)
+        assert result_event.result.header_value == "from-the-worker"
+
+
+class TestAttributionForwardingIsWired:
+    """The one-line wiring, and the bootstrap invariant it depends on."""
+
+    def test_attribution_is_a_forwarded_request_type(self) -> None:
+        assert GetAttributionContextRequest in FORWARDED_REQUEST_TYPES
+
+    def test_register_remote_handlers_finds_a_budget_manager_owner(self) -> None:
+        """`register_remote_handlers` raises for a forwarded type with no registered owner.
+
+        BudgetManager is therefore constructed unconditionally, including on workers -- a
+        bootstrap-order bug here would surface as a worker that cannot start at all.
+        """
+        worker_engine = Engine()
+
+        register_remote_handlers(worker_engine.event_manager)
+
+        handler = worker_engine.event_manager.get_manager_for_request_type(GetAttributionContextRequest)
+        assert isinstance(handler, RemoteHandler)
+
+    def test_forwarding_works_from_a_pool_thread(self) -> None:
+        """Covers the sync caller: a driver on a library pool thread inside `process()`.
+
+        Every credit-consuming Cloud node is `aprocess()` today, and that path -- awaiting
+        the RemoteHandler on the worker's own loop -- is what the two harness tests above
+        exercise. A sync `process()` node reaches the same handler through a different
+        bridge: the pool thread has no running loop, so `_invoke_handler_from_sync` takes
+        its `RemoteHandler` branch and drives the coroutine with `asyncio.run`. Both need
+        to work, and only this one is off the async path.
+
+        The node-execution scope is a lock-guarded int on the EventManager rather than a
+        ContextVar precisely so entering it here is visible on the pool thread.
+        """
+        worker_engine = Engine()
+        event_manager = worker_engine.event_manager
+        local_handler = event_manager.get_manager_for_request_type(GetAttributionContextRequest)
+        assert local_handler is not None
+
+        async def fake_forward(request: Any, result_context: Any) -> EventResultSuccess:  # noqa: ARG001
+            return EventResultSuccess(request=request, result=_orchestrator_answer())
+
+        event_manager.forward_to_orchestrator = fake_forward  # type: ignore[method-assign]
+        event_manager.remove_manager_from_request_type(GetAttributionContextRequest)
+        event_manager.assign_manager_to_request_type(
+            GetAttributionContextRequest,
+            RemoteHandler(original=local_handler, event_manager=event_manager),
+        )
+
+        with event_manager.worker_node_execution_scope(), ThreadPoolExecutor(max_workers=1) as pool:
+            event_result = pool.submit(event_manager.handle_request, GetAttributionContextRequest()).result()
+
+        assert isinstance(event_result.result, GetAttributionContextResultSuccess)
+        assert event_result.result.header_value == "from-the-orchestrator"


### PR DESCRIPTION
Refs #5510 · Epic #5422 · Cross-repo epic griptape-ai/internal#221
Design doc: [budgets-and-usage-auditing-design.md](https://github.com/griptape-ai/griptape-cloud/blob/design/budgets-usage-auditing/docs/budgets-and-usage-auditing-design.md) §3.2, §5.1, §5.2, §10.1–§10.4
Cloud parser: griptape-ai/griptape-cloud#2225 · Consumers: griptape-ai/griptape-nodes-library-standard#589 (L1), griptape-ai/griptape-nodes-library-standard#601 (L2)

## What this does

Griptape Cloud is adding org-level budgets and usage auditing. Every credit-consuming call has to say which project it belongs to, and the engine is the only party that knows — the Cloud holds no project model. Today `ProjectManager` has the chain, and it isn't reachable from a node about to spend money.

E1 adds one request that answers the question: dispatch `GetAttributionContextRequest`, get back a ready-to-send `X-Griptape-Attribution` header value.

**No enforcement, no network calls.** Callers land in L1/L2 and #5515.

## The wire shape

The payload is `base64url(utf-8 JSON)`, padding kept. Working three deep in a project:

```jsonc
{
  "v": 1,
  "tags": {
    "project": ["shot-020-7c1e4a", "season-02-a3f9c1", "acme-studios-0b12d8"]  // leaf-first ids
  }
}
```

```
X-Griptape-Attribution: eyJ2IjoxLCJ0YWdzIjp7InByb2plY3QiOlsic2hvdC0wMjAtN2MxZTRhIiwic2Vhc29uLTAyLWEzZjljMSIsImFjbWUtc3R1ZGlvcy0wYjEyZDgiXX19
```

116 bytes. With no project open:

```jsonc
{ "v": 1 }
```

```
X-Griptape-Attribution: eyJ2IjoxfQ==
```

**`project` is the only key, because it is the only one the Cloud matches budgets against** (`MATCHABLE_TAG_KEYS = frozenset({PROJECT_TAG_KEY})`). It nests under `tags`; the parser reads no second namespace, so a top-level key is silently invisible, and `v` is the only sibling.

**The bare `{"v": 1}` reads exactly as no header at all** — a correction to an earlier revision of this description, caught by the review bot and verified against the parser. `Attribution()` defaults `tags_read` and `interpreted` to `True`, so the absent-header early return satisfies every conjunct of `project_chain_absent` just as the bare envelope does; the two produce equal objects and neither emits a metric. The envelope still goes out, but for forward-compatibility — if the Cloud adds a `client_attributed` flag it becomes a real signal without a client release — not because it currently says anything.

## Files

| File | |
| :-- | :-- |
| `retained_mode/events/budget_events.py` | new — the request, its two results, the header name and schema version |
| `retained_mode/managers/budget_manager.py` | new — `BudgetManager(EngineScoped)`: one resolver, a builder, an encoder |
| `retained_mode/engine.py`, `griptape_nodes.py` | standard manager wiring |
| `app/worker_routing.py` | one member added to `FORWARDED_REQUEST_TYPES` |
| `tests/…/test_budget_manager.py` | new — 33 tests |
| `tests/unit/worker/test_attribution_forwarding.py` | new — 5 tests |
| `tests/…/test_manifest_manager.py` | +1 regression test; `_project_info()` parameterized with defaults |

## Decision 1 — `tags.project` carries project ids, and ids are not opaque

Ids are what design doc §5.1 and internal#221 specify, and they are the right value: an id survives a rename, where a name would silently re-point that project's spend the moment a user edited it.

**But an id is not the opaque GUID that rule assumes, and this is the item most worth a reviewer's attention.** `ProjectTemplate.id` has no pattern and no length cap (`common/project_templates/project.py:52`). Its own field description says the editor proposes a slug of the project *name* plus a short random suffix, and that the user may override it with any unique string. A project created before ids existed gets the canonical absolute path to its file written in permanently (`project_manager.py:3386`):

```
/Users/alice/Documents/clients/acme/season-02/griptape-nodes-project.yml
```

So in practice an id discloses roughly what a name would, plus directory layout, in a header SSL-inspecting egress proxies log. Since this PR now sends nothing else, that is the entire privacy surface — which cuts both ways.

**Budget admins need an id picker.** `project` is the only matchable dimension, so an admin has to be able to author the value into a rule. Nobody types `season-02-a3f9c1` from memory, and nobody types that path at all. internal#221 specifies ids, so presumably the Cloud UI plans for this — worth confirming rather than assuming.

## Decision 2 — the engine never repairs a tag, never abstains, and enforces no size

The parser doesn't just clean a malformed tag, it *records* the cleaning. An over-long value sets `ENTRY_TRUNCATED`, an over-deep chain sets `CHAIN_TRUNCATED`, either sets `mangled`, and `is_chain_matchable` excludes a mangled chain from budget matching outright. Each also feeds `griptape_cloud.attribution.degraded`, so an admin can see it.

A client-side fix destroys all of that. A chain cut to 32 here, or a value cut to 256, arrives looking intact: no reason recorded, no metric, `mangled` stays false, and the Cloud confidently matches a budget against a chain missing its root. Loud non-billing becomes silent wrong-billing.

So **every id that travels does so exactly as the project stores it** — unstripped, uncut, unexamined. The one entry filtered is the `<system-defaults>` rest-state sentinel: not an ancestor the Cloud models, and a string it reserves as its own marker.

That filter matches on the *stripped* id, because that is the form the far end matches on — it strips each entry before testing the reserved value, so `"  <system-defaults>  "` is the same claim to it. Left whole, such an entry is dropped there rather than here, and per the section below a dropped entry bills a real ancestor. Skipping an entry is not the value-repair the rule forbids. Still uncovered: an id long enough that the far end's 256-character cut leaves exactly the reserved string, which would mean mirroring `MAX_VALUE_LENGTH` — the constant-mirroring this PR deleted on purpose. The durable fix is on the far end: `ENTRY_DROPPED` belongs in `mangled`.

### Why the sentinel is filtered rather than sent

An earlier revision of this PR did send it. The resolver returned every chain entry verbatim, and since `_current_project_id` rests at `<system-defaults>` and `get_project_chain()` always returns at least the starting project, an engine with no project open put `{"v": 1, "tags": {"project": ["<system-defaults>"]}}` on every metered call.

The far end does not read that as "default project", because it is the value the far end writes in itself. [cloud#2225](https://github.com/griptape-ai/griptape-cloud/pull/2225) degrades absent, malformed, oversize, unknown-version and empty headers alike to the Default chain `("<system-defaults>",)`, and rejects a client copy on the way in — its parser validates *after* truncation specifically because "a padded entry can cut down to exactly the reserved sentinel".

So the two spellings bill identically and differ only in what the platform's health metric then says about this client:

| what the engine sends | how the Cloud reads it | budget charged | metric |
| :-- | :-- | :-- | :-- |
| `{"v":1}` | client attributed no project | default | none |
| `{"v":1,"tags":{"project":["<system-defaults>"]}}` | entry dropped, `project` key left empty — "a loss, not an absence" | default | `griptape_cloud.attribution.degraded`, `outcome:default_chain` |

That vocabulary has a `no_chain` value precisely so a client which has not adopted project attribution "does not read as broken attribution in the slice that gates enforcement". `default_chain` is the fault slice, and it is the one Phase 2's exit criteria are read off. Sending the sentinel would park the entire desktop fleet in that slice permanently, on every idle call, in exchange for nothing — the spend lands in the same bucket either way.

Reversing this is one line in the resolver, and it becomes the right call only if the Cloud stops reserving the string and starts treating a client-sent `<system-defaults>` as a matchable project. That is a platform decision, not a client one.

**No size bound either.** Measured against the real endpoint with a synthetic header:

| header bytes | result |
| --: | :-- |
| 4000 – 32000 | 200 |
| 36000 – 44000 | **400** |
| 100000 | connection reset |

The edge carries at least 32 KB and fails loud past ~34 KB — never a silent truncation, which was the failure mode worth checking for. Against that, the engine's plausible worst case is 4008 bytes: 32 legacy path-shaped ids, which is the deepest chain the Cloud keeps. A slug-shaped chain three deep is 116. Between the parser's own 5632-byte raw cap and the edge's ~34 KB the request still succeeds and the Cloud reports `OVERSIZE` loudly, so there is no band where shrinking the header buys anything.

### The cost, stated plainly

**A dropped entry can now mis-bill an ancestor.** If an id reaches the Cloud that it won't store, `_clean_chain` drops that entry and promotes its parent to leaf — and `ENTRY_DROPPED` is deliberately excluded from `mangled`, so the shortened chain still matches a budget. A real ancestor gets billed for spend it never incurred.

An earlier revision of this PR abstained (dropped the whole chain) precisely to prevent that. Abstention is gone because it required the engine to predict the Cloud's storability rules, and a wrong prediction costs attribution silently in the other direction. This is the accepted trade, not an oversight.

## Other decisions worth a reviewer's attention

**3. No dimension but `project` ships in v1** — and that closes the `node_id` question [library-standard#601](https://github.com/griptape-ai/griptape-nodes-library-standard/pull/601) left to "whoever lands E1". `workflow`, `node_type`, `engine_id`, and `session_id` were in an earlier revision and came out: none is matchable, so all four were diagnostic breadcrumbs riding in a proxy-logged header on every metered call. Additive later — the parser ignores unknown envelope keys and keeps unknown tag keys.

**L2 impact:** `GetAttributionContextRequest` no longer takes `node_type`, so L2 dispatches it bare rather than resolving `node.metadata.get("node_type") or type(node).__name__`.

**4. Worker support is forwarding, not plumbing** — on a narrower rationale than before. With engine id and workflow out of the payload, the one reason left is that a worker's `ProjectManager` is a replica populated by `ActivateProjectRequest` broadcast and can serve a stale chain. Adding the request to `FORWARDED_REQUEST_TYPES` makes the orchestrator answer — one line plus an import — and costs the orchestrator path, which is all shipping traffic today, nothing. The rejected alternative (a field on `ExecuteNodeRequest` plus new `EventManager` state) was 4 files and a permanent public API for a path with zero traffic. Accepted cost on that same empty path: the calling thread blocks on IPC and a wedged orchestrator stalls it against the shared 30s `_forward_timeout_ms`. E1 owns neither, so **L2 must wrap its dispatch in its own ~2s budget.**

**5. "Never logged" is a convention, not an invariant** — the module docstring says so rather than claiming otherwise. `broadcast_result=False` is flippable per-instance, post-dispatch hooks get the full result regardless, and on a worker the payload crosses the response topic by construction. The one redaction primitive, `omit_from_result`, is request-side only; `header_value` is on the result. Follow-up.

## Never raise, and never guess on the caller's behalf

A caller asking for attribution is about to spend money, so failing to describe the spend must not stop it. Nothing here raises: no blanket try/except around the handler either, since `Engine.handle_request` already converts a raised handler exception into a Failure.

**Two Failure paths, and both send no header at all rather than a header the engine cannot stand behind.** A Failure does not block the call — it proceeds unattributed, and the spend lands in the default budget.

1. **The chain could not be read.** A raise out of `get_project_chain()` used to degrade to `[]`, which encodes to `{"v": 1}`. The engine at that moment knows nothing about whether a project is open, so it should not send an envelope that asserts one way or the other. Note this is an engine-honesty argument, not a wire one: per the correction above, the far end cannot tell the bare envelope from no header, so nothing downstream changes.
2. **An id cannot be encoded.** A legacy project's id is the path to its file, and a path whose bytes are not valid UTF-8 comes back from the OS carrying lone surrogates from `surrogateescape` that `str.encode` refuses. That costs the whole header: there is no honest partial form, and dropping just that entry would promote its parent to leaf and bill a real ancestor.

Both log at **WARNING**, via an explicit `ResultDetails` rather than the bare string that `ResultPayloadFailure` promotes to ERROR. Neither condition clears on its own — a legacy project keeps its unencodable id — so an ERROR would repeat once per metered call for something the artist cannot act on and that did not stop the work. The encoder returns `None` rather than raising for the same reason: an escaping handler exception becomes a `GenericResultFailure`, which ignores `failure_log_level` entirely.

**What this does not buy.** Both failures bill identically to the `{"v": 1}` they replace, and — since the two are indistinguishable at the parser — produce a bit-for-bit identical result there. No credits recovered, nothing new visible to an admin. What changes is engine-local: the engine stops asserting a fact it does not have, and the caller gets a Failure it can act on rather than a Success carrying an empty chain. The gap that remains is that no form raises an alarm; there is no reason code saying "this client attributes and failed to," so the only record is a local WARNING. See the follow-up on cloud#2239.

## Verification

- `make check` clean — ruff (incl. the TID251 facade ban), format, ty.
- `uv run pytest tests/unit -q` → **5894 passed, 23 skipped, 14 xfailed**. 100% line coverage on `budget_manager.py` and `budget_events.py`.
- Dispatched against a real engine and decoded: `project` under `tags`, leaf-first ids, no `<system-defaults>`, no project *name* anywhere, no `tags` key at all with no project open.
- The oversize table above is a live probe against `cloud.griptape.ai`, not a reading of nginx defaults.

## Still open across repos

The exact header name (mitigated — `header_name` ships on the result), and whether the budget admin UI can author ids (decision 1). Closed against #2225: the parser accepts omitted-when-unknown keys, and decodes padded base64url.

## Follow-ups (separate tickets)

- **griptape-cloud#2239, re-scoped rather than closed.** It asked the Cloud for a reason code so the engine could report client-side reductions. The engine makes no reductions any more, but it does have two failure paths where it knows attribution was lost and has no way to say so — a header that is simply absent is indistinguishable from a client that never attributes. Worth a `CLIENT_FAILED` reason or an equivalent.
- Extend `omit_from_result` to result payload fields.
- Give L2 its own ~2s attribution timeout instead of inheriting the 30s worker bound.
- Design doc §3.5 / §12 still list the manifest `parent_project_id` ask as open; it shipped in `72fac480` (#4835), and this PR adds the regression pin. §5.2's degradation table says 10 where the parser says 32.
- #5515 — the chat sidebar is an engine-side credit consumer L1/L2 can't reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



