### PR TITLE
fix(workflows): open a workflow whose library will not register

### DIFF
--- a/src/griptape_nodes/bootstrap/workflow_executors/local_workflow_executor.py
+++ b/src/griptape_nodes/bootstrap/workflow_executors/local_workflow_executor.py
@@ -38,8 +38,10 @@ from griptape_nodes.retained_mode.events.project_events import (
 )
 from griptape_nodes.retained_mode.events.workflow_events import (
     RunWorkflowFromScratchRequest,
+    RunWorkflowFromScratchResultSuccess,
     SaveWorkflowFileFromSerializedFlowRequest,
     SaveWorkflowFileFromSerializedFlowResultSuccess,
+    WorkflowStatus,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
@@ -202,6 +204,17 @@ class LocalWorkflowExecutor(WorkflowExecutor):
 
         if result.failed():
             msg = f"Failed to load workflow from path {workflow_path}"
+            _raise_load_error(msg)
+
+        # A FLAWED load succeeded but is missing pieces -- placeholders stand in for nodes whose
+        # library would not register. That trade is right in the editor, where an artist can see
+        # the placeholders and decide; here there is nobody to see them, so a run would silently
+        # produce output from an incomplete graph.
+        if isinstance(result, RunWorkflowFromScratchResultSuccess) and result.status is not WorkflowStatus.GOOD:
+            msg = (
+                f"Loaded workflow from path {workflow_path} with status {result.status}, "
+                f"which cannot be executed: {result.result_details}"
+            )
             _raise_load_error(msg)
 
     async def _handle_event_request(self, event: EventRequest) -> None:

--- a/src/griptape_nodes/exe_types/workflow_node.py
+++ b/src/griptape_nodes/exe_types/workflow_node.py
@@ -32,6 +32,7 @@ from griptape_nodes.retained_mode.events.parameter_events import SetParameterVal
 from griptape_nodes.retained_mode.events.workflow_events import (
     ImportWorkflowAsReferencedSubFlowRequest,
     ImportWorkflowAsReferencedSubFlowResultSuccess,
+    WorkflowStatus,
 )
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 
@@ -379,6 +380,19 @@ class WorkflowNode(ControlNode):
                 f"Failed because the workflow could not be loaded: {import_result.result_details}"
             )
             raise RuntimeError(msg)  # noqa: TRY004 - the import failed at run time; this is not a type error
+
+        # A FLAWED subflow loaded, but with placeholders standing in for nodes whose library would
+        # not register. This node is about to RUN it, and nothing downstream stops a placeholder
+        # that never resolves: ErrorProxyNode refuses only at validate_before_node_run, so a
+        # placeholder off the resolution path would let the subflow report output computed without
+        # it. Refuse here, the way the headless executor does for the same reason.
+        if import_result.status is not WorkflowStatus.GOOD:
+            msg = (
+                f"Attempted to load the workflow at '{self.workflow_file_path}' for node '{self.name}'. "
+                f"Failed because it loaded with status {import_result.status}, which cannot be executed: "
+                f"{import_result.result_details}"
+            )
+            raise RuntimeError(msg)
 
         self.metadata[SUBFLOW_NAME_KEY] = import_result.created_flow_name
         return import_result.created_flow_name

--- a/src/griptape_nodes/exe_types/workflow_node.py
+++ b/src/griptape_nodes/exe_types/workflow_node.py
@@ -387,6 +387,13 @@ class WorkflowNode(ControlNode):
         # placeholder off the resolution path would let the subflow report output computed without
         # it. Refuse here, the way the headless executor does for the same reason.
         if import_result.status is not WorkflowStatus.GOOD:
