### PR TITLE
refactor: move the skills capability onto pydantic-ai-harness

### DIFF
--- a/docs/guides/agent/skills.md
+++ b/docs/guides/agent/skills.md
@@ -39,6 +39,8 @@ part of its context.
 
 The `name` must match the skill's folder name, and `description` tells the agent when to use the skill. The body can be as long or short as you need — code snippets, step-by-step instructions, reference tables, etc.
 
+Only `SKILL.md` is read. Files bundled beside it, such as `references/` or `scripts/`, are neither read nor run, so put everything the agent needs in the body.
+
 ## Example: a house style guide
 
 ```markdown

--- a/docs/guides/agent/skills.md
+++ b/docs/guides/agent/skills.md
@@ -39,8 +39,6 @@ part of its context.
 
 The `name` must match the skill's folder name, and `description` tells the agent when to use the skill. The body can be as long or short as you need — code snippets, step-by-step instructions, reference tables, etc.
 
-Only `SKILL.md` becomes part of the skill. Files bundled beside it, such as `references/` or `scripts/`, are never loaded into the agent's context or run for you, so put everything the agent needs in the body. If you have connected an MCP server that can read files, the agent can still open them when asked, but nothing in the skill points it there.
-
 ## Example: a house style guide
 
 ```markdown

--- a/docs/guides/agent/skills.md
+++ b/docs/guides/agent/skills.md
@@ -39,7 +39,7 @@ part of its context.
 
 The `name` must match the skill's folder name, and `description` tells the agent when to use the skill. The body can be as long or short as you need — code snippets, step-by-step instructions, reference tables, etc.
 
-Only `SKILL.md` is read. Files bundled beside it, such as `references/` or `scripts/`, are neither read nor run, so put everything the agent needs in the body.
+Only `SKILL.md` becomes part of the skill. Files bundled beside it, such as `references/` or `scripts/`, are never loaded into the agent's context or run for you, so put everything the agent needs in the body. If you have connected an MCP server that can read files, the agent can still open them when asked, but nothing in the skill points it there.
 
 ## Example: a house style guide
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,13 +46,15 @@ dependencies = [
   # Below this, `pydantic_ai/mcp.py` imports symbols (e.g. `mcp.shared.context.RequestContext`)
   # that mcp 2.x moved/renamed, so `agent_manager` fails to import at construction time.
   # PR #5449 raised the `mcp` ceiling without checking this; PR #5493 papered over the fallout
-  # for pydantic-ai-skills but left this one. Lift no lower than this floor.
+  # for the skills capability but left this one. Lift no lower than this floor.
   "pydantic-ai-slim[mcp,openai]>=2.29.0",
-  # Floor at 2.0: agents/pydantic_ai/runner.py builds a SkillsCapability with the 2.x
-  # arguments (`scripts`, `include`) that replaced 1.x's `exclude_tools`/`auto_reload`.
-  # Ceiling below 3.0 so the next major cannot silently break the sidebar agent at
-  # construction time the way 2.0.0 did (see issue 5491).
-  "pydantic-ai-skills>=2.0,<3",
+  # Supplies the `Skills` capability agents/pydantic_ai/runner.py builds from
+  # `<workspace>/.agents/skills`. The `skills` extra installs the PyYAML that parses
+  # `SKILL.md` frontmatter.
+  # Locked and tested at 0.29.1. Ceiling below 1.0 so a major cannot silently break the
+  # sidebar agent at construction time (see issue 5491). The harness is pre-1.0 and its
+  # API can change between minors, so treat a minor bump as a change to verify.
+  "pydantic-ai-harness[skills]>=0.29.1,<1.0",
 ]
 
 [project.optional-dependencies]

--- a/src/griptape_nodes/agents/pydantic_ai/runner.py
+++ b/src/griptape_nodes/agents/pydantic_ai/runner.py
@@ -46,7 +46,7 @@ from pydantic_ai.messages import (
     ToolCallPart,
     UserPromptPart,
 )
