### PR TITLE
docs: stop telling library authors to depend on the engine

### DIFF
--- a/docs/development/custom_nodes/authoring_libraries.md
+++ b/docs/development/custom_nodes/authoring_libraries.md
@@ -358,13 +358,15 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "griptape-nodes-engine",
     "requests",
-    # Add other dependencies
+    # Add other packages your nodes import at runtime
 ]
 
+[dependency-groups]
+dev = ["griptape-nodes-engine", "pytest", "pyright", "ruff"]
+
 [tool.uv.sources]
-griptape-nodes-engine = { git = "https://github.com/griptape-ai/griptape-nodes", rev="latest"}
+griptape-nodes-engine = { git = "https://github.com/griptape-ai/griptape-nodes-engine", rev = "latest" }
 
 [tool.hatch.build.targets.wheel]
 packages = ["library_name"]
@@ -373,6 +375,20 @@ packages = ["library_name"]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 ```
+
+#### Do not list the engine as a runtime dependency
+
+The engine is the host that loads your library, not a package your library pulls in. Keep `griptape-nodes-engine` out of `[project] dependencies`:
+
+- Installing your library would otherwise install a **second engine**. The engine puts a library's virtual environment at the front of its own import path, so that second copy can shadow the engine that is actually running, and the resulting errors look like engine bugs rather than library ones.
+- `[dependency-groups] dev` still gives your tests, type checker, and editor an engine to resolve against, because `uv sync` installs dev groups by default. Your development workflow is unchanged.
+- The engine version your library needs belongs in `engine_version` in your library JSON. That is the value the engine actually checks when it loads you; the pyproject specifier is never consulted at load time.
+
+Declaring it in both places means maintaining the same fact twice, and the two drift.
+
+!!! note "This changes with library packaging"
+
+    Once libraries are resolved as packages into their own environments, the engine becomes a normal bounded dependency (`griptape-nodes-engine>=X,<Y`) and that single resolution replaces the `engine_version` check. Use the layout above until that ships.
 
 ### Library Configuration (inside subdirectory)
 


### PR DESCRIPTION
## Problem

The pyproject example in the library authoring guide instructed:

```toml
dependencies = [
    "griptape-nodes-engine",
    ...
]
```

This is how the pattern spread. Every non-archived library repo in the org declares the engine as a runtime dependency, and this is the doc that told them to.

Declaring the host as a runtime dependency means installing a library installs a **second engine**. The engine puts a library's venv at the front of its own import path (`_add_library_paths_to_sys_path` inserts at `sys.path[0]`), so that second copy can shadow the engine that is actually running, and the resulting failures look like engine bugs rather than library ones.

It also duplicates a fact that already has an enforced home. The engine gates compatibility on `engine_version` in the library manifest via `requires_engine`; the pyproject specifier is never consulted at load time. Two declarations, no enforcement, and they drift.

## Change

- Moved the engine to `[dependency-groups] dev` in the example, so tests, type checking, and editors still resolve it (uv installs dev groups by default) while nothing that installs the library as a package pulls a host.
- Pointed `[tool.uv.sources]` at `griptape-ai/griptape-nodes-engine` instead of the old `griptape-ai/griptape-nodes` monolith repo, which was stale.
- Added a short section explaining why, and where the compatibility floor belongs.
- Added a note that this reverses under library packaging: once libraries resolve as packages into their own environments, the engine becomes a normal bounded dependency (`griptape-nodes-engine>=X,<Y`) and that single resolution replaces the `engine_version` check.

## Verification

`uv run mkdocs build --strict` passes. No new pages, so no `mkdocs.yml` changes needed.

## Related

Companion PRs move the engine out of runtime dependencies across the library repos.

<!-- readthedocs-preview griptape-nodes start -->
----
📚 Documentation preview 📚: https://griptape-nodes--5519.org.readthedocs.build/en/5519/

<!-- readthedocs-preview griptape-nodes end -->