+            # The import already built a flow full of nodes. Hand it to the usual cleanup before
+            # refusing: left behind it would sit in ObjectManager for the rest of the session and
+            # keep its node names, so a later import of the same workflow gets suffixed ones.
+            # Tracking it only to discard it is deliberate -- the key must not outlive this call,
+            # or the next one would find a live subflow tracked and reuse it without re-checking.
+            self.metadata[SUBFLOW_NAME_KEY] = import_result.created_flow_name
+            self._discard_subflow()
             msg = (
                 f"Attempted to load the workflow at '{self.workflow_file_path}' for node '{self.name}'. "
                 f"Failed because it loaded with status {import_result.status}, which cannot be executed: "

--- a/src/griptape_nodes/retained_mode/events/workflow_events.py
+++ b/src/griptape_nodes/retained_mode/events/workflow_events.py
@@ -416,9 +416,13 @@ class ImportWorkflowAsReferencedSubFlowResultSuccess(WorkflowAlteredMixin, Resul
 
     Args:
         created_flow_name: Name of the created sub-flow
+        status: Fitness of the imported subflow's own load. FLAWED means placeholders stand in
+            for nodes whose library could not be registered -- editable, but not runnable.
+            Callers that import in order to RUN the subflow should refuse anything but GOOD.
     """
 
     created_flow_name: str
+    status: WorkflowStatus = WorkflowStatus.GOOD
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/events/workflow_events.py
+++ b/src/griptape_nodes/retained_mode/events/workflow_events.py
@@ -23,6 +23,15 @@ if TYPE_CHECKING:
     from griptape_nodes.retained_mode.events.flow_events import SerializedFlowCommands
 
 
+class WorkflowStatus(StrEnum):
+    """The status of a workflow that was attempted to be loaded."""
+
+    GOOD = "GOOD"
+    FLAWED = "FLAWED"
+    UNUSABLE = "UNUSABLE"
+    MISSING = "MISSING"
+
+
 @dataclass
 @PayloadRegistry.register
 class RunWorkflowFromScratchRequest(RequestPayload):
@@ -43,7 +52,16 @@ class RunWorkflowFromScratchRequest(RequestPayload):
 @dataclass
 @PayloadRegistry.register
 class RunWorkflowFromScratchResultSuccess(ResultPayloadSuccess):
-    """Workflow loaded and started successfully from file."""
+    """Workflow loaded and started successfully from file.
+
+    Args:
+        status: Fitness of the load. FLAWED means the graph is on the canvas with placeholders
+            standing in for nodes whose library could not be registered -- editable, but not
+            runnable until that library is available. Callers that need a whole graph (the
+            headless executor, publishing) should refuse anything but GOOD.
+    """
+
+    status: WorkflowStatus = WorkflowStatus.GOOD
 
 
 @dataclass
@@ -72,7 +90,16 @@ class RunWorkflowWithCurrentStateRequest(RequestPayload):
 @dataclass
 @PayloadRegistry.register
 class RunWorkflowWithCurrentStateResultSuccess(WorkflowAlteredMixin, ResultPayloadSuccess):
-    """Workflow loaded successfully while preserving current state."""
+    """Workflow loaded successfully while preserving current state.
+
+    Args:
+        status: Fitness of the load. FLAWED means the graph is on the canvas with placeholders
+            standing in for nodes whose library could not be registered -- editable, but not
+            runnable until that library is available. Callers that need a whole graph (the
+            headless executor, publishing) should refuse anything but GOOD.
+    """
+
+    status: WorkflowStatus = WorkflowStatus.GOOD
 
 
 @dataclass
@@ -103,7 +130,16 @@ class RunWorkflowFromRegistryRequest(RequestPayload):
 @dataclass
 @PayloadRegistry.register
 class RunWorkflowFromRegistryResultSuccess(ResultPayloadSuccess):
-    """Workflow from registry started successfully."""
+    """Workflow from registry started successfully.
+
+    Args:
+        status: Fitness of the load. FLAWED means the graph is on the canvas with placeholders
+            standing in for nodes whose library could not be registered -- editable, but not
+            runnable until that library is available. Callers that need a whole graph (the
+            headless executor, publishing) should refuse anything but GOOD.
+    """
+
+    status: WorkflowStatus = WorkflowStatus.GOOD
 
 
 @dataclass
@@ -909,15 +945,6 @@ class GetWorkflowMetadataResultSuccess(WorkflowNotAlteredMixin, ResultPayloadSuc
 @PayloadRegistry.register
 class GetWorkflowMetadataResultFailure(WorkflowNotAlteredMixin, ResultPayloadFailure):
     """Workflow metadata retrieval failed. Common causes: workflow not found, registry error, file load error."""
-
-
-class WorkflowStatus(StrEnum):
-    """The status of a workflow that was attempted to be loaded."""
-
-    GOOD = "GOOD"
-    FLAWED = "FLAWED"
-    UNUSABLE = "UNUSABLE"
-    MISSING = "MISSING"
 
 
 class WorkflowDependencyStatus(StrEnum):

--- a/src/griptape_nodes/retained_mode/managers/fitness_problems/workflows/library_not_registered_problem.py
+++ b/src/griptape_nodes/retained_mode/managers/fitness_problems/workflows/library_not_registered_problem.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import ClassVar
 
 from griptape_nodes.retained_mode.managers.fitness_problems.workflows.workflow_problem import WorkflowProblem
 
@@ -21,6 +22,8 @@ class LibraryNotRegisteredProblem(WorkflowProblem):
     library_name: str
     reason: str | None = None
 
+    _GENERIC_REASON: ClassVar[str] = "May have other problems preventing load."
+
     @classmethod
     def collate_problems_for_display(cls, instances: list[LibraryNotRegisteredProblem]) -> str:
         """Display library not registered problems.
@@ -29,20 +32,21 @@ class LibraryNotRegisteredProblem(WorkflowProblem):
         """
         if len(instances) == 1:
             problem = instances[0]
-            return f"'{problem.library_name}' not registered. {problem._reason_or_default()}"
+            return f"'{problem.library_name}' not registered. {problem.reason or cls._GENERIC_REASON}"
 
         # Sort by library_name
         sorted_instances = sorted(instances, key=lambda p: p.library_name)
 
-        output_lines = []
-        output_lines.append(f"{len(instances)} libraries not registered:")
-        for i, problem in enumerate(sorted_instances, 1):
-            output_lines.append(f"  {i}. {problem.library_name}: {problem._reason_or_default()}")
+        # Only a recorded reason earns a per-library line. With none, the generic sentence
+        # belongs in the header: repeating it against every name says nothing N times.
+        if any(problem.reason for problem in sorted_instances):
+            header = f"{len(instances)} libraries not registered:"
+            rows = [
+                f"  {i}. {problem.library_name}: {problem.reason or cls._GENERIC_REASON}"
+                for i, problem in enumerate(sorted_instances, 1)
+            ]
+        else:
+            header = f"{len(instances)} libraries not registered (may have other problems preventing load):"
+            rows = [f"  {i}. {problem.library_name}" for i, problem in enumerate(sorted_instances, 1)]
 
-        return "\n".join(output_lines)
-
-    def _reason_or_default(self) -> str:
-        """The recorded reason, or the generic stand-in when none was captured."""
-        if self.reason is None:
-            return "May have other problems preventing load."
-        return self.reason
+        return "\n".join([header, *rows])

--- a/src/griptape_nodes/retained_mode/managers/fitness_problems/workflows/library_not_registered_problem.py
+++ b/src/griptape_nodes/retained_mode/managers/fitness_problems/workflows/library_not_registered_problem.py
@@ -10,9 +10,16 @@ class LibraryNotRegisteredProblem(WorkflowProblem):
     """Problem indicating a required library was not successfully registered.
 
     This is stackable - multiple libraries can fail to register.
+
+    `reason` carries why registration failed, when the recorder knows. A library that is
+    present on disk but switched off in `libraries_to_register` is the case that most needs
+    it: without the reason the reader goes looking for something that is already there.
+    Callers that only observed the absence (the metadata dependency check, which reads the
+    registered-library list rather than attempting a registration) leave it None.
     """
 
     library_name: str
+    reason: str | None = None
 
     @classmethod
     def collate_problems_for_display(cls, instances: list[LibraryNotRegisteredProblem]) -> str:
@@ -22,14 +29,20 @@ class LibraryNotRegisteredProblem(WorkflowProblem):
         """
         if len(instances) == 1:
             problem = instances[0]
-            return f"'{problem.library_name}' not registered. May have other problems preventing load."
+            return f"'{problem.library_name}' not registered. {problem._reason_or_default()}"
 
         # Sort by library_name
         sorted_instances = sorted(instances, key=lambda p: p.library_name)
 
         output_lines = []
-        output_lines.append(f"{len(instances)} libraries not registered (may have other problems preventing load):")
+        output_lines.append(f"{len(instances)} libraries not registered:")
         for i, problem in enumerate(sorted_instances, 1):
-            output_lines.append(f"  {i}. {problem.library_name}")
+            output_lines.append(f"  {i}. {problem.library_name}: {problem._reason_or_default()}")
 
         return "\n".join(output_lines)
+
+    def _reason_or_default(self) -> str:
+        """The recorded reason, or the generic stand-in when none was captured."""
+        if self.reason is None:
+            return "May have other problems preventing load."
+        return self.reason

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import contextvars
 import logging
 import pickle
 import re
@@ -247,6 +248,12 @@ WorkflowShapeNodes = dict[str, NodeParameterMap]  # {node_name: {param_name: par
 
 logger = logging.getLogger("griptape_nodes")
 
+# WorkflowManager.LoadProblemFrame writes this; is_loading_workflow reads it. Scoped to the
+# current context so concurrent loads cannot pop or read each other's frames.
+_load_problem_frames: contextvars.ContextVar[tuple[list[WorkflowProblem], ...]] = contextvars.ContextVar(
+    "workflow_load_problem_frames", default=()
+)
+
 
 class WorkflowRegistrationResult(NamedTuple):
     """Result of processing workflows for registration."""
@@ -374,6 +381,58 @@ class WorkflowManager(EngineScoped):
             self.manager._referenced_workflow_stack.pop()
 
     _referenced_workflow_stack: list[str] = field(default_factory=list)
+
+    class LoadProblemFrame:
+        """Collects one workflow load's problems, bubbling them into the enclosing load on exit.
+
+        A workflow file can import another workflow as a referenced subflow, and that import
+        runs as a nested request dispatched from inside the outer file's exec() -- so the inner
+        load's problems have no return path to the outer one. Without bubbling, an outer load
+        reports GOOD while the canvas holds the inner load's placeholders, and a caller that
+        gates on status (the headless executor) runs an incomplete graph.
+
+        The stack lives in a ContextVar rather than on the manager because loads genuinely run
+        concurrently: in PARALLEL execution mode a WorkflowNode loads its subflow from inside a
+        node body, and those bodies run as separate tasks. A shared list would let one task pop
+        another's frame, so a load would report a library a *different* workflow was missing --
+        or see a sibling's open frame and suppress the only report of its own. A task inherits a
+        copy of the context, so a nested load still reaches the enclosing frame (same task) while
+        siblings stay isolated. `EventSuppressionContext` is contextvar-scoped for the same reason.
+        """
+
+        def __init__(self) -> None:
+            self.problems: list[WorkflowProblem] = []
+            self._tokens: list[contextvars.Token[tuple[list[WorkflowProblem], ...]]] = []
+
+        def __enter__(self) -> WorkflowManager.LoadProblemFrame:
+            self._tokens.append(_load_problem_frames.set((*_load_problem_frames.get(), self.problems)))
+            return self
+
+        def __exit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc_value: BaseException | None,
+            exc_traceback: TracebackType | None,
+        ) -> None:
+            frames = _load_problem_frames.get()
+            if len(frames) > 1:
+                enclosing = frames[-2]
+                # A library the outer file declares for itself AND reaches through a subflow
+                # would otherwise be counted twice, and the collated display would name it
+                # twice while claiming two libraries are missing.
+                enclosing.extend(problem for problem in self.problems if problem not in enclosing)
+            if self._tokens:
+                _load_problem_frames.reset(self._tokens.pop())
+
+    def is_loading_workflow(self) -> bool:
+        """Whether a workflow load is in progress, so its result will report the problems found.
+
+        Read after a nested load has closed, so a frame still on the stack is an ENCLOSING load.
+        That makes this the complement of the bubble in LoadProblemFrame.__exit__: exactly one of
+        the two names any given problem. A frame that stopped bubbling would have to stop
+        answering True here as well, or nothing would report it.
+        """
+        return len(_load_problem_frames.get()) > 0
 
     class WorkflowExecutionResult(NamedTuple):
         """Result of a workflow execution.
@@ -792,7 +851,7 @@ class WorkflowManager(EngineScoped):
             if not wf_info.problems:
                 problems = "No problems detected."
             else:
-                collated_strings = self.collate_problems_for_display(wf_info.problems)
+                collated_strings = self.collate_problems_by_type(wf_info.problems)
 
                 # Format for display
                 if len(collated_strings) == 1:
@@ -878,7 +937,17 @@ class WorkflowManager(EngineScoped):
         # Resolve path using utility function
         workspace_path = self.engine.config_manager.workspace_path
         complete_file_path = resolve_workspace_path(Path(relative_file_path), workspace_path)
-        problems: list[WorkflowProblem] = []
+        # Problems found anywhere under this load land in the frame, including those of a
+        # referenced subflow imported from inside exec() -- see LoadProblemFrame.
+        with WorkflowManager.LoadProblemFrame() as frame:
+            return await self._run_workflow_in_frame(
+                relative_file_path=relative_file_path, complete_file_path=complete_file_path, frame=frame
+            )
+
+    async def _run_workflow_in_frame(
+        self, *, relative_file_path: str, complete_file_path: Path, frame: LoadProblemFrame
+    ) -> WorkflowExecutionResult:
+        """Read, resolve libraries for, and exec one workflow file, recording problems in `frame`."""
         try:
             async with await anyio.open_file(Path(complete_file_path), encoding="utf-8") as file:
                 workflow_content = await file.read()
@@ -887,7 +956,7 @@ class WorkflowManager(EngineScoped):
             # The metadata header lists every library the workflow uses; each must
             # be registered (discovery is triggered if needed) so node construction
             # inside the script can succeed.
-            problems = await self._ensure_libraries_for_workflow(relative_file_path=relative_file_path)
+            frame.problems.extend(await self._ensure_libraries_for_workflow(relative_file_path=relative_file_path))
 
             # _generate_workflow_run_prerequisite_code emits one registration per header entry,
             # so each library we just failed to register is about to fail again on a request the
@@ -896,7 +965,7 @@ class WorkflowManager(EngineScoped):
             # in-file failures are the only record of what the workflow needs.
             duplicate_library_failures = (
                 EventSuppressionContext(self.engine.event_manager, {RegisterLibraryFromFileResultFailure})
-                if problems
+                if frame.problems
                 else nullcontext()
             )
             with duplicate_library_failures:
@@ -926,15 +995,15 @@ class WorkflowManager(EngineScoped):
                 execution_successful=False,
                 execution_details=f"Failed to run workflow on path '{complete_file_path}'. Exception: {e}",
                 status=WorkflowStatus.UNUSABLE,
-                problems=tuple(problems),
+                problems=tuple(frame.problems),
             )
         return WorkflowManager.WorkflowExecutionResult(
             execution_successful=True,
             execution_details=f"Succeeded in running workflow on path '{complete_file_path}'.",
             # A problem that did not stop the load leaves it recoverable: the graph is on the
             # canvas, with placeholders where the missing library's nodes belong.
-            status=WorkflowStatus.FLAWED if problems else WorkflowStatus.GOOD,
-            problems=tuple(problems),
+            status=WorkflowStatus.FLAWED if frame.problems else WorkflowStatus.GOOD,
+            problems=tuple(frame.problems),
         )
 
     async def _ensure_libraries_for_workflow(self, *, relative_file_path: str) -> list[WorkflowProblem]:
@@ -1005,7 +1074,7 @@ class WorkflowManager(EngineScoped):
         return problems
 
     @staticmethod
-    def collate_problems_for_display(problems: Iterable[WorkflowProblem]) -> list[str]:
+    def collate_problems_by_type(problems: Iterable[WorkflowProblem]) -> list[str]:
         """Group problems by type and let each type render its own instances, one string per group.
 
         Every problem class owns its wording and its singular/plural form, so grouping is what
@@ -1032,7 +1101,7 @@ class WorkflowManager(EngineScoped):
         """
         details = [
             ResultDetail(message=problem, level=logging.WARNING)
-            for problem in cls.collate_problems_for_display(execution_result.problems)
+            for problem in cls.collate_problems_by_type(execution_result.problems)
         ]
         # Only a load that survived has placeholders to point at; a failed one cleared the
         # canvas. Said once for the whole load rather than per problem, which is what keeps
@@ -1526,7 +1595,7 @@ class WorkflowManager(EngineScoped):
 
     def _build_workflow_info_payload(self, wf_info: WorkflowInfo) -> WorkflowInfoSummary:
         """Build a WorkflowInfoSummary from a WorkflowInfo, collating problems for display."""
-        collated_problems = self.collate_problems_for_display(wf_info.problems)
+        collated_problems = self.collate_problems_by_type(wf_info.problems)
         return WorkflowInfoSummary(
             status=wf_info.status,
             workflow_name=wf_info.workflow_name,
@@ -6120,9 +6189,7 @@ class WorkflowManager(EngineScoped):
         if not workflow_result.execution_successful:
             details = f"Attempted to import workflow '{request.workflow_name}' as referenced sub flow. Failed because workflow execution failed: {workflow_result.execution_details}"
             return ImportWorkflowAsReferencedSubFlowResultFailure(
-                result_details=ResultDetails(
-                    *self._execution_result_details(workflow_result, level=logging.ERROR, message=details)
-                )
+                result_details=self._import_result_details(workflow_result, details, level=logging.ERROR)
             )
 
         # Get flows after importing to find the new referenced sub flow
@@ -6155,14 +6222,25 @@ class WorkflowManager(EngineScoped):
         details = (
             f"Successfully imported workflow '{request.workflow_name}' as referenced sub flow '{created_flow_name}'"
         )
-        # A referenced subflow's libraries are not in the importing workflow's own header, so this
-        # is the only result that can name them -- the outer load has nothing to report.
         return ImportWorkflowAsReferencedSubFlowResultSuccess(
             created_flow_name=created_flow_name,
-            result_details=ResultDetails(
-                *self._execution_result_details(workflow_result, level=logging.DEBUG, message=details)
-            ),
+            status=workflow_result.status,
+            result_details=self._import_result_details(workflow_result, details, level=logging.DEBUG),
         )
+
+    def _import_result_details(
+        self, workflow_result: WorkflowExecutionResult, message: str, *, level: int
+    ) -> ResultDetails:
+        """Render an import result, naming the subflow's problems only if nobody else will.
+
+        Nested inside a load, the subflow's problems have already bubbled into the enclosing
+        frame and will be reported on that load's result; naming them here too would warn twice
+        for one condition. Imported on its own -- the editor dropping a workflow into a flow --
+        there is no such load, so this is the only result that can name them.
+        """
+        if self.is_loading_workflow():
+            return ResultDetails(message=message, level=level)
+        return ResultDetails(*self._execution_result_details(workflow_result, level=level, message=message))
 
     @staticmethod
     def _select_top_level_imported_flow(

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -7,6 +7,7 @@ import pickle
 import re
 import sys
 from collections import defaultdict
+from contextlib import nullcontext
 from dataclasses import dataclass, field, fields, is_dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
@@ -78,6 +79,7 @@ from griptape_nodes.retained_mode.events.library_events import (
     ListRegisteredLibrariesRequest,
     ListRegisteredLibrariesResultSuccess,
     RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultFailure,
 )
 from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
 from griptape_nodes.retained_mode.events.os_events import (
@@ -199,6 +201,7 @@ from griptape_nodes.retained_mode.events.workflow_events import (
     WorkflowInfoSummary,
     WorkflowStatus,
 )
+from griptape_nodes.retained_mode.managers.event_manager import EventSuppressionContext
 from griptape_nodes.retained_mode.managers.fitness_problems.workflows import (
     InvalidDependencyVersionStringProblem,
     InvalidLibraryVersionStringProblem,
@@ -373,10 +376,18 @@ class WorkflowManager(EngineScoped):
     _referenced_workflow_stack: list[str] = field(default_factory=list)
 
     class WorkflowExecutionResult(NamedTuple):
-        """Result of a workflow execution."""
+        """Result of a workflow execution.
+
+        `unresolved_libraries` names the declared libraries that would not register, one
+        user-facing message each. It is populated whether or not the run succeeded: a
+        library that never loads is reported as a warning on an otherwise-successful load
+        (its nodes come back as placeholders), and is the likeliest explanation when the
+        load fails outright.
+        """
 
         execution_successful: bool
         execution_details: str
+        unresolved_libraries: tuple[str, ...] = ()
 
     class SaveWorkflowScenario(StrEnum):
         """Scenarios for saving workflows."""
@@ -871,6 +882,7 @@ class WorkflowManager(EngineScoped):
         # Resolve path using utility function
         workspace_path = self.engine.config_manager.workspace_path
         complete_file_path = resolve_workspace_path(Path(relative_file_path), workspace_path)
+        unresolved_libraries: list[str] = []
         try:
             async with await anyio.open_file(Path(complete_file_path), encoding="utf-8") as file:
                 workflow_content = await file.read()
@@ -879,53 +891,74 @@ class WorkflowManager(EngineScoped):
             # The metadata header lists every library the workflow uses; each must
             # be registered (discovery is triggered if needed) so node construction
             # inside the script can succeed.
-            library_resolution_error = await self._ensure_libraries_for_workflow(
+            unresolved_libraries = await self._ensure_libraries_for_workflow(
                 relative_file_path=relative_file_path,
                 complete_file_path=complete_file_path,
             )
-            if library_resolution_error is not None:
-                return library_resolution_error
 
-            # Execute the workflow module with a dedicated namespace so `__file__` resolves
-            # to the workflow path and the `if __name__ == "__main__"` guard does not fire
-            # (which would try to spin up a second event loop via asyncio.run).
-            namespace: dict[str, Any] = {
-                "__file__": str(complete_file_path),
-                "__name__": "__gtn_workflow__",
-            }
-            exec(workflow_content, namespace)  # noqa: S102
+            # _generate_workflow_run_prerequisite_code emits one registration per header entry,
+            # so each library we just failed to register is about to fail again on a request the
+            # GUI would toast -- that equivalence is what makes suppressing the type here safe.
+            # It is conditional because an unreadable header pre-registers nothing: there the
+            # in-file failures are the only record of what the workflow needs.
+            duplicate_library_failures = (
+                EventSuppressionContext(self.engine.event_manager, {RegisterLibraryFromFileResultFailure})
+                if unresolved_libraries
+                else nullcontext()
+            )
+            with duplicate_library_failures:
+                # Execute the workflow module with a dedicated namespace so `__file__` resolves
+                # to the workflow path and the `if __name__ == "__main__"` guard does not fire
+                # (which would try to spin up a second event loop via asyncio.run).
+                namespace: dict[str, Any] = {
+                    "__file__": str(complete_file_path),
+                    "__name__": "__gtn_workflow__",
+                }
+                exec(workflow_content, namespace)  # noqa: S102
 
-            # New-style workflows wrap graph-building requests in `async def build_workflow()`
-            # so the module is inert at import time. Await it here. Legacy workflows without
-            # build_workflow() have already executed their requests top-to-bottom during exec().
-            workflow_builder = namespace.get("build_workflow")
-            if workflow_builder is not None and iscoroutinefunction(workflow_builder):
-                await workflow_builder()
+                # New-style workflows wrap graph-building requests in `async def build_workflow()`
+                # so the module is inert at import time. Await it here. Legacy workflows without
+                # build_workflow() have already executed their requests top-to-bottom during exec().
+                workflow_builder = namespace.get("build_workflow")
+                if workflow_builder is not None and iscoroutinefunction(workflow_builder):
+                    await workflow_builder()
 
-            # After workflow execution, ensure there's always a current context by pushing
-            # the top-level flow if the context is empty. This fixes regressions where
-            # with Workflow Schema version 0.6.0+ workflows expect context to be established.
-            await self._ensure_workflow_context_established()
+                # After workflow execution, ensure there's always a current context by pushing
+                # the top-level flow if the context is empty. This fixes regressions where
+                # with Workflow Schema version 0.6.0+ workflows expect context to be established.
+                await self._ensure_workflow_context_established()
 
         except Exception as e:
             return WorkflowManager.WorkflowExecutionResult(
                 execution_successful=False,
                 execution_details=f"Failed to run workflow on path '{complete_file_path}'. Exception: {e}",
+                unresolved_libraries=tuple(unresolved_libraries),
             )
         return WorkflowManager.WorkflowExecutionResult(
             execution_successful=True,
             execution_details=f"Succeeded in running workflow on path '{complete_file_path}'.",
+            unresolved_libraries=tuple(unresolved_libraries),
         )
 
-    async def _ensure_libraries_for_workflow(
-        self, *, relative_file_path: str, complete_file_path: Path
-    ) -> WorkflowExecutionResult | None:
-        """Ensure every library the workflow declares is registered before exec.
+    async def _ensure_libraries_for_workflow(self, *, relative_file_path: str, complete_file_path: Path) -> list[str]:
+        """Register every library the workflow declares before exec, tolerating the ones that won't.
 
         Reads node_libraries_referenced from the workflow's TOML metadata header
         and dispatches a RegisterLibraryFromFileRequest for each entry via
-        ahandle_request. Returns a failure WorkflowExecutionResult if a library
-        cannot be resolved; None on success.
+        ahandle_request. Returns one user-facing message per library that would
+        not register; an empty list when every library resolved.
+
+        A library that cannot be registered does not by itself stop the load. The
+        nodes it owns come back from CreateNodeRequest as ErrorProxyNode placeholders
+        that carry the reason and preserve the graph's values and connections, so the
+        rest of the workflow stays open and editable and only execution is lost.
+        Refusing the load instead would deny the artist the one view that shows
+        which nodes need the library (issue #5505).
+
+        The load can still fail downstream for a reason the missing library causes:
+        a parameter value whose CLASS the library declares is emitted as a hard
+        import inside build_workflow() (see _build_deferred_import_statements), and
+        that raises before any node is created. Only the node types are recoverable.
 
         The engine (not the workflow file itself) owns library registration
         because worker-backed libraries spin up a dedicated subprocess when they
@@ -944,15 +977,16 @@ class WorkflowManager(EngineScoped):
             # Fall through to exec without pre-registering libraries; the engine
             # startup path may have already loaded them. This mirrors prior
             # behavior where a missing prereq block was survivable.
-            return None
+            return []
+        unresolved_libraries: list[str] = []
         for lib_ref in load_metadata_result.metadata.node_libraries_referenced:
             register_result = await self.engine.ahandle_request(
                 RegisterLibraryFromFileRequest(
                     library_name=lib_ref.library_name,
                     perform_discovery_if_not_found=True,
-                    # The outer RunWorkflowFromRegistry failure already names the missing library
-                    # in a user-readable form; suppressing this inner result keeps the GUI from
-                    # showing a duplicate `RegisterLibraryFromFile Failed` toast on top of it.
+                    # The run result carries this library in a user-readable form already;
+                    # suppressing this inner result keeps the GUI from showing a
+                    # `RegisterLibraryFromFile Failed` toast on top of it.
                     failure_log_level=logging.DEBUG,
                 )
             )
@@ -965,15 +999,43 @@ class WorkflowManager(EngineScoped):
                 )
                 version_suffix = f" v{lib_ref.library_version}" if has_real_version else ""
                 inner_details = getattr(register_result, "result_details", "")
-                details = (
-                    f"Workflow '{complete_file_path.name}' requires library "
+                # Stated as the fact alone. Whether its nodes actually became placeholders
+                # depends on the load surviving, which only the caller knows, so
+                # _execution_result_details adds that outcome on the success path.
+                unresolved_libraries.append(
+                    f"Workflow '{complete_file_path.name}' references library "
                     f"'{lib_ref.library_name}'{version_suffix}, which is not loaded. {inner_details}"
                 )
-                return WorkflowManager.WorkflowExecutionResult(
-                    execution_successful=False,
-                    execution_details=details,
-                )
-        return None
+        return unresolved_libraries
+
+    @staticmethod
+    def _execution_result_details(
+        execution_result: WorkflowExecutionResult, *, level: int, message: str | None = None
+    ) -> list[ResultDetail]:
+        """One warning per unresolved library, ahead of the run's detail (or `message` in its place).
+
+        The libraries come first: they explain both the placeholders on a successful load and,
+        on a failed one, the most likely reason the file could not be replayed. Every handler
+        that consumes a WorkflowExecutionResult reports them, or the load looks clean to the
+        caller while its graph is quietly full of placeholders.
+
+        Only a load that survived has placeholders to point at -- a failed one cleared the
+        canvas -- so the outcome is appended here rather than baked into the reason.
+        """
+        outcome = (
+            "Its nodes opened as placeholders that cannot run until the library is available."
+            if execution_result.execution_successful
+            else ""
+        )
+        details = [
+            # The reason ends in whatever the library manager left there -- a period, a paren,
+            # or the trailing newline of a subprocess's stderr -- so normalize before appending
+            # rather than emitting a run-on sentence or an orphan line break.
+            ResultDetail(message=f"{library.rstrip().rstrip('.')}. {outcome}".rstrip(), level=logging.WARNING)
+            for library in execution_result.unresolved_libraries
+        ]
+        details.append(ResultDetail(message=message or execution_result.execution_details, level=level))
+        return details
 
     async def on_run_workflow_from_scratch_request(self, request: RunWorkflowFromScratchRequest) -> ResultPayload:
         # Squelch any ResultPayloads that indicate the workflow was changed, because we are loading it into a blank slate.
@@ -995,10 +1057,14 @@ class WorkflowManager(EngineScoped):
             # Run the file, goddamn it
             execution_result = await self.run_workflow(relative_file_path=relative_file_path)
             if execution_result.execution_successful:
-                return RunWorkflowFromScratchResultSuccess(result_details=execution_result.execution_details)
+                return RunWorkflowFromScratchResultSuccess(
+                    result_details=ResultDetails(*self._execution_result_details(execution_result, level=logging.DEBUG))
+                )
 
             logger.error(execution_result.execution_details)
-            return RunWorkflowFromScratchResultFailure(result_details=execution_result.execution_details)
+            return RunWorkflowFromScratchResultFailure(
+                result_details=ResultDetails(*self._execution_result_details(execution_result, level=logging.ERROR))
+            )
 
     async def on_run_workflow_with_current_state_request(
         self, request: RunWorkflowWithCurrentStateRequest
@@ -1011,9 +1077,13 @@ class WorkflowManager(EngineScoped):
         execution_result = await self.run_workflow(relative_file_path=relative_file_path)
 
         if execution_result.execution_successful:
-            return RunWorkflowWithCurrentStateResultSuccess(result_details=execution_result.execution_details)
+            return RunWorkflowWithCurrentStateResultSuccess(
+                result_details=ResultDetails(*self._execution_result_details(execution_result, level=logging.DEBUG))
+            )
         logger.error(execution_result.execution_details)
-        return RunWorkflowWithCurrentStateResultFailure(result_details=execution_result.execution_details)
+        return RunWorkflowWithCurrentStateResultFailure(
+            result_details=ResultDetails(*self._execution_result_details(execution_result, level=logging.ERROR))
+        )
 
     async def on_run_workflow_from_registry_request(self, request: RunWorkflowFromRegistryRequest) -> ResultPayload:
         await self._workflows_loading_complete.wait()
@@ -1065,7 +1135,7 @@ class WorkflowManager(EngineScoped):
                 result_messages = []
                 if context_warning:
                     result_messages.append(ResultDetail(message=context_warning, level=logging.WARNING))
-                result_messages.append(ResultDetail(message=execution_result.execution_details, level=logging.ERROR))
+                result_messages.extend(self._execution_result_details(execution_result, level=logging.ERROR))
 
                 # Attempt to clear everything out, as we modified the engine state getting here.
                 clear_all_request = ClearAllObjectStateRequest(i_know_what_im_doing=True)
@@ -1078,7 +1148,7 @@ class WorkflowManager(EngineScoped):
         result_messages = []
         if context_warning:
             result_messages.append(ResultDetail(message=context_warning, level=logging.WARNING))
-        result_messages.append(ResultDetail(message=execution_result.execution_details, level=logging.DEBUG))
+        result_messages.extend(self._execution_result_details(execution_result, level=logging.DEBUG))
         return RunWorkflowFromRegistryResultSuccess(result_details=ResultDetails(*result_messages))
 
     def _persist_external_workflow_registration(self, full_path: str) -> None:
@@ -6038,7 +6108,11 @@ class WorkflowManager(EngineScoped):
 
         if not workflow_result.execution_successful:
             details = f"Attempted to import workflow '{request.workflow_name}' as referenced sub flow. Failed because workflow execution failed: {workflow_result.execution_details}"
-            return ImportWorkflowAsReferencedSubFlowResultFailure(result_details=details)
+            return ImportWorkflowAsReferencedSubFlowResultFailure(
+                result_details=ResultDetails(
+                    *self._execution_result_details(workflow_result, level=logging.ERROR, message=details)
+                )
+            )
 
         # Get flows after importing to find the new referenced sub flow
         flows_after = set(obj_manager.get_filtered_subset(type=ControlFlow).keys())
@@ -6070,8 +6144,13 @@ class WorkflowManager(EngineScoped):
         details = (
             f"Successfully imported workflow '{request.workflow_name}' as referenced sub flow '{created_flow_name}'"
         )
+        # A referenced subflow's libraries are not in the importing workflow's own header, so this
+        # is the only result that can name them -- the outer load has nothing to report.
         return ImportWorkflowAsReferencedSubFlowResultSuccess(
-            created_flow_name=created_flow_name, result_details=details
+            created_flow_name=created_flow_name,
+            result_details=ResultDetails(
+                *self._execution_result_details(workflow_result, level=logging.DEBUG, message=details)
+            ),
         )
 
     @staticmethod

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -226,7 +226,7 @@ from griptape_nodes.utils.file_utils import find_files_recursive
 from griptape_nodes.utils.string_utils import normalize_display_name
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Callable, Iterable, Sequence
     from types import TracebackType
 
     from griptape_nodes.exe_types.core_types import Parameter
@@ -378,16 +378,21 @@ class WorkflowManager(EngineScoped):
     class WorkflowExecutionResult(NamedTuple):
         """Result of a workflow execution.
 
-        `unresolved_libraries` names the declared libraries that would not register, one
-        user-facing message each. It is populated whether or not the run succeeded: a
-        library that never loads is reported as a warning on an otherwise-successful load
-        (its nodes come back as placeholders), and is the likeliest explanation when the
-        load fails outright.
+        `status` and `problems` mirror WorkflowInfo's fields, so a load's fitness is described
+        the same way whether it was assessed from the metadata header or observed while
+        replaying the file. Both are populated whether or not the run succeeded: a library that
+        never loads leaves the load FLAWED (its nodes come back as placeholders), and is the
+        likeliest explanation when the load fails outright.
+
+        Keeping the problems typed rather than pre-rendered lets a caller decide per problem
+        class -- an executor can refuse a FLAWED load that the editor is happy to open -- and
+        leaves the wording to each problem's own collate_problems_for_display.
         """
 
         execution_successful: bool
         execution_details: str
-        unresolved_libraries: tuple[str, ...] = ()
+        status: WorkflowStatus = WorkflowStatus.GOOD
+        problems: tuple[WorkflowProblem, ...] = ()
 
     class SaveWorkflowScenario(StrEnum):
         """Scenarios for saving workflows."""
@@ -703,7 +708,7 @@ class WorkflowManager(EngineScoped):
 
         return find_metadata_blocks(workflow_content, block_name)
 
-    def print_workflow_load_status(self, min_status: WorkflowStatus = WorkflowStatus.FLAWED) -> None:  # noqa: PLR0915
+    def print_workflow_load_status(self, min_status: WorkflowStatus = WorkflowStatus.FLAWED) -> None:
         workflow_file_paths = self.get_workflows_attempted_to_load()
         workflow_infos = []
         for workflow_file_path in workflow_file_paths:
@@ -787,16 +792,7 @@ class WorkflowManager(EngineScoped):
             if not wf_info.problems:
                 problems = "No problems detected."
             else:
-                # Group problems by type
-                problems_by_type = defaultdict(list)
-                for problem in wf_info.problems:
-                    problems_by_type[type(problem)].append(problem)
-
-                # Collate each group
-                collated_strings = []
-                for problem_class, instances in problems_by_type.items():
-                    collated_display = problem_class.collate_problems_for_display(instances)
-                    collated_strings.append(collated_display)
+                collated_strings = self.collate_problems_for_display(wf_info.problems)
 
                 # Format for display
                 if len(collated_strings) == 1:
@@ -882,7 +878,7 @@ class WorkflowManager(EngineScoped):
         # Resolve path using utility function
         workspace_path = self.engine.config_manager.workspace_path
         complete_file_path = resolve_workspace_path(Path(relative_file_path), workspace_path)
-        unresolved_libraries: list[str] = []
+        problems: list[WorkflowProblem] = []
         try:
             async with await anyio.open_file(Path(complete_file_path), encoding="utf-8") as file:
                 workflow_content = await file.read()
@@ -891,10 +887,7 @@ class WorkflowManager(EngineScoped):
             # The metadata header lists every library the workflow uses; each must
             # be registered (discovery is triggered if needed) so node construction
             # inside the script can succeed.
-            unresolved_libraries = await self._ensure_libraries_for_workflow(
-                relative_file_path=relative_file_path,
-                complete_file_path=complete_file_path,
-            )
+            problems = await self._ensure_libraries_for_workflow(relative_file_path=relative_file_path)
 
             # _generate_workflow_run_prerequisite_code emits one registration per header entry,
             # so each library we just failed to register is about to fail again on a request the
@@ -903,7 +896,7 @@ class WorkflowManager(EngineScoped):
             # in-file failures are the only record of what the workflow needs.
             duplicate_library_failures = (
                 EventSuppressionContext(self.engine.event_manager, {RegisterLibraryFromFileResultFailure})
-                if unresolved_libraries
+                if problems
                 else nullcontext()
             )
             with duplicate_library_failures:
@@ -932,21 +925,27 @@ class WorkflowManager(EngineScoped):
             return WorkflowManager.WorkflowExecutionResult(
                 execution_successful=False,
                 execution_details=f"Failed to run workflow on path '{complete_file_path}'. Exception: {e}",
-                unresolved_libraries=tuple(unresolved_libraries),
+                status=WorkflowStatus.UNUSABLE,
+                problems=tuple(problems),
             )
         return WorkflowManager.WorkflowExecutionResult(
             execution_successful=True,
             execution_details=f"Succeeded in running workflow on path '{complete_file_path}'.",
-            unresolved_libraries=tuple(unresolved_libraries),
+            # A problem that did not stop the load leaves it recoverable: the graph is on the
+            # canvas, with placeholders where the missing library's nodes belong.
+            status=WorkflowStatus.FLAWED if problems else WorkflowStatus.GOOD,
+            problems=tuple(problems),
         )
 
-    async def _ensure_libraries_for_workflow(self, *, relative_file_path: str, complete_file_path: Path) -> list[str]:
+    async def _ensure_libraries_for_workflow(self, *, relative_file_path: str) -> list[WorkflowProblem]:
         """Register every library the workflow declares before exec, tolerating the ones that won't.
 
         Reads node_libraries_referenced from the workflow's TOML metadata header
         and dispatches a RegisterLibraryFromFileRequest for each entry via
-        ahandle_request. Returns one user-facing message per library that would
-        not register; an empty list when every library resolved.
+        ahandle_request. Returns a LibraryNotRegisteredProblem per library that
+        would not register; an empty list when every library resolved. That is the
+        same problem type on_load_workflow_metadata_request records for the same
+        condition, so the two paths describe it identically.
 
         A library that cannot be registered does not by itself stop the load. The
         nodes it owns come back from CreateNodeRequest as ErrorProxyNode placeholders
@@ -978,7 +977,7 @@ class WorkflowManager(EngineScoped):
             # startup path may have already loaded them. This mirrors prior
             # behavior where a missing prereq block was survivable.
             return []
-        unresolved_libraries: list[str] = []
+        problems: list[WorkflowProblem] = []
         for lib_ref in load_metadata_result.metadata.node_libraries_referenced:
             register_result = await self.engine.ahandle_request(
                 RegisterLibraryFromFileRequest(
@@ -991,49 +990,61 @@ class WorkflowManager(EngineScoped):
                 )
             )
             if not register_result.succeeded():
-                # `library_version` may carry a non-semver placeholder (e.g. when the workflow was
-                # saved while the library was already unavailable, see node_manager._serialize_node_to_commands).
-                # Only render the version suffix when the stored value parses as semver.
-                has_real_version = bool(lib_ref.library_version) and semver.VersionInfo.is_valid(
-                    lib_ref.library_version
+                # The declared version is deliberately not reported. A library that never
+                # registered has no version to compare against, which is why the not-registered
+                # problem carries none -- the version-mismatch problems cover the case where a
+                # library IS present at the wrong version. It also keeps the non-semver
+                # placeholder a workflow stores when saved without its library (see
+                # node_manager._serialize_node_to_commands) from ever reaching the reader.
+                problems.append(
+                    LibraryNotRegisteredProblem(
+                        library_name=lib_ref.library_name,
+                        reason=str(getattr(register_result, "result_details", "")) or None,
+                    )
                 )
-                version_suffix = f" v{lib_ref.library_version}" if has_real_version else ""
-                inner_details = getattr(register_result, "result_details", "")
-                # Stated as the fact alone. Whether its nodes actually became placeholders
-                # depends on the load surviving, which only the caller knows, so
-                # _execution_result_details adds that outcome on the success path.
-                unresolved_libraries.append(
-                    f"Workflow '{complete_file_path.name}' references library "
-                    f"'{lib_ref.library_name}'{version_suffix}, which is not loaded. {inner_details}"
-                )
-        return unresolved_libraries
+        return problems
 
     @staticmethod
-    def _execution_result_details(
-        execution_result: WorkflowExecutionResult, *, level: int, message: str | None = None
-    ) -> list[ResultDetail]:
-        """One warning per unresolved library, ahead of the run's detail (or `message` in its place).
+    def collate_problems_for_display(problems: Iterable[WorkflowProblem]) -> list[str]:
+        """Group problems by type and let each type render its own instances, one string per group.
 
-        The libraries come first: they explain both the placeholders on a successful load and,
+        Every problem class owns its wording and its singular/plural form, so grouping is what
+        lets a workflow with five unregistered libraries say so once instead of five times.
+        """
+        problems_by_type: dict[type, list[WorkflowProblem]] = defaultdict(list)
+        for problem in problems:
+            problems_by_type[type(problem)].append(problem)
+        return [
+            problem_class.collate_problems_for_display(instances)
+            for problem_class, instances in problems_by_type.items()
+        ]
+
+    @classmethod
+    def _execution_result_details(
+        cls, execution_result: WorkflowExecutionResult, *, level: int, message: str | None = None
+    ) -> list[ResultDetail]:
+        """The run's problems as warnings, ahead of its detail (or `message` in its place).
+
+        The problems come first: they explain both the placeholders on a successful load and,
         on a failed one, the most likely reason the file could not be replayed. Every handler
         that consumes a WorkflowExecutionResult reports them, or the load looks clean to the
         caller while its graph is quietly full of placeholders.
-
-        Only a load that survived has placeholders to point at -- a failed one cleared the
-        canvas -- so the outcome is appended here rather than baked into the reason.
         """
-        outcome = (
-            "Its nodes opened as placeholders that cannot run until the library is available."
-            if execution_result.execution_successful
-            else ""
-        )
         details = [
-            # The reason ends in whatever the library manager left there -- a period, a paren,
-            # or the trailing newline of a subprocess's stderr -- so normalize before appending
-            # rather than emitting a run-on sentence or an orphan line break.
-            ResultDetail(message=f"{library.rstrip().removesuffix('.')}. {outcome}".rstrip(), level=logging.WARNING)
-            for library in execution_result.unresolved_libraries
+            ResultDetail(message=problem, level=logging.WARNING)
+            for problem in cls.collate_problems_for_display(execution_result.problems)
         ]
+        # Only a load that survived has placeholders to point at; a failed one cleared the
+        # canvas. Said once for the whole load rather than per problem, which is what keeps
+        # the problems' own wording intact.
+        if execution_result.problems and execution_result.execution_successful:
+            details.append(
+                ResultDetail(
+                    message="Nodes from the libraries above opened as placeholders. "
+                    "They preserve the graph but cannot run until their library is available.",
+                    level=logging.WARNING,
+                )
+            )
         details.append(ResultDetail(message=message or execution_result.execution_details, level=level))
         return details
 
@@ -1058,7 +1069,10 @@ class WorkflowManager(EngineScoped):
             execution_result = await self.run_workflow(relative_file_path=relative_file_path)
             if execution_result.execution_successful:
                 return RunWorkflowFromScratchResultSuccess(
-                    result_details=ResultDetails(*self._execution_result_details(execution_result, level=logging.DEBUG))
+                    status=execution_result.status,
+                    result_details=ResultDetails(
+                        *self._execution_result_details(execution_result, level=logging.DEBUG)
+                    ),
                 )
 
             logger.error(execution_result.execution_details)
@@ -1078,7 +1092,8 @@ class WorkflowManager(EngineScoped):
 
         if execution_result.execution_successful:
             return RunWorkflowWithCurrentStateResultSuccess(
-                result_details=ResultDetails(*self._execution_result_details(execution_result, level=logging.DEBUG))
+                status=execution_result.status,
+                result_details=ResultDetails(*self._execution_result_details(execution_result, level=logging.DEBUG)),
             )
         logger.error(execution_result.execution_details)
         return RunWorkflowWithCurrentStateResultFailure(
@@ -1149,7 +1164,9 @@ class WorkflowManager(EngineScoped):
         if context_warning:
             result_messages.append(ResultDetail(message=context_warning, level=logging.WARNING))
         result_messages.extend(self._execution_result_details(execution_result, level=logging.DEBUG))
-        return RunWorkflowFromRegistryResultSuccess(result_details=ResultDetails(*result_messages))
+        return RunWorkflowFromRegistryResultSuccess(
+            status=execution_result.status, result_details=ResultDetails(*result_messages)
+        )
 
     def _persist_external_workflow_registration(self, full_path: str) -> None:
         """Persist an out-of-workspace workflow path to global config so it survives restarts.
@@ -1509,13 +1526,7 @@ class WorkflowManager(EngineScoped):
 
     def _build_workflow_info_payload(self, wf_info: WorkflowInfo) -> WorkflowInfoSummary:
         """Build a WorkflowInfoSummary from a WorkflowInfo, collating problems for display."""
-        problems_by_type: dict[type, list] = defaultdict(list)
-        for problem in wf_info.problems:
-            problems_by_type[type(problem)].append(problem)
-        collated_problems = [
-            problem_class.collate_problems_for_display(instances)
-            for problem_class, instances in problems_by_type.items()
-        ]
+        collated_problems = self.collate_problems_for_display(wf_info.problems)
         return WorkflowInfoSummary(
             status=wf_info.status,
             workflow_name=wf_info.workflow_name,

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -965,7 +965,7 @@ class WorkflowManager(EngineScoped):
             # in-file failures are the only record of what the workflow needs.
             duplicate_library_failures = (
                 EventSuppressionContext(self.engine.event_manager, {RegisterLibraryFromFileResultFailure})
-                if frame.problems
+                if any(isinstance(problem, LibraryNotRegisteredProblem) for problem in frame.problems)
                 else nullcontext()
             )
             with duplicate_library_failures:
@@ -2119,8 +2119,10 @@ class WorkflowManager(EngineScoped):
             # See how our desired version compares against the actual library we (may) have.
             # Check if library is registered (silent check - no error logging)
             if library_name not in registered_libraries:
-                # Library not registered
-                had_critical_error = True
+                # Library not registered. Recoverable, not critical: the workflow opens with
+                # ErrorProxyNode placeholders standing in for that library's nodes, so calling it
+                # UNUSABLE would contradict what the editor is about to show (issue #5505). The
+                # version-mismatch and malformed-metadata problems below stay critical.
                 problems.append(LibraryNotRegisteredProblem(library_name=library_name))
                 dependency_infos.append(
                     WorkflowManager.WorkflowDependencyInfo(
@@ -2138,8 +2140,9 @@ class WorkflowManager(EngineScoped):
             library_metadata_result = self.engine.library_manager.get_library_metadata_request(library_metadata_request)
 
             if not isinstance(library_metadata_result, GetLibraryMetadataResultSuccess):
-                # Should not happen since we verified library is registered, but handle gracefully
-                had_critical_error = True
+                # Should not happen since we verified library is registered, but handle gracefully.
+                # Recoverable for the same reason as the unregistered case above: the library IS
+                # in the registry, so its nodes still construct -- only its version is unknown.
                 problems.append(LibraryNotRegisteredProblem(library_name=library_name))
                 dependency_infos.append(
                     WorkflowManager.WorkflowDependencyInfo(

--- a/src/griptape_nodes/retained_mode/managers/workflow_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/workflow_manager.py
@@ -1031,7 +1031,7 @@ class WorkflowManager(EngineScoped):
             # The reason ends in whatever the library manager left there -- a period, a paren,
             # or the trailing newline of a subprocess's stderr -- so normalize before appending
             # rather than emitting a run-on sentence or an orphan line break.
-            ResultDetail(message=f"{library.rstrip().rstrip('.')}. {outcome}".rstrip(), level=logging.WARNING)
+            ResultDetail(message=f"{library.rstrip().removesuffix('.')}. {outcome}".rstrip(), level=logging.WARNING)
             for library in execution_result.unresolved_libraries
         ]
         details.append(ResultDetail(message=message or execution_result.execution_details, level=level))

--- a/tests/unit/retained_mode/managers/test_workflow_load_missing_library.py
+++ b/tests/unit/retained_mode/managers/test_workflow_load_missing_library.py
@@ -1,0 +1,628 @@
+"""Opening a saved workflow whose library will not register (issue #5505).
+
+A library that cannot be registered -- uninstalled, or present on disk but disabled in
+``libraries_to_register`` -- must cost execution, never editing. The workflow still opens:
+nodes from the missing library come back as ``ErrorProxyNode`` placeholders carrying the
+reason, while every node, value, and connection from the libraries that did load is intact.
+
+What that covers is the missing library's NODE TYPES. A parameter value whose class the
+library declares is a separate matter: codegen emits it as a hard import inside
+``build_workflow()``, which raises before any node exists. These tests deliberately hold
+plain values, so none of them stray into that case.
+
+Each test drives the real path an artist takes. A graph is built against two real fixture
+libraries and saved through the real codegen, then the engine is rebuilt with only one of
+those libraries installed and the saved file is replayed through
+``WorkflowManager.run_workflow`` -- the same call ``RunWorkflowFromRegistryRequest`` makes.
+Nothing about the missing library is mocked: it is genuinely absent from the second engine's
+``LibraryRegistry``, so ``CreateNodeRequest`` fails the way it does in production.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+
+import pytest
+
+from griptape_nodes.exe_types.node_types import ErrorProxyNode
+from griptape_nodes.files.path_utils import derive_registry_key
+from griptape_nodes.files.project_file import ProjectFileDestination
+from griptape_nodes.node_library.library_registry import LibraryRegistry
+from griptape_nodes.node_library.workflow_registry import WorkflowRegistry, read_workflow_metadata
+from griptape_nodes.retained_mode.engine import current_engine, reset_root_engine
+from griptape_nodes.retained_mode.events.base_events import ResultDetails
+from griptape_nodes.retained_mode.events.connection_events import (
+    CreateConnectionRequest,
+    CreateConnectionResultSuccess,
+    ListConnectionsForNodeRequest,
+    ListConnectionsForNodeResultSuccess,
+)
+from griptape_nodes.retained_mode.events.flow_events import (
+    CreateFlowRequest,
+    CreateFlowResultSuccess,
+    SerializeFlowToCommandsRequest,
+    SerializeFlowToCommandsResultSuccess,
+)
+from griptape_nodes.retained_mode.events.library_events import (
+    RegisterLibraryFromFileRequest,
+    RegisterLibraryFromFileResultFailure,
+    RegisterLibraryFromFileResultSuccess,
+)
+from griptape_nodes.retained_mode.events.node_events import (
+    CreateNodeRequest,
+    CreateNodeResultSuccess,
+)
+from griptape_nodes.retained_mode.events.object_events import ClearAllObjectStateRequest
+from griptape_nodes.retained_mode.events.parameter_events import (
+    GetParameterValueRequest,
+    GetParameterValueResultSuccess,
+    SetParameterValueRequest,
+    SetParameterValueResultFailure,
+    SetParameterValueResultSuccess,
+)
+from griptape_nodes.retained_mode.events.workflow_events import (
+    ImportWorkflowAsReferencedSubFlowRequest,
+    ImportWorkflowAsReferencedSubFlowResultSuccess,
+    RegisterWorkflowRequest,
+    RegisterWorkflowResultSuccess,
+    RunWorkflowFromRegistryRequest,
+    RunWorkflowFromRegistryResultSuccess,
+    SaveWorkflowFileFromSerializedFlowResultSuccess,
+)
+from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
+from griptape_nodes.utils.version_utils import engine_version
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from pathlib import Path
+
+    from griptape_nodes.retained_mode.engine import Engine
+
+_FLOW_NAME = "ControlFlow_1"
+_AVAILABLE_LIBRARY = "Missing Library Fixture (Available)"
+_UNAVAILABLE_LIBRARY = "Missing Library Fixture (Unavailable)"
+
+# One module body serves both fixture libraries; each library's manifest points at its own
+# copy under its own directory, so the two class names never collide in LibraryRegistry.
+_FIXTURE_NODE_MODULE = '''
+"""Fixture nodes for the missing-library load suite. Not part of any shipped library."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from griptape_nodes.exe_types.core_types import Parameter, ParameterMode
+from griptape_nodes.exe_types.node_types import DataNode
+
+
+class {class_name}(DataNode):
+    """A data node with two independently connectable any-typed parameters."""
+
+    def __init__(self, name: str, metadata: dict[Any, Any] | None = None) -> None:
+        super().__init__(name, metadata=metadata)
+        for param_name in ("value", "value2"):
+            self.add_parameter(
+                Parameter(
+                    name=param_name,
+                    type="any",
+                    default_value=None,
+                    tooltip="",
+                    allowed_modes={{ParameterMode.INPUT, ParameterMode.PROPERTY, ParameterMode.OUTPUT}},
+                )
+            )
+
+    def process(self) -> None:
+        pass
+'''
+
+
+def _library_schema(library_name: str, class_name: str, module_file: str) -> dict[str, Any]:
+    return {
+        "name": library_name,
+        "library_schema_version": "0.7.0",
+        "metadata": {
+            "author": "Test Fixture",
+            "description": "Minimal library used by the missing-library load tests",
+            "library_version": "0.1.0",
+            "engine_version": engine_version,
+            "tags": ["test"],
+            "dependencies": {"pip_dependencies": []},
+        },
+        "categories": [
+            {
+                "test": {
+                    "title": "test",
+                    "description": "Test nodes",
+                    "color": "border-gray-500",
+                    "icon": "Folder",
+                }
+            }
+        ],
+        "nodes": [
+            {
+                "class_name": class_name,
+                "file_path": module_file,
+                "metadata": {"category": "test", "description": "Two any-typed parameters", "display_name": class_name},
+            }
+        ],
+    }
+
+
+@pytest.fixture(autouse=True)
+def _clear_process_global_registries() -> Generator[None, None, None]:
+    """Clear the process-global library and workflow registries around every test in this file.
+
+    Both keep their state in ``ClassVar`` dicts the engine does not own, so the fixture
+    libraries and saved workflows registered here would otherwise leak into whichever test runs
+    next in the same xdist worker. Sibling files clear ``LibraryRegistry`` the same way.
+    """
+    LibraryRegistry._clear()
+    with patch.dict(WorkflowRegistry._workflows, {}, clear=True):
+        yield
+    LibraryRegistry._clear()
+
+
+def _write_library(root: Path, library_name: str, class_name: str) -> Path:
+    """Write one fixture library (manifest + node module) under its own directory."""
+    directory = root / class_name
+    directory.mkdir(parents=True, exist_ok=True)
+    module_file = f"{class_name.lower()}_nodes.py"
+    (directory / module_file).write_text(_FIXTURE_NODE_MODULE.format(class_name=class_name))
+    library_json = directory / "griptape_nodes_library.json"
+    library_json.write_text(json.dumps(_library_schema(library_name, class_name, module_file), indent=2))
+    return library_json
+
+
+def _register(engine: Engine, library_json: Path) -> str:
+    result = engine.handle_request(RegisterLibraryFromFileRequest(file_path=str(library_json)))
+    assert isinstance(result, RegisterLibraryFromFileResultSuccess), result
+    return result.library_name
+
+
+def _create_node(engine: Engine, node_type: str, library_name: str, node_name: str, flow_name: str) -> str:
+    result = engine.handle_request(
+        CreateNodeRequest(
+            node_type=node_type,
+            specific_library_name=library_name,
+            node_name=node_name,
+            override_parent_flow_name=flow_name,
+        )
+    )
+    assert isinstance(result, CreateNodeResultSuccess), result
+    return result.node_name
+
+
+def _set_value(engine: Engine, node_name: str, parameter_name: str, value: Any) -> None:
+    result = engine.handle_request(
+        SetParameterValueRequest(node_name=node_name, parameter_name=parameter_name, value=value)
+    )
+    assert isinstance(result, SetParameterValueResultSuccess), result
+
+
+def _get_value(engine: Engine, node_name: str, parameter_name: str) -> Any:
+    result = engine.handle_request(GetParameterValueRequest(node_name=node_name, parameter_name=parameter_name))
+    assert isinstance(result, GetParameterValueResultSuccess), result
+    return result.value
+
+
+def _save_two_library_workflow(tmp_path: Path, file_stem: str = "two_library_workflow") -> str:
+    """Build and save a graph spanning both fixture libraries; return the relative file name.
+
+    The graph is deliberately mixed: an available-library node feeding an
+    unavailable-library node, values on both sides, so a load can be checked for what it
+    preserved as well as what it replaced.
+    """
+    engine = current_engine()
+    engine.config_manager.workspace_path = tmp_path
+    engine.handle_request(ClearAllObjectStateRequest(i_know_what_im_doing=True))
+
+    available_json = _write_library(tmp_path / "libraries", _AVAILABLE_LIBRARY, "AvailableNode")
+    unavailable_json = _write_library(tmp_path / "libraries", _UNAVAILABLE_LIBRARY, "UnavailableNode")
+    _register(engine, available_json)
+    _register(engine, unavailable_json)
+
+    engine.context_manager.push_workflow(workflow_name=file_stem)
+    flow_result = engine.handle_request(
+        CreateFlowRequest(parent_flow_name=None, flow_name=_FLOW_NAME, set_as_new_context=False)
+    )
+    assert isinstance(flow_result, CreateFlowResultSuccess), flow_result
+
+    _create_node(engine, "AvailableNode", _AVAILABLE_LIBRARY, "Kept", _FLOW_NAME)
+    _create_node(engine, "UnavailableNode", _UNAVAILABLE_LIBRARY, "Vanishing", _FLOW_NAME)
+    _set_value(engine, "Kept", "value", "kept value")
+    _set_value(engine, "Vanishing", "value2", "vanishing value")
+
+    connection_result = engine.handle_request(
+        CreateConnectionRequest(
+            source_node_name="Kept",
+            source_parameter_name="value",
+            target_node_name="Vanishing",
+            target_parameter_name="value",
+        )
+    )
+    assert isinstance(connection_result, CreateConnectionResultSuccess), connection_result
+
+    serialize_result = engine.handle_request(SerializeFlowToCommandsRequest(flow_name=_FLOW_NAME))
+    assert isinstance(serialize_result, SerializeFlowToCommandsResultSuccess), serialize_result
+
+    save_result = engine.workflow_manager._save_workflow_file_inline(
+        destination=ProjectFileDestination(str(tmp_path / f"{file_stem}.py")),
+        serialized_flow_commands=serialize_result.serialized_flow_commands,
+        file_name=file_stem,
+        creation_date=None,
+        display_name=None,
+        image_path=None,
+        description=None,
+        is_template=None,
+        branched_from=None,
+        workflow_shape=None,
+        pickle_control_flow_result=False,
+    )
+    assert isinstance(save_result, SaveWorkflowFileFromSerializedFlowResultSuccess), save_result
+    return f"{file_stem}.py"
+
+
+def _restart_engine(tmp_path: Path) -> Engine:
+    """Hand back an engine in the state a just-restarted editor is in: no libraries at all.
+
+    Rebuilding is what makes the second half of each test honest. Dropping only the registry
+    entry would leave the library manager still believing the missing library is LOADED, and
+    dropping the registry without ``sys.modules`` would leave a library-owned class still
+    importable -- so a test would pass on an import a restarted editor could not resolve.
+    Registering a library imports its node module under a generated name and aliases it into
+    the ``griptape_nodes.node_libraries`` namespace; both live in ``sys.modules``, which is
+    process state no engine reset touches.
+
+    Every rebuild in this file goes through here, so no case can accidentally keep the
+    modules of a library it means to be missing.
+    """
+    reset_root_engine()
+    LibraryRegistry._clear()
+    stale = [
+        name for name in sys.modules if name.startswith(("gtn_dynamic_module_", LibraryManager.STABLE_NAMESPACE_PREFIX))
+    ]
+    for name in stale:
+        del sys.modules[name]
+    engine = current_engine()
+    engine.config_manager.workspace_path = tmp_path
+    return engine
+
+
+def _rebuild_engine_without_library(tmp_path: Path, *, disabled: bool = False) -> Engine:
+    """Restart the engine with the available library registered and the other one absent.
+
+    ``disabled=True`` reproduces the reported case: the library is still on disk and still
+    named in the user's config, just toggled off, so it is discovered and then refused.
+    """
+    engine = _restart_engine(tmp_path)
+    _register(engine, tmp_path / "libraries" / "AvailableNode" / "griptape_nodes_library.json")
+    if disabled:
+        engine.library_manager._create_library_info_entry(
+            str(tmp_path / "libraries" / "UnavailableNode" / "griptape_nodes_library.json"),
+            is_sandbox=False,
+            enabled=False,
+        )
+    return engine
+
+
+def _run(engine: Engine, relative_file_path: str) -> Any:
+    return asyncio.run(engine.workflow_manager.run_workflow(relative_file_path=relative_file_path))
+
+
+def _register_workflow(engine: Engine, tmp_path: Path, relative_file_path: str) -> str:
+    """Put the saved file in the workflow registry so it can be opened by name."""
+    metadata = read_workflow_metadata(tmp_path / relative_file_path)
+    result = engine.handle_request(RegisterWorkflowRequest(metadata=metadata, file_name=relative_file_path))
+    assert isinstance(result, RegisterWorkflowResultSuccess), result
+    return derive_registry_key(relative_file_path)
+
+
+def _node(engine: Engine, node_name: str) -> Any:
+    return engine.object_manager.get_object_by_name(node_name)
+
+
+class TestWorkflowOpensWithoutItsLibrary:
+    """The load succeeds and only the missing library's nodes are degraded."""
+
+    @pytest.mark.parametrize("disabled", [False, True], ids=["library_uninstalled", "library_disabled_in_config"])
+    def test_workflow_opens(self, engine: Engine, tmp_path: Path, disabled: bool) -> None:  # noqa: FBT001
+        del engine  # The fixture builds the first engine; this test replaces it mid-way.
+        relative_path = _save_two_library_workflow(tmp_path)
+
+        reopened = _rebuild_engine_without_library(tmp_path, disabled=disabled)
+        result = _run(reopened, relative_path)
+
+        assert result.execution_successful, result.execution_details
+        # Both nodes exist: the graph is whole, not truncated at the first unusable node.
+        assert not isinstance(_node(reopened, "Kept"), ErrorProxyNode)
+        assert isinstance(_node(reopened, "Vanishing"), ErrorProxyNode)
+
+    def test_unresolved_library_is_reported_once_with_its_reason(self, engine: Engine, tmp_path: Path) -> None:
+        del engine
+        relative_path = _save_two_library_workflow(tmp_path)
+
+        reopened = _rebuild_engine_without_library(tmp_path, disabled=True)
+        result = _run(reopened, relative_path)
+
+        assert len(result.unresolved_libraries) == 1
+        message = result.unresolved_libraries[0]
+        assert _UNAVAILABLE_LIBRARY in message
+        # The library that loaded is not mentioned; only the one that needs attention is.
+        assert _AVAILABLE_LIBRARY not in message
+        # The reason travels with it, so "it's disabled" is not left for the reader to guess.
+        assert "disabled in libraries_to_register" in message
+
+    def test_placeholder_names_the_library_and_node_type_it_stands_in_for(self, engine: Engine, tmp_path: Path) -> None:
+        del engine
+        relative_path = _save_two_library_workflow(tmp_path)
+
+        reopened = _rebuild_engine_without_library(tmp_path)
+        _run(reopened, relative_path)
+
+        placeholder = _node(reopened, "Vanishing")
+        assert placeholder.original_node_type == "UnavailableNode"
+        assert placeholder.original_library_name == _UNAVAILABLE_LIBRARY
+        # The proxy is a load failure, not a permission gate.
+        assert placeholder.denied_by_policy is False
+
+    def test_values_and_connections_survive_on_both_sides(self, engine: Engine, tmp_path: Path) -> None:
+        del engine
+        relative_path = _save_two_library_workflow(tmp_path)
+
+        reopened = _rebuild_engine_without_library(tmp_path)
+        _run(reopened, relative_path)
+
+        # The intact node keeps its own value...
+        assert _get_value(reopened, "Kept", "value") == "kept value"
+        # ...and the placeholder keeps the value it was saved with, on a parameter it had to
+        # invent, because the class that declared it is gone.
+        assert _get_value(reopened, "Vanishing", "value2") == "vanishing value"
+
+        connections = reopened.handle_request(ListConnectionsForNodeRequest(node_name="Kept"))
+        assert isinstance(connections, ListConnectionsForNodeResultSuccess), connections
+        assert [
+            (outgoing.source_parameter_name, outgoing.target_node_name, outgoing.target_parameter_name)
+            for outgoing in connections.outgoing_connections
+        ] == [("value", "Vanishing", "value")]
+
+    def test_placeholder_refuses_to_run_but_the_graph_stays_editable(self, engine: Engine, tmp_path: Path) -> None:
+        del engine
+        relative_path = _save_two_library_workflow(tmp_path)
+
+        reopened = _rebuild_engine_without_library(tmp_path)
+        _run(reopened, relative_path)
+
+        # Execution is what the missing library costs.
+        exceptions = _node(reopened, "Vanishing").validate_before_node_run()
+        assert exceptions is not None
+        assert _UNAVAILABLE_LIBRARY in str(exceptions[0])
+
+        # Editing the healthy side of the graph is not.
+        _set_value(reopened, "Kept", "value2", "edited after reopen")
+        assert _get_value(reopened, "Kept", "value2") == "edited after reopen"
+
+        # A placeholder's parameters stay frozen: they belong to a class that is not loaded,
+        # so accepting edits would invent state the restored node may not accept.
+        rejected = reopened.handle_request(
+            SetParameterValueRequest(node_name="Vanishing", parameter_name="value2", value="nope")
+        )
+        assert isinstance(rejected, SetParameterValueResultFailure)
+
+
+class TestEveryLibraryUnavailable:
+    """A graph made entirely of unavailable nodes still opens; there is nothing left to salvage but the shape."""
+
+    def test_all_nodes_become_placeholders_and_the_flow_survives(self, engine: Engine, tmp_path: Path) -> None:
+        del engine
+        relative_path = _save_two_library_workflow(tmp_path)
+
+        reopened = _restart_engine(tmp_path)
+
+        result = _run(reopened, relative_path)
+
+        assert result.execution_successful, result.execution_details
+        # One warning per library, not one per node.
+        assert len(result.unresolved_libraries) == 2  # noqa: PLR2004
+        assert isinstance(_node(reopened, "Kept"), ErrorProxyNode)
+        assert isinstance(_node(reopened, "Vanishing"), ErrorProxyNode)
+        # The flow itself is engine-owned, so it is there to hold them.
+        assert reopened.flow_manager.get_flow_by_name(_FLOW_NAME) is not None
+
+
+class TestPlaceholdersRoundTripBackToRealNodes:
+    """Saving with placeholders and reopening once the library returns restores the real nodes."""
+
+    def test_reopening_with_the_library_available_restores_the_original_node(
+        self, engine: Engine, tmp_path: Path
+    ) -> None:
+        del engine
+        relative_path = _save_two_library_workflow(tmp_path)
+
+        # Open without the library, save the graph as it now stands (placeholder and all)...
+        degraded = _rebuild_engine_without_library(tmp_path)
+        assert _run(degraded, relative_path).execution_successful
+        resaved_path = _resave_current_flow(degraded, tmp_path, "resaved_workflow")
+
+        # ...then reopen that file on an engine where the library is back.
+        restored = _restart_engine(tmp_path)
+        _register(restored, tmp_path / "libraries" / "AvailableNode" / "griptape_nodes_library.json")
+        _register(restored, tmp_path / "libraries" / "UnavailableNode" / "griptape_nodes_library.json")
+
+        result = _run(restored, resaved_path)
+
+        assert result.execution_successful, result.execution_details
+        assert result.unresolved_libraries == ()
+        # The placeholder was a stand-in, not a replacement: the real node comes back.
+        assert not isinstance(_node(restored, "Vanishing"), ErrorProxyNode)
+        assert _get_value(restored, "Vanishing", "value2") == "vanishing value"
+
+
+def _resave_current_flow(engine: Engine, tmp_path: Path, file_stem: str) -> str:
+    serialize_result = engine.handle_request(SerializeFlowToCommandsRequest(flow_name=_FLOW_NAME))
+    assert isinstance(serialize_result, SerializeFlowToCommandsResultSuccess), serialize_result
+    save_result = engine.workflow_manager._save_workflow_file_inline(
+        destination=ProjectFileDestination(str(tmp_path / f"{file_stem}.py")),
+        serialized_flow_commands=serialize_result.serialized_flow_commands,
+        file_name=file_stem,
+        creation_date=None,
+        display_name=None,
+        image_path=None,
+        description=None,
+        is_template=None,
+        branched_from=None,
+        workflow_shape=None,
+        pickle_control_flow_result=False,
+    )
+    assert isinstance(save_result, SaveWorkflowFileFromSerializedFlowResultSuccess), save_result
+    return f"{file_stem}.py"
+
+
+def _visible_register_failures(engine: Engine, relative_file_path: str) -> tuple[Any, list[str]]:
+    """Run the workflow, returning the register-library failures a user would actually see.
+
+    Two things have to be true at once for a failure to reach the editor as a toast: it has to
+    be broadcast at all, and it has to carry a detail above DEBUG. The engine's own pre-exec
+    registration attempt is broadcast but pinned to DEBUG (``failure_log_level``), so filtering
+    on level is what separates "reported quietly, once" from "toasted twice".
+    """
+    queued: list[Any] = []
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        original = engine.event_manager.aput_event
+
+        async def record(event: Any) -> None:
+            queued.append(event)
+            await original(event)
+
+        monkeypatch.setattr(engine.event_manager, "aput_event", record)
+        result = _run(engine, relative_file_path)
+
+    visible = []
+    for event in queued:
+        payload = getattr(getattr(event, "wrapped_event", None), "result", None)
+        if not isinstance(payload, RegisterLibraryFromFileResultFailure):
+            continue
+        visible.extend(message for level, message in _details(payload) if level > logging.DEBUG)
+    return result, visible
+
+
+def _details(payload: Any) -> list[tuple[int, str]]:
+    """The (level, message) pairs a result payload carries."""
+    assert isinstance(payload.result_details, ResultDetails), payload.result_details
+    return [(detail.level, detail.message) for detail in payload.result_details.result_details]
+
+
+def _strip_metadata_header(workflow_file: Path) -> None:
+    """Remove the `# /// script` metadata block, leaving the rest of the file intact."""
+    lines = workflow_file.read_text().splitlines()
+    closing_index = next(index for index, line in enumerate(lines) if index > 0 and line.strip() == "# ///")
+    workflow_file.write_text("\n".join(lines[closing_index + 1 :]))
+
+
+class TestDuplicateLibraryFailureIsNotBroadcast:
+    """The saved file re-registers its own libraries; that second failure must not reach the GUI.
+
+    Paired with the headerless case below: suppression is conditional on the engine having
+    already reported the library, so the same in-file failure is silenced in one case and
+    broadcast in the other. Suppressing unconditionally would make an unreadable header --
+    where the in-file calls are the only record of what the workflow needs -- load silently.
+    """
+
+    def test_in_file_registration_failure_is_suppressed(self, engine: Engine, tmp_path: Path) -> None:
+        del engine
+        relative_path = _save_two_library_workflow(tmp_path)
+
+        reopened = _rebuild_engine_without_library(tmp_path)
+        result, visible_failures = _visible_register_failures(reopened, relative_path)
+
+        assert result.execution_successful
+        assert result.unresolved_libraries != ()
+        assert visible_failures == [], f"unexpected RegisterLibraryFromFile failure on the wire: {visible_failures}"
+
+    def test_failure_is_broadcast_when_the_header_cannot_be_read(self, engine: Engine, tmp_path: Path) -> None:
+        del engine
+        relative_path = _save_two_library_workflow(tmp_path)
+        _strip_metadata_header(tmp_path / relative_path)
+
+        reopened = _rebuild_engine_without_library(tmp_path)
+        result, visible_failures = _visible_register_failures(reopened, relative_path)
+
+        # Nothing could be pre-registered, so the engine has nothing of its own to report...
+        assert result.unresolved_libraries == ()
+        # ...and the file's own registration failure stays visible as the sole signal.
+        assert len(visible_failures) == 1
+        assert _UNAVAILABLE_LIBRARY in visible_failures[0]
+
+
+class TestImportAsReferencedSubFlow:
+    """Importing a workflow as a subflow reports its unresolved libraries too.
+
+    This is the only result that can: a referenced subflow's libraries are not in the importing
+    workflow's own metadata header, so the outer load has nothing to report about them.
+    """
+
+    def test_import_succeeds_and_names_the_library(self, engine: Engine, tmp_path: Path) -> None:
+        del engine
+        relative_path = _save_two_library_workflow(tmp_path, "importable_workflow")
+        reopened = _rebuild_engine_without_library(tmp_path, disabled=True)
+        workflow_name = _register_workflow(reopened, tmp_path, relative_path)
+
+        # Somewhere to import into.
+        reopened.context_manager.push_workflow(workflow_name="host_workflow")
+        host_flow = reopened.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="HostFlow", set_as_new_context=False)
+        )
+        assert isinstance(host_flow, CreateFlowResultSuccess), host_flow
+
+        result = reopened.handle_request(
+            ImportWorkflowAsReferencedSubFlowRequest(workflow_name=workflow_name, flow_name=host_flow.flow_name)
+        )
+
+        assert isinstance(result, ImportWorkflowAsReferencedSubFlowResultSuccess), result
+        warnings = [
+            message
+            for level, message in _details(result)
+            if level == logging.WARNING and _UNAVAILABLE_LIBRARY in message
+        ]
+        assert len(warnings) == 1, result.result_details
+
+
+class TestOpenWorkflowRequest:
+    """The reported symptom, at the seam the editor's Open Workflow actually calls."""
+
+    def test_run_from_registry_succeeds_and_keeps_the_graph(self, engine: Engine, tmp_path: Path) -> None:
+        """`RunWorkflowFromRegistryRequest` must not fail, because failing there wipes the canvas.
+
+        Its failure branch clears all object state, which is why the reported bug left the
+        editor empty rather than showing a partly-broken graph.
+        """
+        del engine
+        relative_path = _save_two_library_workflow(tmp_path)
+        reopened = _rebuild_engine_without_library(tmp_path, disabled=True)
+        workflow_name = _register_workflow(reopened, tmp_path, relative_path)
+
+        result = reopened.handle_request(RunWorkflowFromRegistryRequest(workflow_name=workflow_name))
+
+        assert isinstance(result, RunWorkflowFromRegistryResultSuccess), result
+        assert not isinstance(_node(reopened, "Kept"), ErrorProxyNode)
+        assert isinstance(_node(reopened, "Vanishing"), ErrorProxyNode)
+
+    def test_the_library_is_named_in_the_result_at_warning_level(self, engine: Engine, tmp_path: Path) -> None:
+        del engine
+        relative_path = _save_two_library_workflow(tmp_path)
+        reopened = _rebuild_engine_without_library(tmp_path, disabled=True)
+        workflow_name = _register_workflow(reopened, tmp_path, relative_path)
+
+        result = reopened.handle_request(RunWorkflowFromRegistryRequest(workflow_name=workflow_name))
+
+        warnings = [
+            message
+            for level, message in _details(result)
+            if level == logging.WARNING and _UNAVAILABLE_LIBRARY in message
+        ]
+        assert len(warnings) == 1, result.result_details

--- a/tests/unit/retained_mode/managers/test_workflow_load_missing_library.py
+++ b/tests/unit/retained_mode/managers/test_workflow_load_missing_library.py
@@ -25,7 +25,7 @@ import json
 import logging
 import sys
 from typing import TYPE_CHECKING, Any
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -77,7 +77,10 @@ from griptape_nodes.retained_mode.events.workflow_events import (
     SaveWorkflowFileFromSerializedFlowResultSuccess,
     WorkflowStatus,
 )
-from griptape_nodes.retained_mode.managers.fitness_problems.workflows import LibraryNotRegisteredProblem
+from griptape_nodes.retained_mode.managers.fitness_problems.workflows import (
+    LibraryNotRegisteredProblem,
+    MissingCreationDateProblem,
+)
 from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
 from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
 from griptape_nodes.utils.version_utils import engine_version
@@ -998,3 +1001,34 @@ class TestWorkflowNodeRefusesAFlawedSubflow:
 
         assert isinstance(result, ImportWorkflowAsReferencedSubFlowResultSuccess), result
         assert result.status is WorkflowStatus.GOOD
+
+
+class TestSuppressionIsKeyedToLibraryProblems:
+    """Only a library-registration problem opens the exec window's suppression.
+
+    Today `_ensure_libraries_for_workflow` produces nothing else, so a bare truthiness check on
+    the problem list behaves identically -- but the frame now also collects problems bubbled up
+    from nested subflow loads, and a future problem type has no business silencing library
+    registration failures the engine did not predict.
+    """
+
+    def test_a_non_library_problem_does_not_silence_registration_failures(self, engine: Engine, tmp_path: Path) -> None:
+        del engine
+        relative_path = _save_two_library_workflow(tmp_path)
+        reopened = _rebuild_engine_without_library(tmp_path, disabled=True)
+
+        # Stand in for a future problem type: present, but not about library registration.
+        other_problem = MissingCreationDateProblem(default_date="1970-01-01")
+        with patch.object(
+            reopened.workflow_manager,
+            "_ensure_libraries_for_workflow",
+            AsyncMock(return_value=[other_problem]),
+        ):
+            result, visible_failures = _visible_register_failures(reopened, relative_path)
+
+        # The load still carries the problem it was handed...
+        assert result.problems == (other_problem,)
+        # ...but the file's own registration failure is NOT suppressed, because nothing reported
+        # that library: the engine never attempted it here.
+        assert len(visible_failures) == 1
+        assert "disabled in libraries_to_register" in visible_failures[0]

--- a/tests/unit/retained_mode/managers/test_workflow_load_missing_library.py
+++ b/tests/unit/retained_mode/managers/test_workflow_load_missing_library.py
@@ -1032,3 +1032,59 @@ class TestSuppressionIsKeyedToLibraryProblems:
         # that library: the engine never attempted it here.
         assert len(visible_failures) == 1
         assert "disabled in libraries_to_register" in visible_failures[0]
+
+
+class TestRefusedSubflowIsNotOrphaned:
+    """Refusing a FLAWED subflow must delete the flow the import already built.
+
+    The refusal happens after ImportWorkflowAsReferencedSubFlow succeeded, so a flow full of
+    nodes exists by then. Raising without deleting strands it in ObjectManager for the rest of
+    the session and consumes the node names, so a later import of the same workflow gets
+    suffixed names and the artist accumulates flows the editor has no path to remove.
+    """
+
+    @staticmethod
+    def _node_class_for(workflow_path: Path) -> type:
+        """A WorkflowNode subclass with an empty surface, the way the library builds one per workflow."""
+        from griptape_nodes.exe_types.workflow_node import WorkflowNode, WorkflowNodeSurface
+
+        return type(
+            "ProbeWorkflowNode",
+            (WorkflowNode,),
+            {
+                "workflow_file_path": workflow_path,
+                "workflow_metadata": read_workflow_metadata(workflow_path),
+                "workflow_surface": WorkflowNodeSurface(parameters={}, start_node_names=[], end_node_names=[]),
+            },
+        )
+
+    def test_repeated_refusals_do_not_accumulate_flows(self, engine: Engine, tmp_path: Path) -> None:
+        del engine
+        from griptape_nodes.exe_types.flow import ControlFlow
+
+        relative_path = _save_two_library_workflow(tmp_path, "inner_workflow")
+        reopened = _rebuild_engine_without_library(tmp_path, disabled=True)
+        _register_workflow(reopened, tmp_path, relative_path)
+
+        reopened.context_manager.push_workflow(workflow_name="host_workflow")
+        host_flow = reopened.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="HostFlow", set_as_new_context=False)
+        )
+        assert isinstance(host_flow, CreateFlowResultSuccess), host_flow
+
+        # Register the node the way CreateNodeRequest would; its class is not in a library, so the
+        # request path is unavailable and _load_subflow needs the parent-flow mapping to resolve.
+        node = self._node_class_for(tmp_path / relative_path)(name="Wrapper")
+        reopened.flow_manager.get_flow_by_name(host_flow.flow_name).add_node(node)
+        reopened.object_manager.add_object_by_name(node.name, node)
+        reopened.node_manager._name_to_parent_flow_name[node.name] = host_flow.flow_name
+
+        flows_before = set(reopened.object_manager.get_filtered_subset(type=ControlFlow))
+        for _ in range(3):
+            with pytest.raises(RuntimeError, match="FLAWED"):
+                asyncio.run(node._load_subflow())
+
+        # Each refusal cleaned up after itself, so three of them leave nothing behind...
+        assert set(reopened.object_manager.get_filtered_subset(type=ControlFlow)) == flows_before
+        # ...and nothing is left tracked for a later run to trip over.
+        assert node.metadata.get("subflow_name") is None

--- a/tests/unit/retained_mode/managers/test_workflow_load_missing_library.py
+++ b/tests/unit/retained_mode/managers/test_workflow_load_missing_library.py
@@ -72,8 +72,12 @@ from griptape_nodes.retained_mode.events.workflow_events import (
     RegisterWorkflowResultSuccess,
     RunWorkflowFromRegistryRequest,
     RunWorkflowFromRegistryResultSuccess,
+    RunWorkflowFromScratchRequest,
+    RunWorkflowFromScratchResultSuccess,
     SaveWorkflowFileFromSerializedFlowResultSuccess,
+    WorkflowStatus,
 )
+from griptape_nodes.retained_mode.managers.fitness_problems.workflows import LibraryNotRegisteredProblem
 from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
 from griptape_nodes.utils.version_utils import engine_version
 
@@ -349,13 +353,24 @@ class TestWorkflowOpensWithoutItsLibrary:
         reopened = _rebuild_engine_without_library(tmp_path, disabled=True)
         result = _run(reopened, relative_path)
 
-        assert len(result.unresolved_libraries) == 1
-        message = result.unresolved_libraries[0]
-        assert _UNAVAILABLE_LIBRARY in message
-        # The library that loaded is not mentioned; only the one that needs attention is.
-        assert _AVAILABLE_LIBRARY not in message
-        # The reason travels with it, so "it's disabled" is not left for the reader to guess.
-        assert "disabled in libraries_to_register" in message
+        assert [type(problem) for problem in result.problems] == [LibraryNotRegisteredProblem]
+        problem = result.problems[0]
+        assert problem.library_name == _UNAVAILABLE_LIBRARY
+        # The reason travels with it, so "it's disabled" is not left for the reader to guess --
+        # the library is on disk and named in the user's config, just switched off.
+        assert problem.reason is not None
+        assert "disabled in libraries_to_register" in problem.reason
+
+    def test_a_load_with_placeholders_is_flawed_not_good(self, engine: Engine, tmp_path: Path) -> None:
+        """The status is what a caller gates on without parsing prose."""
+        del engine
+        relative_path = _save_two_library_workflow(tmp_path)
+
+        reopened = _rebuild_engine_without_library(tmp_path, disabled=True)
+        result = _run(reopened, relative_path)
+
+        assert result.execution_successful
+        assert result.status is WorkflowStatus.FLAWED
 
     def test_placeholder_names_the_library_and_node_type_it_stands_in_for(self, engine: Engine, tmp_path: Path) -> None:
         del engine
@@ -426,8 +441,10 @@ class TestEveryLibraryUnavailable:
         result = _run(reopened, relative_path)
 
         assert result.execution_successful, result.execution_details
-        # One warning per library, not one per node.
-        assert len(result.unresolved_libraries) == 2  # noqa: PLR2004
+        # One problem per library, not one per node...
+        assert {problem.library_name for problem in result.problems} == {_AVAILABLE_LIBRARY, _UNAVAILABLE_LIBRARY}
+        # ...and both collate into a single warning, because they are the same problem type.
+        assert len(reopened.workflow_manager.collate_problems_for_display(result.problems)) == 1
         assert isinstance(_node(reopened, "Kept"), ErrorProxyNode)
         assert isinstance(_node(reopened, "Vanishing"), ErrorProxyNode)
         # The flow itself is engine-owned, so it is there to hold them.
@@ -456,7 +473,8 @@ class TestPlaceholdersRoundTripBackToRealNodes:
         result = _run(restored, resaved_path)
 
         assert result.execution_successful, result.execution_details
-        assert result.unresolved_libraries == ()
+        assert result.status is WorkflowStatus.GOOD
+        assert result.problems == ()
         # The placeholder was a stand-in, not a replacement: the real node comes back.
         assert not isinstance(_node(restored, "Vanishing"), ErrorProxyNode)
         assert _get_value(restored, "Vanishing", "value2") == "vanishing value"
@@ -541,7 +559,7 @@ class TestDuplicateLibraryFailureIsNotBroadcast:
         result, visible_failures = _visible_register_failures(reopened, relative_path)
 
         assert result.execution_successful
-        assert result.unresolved_libraries != ()
+        assert result.problems != ()
         assert visible_failures == [], f"unexpected RegisterLibraryFromFile failure on the wire: {visible_failures}"
 
     def test_failure_is_broadcast_when_the_header_cannot_be_read(self, engine: Engine, tmp_path: Path) -> None:
@@ -553,7 +571,7 @@ class TestDuplicateLibraryFailureIsNotBroadcast:
         result, visible_failures = _visible_register_failures(reopened, relative_path)
 
         # Nothing could be pre-registered, so the engine has nothing of its own to report...
-        assert result.unresolved_libraries == ()
+        assert result.problems == ()
         # ...and the file's own registration failure stays visible as the sole signal.
         assert len(visible_failures) == 1
         assert _UNAVAILABLE_LIBRARY in visible_failures[0]
@@ -626,3 +644,65 @@ class TestOpenWorkflowRequest:
             if level == logging.WARNING and _UNAVAILABLE_LIBRARY in message
         ]
         assert len(warnings) == 1, result.result_details
+
+
+class TestHeadlessLoadRefusesPlaceholders:
+    """The tolerance is the editor's trade, not the executor's.
+
+    An artist can see placeholders on a canvas and decide what to do. A headless run has
+    nobody to see them, so proceeding would produce output from a graph that is missing nodes.
+    `LocalWorkflowExecutor` is the only sender of `RunWorkflowFromScratchRequest`.
+    """
+
+    def test_a_flawed_load_is_reported_on_the_result_payload(self, engine: Engine, tmp_path: Path) -> None:
+        """The status rides on the payload, so a caller gates without parsing prose."""
+        del engine
+        relative_path = _save_two_library_workflow(tmp_path)
+        reopened = _rebuild_engine_without_library(tmp_path, disabled=True)
+
+        result = asyncio.run(reopened.ahandle_request(RunWorkflowFromScratchRequest(file_path=relative_path)))
+
+        assert isinstance(result, RunWorkflowFromScratchResultSuccess), result
+        assert result.status is WorkflowStatus.FLAWED
+
+    def test_a_clean_load_reports_good(self, engine: Engine, tmp_path: Path) -> None:
+        """The gate has to distinguish, so a healthy load must not be refused."""
+        del engine
+        relative_path = _save_two_library_workflow(tmp_path)
+        restored = _restart_engine(tmp_path)
+        _register(restored, tmp_path / "libraries" / "AvailableNode" / "griptape_nodes_library.json")
+        _register(restored, tmp_path / "libraries" / "UnavailableNode" / "griptape_nodes_library.json")
+
+        result = asyncio.run(restored.ahandle_request(RunWorkflowFromScratchRequest(file_path=relative_path)))
+
+        assert isinstance(result, RunWorkflowFromScratchResultSuccess), result
+        assert result.status is WorkflowStatus.GOOD
+
+    def test_the_executor_refuses_a_flawed_load(self, engine: Engine, tmp_path: Path) -> None:
+        """The graph loaded, but the executor must not run it."""
+        del engine
+        from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import (
+            LocalExecutorError,
+            LocalWorkflowExecutor,
+        )
+
+        relative_path = _save_two_library_workflow(tmp_path)
+        reopened = _rebuild_engine_without_library(tmp_path, disabled=True)
+        del reopened
+
+        with pytest.raises(LocalExecutorError, match="FLAWED"):
+            asyncio.run(LocalWorkflowExecutor()._load_workflow_from_path(relative_path))
+
+    def test_the_executor_accepts_a_clean_load(self, engine: Engine, tmp_path: Path) -> None:
+        """The refusal must key on the status, not on merely having gone through this path."""
+        del engine
+        from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import LocalWorkflowExecutor
+
+        relative_path = _save_two_library_workflow(tmp_path)
+        restored = _restart_engine(tmp_path)
+        _register(restored, tmp_path / "libraries" / "AvailableNode" / "griptape_nodes_library.json")
+        _register(restored, tmp_path / "libraries" / "UnavailableNode" / "griptape_nodes_library.json")
+
+        asyncio.run(LocalWorkflowExecutor()._load_workflow_from_path(relative_path))
+
+        assert not isinstance(_node(restored, "Vanishing"), ErrorProxyNode)

--- a/tests/unit/retained_mode/managers/test_workflow_load_missing_library.py
+++ b/tests/unit/retained_mode/managers/test_workflow_load_missing_library.py
@@ -79,6 +79,7 @@ from griptape_nodes.retained_mode.events.workflow_events import (
 )
 from griptape_nodes.retained_mode.managers.fitness_problems.workflows import LibraryNotRegisteredProblem
 from griptape_nodes.retained_mode.managers.library_manager import LibraryManager
+from griptape_nodes.retained_mode.managers.workflow_manager import WorkflowManager
 from griptape_nodes.utils.version_utils import engine_version
 
 if TYPE_CHECKING:
@@ -86,6 +87,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from griptape_nodes.retained_mode.engine import Engine
+    from griptape_nodes.retained_mode.managers.fitness_problems.workflows import WorkflowProblem
 
 _FLOW_NAME = "ControlFlow_1"
 _AVAILABLE_LIBRARY = "Missing Library Fixture (Available)"
@@ -271,6 +273,43 @@ def _save_two_library_workflow(tmp_path: Path, file_stem: str = "two_library_wor
     return f"{file_stem}.py"
 
 
+def _save_flow_as_workflow(engine: Engine, tmp_path: Path, flow_name: str, file_stem: str) -> str:
+    """Serialize `flow_name` and write it to `tmp_path` the way SaveWorkflowRequest does."""
+    serialized = engine.handle_request(SerializeFlowToCommandsRequest(flow_name=flow_name))
+    assert isinstance(serialized, SerializeFlowToCommandsResultSuccess), serialized
+    saved = engine.workflow_manager._save_workflow_file_inline(
+        destination=ProjectFileDestination(str(tmp_path / f"{file_stem}.py")),
+        serialized_flow_commands=serialized.serialized_flow_commands,
+        file_name=file_stem,
+        creation_date=None,
+        display_name=None,
+        image_path=None,
+        description=None,
+        is_template=None,
+        branched_from=None,
+        workflow_shape=None,
+        pickle_control_flow_result=False,
+    )
+    assert isinstance(saved, SaveWorkflowFileFromSerializedFlowResultSuccess), saved
+    return f"{file_stem}.py"
+
+
+def _save_host_importing_subflow(
+    tmp_path: Path, engine: Engine, inner_name: str, file_stem: str = "host_workflow"
+) -> str:
+    """Build and save a workflow whose only content is an import of `inner_name` as a subflow."""
+    engine.context_manager.push_workflow(workflow_name=file_stem)
+    host_flow = engine.handle_request(
+        CreateFlowRequest(parent_flow_name=None, flow_name=f"{file_stem}_HostFlow", set_as_new_context=False)
+    )
+    assert isinstance(host_flow, CreateFlowResultSuccess), host_flow
+    imported = engine.handle_request(
+        ImportWorkflowAsReferencedSubFlowRequest(workflow_name=inner_name, flow_name=host_flow.flow_name)
+    )
+    assert isinstance(imported, ImportWorkflowAsReferencedSubFlowResultSuccess), imported
+    return _save_flow_as_workflow(engine, tmp_path, host_flow.flow_name, file_stem)
+
+
 def _restart_engine(tmp_path: Path) -> Engine:
     """Hand back an engine in the state a just-restarted editor is in: no libraries at all.
 
@@ -444,11 +483,20 @@ class TestEveryLibraryUnavailable:
         # One problem per library, not one per node...
         assert {problem.library_name for problem in result.problems} == {_AVAILABLE_LIBRARY, _UNAVAILABLE_LIBRARY}
         # ...and both collate into a single warning, because they are the same problem type.
-        assert len(reopened.workflow_manager.collate_problems_for_display(result.problems)) == 1
+        assert len(reopened.workflow_manager.collate_problems_by_type(result.problems)) == 1
         assert isinstance(_node(reopened, "Kept"), ErrorProxyNode)
         assert isinstance(_node(reopened, "Vanishing"), ErrorProxyNode)
         # The flow itself is engine-owned, so it is there to hold them.
         assert reopened.flow_manager.get_flow_by_name(_FLOW_NAME) is not None
+
+        # A connection with a placeholder on BOTH ends survives: each side has to invent the
+        # parameter it is asked for, since neither class is loaded to declare it.
+        connections = reopened.handle_request(ListConnectionsForNodeRequest(node_name="Kept"))
+        assert isinstance(connections, ListConnectionsForNodeResultSuccess), connections
+        assert [
+            (outgoing.source_parameter_name, outgoing.target_node_name, outgoing.target_parameter_name)
+            for outgoing in connections.outgoing_connections
+        ] == [("value", "Vanishing", "value")]
 
 
 class TestPlaceholdersRoundTripBackToRealNodes:
@@ -481,23 +529,8 @@ class TestPlaceholdersRoundTripBackToRealNodes:
 
 
 def _resave_current_flow(engine: Engine, tmp_path: Path, file_stem: str) -> str:
-    serialize_result = engine.handle_request(SerializeFlowToCommandsRequest(flow_name=_FLOW_NAME))
-    assert isinstance(serialize_result, SerializeFlowToCommandsResultSuccess), serialize_result
-    save_result = engine.workflow_manager._save_workflow_file_inline(
-        destination=ProjectFileDestination(str(tmp_path / f"{file_stem}.py")),
-        serialized_flow_commands=serialize_result.serialized_flow_commands,
-        file_name=file_stem,
-        creation_date=None,
-        display_name=None,
-        image_path=None,
-        description=None,
-        is_template=None,
-        branched_from=None,
-        workflow_shape=None,
-        pickle_control_flow_result=False,
-    )
-    assert isinstance(save_result, SaveWorkflowFileFromSerializedFlowResultSuccess), save_result
-    return f"{file_stem}.py"
+    """Save the live top-level flow back to disk, placeholders and all."""
+    return _save_flow_as_workflow(engine, tmp_path, _FLOW_NAME, file_stem)
 
 
 def _visible_register_failures(engine: Engine, relative_file_path: str) -> tuple[Any, list[str]]:
@@ -580,8 +613,9 @@ class TestDuplicateLibraryFailureIsNotBroadcast:
 class TestImportAsReferencedSubFlow:
     """Importing a workflow as a subflow reports its unresolved libraries too.
 
-    This is the only result that can: a referenced subflow's libraries are not in the importing
-    workflow's own metadata header, so the outer load has nothing to report about them.
+    A referenced subflow's libraries are not in the importing workflow's own metadata header, so
+    pre-registration never sees them. Imported on its own, the import result is the only thing
+    that can name them; imported from inside a load, they bubble to that load's own result.
     """
 
     def test_import_succeeds_and_names_the_library(self, engine: Engine, tmp_path: Path) -> None:
@@ -706,3 +740,261 @@ class TestHeadlessLoadRefusesPlaceholders:
         asyncio.run(LocalWorkflowExecutor()._load_workflow_from_path(relative_path))
 
         assert not isinstance(_node(restored, "Vanishing"), ErrorProxyNode)
+
+
+class TestNestedSubflowProblemsReachTheOuterLoad:
+    """A referenced subflow's missing library must show up on the load that pulled it in.
+
+    The importing workflow's header doesn't list the subflow's libraries, so pre-registration
+    never sees them -- the inner load discovers them while the outer file is mid-exec. If they
+    stop there, the outer load reports GOOD with placeholders on the canvas, and the headless
+    gate that exists to refuse an incomplete graph waves it through.
+    """
+
+    def _open_host_without_the_library(self, tmp_path: Path) -> tuple[Engine, Any]:
+        inner_path = _save_two_library_workflow(tmp_path, "inner_workflow")
+        building = _rebuild_engine_without_library(tmp_path, disabled=True)
+        inner_name = _register_workflow(building, tmp_path, inner_path)
+        host_path = _save_host_importing_subflow(tmp_path, building, inner_name)
+
+        # Reopen the host on a fresh engine, library still disabled.
+        reopened = _rebuild_engine_without_library(tmp_path, disabled=True)
+        return reopened, _run(reopened, host_path)
+
+    def test_the_outer_load_is_flawed_and_names_the_library(self, engine: Engine, tmp_path: Path) -> None:
+        del engine
+        reopened, result = self._open_host_without_the_library(tmp_path)
+
+        # The graph really is incomplete...
+        assert any(
+            isinstance(node, ErrorProxyNode)
+            for node in reopened.object_manager.get_filtered_subset(type=ErrorProxyNode).values()
+        )
+        # ...so the load that produced it must not claim to be GOOD.
+        assert result.status is WorkflowStatus.FLAWED
+        assert [problem.library_name for problem in result.problems] == [_UNAVAILABLE_LIBRARY]
+
+    def test_the_executor_refuses_a_host_whose_subflow_lost_its_library(self, engine: Engine, tmp_path: Path) -> None:
+        """The gate is only as good as the status it reads."""
+        del engine
+        from griptape_nodes.bootstrap.workflow_executors.local_workflow_executor import (
+            LocalExecutorError,
+            LocalWorkflowExecutor,
+        )
+
+        inner_path = _save_two_library_workflow(tmp_path, "inner_workflow")
+        building = _rebuild_engine_without_library(tmp_path, disabled=True)
+        inner_name = _register_workflow(building, tmp_path, inner_path)
+        host_path = _save_host_importing_subflow(tmp_path, building, inner_name)
+
+        reopened = _rebuild_engine_without_library(tmp_path, disabled=True)
+        del reopened
+
+        with pytest.raises(LocalExecutorError, match="FLAWED"):
+            asyncio.run(LocalWorkflowExecutor()._load_workflow_from_path(host_path))
+
+    def test_the_nested_import_result_does_not_repeat_the_warning(self, engine: Engine, tmp_path: Path) -> None:
+        """The enclosing load reports the problems, so the inner import's own result must not.
+
+        This inspects the ImportWorkflowAsReferencedSubFlow result the outer load emits while it
+        runs -- the payload the GUI would toast -- not the outer result. Suppressing on the wrong
+        side, or not at all, shows the artist the same missing library twice.
+        """
+        del engine
+        inner_path = _save_two_library_workflow(tmp_path, "inner_workflow")
+        building = _rebuild_engine_without_library(tmp_path, disabled=True)
+        inner_name = _register_workflow(building, tmp_path, inner_path)
+        host_path = _save_host_importing_subflow(tmp_path, building, inner_name)
+
+        reopened = _rebuild_engine_without_library(tmp_path, disabled=True)
+
+        queued: list[Any] = []
+        with pytest.MonkeyPatch.context() as monkeypatch:
+            original = reopened.event_manager.aput_event
+
+            async def record(event: Any) -> None:
+                queued.append(event)
+                await original(event)
+
+            monkeypatch.setattr(reopened.event_manager, "aput_event", record)
+            result = _run(reopened, host_path)
+
+        # The outer load is the one that reports it...
+        assert [problem.library_name for problem in result.problems] == [_UNAVAILABLE_LIBRARY]
+
+        # ...so the nested import's own broadcast payload carries no warning about it.
+        import_payloads = [
+            payload
+            for event in queued
+            if isinstance(
+                payload := getattr(getattr(event, "wrapped_event", None), "result", None),
+                ImportWorkflowAsReferencedSubFlowResultSuccess,
+            )
+        ]
+        assert len(import_payloads) == 1, "expected exactly one nested import to be broadcast"
+        assert [message for level, message in _details(import_payloads[0]) if level >= logging.WARNING] == []
+
+    def test_a_library_reached_twice_is_reported_once(self, engine: Engine, tmp_path: Path) -> None:
+        """A host that both uses a library directly and imports a subflow using it counts it once.
+
+        Bubbling without dedup told the artist two libraries were missing, naming the same one
+        twice with identical reasons.
+        """
+        del engine
+        inner_path = _save_two_library_workflow(tmp_path, "inner_workflow")
+        building = _rebuild_engine_without_library(tmp_path, disabled=True)
+        inner_name = _register_workflow(building, tmp_path, inner_path)
+
+        # The host holds its own node from the unavailable library AND imports the subflow, so the
+        # same library arrives from the header and from the nested load.
+        building.context_manager.push_workflow(workflow_name="host_workflow")
+        host_flow = building.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="HostFlow", set_as_new_context=False)
+        )
+        assert isinstance(host_flow, CreateFlowResultSuccess), host_flow
+        _create_node(building, "UnavailableNode", _UNAVAILABLE_LIBRARY, "HostOwn", host_flow.flow_name)
+        imported = building.handle_request(
+            ImportWorkflowAsReferencedSubFlowRequest(workflow_name=inner_name, flow_name=host_flow.flow_name)
+        )
+        assert isinstance(imported, ImportWorkflowAsReferencedSubFlowResultSuccess), imported
+        host_path = _save_flow_as_workflow(building, tmp_path, host_flow.flow_name, "host_workflow")
+
+        reopened = _rebuild_engine_without_library(tmp_path, disabled=True)
+        result = _run(reopened, host_path)
+
+        assert [problem.library_name for problem in result.problems] == [_UNAVAILABLE_LIBRARY]
+        collated = reopened.workflow_manager.collate_problems_by_type(result.problems)
+        assert len(collated) == 1
+        assert "2 libraries" not in collated[0]
+
+
+class TestConcurrentLoadsDoNotCrossContaminate:
+    """A nested subflow load must bubble into its own parent, not a sibling load's frame.
+
+    In PARALLEL execution mode a WorkflowNode loads its subflow from inside a node body, and
+    those bodies run as separate asyncio tasks. A load suspends while reading its file, so two
+    gathered loads really do have frames open at the same time -- and on a stack shared across
+    tasks a nested load then bubbles into whichever frame happens to sit beneath it, which is
+    the sibling's rather than its own parent's.
+
+    Two tests, because they pin different things. The first drives real loads, so the interleave
+    is production's and the assertion is the user-visible consequence -- a host reporting GOOD
+    over placeholder nodes, which the headless gate waves through. It pins the bubbling, but not
+    the task isolation: whether the sibling's frame is still open at the moment the nested frame
+    closes depends on the schedule, and the sibling usually finishes first. The second forces
+    that exact overlap by hand, which is the only way to hold the isolation in place.
+    """
+
+    def test_a_host_load_keeps_its_subflow_problem_beside_a_concurrent_load(
+        self, engine: Engine, tmp_path: Path
+    ) -> None:
+        del engine
+        inner_path = _save_two_library_workflow(tmp_path, "inner_workflow")
+        building = _rebuild_engine_without_library(tmp_path, disabled=True)
+        inner_name = _register_workflow(building, tmp_path, inner_path)
+        host_path = _save_host_importing_subflow(tmp_path, building, inner_name)
+
+        reopened = _rebuild_engine_without_library(tmp_path, disabled=True)
+
+        async def load_both() -> tuple[Any, Any]:
+            return await asyncio.gather(  # type: ignore[return-value]
+                reopened.workflow_manager.run_workflow(relative_file_path=host_path),
+                reopened.workflow_manager.run_workflow(relative_file_path=inner_path),
+            )
+
+        host_result, sibling_result = asyncio.run(load_both())
+
+        # The host's own problem came from its subflow, and it has to survive the sibling load
+        # running alongside it -- otherwise the host reports GOOD over placeholder nodes.
+        assert host_result.status is WorkflowStatus.FLAWED
+        assert [problem.library_name for problem in host_result.problems] == [_UNAVAILABLE_LIBRARY]
+        # The sibling reports its own, once.
+        assert [problem.library_name for problem in sibling_result.problems] == [_UNAVAILABLE_LIBRARY]
+
+    def test_a_nested_frame_bubbles_to_its_own_parent_not_a_sibling(self) -> None:
+        """Force the overlap the schedule usually hides: sibling frame open, nested frame closing.
+
+        On a stack shared across tasks the nested frame bubbles into whatever sits beneath it,
+        which here is the sibling task's frame instead of its own parent's.
+        """
+
+        def _library_names(problems: list[WorkflowProblem]) -> list[str]:
+            return [p.library_name for p in problems if isinstance(p, LibraryNotRegisteredProblem)]
+
+        async def load_with_subflow() -> list[str]:
+            with WorkflowManager.LoadProblemFrame() as outer:
+                outer.problems.append(LibraryNotRegisteredProblem(library_name="Outer Library"))
+                await asyncio.sleep(0)  # let the sibling open its frame beneath this one
+                with WorkflowManager.LoadProblemFrame() as inner:
+                    inner.problems.append(LibraryNotRegisteredProblem(library_name="Subflow Library"))
+                    await asyncio.sleep(0)
+                return _library_names(outer.problems)
+
+        async def sibling_load() -> list[str]:
+            with WorkflowManager.LoadProblemFrame() as frame:
+                frame.problems.append(LibraryNotRegisteredProblem(library_name="Sibling Library"))
+                await asyncio.sleep(0)
+                await asyncio.sleep(0)
+                await asyncio.sleep(0)
+                return _library_names(frame.problems)
+
+        async def load_both() -> tuple[list[str], list[str]]:
+            return await asyncio.gather(load_with_subflow(), sibling_load())  # type: ignore[return-value]
+
+        with_subflow, sibling = asyncio.run(load_both())
+
+        assert with_subflow == ["Outer Library", "Subflow Library"]
+        assert sibling == ["Sibling Library"]
+
+
+class TestWorkflowNodeRefusesAFlawedSubflow:
+    """A WorkflowNode imports in order to RUN, so it refuses a subflow full of placeholders.
+
+    Nothing downstream would catch it: ErrorProxyNode refuses only at validate_before_node_run,
+    which never fires for a placeholder off the resolution path, so the subflow would report
+    output computed without those nodes. Same reason the headless executor refuses.
+    """
+
+    def test_the_import_payload_carries_the_subflow_status(self, engine: Engine, tmp_path: Path) -> None:
+        del engine
+        inner_path = _save_two_library_workflow(tmp_path, "inner_workflow")
+        reopened = _rebuild_engine_without_library(tmp_path, disabled=True)
+        inner_name = _register_workflow(reopened, tmp_path, inner_path)
+
+        reopened.context_manager.push_workflow(workflow_name="host_workflow")
+        host_flow = reopened.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="HostFlow", set_as_new_context=False)
+        )
+        assert isinstance(host_flow, CreateFlowResultSuccess), host_flow
+
+        result = reopened.handle_request(
+            ImportWorkflowAsReferencedSubFlowRequest(workflow_name=inner_name, flow_name=host_flow.flow_name)
+        )
+
+        # The import still succeeds -- importing is editing, and the graph is there to look at...
+        assert isinstance(result, ImportWorkflowAsReferencedSubFlowResultSuccess), result
+        # ...but it says plainly that what arrived is not whole.
+        assert result.status is WorkflowStatus.FLAWED
+
+    def test_a_clean_subflow_import_reports_good(self, engine: Engine, tmp_path: Path) -> None:
+        """The gate has to distinguish, so a healthy subflow must not be refused."""
+        del engine
+        inner_path = _save_two_library_workflow(tmp_path, "inner_workflow")
+
+        restored = _restart_engine(tmp_path)
+        _register(restored, tmp_path / "libraries" / "AvailableNode" / "griptape_nodes_library.json")
+        _register(restored, tmp_path / "libraries" / "UnavailableNode" / "griptape_nodes_library.json")
+        inner_name = _register_workflow(restored, tmp_path, inner_path)
+
+        restored.context_manager.push_workflow(workflow_name="host_workflow")
+        host_flow = restored.handle_request(
+            CreateFlowRequest(parent_flow_name=None, flow_name="HostFlow", set_as_new_context=False)
+        )
+        assert isinstance(host_flow, CreateFlowResultSuccess), host_flow
+
+        result = restored.handle_request(
+            ImportWorkflowAsReferencedSubFlowRequest(workflow_name=inner_name, flow_name=host_flow.flow_name)
+        )
+
+        assert isinstance(result, ImportWorkflowAsReferencedSubFlowResultSuccess), result
+        assert result.status is WorkflowStatus.GOOD

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -2655,27 +2655,37 @@ class TestVariableReferenceAccess:
 class TestLibraryResolutionOnLoad:
     """run_workflow resolves declared libraries before exec via the metadata header."""
 
-    def test_ensure_libraries_dispatches_ahandle_request_per_library(self, engine: Engine) -> None:
-        """_ensure_libraries_for_workflow dispatches one RegisterLibraryFromFileRequest per declared library."""
+    @staticmethod
+    def _metadata(*libraries: tuple[str, str]) -> WorkflowMetadata:
         from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
-        from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
-        from griptape_nodes.retained_mode.events.library_events import (
-            RegisterLibraryFromFileRequest,
-            RegisterLibraryFromFileResultSuccess,
-        )
-        from griptape_nodes.retained_mode.events.workflow_events import LoadWorkflowMetadataResultSuccess
 
-        workflow_manager = engine.workflow_manager
-        metadata = WorkflowMetadata(
+        return WorkflowMetadata(
             name="t",
             schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
             engine_version_created_with="0.0.0",
             node_libraries_referenced=[
-                LibraryNameAndVersion(library_name="Example Library", library_version="0.1.0"),
-                LibraryNameAndVersion(library_name="Other Library", library_version="0.2.0"),
+                LibraryNameAndVersion(library_name=name, library_version=version) for name, version in libraries
             ],
         )
+
+    def _resolve(self, engine: Engine, metadata: WorkflowMetadata, ahandle_request: object) -> list:
+        """Drive _ensure_libraries_for_workflow against a stubbed metadata header and dispatcher."""
+        from griptape_nodes.retained_mode.events.workflow_events import LoadWorkflowMetadataResultSuccess
+
+        workflow_manager = engine.workflow_manager
         load_result = LoadWorkflowMetadataResultSuccess(metadata=metadata, result_details="ok")
+        with (
+            patch.object(workflow_manager, "on_load_workflow_metadata_request", AsyncMock(return_value=load_result)),
+            patch.object(engine, "ahandle_request", ahandle_request),
+        ):
+            return asyncio.run(workflow_manager._ensure_libraries_for_workflow(relative_file_path="whatever.py"))
+
+    def test_ensure_libraries_dispatches_ahandle_request_per_library(self, engine: Engine) -> None:
+        """_ensure_libraries_for_workflow dispatches one RegisterLibraryFromFileRequest per declared library."""
+        from griptape_nodes.retained_mode.events.library_events import (
+            RegisterLibraryFromFileRequest,
+            RegisterLibraryFromFileResultSuccess,
+        )
 
         dispatched: list[RegisterLibraryFromFileRequest] = []
 
@@ -2686,62 +2696,52 @@ class TestLibraryResolutionOnLoad:
                 result_details="ok",
             )
 
-        with (
-            patch.object(workflow_manager, "on_load_workflow_metadata_request", AsyncMock(return_value=load_result)),
-            patch.object(engine, "ahandle_request", side_effect=fake_ahandle_request),
-        ):
-            result = asyncio.run(
-                workflow_manager._ensure_libraries_for_workflow(
-                    relative_file_path="whatever.py",
-                    complete_file_path=Path("whatever.py"),
-                )
-            )
+        problems = self._resolve(
+            engine,
+            self._metadata(("Example Library", "0.1.0"), ("Other Library", "0.2.0")),
+            fake_ahandle_request,
+        )
 
-        assert result == []
+        assert problems == []
         assert [r.library_name for r in dispatched] == ["Example Library", "Other Library"]
         assert all(r.perform_discovery_if_not_found for r in dispatched)
 
     def test_ensure_libraries_reports_the_library_instead_of_refusing_the_load(self, engine: Engine) -> None:
-        """A failed library registration is reported, not fatal: the caller still execs the file.
+        """A failed registration becomes a problem, not a refusal: the caller still execs the file.
 
         A library that will not register costs execution, never editing (issue #5505). The nodes
         it owns come back as placeholders, which is only possible if the load continues.
         """
-        from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
-        from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
         from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileResultFailure
-        from griptape_nodes.retained_mode.events.workflow_events import LoadWorkflowMetadataResultSuccess
+        from griptape_nodes.retained_mode.managers.fitness_problems.workflows import LibraryNotRegisteredProblem
 
-        workflow_manager = engine.workflow_manager
-        metadata = WorkflowMetadata(
-            name="t",
-            schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
-            engine_version_created_with="0.0.0",
-            node_libraries_referenced=[
-                LibraryNameAndVersion(library_name="Missing Library", library_version="0.1.0"),
-            ],
+        problems = self._resolve(
+            engine,
+            self._metadata(("Missing Library", "0.1.0")),
+            AsyncMock(return_value=RegisterLibraryFromFileResultFailure(result_details="not found")),
         )
-        load_result = LoadWorkflowMetadataResultSuccess(metadata=metadata, result_details="ok")
 
-        with (
-            patch.object(workflow_manager, "on_load_workflow_metadata_request", AsyncMock(return_value=load_result)),
-            patch.object(
-                engine,
-                "ahandle_request",
-                AsyncMock(return_value=RegisterLibraryFromFileResultFailure(result_details="not found")),
-            ),
-        ):
-            result = asyncio.run(
-                workflow_manager._ensure_libraries_for_workflow(
-                    relative_file_path="whatever.py",
-                    complete_file_path=Path("whatever.py"),
-                )
-            )
+        assert problems == [LibraryNotRegisteredProblem(library_name="Missing Library", reason="not found")]
 
-        assert len(result) == 1
-        assert "Missing Library" in result[0]
-        # The inner reason travels with it so the reader isn't sent hunting.
-        assert "not found" in result[0]
+    def test_ensure_libraries_records_the_registration_reason(self, engine: Engine) -> None:
+        """The reason travels on the problem, so "it's switched off" isn't left for the reader to guess.
+
+        The disabled case is the one that needs it: the library is on disk and named in the
+        user's config, so a bare "not registered" sends them hunting for something already there.
+        """
+        from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileResultFailure
+        from griptape_nodes.retained_mode.managers.fitness_problems.workflows import LibraryNotRegisteredProblem
+
+        disabled = "Library at '/libs/x/griptape_nodes_library.json' is disabled in libraries_to_register"
+        problems = self._resolve(
+            engine,
+            self._metadata(("Missing Library", "0.1.0")),
+            AsyncMock(return_value=RegisterLibraryFromFileResultFailure(result_details=disabled)),
+        )
+
+        assert problems[0].reason == disabled
+        collated = LibraryNotRegisteredProblem.collate_problems_for_display(problems)
+        assert "disabled in libraries_to_register" in collated
 
     def test_ensure_libraries_attempts_every_library_after_one_fails(self, engine: Engine) -> None:
         """One unresolvable library does not stop the others from registering.
@@ -2749,27 +2749,11 @@ class TestLibraryResolutionOnLoad:
         Short-circuiting here would strand libraries later in the list, turning their perfectly
         loadable nodes into placeholders too.
         """
-        from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
-        from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
         from griptape_nodes.retained_mode.events.library_events import (
             RegisterLibraryFromFileRequest,
             RegisterLibraryFromFileResultFailure,
             RegisterLibraryFromFileResultSuccess,
         )
-        from griptape_nodes.retained_mode.events.workflow_events import LoadWorkflowMetadataResultSuccess
-
-        workflow_manager = engine.workflow_manager
-        metadata = WorkflowMetadata(
-            name="t",
-            schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
-            engine_version_created_with="0.0.0",
-            node_libraries_referenced=[
-                LibraryNameAndVersion(library_name="Missing Library", library_version="0.1.0"),
-                LibraryNameAndVersion(library_name="Present Library", library_version="0.2.0"),
-                LibraryNameAndVersion(library_name="Also Missing Library", library_version="0.3.0"),
-            ],
-        )
-        load_result = LoadWorkflowMetadataResultSuccess(metadata=metadata, result_details="ok")
 
         dispatched: list[RegisterLibraryFromFileRequest] = []
 
@@ -2780,46 +2764,26 @@ class TestLibraryResolutionOnLoad:
                 return RegisterLibraryFromFileResultSuccess(library_name=library_name, result_details="ok")
             return RegisterLibraryFromFileResultFailure(result_details="not found")
 
-        with (
-            patch.object(workflow_manager, "on_load_workflow_metadata_request", AsyncMock(return_value=load_result)),
-            patch.object(engine, "ahandle_request", side_effect=fake_ahandle_request),
-        ):
-            result = asyncio.run(
-                workflow_manager._ensure_libraries_for_workflow(
-                    relative_file_path="whatever.py",
-                    complete_file_path=Path("whatever.py"),
-                )
-            )
+        problems = self._resolve(
+            engine,
+            self._metadata(
+                ("Missing Library", "0.1.0"), ("Present Library", "0.2.0"), ("Also Missing Library", "0.3.0")
+            ),
+            fake_ahandle_request,
+        )
 
         assert [r.library_name for r in dispatched] == ["Missing Library", "Present Library", "Also Missing Library"]
-        assert len(result) == 2  # noqa: PLR2004
-        assert "Missing Library" in result[0]
-        assert "Also Missing Library" in result[1]
         # The library that loaded is not reported as a problem.
-        assert not any("Present Library" in message for message in result)
+        assert [p.library_name for p in problems] == ["Missing Library", "Also Missing Library"]
 
-    def test_ensure_libraries_message_uses_filename_and_renders_semver(self, engine: Engine) -> None:
-        """The report uses the workflow file name (not full path) and renders v<version> for semver values."""
+    def test_ensure_libraries_suppresses_the_inner_registration_toast(self, engine: Engine) -> None:
+        """The run result names the library, so the inner request must not toast on top of it."""
         import logging as _logging
 
-        from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
-        from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
         from griptape_nodes.retained_mode.events.library_events import (
             RegisterLibraryFromFileRequest,
             RegisterLibraryFromFileResultFailure,
         )
-        from griptape_nodes.retained_mode.events.workflow_events import LoadWorkflowMetadataResultSuccess
-
-        workflow_manager = engine.workflow_manager
-        metadata = WorkflowMetadata(
-            name="t",
-            schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
-            engine_version_created_with="0.0.0",
-            node_libraries_referenced=[
-                LibraryNameAndVersion(library_name="Missing Library", library_version="1.2.3"),
-            ],
-        )
-        load_result = LoadWorkflowMetadataResultSuccess(metadata=metadata, result_details="ok")
 
         dispatched: list[RegisterLibraryFromFileRequest] = []
 
@@ -2827,106 +2791,44 @@ class TestLibraryResolutionOnLoad:
             dispatched.append(request)  # type: ignore[arg-type]
             return RegisterLibraryFromFileResultFailure(result_details="not found")
 
-        with (
-            patch.object(workflow_manager, "on_load_workflow_metadata_request", AsyncMock(return_value=load_result)),
-            patch.object(engine, "ahandle_request", side_effect=fake_ahandle_request),
-        ):
-            result = asyncio.run(
-                workflow_manager._ensure_libraries_for_workflow(
-                    relative_file_path="nested/dir/corridorKey.py",
-                    complete_file_path=Path("/abs/path/to/nested/dir/corridorKey.py"),
-                )
-            )
+        self._resolve(engine, self._metadata(("Missing Library", "1.2.3")), fake_ahandle_request)
 
-        assert len(result) == 1
-        message = result[0]
-        # Filename only, not the absolute path
-        assert "corridorKey.py" in message
-        assert "/abs/path/to" not in message
-        # Semver version renders with v-prefix
-        assert "v1.2.3" in message
-        assert "Missing Library" in message
-        # Inner request is suppressed at DEBUG so the GUI doesn't double-toast.
         assert len(dispatched) == 1
         assert dispatched[0].failure_log_level == _logging.DEBUG
 
-    def test_ensure_libraries_message_omits_non_semver_version(self, engine: Engine) -> None:
-        """Non-semver `library_version` values (e.g. unavailable-library placeholder) are not rendered as v<...>."""
-        from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
-        from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
-        from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileResultFailure
-        from griptape_nodes.retained_mode.events.workflow_events import LoadWorkflowMetadataResultSuccess
-
-        workflow_manager = engine.workflow_manager
-        placeholder = "<version unavailable; workflow was saved when library was unable to be loaded>"
-        metadata = WorkflowMetadata(
-            name="t",
-            schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
-            engine_version_created_with="0.0.0",
-            node_libraries_referenced=[
-                LibraryNameAndVersion(library_name="Missing Library", library_version=placeholder),
-            ],
-        )
-        load_result = LoadWorkflowMetadataResultSuccess(metadata=metadata, result_details="ok")
-
-        with (
-            patch.object(workflow_manager, "on_load_workflow_metadata_request", AsyncMock(return_value=load_result)),
-            patch.object(
-                engine,
-                "ahandle_request",
-                AsyncMock(return_value=RegisterLibraryFromFileResultFailure(result_details="not found")),
+    @pytest.mark.parametrize(
+        ("case_name", "stored_version"),
+        [
+            ("semver", "1.2.3"),
+            (
+                "unavailable_placeholder",
+                "<version unavailable; workflow was saved when library was unable to be loaded>",
             ),
-        ):
-            result = asyncio.run(
-                workflow_manager._ensure_libraries_for_workflow(
-                    relative_file_path="corridorKey.py",
-                    complete_file_path=Path("corridorKey.py"),
-                )
-            )
+            ("empty", ""),
+        ],
+    )
+    def test_ensure_libraries_never_reports_the_declared_version(
+        self, engine: Engine, case_name: str, stored_version: str
+    ) -> None:
+        """A library that never registered has no version to compare against, so none is rendered.
 
-        assert len(result) == 1
-        message = result[0]
-        assert "Missing Library" in message
-        # Placeholder must not leak into the user-facing message in any form
-        assert placeholder not in message
-        assert " v" not in message.split("Missing Library", 1)[1]
-
-    def test_ensure_libraries_message_omits_empty_version(self, engine: Engine) -> None:
-        """An empty `library_version` falls through the semver check and renders no version suffix."""
-        from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
-        from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
+        The version-mismatch problems cover a library that IS present at the wrong version. Not
+        rendering it here also keeps the non-semver placeholder a workflow stores when saved
+        without its library from ever reaching the reader.
+        """
+        del case_name
         from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileResultFailure
-        from griptape_nodes.retained_mode.events.workflow_events import LoadWorkflowMetadataResultSuccess
+        from griptape_nodes.retained_mode.managers.fitness_problems.workflows import LibraryNotRegisteredProblem
 
-        workflow_manager = engine.workflow_manager
-        metadata = WorkflowMetadata(
-            name="t",
-            schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
-            engine_version_created_with="0.0.0",
-            node_libraries_referenced=[
-                LibraryNameAndVersion(library_name="Missing Library", library_version=""),
-            ],
+        problems = self._resolve(
+            engine,
+            self._metadata(("Missing Library", stored_version)),
+            AsyncMock(return_value=RegisterLibraryFromFileResultFailure(result_details="not found")),
         )
-        load_result = LoadWorkflowMetadataResultSuccess(metadata=metadata, result_details="ok")
 
-        with (
-            patch.object(workflow_manager, "on_load_workflow_metadata_request", AsyncMock(return_value=load_result)),
-            patch.object(
-                engine,
-                "ahandle_request",
-                AsyncMock(return_value=RegisterLibraryFromFileResultFailure(result_details="not found")),
-            ),
-        ):
-            result = asyncio.run(
-                workflow_manager._ensure_libraries_for_workflow(
-                    relative_file_path="corridorKey.py",
-                    complete_file_path=Path("corridorKey.py"),
-                )
-            )
-
-        assert len(result) == 1
-        assert "Missing Library" in result[0]
-        assert " v" not in result[0].split("Missing Library", 1)[1]
+        collated = LibraryNotRegisteredProblem.collate_problems_for_display(problems)
+        assert "Missing Library" in collated
+        assert stored_version not in collated or stored_version == ""
 
     def test_ensure_libraries_is_noop_when_metadata_missing(self, engine: Engine) -> None:
         """If metadata can't be loaded, _ensure_libraries_for_workflow reports nothing (tolerant fallback)."""
@@ -2940,40 +2842,47 @@ class TestLibraryResolutionOnLoad:
             patch.object(workflow_manager, "on_load_workflow_metadata_request", AsyncMock(return_value=load_result)),
             patch.object(engine, "ahandle_request", ahandle_spy),
         ):
-            result = asyncio.run(
-                workflow_manager._ensure_libraries_for_workflow(
-                    relative_file_path="whatever.py",
-                    complete_file_path=Path("whatever.py"),
-                )
-            )
+            problems = asyncio.run(workflow_manager._ensure_libraries_for_workflow(relative_file_path="whatever.py"))
 
-        assert result == []
+        assert problems == []
         ahandle_spy.assert_not_awaited()
 
 
 class TestRunResultRendering:
-    """Unresolved libraries reach the caller as warnings, ahead of the run's own detail."""
+    """A run's problems reach the caller as warnings, ahead of its own detail."""
 
-    _PLACEHOLDERS = "Its nodes opened as placeholders that cannot run until the library is available."
+    _PLACEHOLDERS = (
+        "Nodes from the libraries above opened as placeholders. "
+        "They preserve the graph but cannot run until their library is available."
+    )
 
-    def _result(self, *, successful: bool, unresolved: tuple[str, ...]) -> WorkflowManager.WorkflowExecutionResult:
+    def _result(self, *, successful: bool, libraries: tuple[str, ...]) -> WorkflowManager.WorkflowExecutionResult:
+        from griptape_nodes.retained_mode.events.workflow_events import WorkflowStatus
+        from griptape_nodes.retained_mode.managers.fitness_problems.workflows import LibraryNotRegisteredProblem
+
+        problems = tuple(LibraryNotRegisteredProblem(library_name=name, reason="not found") for name in libraries)
+        if successful:
+            status = WorkflowStatus.FLAWED if problems else WorkflowStatus.GOOD
+        else:
+            status = WorkflowStatus.UNUSABLE
         return WorkflowManager.WorkflowExecutionResult(
             execution_successful=successful,
             execution_details="ran the file",
-            unresolved_libraries=unresolved,
+            status=status,
+            problems=problems,
         )
 
-    def test_each_unresolved_library_precedes_the_run_detail_as_a_warning(self, engine: Engine) -> None:
+    def test_problems_of_one_type_are_collated_into_a_single_warning(self, engine: Engine) -> None:
+        """Grouping is what lets five unregistered libraries say so once instead of five times."""
         details = engine.workflow_manager._execution_result_details(
-            self._result(successful=True, unresolved=("Library A is gone.", "Library B is gone.")),
-            level=logging.DEBUG,
+            self._result(successful=True, libraries=("Library A", "Library B")), level=logging.DEBUG
         )
 
-        assert [(detail.level, detail.message) for detail in details] == [
-            (logging.WARNING, f"Library A is gone. {self._PLACEHOLDERS}"),
-            (logging.WARNING, f"Library B is gone. {self._PLACEHOLDERS}"),
-            (logging.DEBUG, "ran the file"),
-        ]
+        assert [detail.level for detail in details] == [logging.WARNING, logging.WARNING, logging.DEBUG]
+        assert "Library A" in details[0].message
+        assert "Library B" in details[0].message
+        assert details[1].message == self._PLACEHOLDERS
+        assert details[2].message == "ran the file"
 
     def test_a_failed_load_is_not_told_its_nodes_became_placeholders(self, engine: Engine) -> None:
         """Nothing opened, so promising placeholders next to an ERROR would misinform.
@@ -2982,63 +2891,39 @@ class TestRunResultRendering:
         the canvas the message would be describing does not exist.
         """
         details = engine.workflow_manager._execution_result_details(
-            self._result(successful=False, unresolved=("Library A is gone.",)), level=logging.ERROR
+            self._result(successful=False, libraries=("Library A",)), level=logging.ERROR
         )
 
         assert [(detail.level, detail.message) for detail in details] == [
-            (logging.WARNING, "Library A is gone."),
+            (logging.WARNING, "'Library A' not registered. not found"),
             (logging.ERROR, "ran the file"),
         ]
 
-    @pytest.mark.parametrize(
-        ("case_name", "reason", "expected_lead"),
-        [
-            (
-                "ends_with_paren",
-                "Library 'A' not found (discovery was attempted)",
-                "Library 'A' not found (discovery was attempted)",
-            ),
-            ("ends_with_period", "Check the log for more details.", "Check the log for more details"),
-            ("ends_with_alnum", "Library 'A' is in FAILURE state", "Library 'A' is in FAILURE state"),
-            ("ends_with_stderr_newline", "Install failed: stderr=boom\n", "Install failed: stderr=boom"),
-            # Only the sentence-final period goes; punctuation inside the reason is left alone.
-            ("ends_with_quoted_period", "Saw 'A.B.'.", "Saw 'A.B.'"),
-        ],
-    )
-    def test_the_outcome_reads_as_its_own_sentence(
-        self, engine: Engine, case_name: str, reason: str, expected_lead: str
-    ) -> None:
-        """Reasons arrive from the library manager however it left them; the join must still read.
-
-        A period-ending reason is the common one, and without normalization it renders a
-        double period; a subprocess's stderr leaves a trailing newline mid-message.
-        """
-        del case_name
-        details = engine.workflow_manager._execution_result_details(
-            self._result(successful=True, unresolved=(reason,)), level=logging.DEBUG
-        )
-
-        assert details[0].message == f"{expected_lead}. {self._PLACEHOLDERS}"
-
     def test_a_clean_run_renders_only_its_own_detail(self, engine: Engine) -> None:
         details = engine.workflow_manager._execution_result_details(
-            self._result(successful=True, unresolved=()), level=logging.DEBUG
+            self._result(successful=True, libraries=()), level=logging.DEBUG
         )
 
         assert [(detail.level, detail.message) for detail in details] == [(logging.DEBUG, "ran the file")]
 
     def test_an_explicit_message_replaces_the_run_detail(self, engine: Engine) -> None:
-        """A wrapping handler keeps its own wording and still reports the libraries."""
+        """A wrapping handler keeps its own wording and still reports the problems."""
         details = engine.workflow_manager._execution_result_details(
-            self._result(successful=True, unresolved=("Library A is gone.",)),
+            self._result(successful=True, libraries=("Library A",)),
             level=logging.DEBUG,
             message="Successfully imported workflow 'x' as referenced sub flow 'y'",
         )
 
-        assert [(detail.level, detail.message) for detail in details] == [
-            (logging.WARNING, f"Library A is gone. {self._PLACEHOLDERS}"),
-            (logging.DEBUG, "Successfully imported workflow 'x' as referenced sub flow 'y'"),
-        ]
+        assert details[-1].message == "Successfully imported workflow 'x' as referenced sub flow 'y'"
+        assert "Library A" in details[0].message
+
+    def test_a_flawed_load_is_distinguishable_from_a_clean_one_without_reading_prose(self) -> None:
+        """The status is what a caller gates on; the strings are for the reader."""
+        from griptape_nodes.retained_mode.events.workflow_events import WorkflowStatus
+
+        assert self._result(successful=True, libraries=()).status is WorkflowStatus.GOOD
+        assert self._result(successful=True, libraries=("Library A",)).status is WorkflowStatus.FLAWED
+        assert self._result(successful=False, libraries=()).status is WorkflowStatus.UNUSABLE
 
 
 class TestWorkflowsLoadingGate:

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -1612,10 +1612,9 @@ class TestWorkflowManager:
     async def test_unregistered_library_reports_flawed_not_unusable(self, engine: Engine, tmp_path: Path) -> None:
         """A header naming a library that is not registered leaves the workflow FLAWED.
 
-        It used to be critical, which meant UNUSABLE. That contradicts what the editor now does
-        with such a workflow: it opens, with ErrorProxyNode placeholders standing in for that
-        library's nodes (issue #5505). UNUSABLE would tell the artist not to bother opening the
-        thing they can in fact open and edit.
+        Such a workflow opens, with ErrorProxyNode placeholders standing in for that library's
+        nodes (issue #5505). UNUSABLE would tell the artist not to bother opening the thing they
+        can in fact open and edit.
         """
         workflow_manager = engine.workflow_manager
         engine.config_manager.workspace_path = tmp_path

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -2697,12 +2697,16 @@ class TestLibraryResolutionOnLoad:
                 )
             )
 
-        assert result is None
+        assert result == []
         assert [r.library_name for r in dispatched] == ["Example Library", "Other Library"]
         assert all(r.perform_discovery_if_not_found for r in dispatched)
 
-    def test_ensure_libraries_returns_failure_when_registration_fails(self, engine: Engine) -> None:
-        """A failed library registration short-circuits with a WorkflowExecutionResult failure."""
+    def test_ensure_libraries_reports_the_library_instead_of_refusing_the_load(self, engine: Engine) -> None:
+        """A failed library registration is reported, not fatal: the caller still execs the file.
+
+        A library that will not register costs execution, never editing (issue #5505). The nodes
+        it owns come back as placeholders, which is only possible if the load continues.
+        """
         from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
         from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
         from griptape_nodes.retained_mode.events.library_events import RegisterLibraryFromFileResultFailure
@@ -2734,12 +2738,68 @@ class TestLibraryResolutionOnLoad:
                 )
             )
 
-        assert result is not None
-        assert result.execution_successful is False
-        assert "Missing Library" in result.execution_details
+        assert len(result) == 1
+        assert "Missing Library" in result[0]
+        # The inner reason travels with it so the reader isn't sent hunting.
+        assert "not found" in result[0]
 
-    def test_ensure_libraries_failure_message_uses_filename_and_renders_semver(self, engine: Engine) -> None:
-        """Failure message uses the workflow file name (not full path) and renders v<version> for semver values."""
+    def test_ensure_libraries_attempts_every_library_after_one_fails(self, engine: Engine) -> None:
+        """One unresolvable library does not stop the others from registering.
+
+        Short-circuiting here would strand libraries later in the list, turning their perfectly
+        loadable nodes into placeholders too.
+        """
+        from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
+        from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
+        from griptape_nodes.retained_mode.events.library_events import (
+            RegisterLibraryFromFileRequest,
+            RegisterLibraryFromFileResultFailure,
+            RegisterLibraryFromFileResultSuccess,
+        )
+        from griptape_nodes.retained_mode.events.workflow_events import LoadWorkflowMetadataResultSuccess
+
+        workflow_manager = engine.workflow_manager
+        metadata = WorkflowMetadata(
+            name="t",
+            schema_version=WorkflowMetadata.LATEST_SCHEMA_VERSION,
+            engine_version_created_with="0.0.0",
+            node_libraries_referenced=[
+                LibraryNameAndVersion(library_name="Missing Library", library_version="0.1.0"),
+                LibraryNameAndVersion(library_name="Present Library", library_version="0.2.0"),
+                LibraryNameAndVersion(library_name="Also Missing Library", library_version="0.3.0"),
+            ],
+        )
+        load_result = LoadWorkflowMetadataResultSuccess(metadata=metadata, result_details="ok")
+
+        dispatched: list[RegisterLibraryFromFileRequest] = []
+
+        async def fake_ahandle_request(request: object) -> object:
+            dispatched.append(request)  # type: ignore[arg-type]
+            library_name = request.library_name  # type: ignore[attr-defined]
+            if library_name == "Present Library":
+                return RegisterLibraryFromFileResultSuccess(library_name=library_name, result_details="ok")
+            return RegisterLibraryFromFileResultFailure(result_details="not found")
+
+        with (
+            patch.object(workflow_manager, "on_load_workflow_metadata_request", AsyncMock(return_value=load_result)),
+            patch.object(engine, "ahandle_request", side_effect=fake_ahandle_request),
+        ):
+            result = asyncio.run(
+                workflow_manager._ensure_libraries_for_workflow(
+                    relative_file_path="whatever.py",
+                    complete_file_path=Path("whatever.py"),
+                )
+            )
+
+        assert [r.library_name for r in dispatched] == ["Missing Library", "Present Library", "Also Missing Library"]
+        assert len(result) == 2  # noqa: PLR2004
+        assert "Missing Library" in result[0]
+        assert "Also Missing Library" in result[1]
+        # The library that loaded is not reported as a problem.
+        assert not any("Present Library" in message for message in result)
+
+    def test_ensure_libraries_message_uses_filename_and_renders_semver(self, engine: Engine) -> None:
+        """The report uses the workflow file name (not full path) and renders v<version> for semver values."""
         import logging as _logging
 
         from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
@@ -2778,19 +2838,19 @@ class TestLibraryResolutionOnLoad:
                 )
             )
 
-        assert result is not None
-        assert result.execution_successful is False
+        assert len(result) == 1
+        message = result[0]
         # Filename only, not the absolute path
-        assert "corridorKey.py" in result.execution_details
-        assert "/abs/path/to" not in result.execution_details
+        assert "corridorKey.py" in message
+        assert "/abs/path/to" not in message
         # Semver version renders with v-prefix
-        assert "v1.2.3" in result.execution_details
-        assert "Missing Library" in result.execution_details
+        assert "v1.2.3" in message
+        assert "Missing Library" in message
         # Inner request is suppressed at DEBUG so the GUI doesn't double-toast.
         assert len(dispatched) == 1
         assert dispatched[0].failure_log_level == _logging.DEBUG
 
-    def test_ensure_libraries_failure_message_omits_non_semver_version(self, engine: Engine) -> None:
+    def test_ensure_libraries_message_omits_non_semver_version(self, engine: Engine) -> None:
         """Non-semver `library_version` values (e.g. unavailable-library placeholder) are not rendered as v<...>."""
         from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
         from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
@@ -2824,14 +2884,14 @@ class TestLibraryResolutionOnLoad:
                 )
             )
 
-        assert result is not None
-        assert result.execution_successful is False
-        assert "Missing Library" in result.execution_details
+        assert len(result) == 1
+        message = result[0]
+        assert "Missing Library" in message
         # Placeholder must not leak into the user-facing message in any form
-        assert placeholder not in result.execution_details
-        assert " v" not in result.execution_details.split("Missing Library", 1)[1]
+        assert placeholder not in message
+        assert " v" not in message.split("Missing Library", 1)[1]
 
-    def test_ensure_libraries_failure_message_omits_empty_version(self, engine: Engine) -> None:
+    def test_ensure_libraries_message_omits_empty_version(self, engine: Engine) -> None:
         """An empty `library_version` falls through the semver check and renders no version suffix."""
         from griptape_nodes.node_library.library_registry import LibraryNameAndVersion
         from griptape_nodes.node_library.workflow_registry import WorkflowMetadata
@@ -2864,13 +2924,12 @@ class TestLibraryResolutionOnLoad:
                 )
             )
 
-        assert result is not None
-        assert result.execution_successful is False
-        assert "Missing Library" in result.execution_details
-        assert " v" not in result.execution_details.split("Missing Library", 1)[1]
+        assert len(result) == 1
+        assert "Missing Library" in result[0]
+        assert " v" not in result[0].split("Missing Library", 1)[1]
 
     def test_ensure_libraries_is_noop_when_metadata_missing(self, engine: Engine) -> None:
-        """If metadata can't be loaded, _ensure_libraries_for_workflow returns None (tolerant fallback)."""
+        """If metadata can't be loaded, _ensure_libraries_for_workflow reports nothing (tolerant fallback)."""
         from griptape_nodes.retained_mode.events.workflow_events import LoadWorkflowMetadataResultFailure
 
         workflow_manager = engine.workflow_manager
@@ -2888,8 +2947,98 @@ class TestLibraryResolutionOnLoad:
                 )
             )
 
-        assert result is None
+        assert result == []
         ahandle_spy.assert_not_awaited()
+
+
+class TestRunResultRendering:
+    """Unresolved libraries reach the caller as warnings, ahead of the run's own detail."""
+
+    _PLACEHOLDERS = "Its nodes opened as placeholders that cannot run until the library is available."
+
+    def _result(self, *, successful: bool, unresolved: tuple[str, ...]) -> WorkflowManager.WorkflowExecutionResult:
+        return WorkflowManager.WorkflowExecutionResult(
+            execution_successful=successful,
+            execution_details="ran the file",
+            unresolved_libraries=unresolved,
+        )
+
+    def test_each_unresolved_library_precedes_the_run_detail_as_a_warning(self, engine: Engine) -> None:
+        details = engine.workflow_manager._execution_result_details(
+            self._result(successful=True, unresolved=("Library A is gone.", "Library B is gone.")),
+            level=logging.DEBUG,
+        )
+
+        assert [(detail.level, detail.message) for detail in details] == [
+            (logging.WARNING, f"Library A is gone. {self._PLACEHOLDERS}"),
+            (logging.WARNING, f"Library B is gone. {self._PLACEHOLDERS}"),
+            (logging.DEBUG, "ran the file"),
+        ]
+
+    def test_a_failed_load_is_not_told_its_nodes_became_placeholders(self, engine: Engine) -> None:
+        """Nothing opened, so promising placeholders next to an ERROR would misinform.
+
+        The failure branch of on_run_workflow_from_registry_request clears all object state, so
+        the canvas the message would be describing does not exist.
+        """
+        details = engine.workflow_manager._execution_result_details(
+            self._result(successful=False, unresolved=("Library A is gone.",)), level=logging.ERROR
+        )
+
+        assert [(detail.level, detail.message) for detail in details] == [
+            (logging.WARNING, "Library A is gone."),
+            (logging.ERROR, "ran the file"),
+        ]
+
+    @pytest.mark.parametrize(
+        ("case_name", "reason", "expected_lead"),
+        [
+            (
+                "ends_with_paren",
+                "Library 'A' not found (discovery was attempted)",
+                "Library 'A' not found (discovery was attempted)",
+            ),
+            ("ends_with_period", "Check the log for more details.", "Check the log for more details"),
+            ("ends_with_alnum", "Library 'A' is in FAILURE state", "Library 'A' is in FAILURE state"),
+            ("ends_with_stderr_newline", "Install failed: stderr=boom\n", "Install failed: stderr=boom"),
+            # Only the sentence-final period goes; punctuation inside the reason is left alone.
+            ("ends_with_quoted_period", "Saw 'A.B.'.", "Saw 'A.B.'"),
+        ],
+    )
+    def test_the_outcome_reads_as_its_own_sentence(
+        self, engine: Engine, case_name: str, reason: str, expected_lead: str
+    ) -> None:
+        """Reasons arrive from the library manager however it left them; the join must still read.
+
+        A period-ending reason is the common one, and without normalization it renders a
+        double period; a subprocess's stderr leaves a trailing newline mid-message.
+        """
+        del case_name
+        details = engine.workflow_manager._execution_result_details(
+            self._result(successful=True, unresolved=(reason,)), level=logging.DEBUG
+        )
+
+        assert details[0].message == f"{expected_lead}. {self._PLACEHOLDERS}"
+
+    def test_a_clean_run_renders_only_its_own_detail(self, engine: Engine) -> None:
+        details = engine.workflow_manager._execution_result_details(
+            self._result(successful=True, unresolved=()), level=logging.DEBUG
+        )
+
+        assert [(detail.level, detail.message) for detail in details] == [(logging.DEBUG, "ran the file")]
+
+    def test_an_explicit_message_replaces_the_run_detail(self, engine: Engine) -> None:
+        """A wrapping handler keeps its own wording and still reports the libraries."""
+        details = engine.workflow_manager._execution_result_details(
+            self._result(successful=True, unresolved=("Library A is gone.",)),
+            level=logging.DEBUG,
+            message="Successfully imported workflow 'x' as referenced sub flow 'y'",
+        )
+
+        assert [(detail.level, detail.message) for detail in details] == [
+            (logging.WARNING, f"Library A is gone. {self._PLACEHOLDERS}"),
+            (logging.DEBUG, "Successfully imported workflow 'x' as referenced sub flow 'y'"),
+        ]
 
 
 class TestWorkflowsLoadingGate:

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -2804,7 +2804,6 @@ class TestLibraryResolutionOnLoad:
                 "unavailable_placeholder",
                 "<version unavailable; workflow was saved when library was unable to be loaded>",
             ),
-            ("empty", ""),
         ],
     )
     def test_ensure_libraries_never_reports_the_declared_version(
@@ -2828,7 +2827,7 @@ class TestLibraryResolutionOnLoad:
 
         collated = LibraryNotRegisteredProblem.collate_problems_for_display(problems)
         assert "Missing Library" in collated
-        assert stored_version not in collated or stored_version == ""
+        assert stored_version not in collated
 
     def test_ensure_libraries_is_noop_when_metadata_missing(self, engine: Engine) -> None:
         """If metadata can't be loaded, _ensure_libraries_for_workflow reports nothing (tolerant fallback)."""
@@ -2916,14 +2915,6 @@ class TestRunResultRendering:
 
         assert details[-1].message == "Successfully imported workflow 'x' as referenced sub flow 'y'"
         assert "Library A" in details[0].message
-
-    def test_a_flawed_load_is_distinguishable_from_a_clean_one_without_reading_prose(self) -> None:
-        """The status is what a caller gates on; the strings are for the reader."""
-        from griptape_nodes.retained_mode.events.workflow_events import WorkflowStatus
-
-        assert self._result(successful=True, libraries=()).status is WorkflowStatus.GOOD
-        assert self._result(successful=True, libraries=("Library A",)).status is WorkflowStatus.FLAWED
-        assert self._result(successful=False, libraries=()).status is WorkflowStatus.UNUSABLE
 
 
 class TestWorkflowsLoadingGate:

--- a/tests/unit/retained_mode/managers/test_workflow_manager.py
+++ b/tests/unit/retained_mode/managers/test_workflow_manager.py
@@ -74,6 +74,7 @@ from griptape_nodes.retained_mode.events.workflow_events import (
 from griptape_nodes.retained_mode.managers.context_manager import ContextManager
 from griptape_nodes.retained_mode.managers.fitness_problems.workflows import (
     InvalidTomlFormatProblem,
+    LibraryNotRegisteredProblem,
     MissingTomlSectionProblem,
 )
 from griptape_nodes.retained_mode.managers.flow_manager import FlowManager
@@ -1606,6 +1607,77 @@ class TestWorkflowManager:
             info = workflow_manager._workflow_file_path_to_info[str(tmp_path / file_name)]
             assert info.status is WorkflowManager.WorkflowStatus.UNUSABLE, file_name
             assert any(isinstance(problem, MissingTomlSectionProblem) for problem in info.problems), file_name
+
+    @pytest.mark.asyncio
+    async def test_unregistered_library_reports_flawed_not_unusable(self, engine: Engine, tmp_path: Path) -> None:
+        """A header naming a library that is not registered leaves the workflow FLAWED.
+
+        It used to be critical, which meant UNUSABLE. That contradicts what the editor now does
+        with such a workflow: it opens, with ErrorProxyNode placeholders standing in for that
+        library's nodes (issue #5505). UNUSABLE would tell the artist not to bother opening the
+        thing they can in fact open and edit.
+        """
+        workflow_manager = engine.workflow_manager
+        engine.config_manager.workspace_path = tmp_path
+        engine.library_manager._libraries_loading_complete.set()
+
+        header = WorkflowManager.WORKFLOW_METADATA_HEADER
+        (tmp_path / "missing_library.py").write_text(
+            "\n".join(
+                [
+                    f"# /// {header}",
+                    "# [tool.griptape-nodes]",
+                    '# name = "missing_library"',
+                    f'# schema_version = "{WorkflowMetadata.LATEST_SCHEMA_VERSION}"',
+                    '# engine_version_created_with = "0.0.0"',
+                    '# node_libraries_referenced = [["Nowhere Library", "1.0.0"]]',
+                    "# ///",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        result = await workflow_manager.on_load_workflow_metadata_request(
+            LoadWorkflowMetadata(file_name="missing_library.py")
+        )
+
+        assert isinstance(result, LoadWorkflowMetadataResultSuccess)
+        info = workflow_manager._workflow_file_path_to_info[str(tmp_path / "missing_library.py")]
+        assert info.status is WorkflowManager.WorkflowStatus.FLAWED
+        assert any(isinstance(problem, LibraryNotRegisteredProblem) for problem in info.problems)
+
+    @pytest.mark.asyncio
+    async def test_a_malformed_dependency_version_is_still_unusable(self, engine: Engine, tmp_path: Path) -> None:
+        """Only the not-registered case was downgraded; a header the engine cannot parse still is not loadable."""
+        workflow_manager = engine.workflow_manager
+        engine.config_manager.workspace_path = tmp_path
+        engine.library_manager._libraries_loading_complete.set()
+
+        header = WorkflowManager.WORKFLOW_METADATA_HEADER
+        (tmp_path / "bad_version.py").write_text(
+            "\n".join(
+                [
+                    f"# /// {header}",
+                    "# [tool.griptape-nodes]",
+                    '# name = "bad_version"',
+                    f'# schema_version = "{WorkflowMetadata.LATEST_SCHEMA_VERSION}"',
+                    '# engine_version_created_with = "0.0.0"',
+                    '# node_libraries_referenced = [["Nowhere Library", "not-a-version"]]',
+                    "# ///",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        result = await workflow_manager.on_load_workflow_metadata_request(
+            LoadWorkflowMetadata(file_name="bad_version.py")
+        )
+
+        assert isinstance(result, LoadWorkflowMetadataResultSuccess)
+        info = workflow_manager._workflow_file_path_to_info[str(tmp_path / "bad_version.py")]
+        assert info.status is WorkflowManager.WorkflowStatus.UNUSABLE
 
     # --- WorkflowInfo payload helpers ---
 


### PR DESCRIPTION
Closes #5505.

## The bug

A saved workflow that references a library which cannot be registered — uninstalled, or present on disk but **disabled in `libraries_to_register`** — did not open at all. `_ensure_libraries_for_workflow` returned a failing `WorkflowExecutionResult` on the first such library and aborted before `exec()`, so no nodes were created. The failure branch of `on_run_workflow_from_registry_request` then calls `ClearAllObjectStateRequest`, which is what left the canvas empty behind two error toasts.

An artist with a toggled-off library couldn't get in to see which nodes were affected, let alone edit or save the parts that didn't depend on it — and there was no in-editor path to recovery, since the workflow has to open before you can see what it needs.

## The change

Report the library; don't refuse the load. The placeholder machinery this needs already existed and was simply unreachable: `CreateNodeRequest` substitutes an `ErrorProxyNode` for a node type it can't construct (`create_error_proxy_on_failure` defaults `True`), and that proxy carries the failure reason, invents the parameters it's asked for, and accepts connections — so values and connections survive on both sides of the graph. This is the rule #5427 and #5452 established for a library whose execution dependencies won't install and one whose resource requirements aren't met: **a library failure costs execution, never editing.**

- `_ensure_libraries_for_workflow` returns one user-facing message per library that wouldn't register instead of a failing result, and no longer short-circuits — a library later in the header still gets its chance to load.
- `WorkflowExecutionResult` carries `unresolved_libraries`. Every handler that consumes one reports them as WARNINGs ahead of its own detail, or a load would look clean to its caller while the graph was quietly full of placeholders. That includes `_execute_workflow_import`, which is the *only* result that can name them for a referenced subflow — a subflow's libraries aren't in the importing workflow's own header.
- The outcome clause ("its nodes opened as placeholders…") is appended at render time, not baked into the reason, because only a load that survived has placeholders to point at; a failed one cleared the canvas.
- Saved files re-register their own libraries inside `build_workflow()`, so each library that just failed would fail again on a request the GUI would toast. That window is suppressed — but only when the header was readable and the engine has something of its own to report. An unreadable header pre-registers nothing, and there the in-file failures are the only record of what the workflow needs. Both directions are pinned by tests.

## Scope

**Only the missing library's node types are recoverable.** A parameter value whose *class* the library declares is emitted by codegen as a hard `from griptape_nodes.node_libraries.<lib>.<mod> import Klass` inside `build_workflow()`, which raises `ModuleNotFoundError` before any node exists. That can't be retrofitted to already-saved files and needs a decision about what the value becomes, so it's called out in the docstrings and left for a follow-up rather than half-fixed here.

## Tests

New `test_workflow_load_missing_library.py` (13 tests) builds a graph against two real fixture libraries, saves it through real codegen, restarts the engine with only one library installed, and replays the file. Nothing about the missing library is mocked — it is genuinely absent from the second engine's `LibraryRegistry` and its modules are evicted from `sys.modules`, so `CreateNodeRequest` fails the way it does in production.

Covers both reported variants (uninstalled, and disabled-in-config via the real `DISABLED` lifecycle branch); one warning per library carrying its reason; placeholder identity; values and connections preserved across the proxy; the placeholder refusing to run while the healthy side stays editable; every library missing at once; the placeholder → real node round trip once the library returns; the suppression / no-suppression pair; `RunWorkflowFromRegistryRequest` itself; and import-as-referenced-subflow.

Plus 15 in `test_workflow_manager.py` for the new resolution contract and result rendering. **All 13 end-to-end tests fail against the base commit** — verified by reverting the fix — so they pin the behavior rather than describing it.

`make check` clean; unit + integration 5958 passed, e2e 39 passed.

## Follow-ups found while reviewing (not addressed here)

1. **Publishing does not refuse a placeholder graph.** `LocalWorkflowPublisher` loads via `RunWorkflowFromScratchRequest` and publishes whatever loaded; `node_manager` stamps `<version unavailable…>` into the bundle's `node_libraries_referenced`. This predates the change — a library that registers but whose nodes raise in `__init__` already produces placeholders, and `_ensure_libraries_for_workflow` never inspected node construction — but this change widens the trigger to unregistered libraries.
2. **`_set_input_for_flow` silently drops `flow_input`** for a proxied `StartNode`: it selects by `isinstance(node, StartNode)`, and a library-supplied `StartNode` subclass that became a placeholder fails that check without a word. Also pre-existing.
3. **`node_manager` logs one ERROR per proxied node**, so a 40-node graph from a missing library emits 40 error lines beside the single intended warning.
4. **Suppression matches by event type**, not by library name, for the duration of `exec()`. Sound for engine-generated files, but an outer workflow with an unresolved library plus a referenced subflow whose own header is unreadable would swallow the inner file's registration failures.
5. **A genuinely-missing library triggers two discovery scans** per open (the engine's pre-registration and the file's own), on an already-degraded path.