-from pydantic_ai_skills import SkillsCapability
+from pydantic_ai_harness import Skills
 
 from griptape_nodes.agents.pydantic_ai.image_tools import (
     IMAGE_TOOL_NAME,
@@ -62,6 +62,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from pydantic_ai._run_context import RunContext
+    from pydantic_ai.capabilities import AbstractCapability
     from pydantic_ai.messages import ModelMessage, UserContent
     from pydantic_ai.settings import ModelSettings
     from pydantic_ai.toolsets import AbstractToolset
@@ -235,14 +236,12 @@ class PydanticAgentRunner:
             return None
         return skills_dir
 
-    def _build_skills_capabilities(self) -> list[SkillsCapability]:
+    def _build_skills_capabilities(self) -> list[Skills]:
         """Build the skills capability exposing ``.agents/skills`` to the agent.
 
         Built per run rather than per runner: discovery is a construction-time
         snapshot, so rebuilding it each turn is what makes an edited skill land
-        without restarting the engine. ``scripts=False`` leaves
-        ``run_skill_script`` unregistered because the workspace already exposes a
-        gated shell tool and skills here ship no scripts.
+        without restarting the engine.
 
         Returns an empty list when skills are disabled, the directory is absent,
         or no skill in it loads, so the run proceeds without skills instead of
@@ -258,32 +257,18 @@ class PydanticAgentRunner:
             return []
         return [capability]
 
-    def _load_skills(
-        self,
-        skills_dir: Path,
-        include: list[str] | None = None,
-        *,
-        index_resources: bool = True,
-    ) -> SkillsCapability | None:
+    def _load_skills(self, skills_dir: Path, include: list[str] | None = None) -> Skills | None:
         """Build a capability over ``skills_dir``, or ``None`` when the loader rejects a skill.
 
         The loader validates every selected skill while constructing and raises on the
         first one it rejects, so this succeeds only when all of them load. ``ValueError``
         is a frontmatter report and ``OSError`` an unreadable ``SKILL.md``; both cost
         skills rather than the run.
-
-        ``index_resources=False`` skips indexing bundled *resources*, which a probe does
-        not need and which is the bulk of what makes probing expensive. Scripts are still
-        discovered, so a library shipping them pays more per probe than one that does not.
         """
-        exclude_resources = None if index_resources else ["*"]
         try:
-            return SkillsCapability(
-                directories=[skills_dir],
-                scripts=False,
-                include=include,
-                exclude_resources=exclude_resources,
-            )
+            if include is None:
+                return Skills(skills_dir)
+            return Skills(skills_dir, include=include)
         except (ValueError, OSError) as e:
             logger.warning(
                 "Attempted to load skills %s from %s. Failed because of: %s",
@@ -293,18 +278,14 @@ class PydanticAgentRunner:
             )
             return None
 
-    def _load_usable_skills(self, skills_dir: Path) -> SkillsCapability | None:
+    def _load_usable_skills(self, skills_dir: Path) -> Skills | None:
         """Build a capability over only the skills in ``skills_dir`` that load on their own.
 
         One rejected ``SKILL.md`` fails the whole library, so probe each skill by name
         first: ``include`` filters before the loader parses anything, which pins a
         rejection to the skill that caused it and keeps the others. Returns ``None`` when
-        nothing survives.
-
-        Probing costs a construction per skill, and every construction walks the whole
-        library's bundled files, so probes skip indexing its resources: a probe only has
-        to answer whether the frontmatter parses, and the survivors' resources are indexed
-        by the build below.
+        nothing survives. Costs a construction per skill, each of which reads one
+        ``SKILL.md``.
         """
         try:
             candidates = sorted(entry.name for entry in skills_dir.iterdir() if (entry / "SKILL.md").is_file())
@@ -312,11 +293,7 @@ class PydanticAgentRunner:
             logger.warning("Attempted to list the skills in %s. Failed because of: %s", skills_dir, e)
             return None
 
-        usable = [
-            name
-            for name in candidates
-            if self._load_skills(skills_dir, include=[name], index_resources=False) is not None
-        ]
+        usable = [name for name in candidates if self._load_skills(skills_dir, include=[name]) is not None]
         if not usable:
             return None
         return self._load_skills(skills_dir, include=usable)
@@ -392,7 +369,7 @@ class PydanticAgentRunner:
             run_id,
             self.model_name,
             len(history),
-            [name for capability in capabilities for name in capability.skill_names],
+            _skill_names(capabilities),
             _prompt_preview(prompt),
         )
         started = time.monotonic()
@@ -516,6 +493,23 @@ class PydanticAgentRunner:
         with contextlib.suppress(asyncio.CancelledError):
             await run_task
         return None
+
+
+def _skill_names(capabilities: Sequence[Skills]) -> list[str]:
+    """The names of the skills ``capabilities`` offers the model, for logging.
+
+    ``Skills`` keeps its per-skill capabilities private, so walk each tree the way
+    Pydantic AI does and read the leaf ids, which are the skill names.
+    """
+    names: list[str] = []
+
+    def collect(leaf: AbstractCapability[Any]) -> None:
+        if leaf.id is not None:
+            names.append(leaf.id)
+
+    for capability in capabilities:
+        capability.apply(collect)
+    return names
 
 
 @dataclass

--- a/tests/unit/agents/pydantic_ai/test_skills.py
+++ b/tests/unit/agents/pydantic_ai/test_skills.py
@@ -1,8 +1,8 @@
-"""Tests for how the runner wires `.agents/skills` into a `SkillsCapability`.
+"""Tests for how the runner wires `.agents/skills` into a `Skills` capability.
 
-Skill discovery and progressive disclosure are owned by `pydantic-ai-skills`;
+Skill discovery and progressive disclosure are owned by the Pydantic AI harness;
 these tests cover only the runner's contract: when a capability is built, what
-it discovers, which tools it exposes, and what a broken skill costs.
+it discovers, and what a broken skill costs.
 
 The skills reaching the model on a run is covered in `test_runner.py`, which is
 where a `FunctionModel` can observe the offered tools.
@@ -14,9 +14,8 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from pydantic_ai.toolsets import FunctionToolset
 
-from griptape_nodes.agents.pydantic_ai.runner import PydanticAgentRunner
+from griptape_nodes.agents.pydantic_ai.runner import PydanticAgentRunner, _skill_names
 from griptape_nodes.drivers.thread_storage.local_thread_storage_driver import LocalThreadStorageDriver
 
 
@@ -68,41 +67,22 @@ def test_discovers_skill(workspace: Path, tmp_path: Path) -> None:
 
     capabilities = runner._build_skills_capabilities()
     assert len(capabilities) == 1
-    assert capabilities[0].skill_names == ["demo-skill"]
-
-
-def test_excludes_script_tool(workspace: Path, tmp_path: Path) -> None:
-    """A skill shipping both kinds of files gets the resource tool but not the script tool."""
-    skill_dir = _write_skill(workspace, "demo-skill")
-    (skill_dir / "references").mkdir()
-    (skill_dir / "references/notes.md").write_text("Reference material.")
-    (skill_dir / "scripts").mkdir()
-    (skill_dir / "scripts/go.py").write_text("print('hi')\n")
-    runner = _runner(workspace, tmp_path / "threads")
-
-    toolset = runner._build_skills_capabilities()[0].get_toolset()
-
-    assert isinstance(toolset, FunctionToolset)
-    assert "read_skill_resource" in toolset.tools
-    assert "run_skill_script" not in toolset.tools
+    assert _skill_names(capabilities) == ["demo-skill"]
 
 
 def test_broken_skill_costs_only_itself(workspace: Path, tmp_path: Path) -> None:
-    """A `SKILL.md` the loader rejects is skipped; the valid skills beside it still load."""
-    skill_dir = _write_skill(workspace, "good-skill")
-    (skill_dir / "references").mkdir()
-    (skill_dir / "references/notes.md").write_text("Reference material.")
+    """A `SKILL.md` the loader rejects is skipped, and a stray non-skill file beside it doesn't disrupt loading."""
+    _write_skill(workspace, "good-skill")
     broken = workspace / ".agents/skills/broken-skill"
     broken.mkdir(parents=True)
     (broken / "SKILL.md").write_text("no frontmatter at all\n")
+    (workspace / ".agents/skills/README.md").write_text("Scaffolded by AgentManager.")
     runner = _runner(workspace, tmp_path / "threads")
 
     capabilities = runner._build_skills_capabilities()
 
     assert len(capabilities) == 1
-    assert capabilities[0].skill_names == ["good-skill"]
-    # Probes skip bundled-file indexing; the surviving skill's files must not skip it too.
-    assert [resource.name for resource in capabilities[0].packages["good-skill"].resources] == ["references/notes.md"]
+    assert _skill_names(capabilities) == ["good-skill"]
 
 
 def test_unreadable_skill_costs_skills_not_the_run(workspace: Path, tmp_path: Path) -> None:
@@ -128,8 +108,8 @@ def test_rebuilds_snapshot_per_call(workspace: Path, tmp_path: Path) -> None:
     """Discovery is a snapshot, so a skill added after the first build still lands."""
     _write_skill(workspace, "first-skill")
     runner = _runner(workspace, tmp_path / "threads")
-    assert runner._build_skills_capabilities()[0].skill_names == ["first-skill"]
+    assert _skill_names(runner._build_skills_capabilities()) == ["first-skill"]
 
     _write_skill(workspace, "second-skill")
 
-    assert runner._build_skills_capabilities()[0].skill_names == ["first-skill", "second-skill"]
+    assert _skill_names(runner._build_skills_capabilities()) == ["first-skill", "second-skill"]

--- a/uv.lock
+++ b/uv.lock
@@ -599,7 +599,7 @@ dependencies = [
     { name = "pillow" },
     { name = "portalocker" },
     { name = "pydantic" },
-    { name = "pydantic-ai-skills" },
+    { name = "pydantic-ai-harness", extra = ["skills"] },
     { name = "pydantic-ai-slim", extra = ["mcp", "openai"] },
     { name = "python-dotenv" },
     { name = "python-multipart" },
@@ -672,7 +672,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=11.3.0" },
     { name = "portalocker", specifier = ">=2.10.0" },
     { name = "pydantic", specifier = ">=2.10.6" },
-    { name = "pydantic-ai-skills", specifier = ">=2.0,<3" },
+    { name = "pydantic-ai-harness", extras = ["skills"], specifier = ">=0.29.1,<1.0" },
     { name = "pydantic-ai-slim", extras = ["mcp", "openai"], specifier = ">=2.29.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "python-multipart", specifier = ">=0.0.20" },
@@ -1748,21 +1748,6 @@ wheels = [
 [package.optional-dependencies]
 skills = [
     { name = "pyyaml" },
-]
-
-[[package]]
-name = "pydantic-ai-skills"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "pydantic-ai-harness", extra = ["skills"] },
-    { name = "pydantic-ai-slim" },
-    { name = "pyyaml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cf/d5/f3059f89077f257e43475ad81878d5ee7e03c501579bf9a7b05166a7e18a/pydantic_ai_skills-2.0.0.tar.gz", hash = "sha256:25fd5f14268f68d25d68e38bc94fb93323092d3b7d96db0b5e499c074e3d40c7", size = 9110556, upload-time = "2026-09-06T01:44:21.651Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/8a/b05c3540dfe4e1491aa3f3de06d320bb93b61dbe49b805e2d5c4465c47b5/pydantic_ai_skills-2.0.0-py3-none-any.whl", hash = "sha256:d3bed993fe65a7a4a1c6e37c71914e9594cec86114e446a332f203f2cdc755f2", size = 73558, upload-time = "2026-09-06T01:44:20.268Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Moves skills onto the harness's first-party `Skills` capability. While adding retry logic I found the third-party plugin does not respect `Agent.retries`, and keeping the whole agent stack on the first-party plugin avoids that class of gap.