### PR TITLE
feat(model-access): show catalog display names in model dropdowns

### DIFF
--- a/src/griptape_nodes/exe_types/param_components/model_access_component.py
+++ b/src/griptape_nodes/exe_types/param_components/model_access_component.py
@@ -1,10 +1,15 @@
 """Model-access parameter component for license/policy-gated dropdowns.
 
 Owns the model list and decorates a node's model-selection ``Parameter`` with
-an ``Options`` trait, an inline ``Button`` refresh trait, per-row entitlement
-icons + subtitles, an error badge on denied selections, and runtime denial
-queries. Node identity (parameter name, type, input_types, tooltip) stays with
-the node so saved workflows round-trip byte-identically.
+an ``Options`` trait, an inline ``Button`` refresh trait, per-row readable
+labels, per-row entitlement icons + subtitles, an error badge on denied
+selections, and runtime denial queries. Node identity (parameter name, type,
+input_types, tooltip) stays with the node so saved workflows round-trip
+byte-identically.
+
+Labels are display-only. A row's ``name`` remains the ``provider_model_id``, so
+what the parameter stores, what the proxy receives, and what provenance metadata
+records are all unchanged by how a row reads. See ``_build_ui_options``.
 
 ``model_choices`` are ``provider_model_id``s, which the component resolves to
 the catalog ``model_id`` the permission layer gates on. ``deprecated_values``
@@ -583,13 +588,31 @@ class ModelAccessComponent:
         Built from ``model_choices`` alone, never ``deprecated_values`` -- a
         legacy value is accepted when assigned but never offered as a fresh
         selection.
+
+        ``name`` stays the provider id on every row: it is what the UI pairs
+        against ``Options.choices``, what the parameter stores, and what the
+        node sends. ``label`` is the catalog's readable name and is the ONLY
+        place a display string is written -- it is deliberately not assigned to
+        the parameter, so provenance metadata (which reads the stored value)
+        keeps recording the exact provider id rather than a prettified name.
+        A choice the catalog does not describe carries no ``label`` and renders
+        as its id, which is what a dropdown did before labels existed.
         """
         data: list[dict[str, str]] = []
         for choice in self._model_choices:
+            row: dict[str, str] = {"name": choice}
+            display_name = self._snapshot.display_name_for(choice)
+            if display_name is not None:
+                row["label"] = display_name
+                # Only worth a second line once the first one is a name: the id is
+                # otherwise already the visible text.
+                row["subtitle"] = choice
             if self._cached_denial(choice) is not None:
-                data.append({"name": choice, "icon": DENIED_ROW_ICON, "subtitle": DENIED_ROW_SUBTITLE})
-            else:
-                data.append({"name": choice})
+                row["icon"] = DENIED_ROW_ICON
+                # Outranks the id: it is the actionable line, and it keeps a denied row
+                # identical to HuggingFace's. The badge still quotes the id verbatim.
+                row["subtitle"] = DENIED_ROW_SUBTITLE
+            data.append(row)
         return {
             "data": data,
             "dropdown_row_icons": True,

--- a/src/griptape_nodes/exe_types/param_components/model_access_component.py
+++ b/src/griptape_nodes/exe_types/param_components/model_access_component.py
@@ -133,6 +133,27 @@ if TYPE_CHECKING:
 _REFRESH_ICON = "list-restart"
 
 
+def _comparable(value: str) -> str:
+    """``value`` reduced to its letters and digits, lowercased.
+
+    Collapses the ways a catalog name and a provider id spell the same thing, so
+    "GPT-5.5" and ``gpt-5.5`` compare equal.
+    """
+    return "".join(character for character in value.lower() if character.isalnum())
+
+
+def _id_adds_detail(display_name: str, provider_model_id: str) -> bool:
+    """Whether ``provider_model_id`` carries something its display name drops.
+
+    "Seedream 5.0 Pro" hides the vendor prefix and build date in
+    ``dola-seedream-5-0-pro-260628``, so the id earns a second line on the row.
+    Most of the catalog does not: "GPT-5.5" and ``gpt-5.5`` differ only in
+    punctuation, and ``o3``'s display name IS ``o3``, so repeating the id there
+    only doubles the row height with the text already above it.
+    """
+    return _comparable(display_name) != _comparable(provider_model_id)
+
+
 class ModelAccessComponent:
     """Composition helper for a model-selection dropdown that respects license policy.
 
@@ -597,6 +618,11 @@ class ModelAccessComponent:
         keeps recording the exact provider id rather than a prettified name.
         A choice the catalog does not describe carries no ``label`` and renders
         as its id, which is what a dropdown did before labels existed.
+
+        The id repeats as a ``subtitle`` only where it says something the label
+        does not -- see ``_id_adds_detail``. Most of the catalog names a model
+        the way its id spells it, and a second line reading ``gpt-5.5`` under
+        "GPT-5.5" costs every row twice the height to say nothing.
         """
         data: list[dict[str, str]] = []
         for choice in self._model_choices:
@@ -604,9 +630,8 @@ class ModelAccessComponent:
             display_name = self._snapshot.display_name_for(choice)
             if display_name is not None:
                 row["label"] = display_name
-                # Only worth a second line once the first one is a name: the id is
-                # otherwise already the visible text.
-                row["subtitle"] = choice
+                if _id_adds_detail(display_name, choice):
+                    row["subtitle"] = choice
             if self._cached_denial(choice) is not None:
                 row["icon"] = DENIED_ROW_ICON
                 # Outranks the id: it is the actionable line, and it keeps a denied row

--- a/src/griptape_nodes/exe_types/param_components/model_access_component.py
+++ b/src/griptape_nodes/exe_types/param_components/model_access_component.py
@@ -628,7 +628,7 @@ class ModelAccessComponent:
         for choice in self._model_choices:
             row: dict[str, str] = {"name": choice}
             display_name = self._snapshot.display_name_for(choice)
-            if display_name is not None:
+            if display_name is not None and display_name.strip():
                 row["label"] = display_name
                 if _id_adds_detail(display_name, choice):
                     row["subtitle"] = choice

--- a/src/griptape_nodes/exe_types/param_components/model_policy.py
+++ b/src/griptape_nodes/exe_types/param_components/model_policy.py
@@ -47,10 +47,12 @@ class ModelPolicySnapshot:
     Frozen and replaced wholesale by ``query_model_policy()``, so the tables cannot drift apart:
     there is no window where denials describe one query and declared ids another.
 
-    Both tables are keyed by ``provider_model_id`` -- the upstream provider's name for the model --
-    because that is the handle a dropdown value can be reduced to. ``denial_by_provider_id`` holds
-    only what policy denied; ``catalog_ids_by_provider_id`` maps every resolved handle to the stable
-    catalog keys policy gates on.
+    All three tables are keyed by ``provider_model_id`` -- the upstream provider's name for the
+    model -- because that is the handle a dropdown value can be reduced to.
+    ``denial_by_provider_id`` holds only what policy denied; ``catalog_ids_by_provider_id`` maps
+    every resolved handle to the stable catalog keys policy gates on;
+    ``display_name_by_provider_id`` maps it to the catalog's readable name, for decorating a row a
+    person reads.
 
     That key is deliberately NOT unique: ``Model``'s contract allows two catalog entries to describe
     the same ``provider_model_id`` with different ``key_support`` (e.g. a BYOK entry and a
@@ -60,6 +62,13 @@ class ModelPolicySnapshot:
     there is exactly one catalog table rather than a handle-to-single-id map beside it: a second
     table holding "whichever entry was seen first" would be the shape this one exists to replace,
     and keeping both invites an edit that updates one and not the other.
+
+    ``display_name_by_provider_id`` is a handle-to-single-value map, which is the shape the
+    paragraph above rejects, and it is safe only because a name decides nothing. It keeps the first
+    name declared for a shared handle: there is no any-wins rule to inherit, because a name is not a
+    verdict, and picking the "wrong" twin's name changes how a row reads rather than what may run.
+    A name must never be used as an identity -- what a dropdown stores and what a payload sends is
+    the handle itself.
 
     ``failure_detail`` is set when the engine could not answer at all (unregistered node class,
     missing manifest declaration). Both tables are then empty, and a caller must not read "no
@@ -88,6 +97,7 @@ class ModelPolicySnapshot:
     denial_by_provider_id: dict[str, CheckpointDenial] = field(default_factory=dict)
     # Every catalog id behind a shared provider_model_id, for callers that re-ask policy live.
     catalog_ids_by_provider_id: dict[str, tuple[str, ...]] = field(default_factory=dict)
+    display_name_by_provider_id: dict[str, str] = field(default_factory=dict)
     failure_detail: str | None = None
     has_unmatchable_entries: bool = False
     unmatchable_denials: tuple[str, ...] = ()
@@ -96,6 +106,15 @@ class ModelPolicySnapshot:
     def catalog_ids_for(self, provider_model_id: str) -> tuple[str, ...]:
         """Every catalog id declared against ``provider_model_id``, in declaration order."""
         return self.catalog_ids_by_provider_id.get(provider_model_id, ())
+
+    def display_name_for(self, provider_model_id: str) -> str | None:
+        """The catalog's readable name for ``provider_model_id``, or ``None`` if it has none.
+
+        ``None`` means the catalog does not describe this handle, which is a legitimate state for a
+        choice the catalog never declared. Callers render the handle itself in that case; they must
+        not synthesize a name.
+        """
+        return self.display_name_by_provider_id.get(provider_model_id)
 
     @property
     def declares_models(self) -> bool:
@@ -230,6 +249,7 @@ def query_model_policy(node_type: str, *, fail_closed: bool = True) -> ModelPoli
 
     denials: dict[str, CheckpointDenial] = {}
     all_catalog_ids: dict[str, list[str]] = {}
+    display_names: dict[str, str] = {}
     unmatchable = False
     unmatchable_denials: list[str] = []
     for verdict in result.verdicts:
@@ -241,6 +261,10 @@ def query_model_policy(node_type: str, *, fail_closed: bool = True) -> ModelPoli
                 unmatchable_denials.append(verdict.model_id)
             continue
         all_catalog_ids.setdefault(verdict.provider_model_id, []).append(verdict.model_id)
+        # First-name-wins for a shared handle, per ModelPolicySnapshot's contract: a name is not a
+        # verdict, so there is nothing here to fail closed on.
+        if verdict.display_name is not None:
+            display_names.setdefault(verdict.provider_model_id, verdict.display_name)
         # Any-denial-wins: two entries can share this handle, and the permitted one must not
         # overwrite the denied one.
         if verdict.denial is not None:
@@ -258,6 +282,7 @@ def query_model_policy(node_type: str, *, fail_closed: bool = True) -> ModelPoli
     return ModelPolicySnapshot(
         denial_by_provider_id=denials,
         catalog_ids_by_provider_id={k: tuple(v) for k, v in all_catalog_ids.items()},
+        display_name_by_provider_id=display_names,
         has_unmatchable_entries=unmatchable,
         unmatchable_denials=tuple(unmatchable_denials),
     )

--- a/src/griptape_nodes/retained_mode/events/access_events.py
+++ b/src/griptape_nodes/retained_mode/events/access_events.py
@@ -40,11 +40,20 @@ class ModelAccessVerdict:
     `denial` is ``None`` when the model is allowed; a ``CheckpointDenial``
     otherwise, carrying the same failure tuple any other denied checkpoint
     surfaces (so the UI renders identical reason text).
+
+    `display_name` is the catalog's human-readable name for the model (e.g.
+    ``Claude Opus 4.7``), for callers rendering a choice to a person. It is
+    ``None`` on the same terms as `provider_model_id`: the candidate did not
+    resolve to a catalog entry. It is never an identity: two entries may share a
+    `provider_model_id`, names are re-cased and reused between generations, and a
+    stored value or a wire payload must always carry `provider_model_id` instead.
     """
 
     model_id: str
     provider_model_id: str | None
     denial: CheckpointDenial | None
+    # Trails `denial` because callers construct this positionally.
+    display_name: str | None = None
 
 
 @dataclass

--- a/src/griptape_nodes/retained_mode/managers/access_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/access_manager.py
@@ -341,11 +341,13 @@ class AccessManager(EngineScoped):
                 attributes[CheckpointAttribute.NODE_TYPE] = node_type
             resolved = resolved_by_id.get(model_id)
             provider_model_id: str | None = None
+            display_name: str | None = None
             if resolved is not None:
                 attributes[CheckpointAttribute.PROVIDER_ID] = resolved.provider_id
                 if resolved.model.family:
                     attributes[CheckpointAttribute.MODEL_FAMILIES] = [resolved.model.family]
                 provider_model_id = resolved.model.provider_model_id
+                display_name = resolved.model.display_name
             denial = event_manager.evaluate_authorization_checkpoint(
                 AuthorizationCheckpoint(
                     action=CheckpointAction.OFFER_MODEL,
@@ -354,5 +356,12 @@ class AccessManager(EngineScoped):
                     attributes=attributes,
                 )
             )
-            verdicts.append(ModelAccessVerdict(model_id=model_id, provider_model_id=provider_model_id, denial=denial))
+            verdicts.append(
+                ModelAccessVerdict(
+                    model_id=model_id,
+                    provider_model_id=provider_model_id,
+                    denial=denial,
+                    display_name=display_name,
+                )
+            )
         return verdicts

--- a/tests/unit/exe_types/param_components/test_model_access_component.py
+++ b/tests/unit/exe_types/param_components/test_model_access_component.py
@@ -254,14 +254,34 @@ class TestInstall:
             ui = param.ui_options
             assert ui["dropdown_row_icons"] is True
             assert ui["dropdown_row_subtitles"] is True
-            # Alpha row carries the denial decoration; beta is bare.
+            # Both rows keep the provider id as `name` and gain the catalog name as `label`.
+            # Alpha carries the denial decoration, whose subtitle outranks the id; beta shows the id.
             data_by_name = {row["name"]: row for row in ui["data"]}
+            assert data_by_name["alpha"]["label"] == "Alpha"
             assert data_by_name["alpha"]["icon"] == "shield-off"
             assert data_by_name["alpha"]["subtitle"] == "Not permitted by your license"
+            assert data_by_name["beta"]["label"] == "Beta"
             assert "icon" not in data_by_name["beta"]
-            assert "subtitle" not in data_by_name["beta"]
+            assert data_by_name["beta"]["subtitle"] == "beta"
         finally:
             engine.event_manager.remove_authorization_hook(deny_alpha)
+
+    def test_choice_the_catalog_does_not_describe_carries_no_label(self) -> None:
+        """An undeclared choice renders as its own id rather than an invented name.
+
+        The component does not synthesize a label, and it omits the id subtitle
+        too: with no label the id is already the row's visible text, so repeating
+        it would print the same string twice.
+        """
+        node, _helper = _install_probe_node_with_helper(
+            model_choices=["alpha", "gamma"],
+            default_model="alpha",
+        )
+
+        param = node.get_parameter_by_name("model")
+        assert param is not None
+        data_by_name = {row["name"]: row for row in param.ui_options["data"]}
+        assert data_by_name["gamma"] == {"name": "gamma"}
 
     def test_install_preserves_parameter_identity(self) -> None:
         """Install must not change parameter name / type / tooltip / stored value."""

--- a/tests/unit/exe_types/param_components/test_model_access_component.py
+++ b/tests/unit/exe_types/param_components/test_model_access_component.py
@@ -111,6 +111,14 @@ def _catalog():  # noqa: ANN202
                         provider_model_id="beta",
                         key_support=KeySupport.REQUIRES_GRIPTAPE_KEY,
                     ),
+                    # Mirrors the real shape a readable name hides: a vendor prefix
+                    # and a build date the display name drops.
+                    "gtc_test_dated": Model(
+                        display_name="Dated Pro",
+                        family="TestFam",
+                        provider_model_id="vendor-dated-pro-260101",
+                        key_support=KeySupport.REQUIRES_GRIPTAPE_KEY,
+                    ),
                 },
             ),
         }
@@ -139,7 +147,7 @@ def _build_probe_node_with_component(
     from griptape_nodes.node_library.library_declarations import ModelUsageNodeProperty
 
     _register_probe_node(
-        node_declarations=[ModelUsageNodeProperty(model_ids=["gtc_test_alpha", "gtc_test_beta"])],
+        node_declarations=[ModelUsageNodeProperty(model_ids=["gtc_test_alpha", "gtc_test_beta", "gtc_test_dated"])],
         library_declarations=[_catalog()],
     )
 
@@ -255,16 +263,39 @@ class TestInstall:
             assert ui["dropdown_row_icons"] is True
             assert ui["dropdown_row_subtitles"] is True
             # Both rows keep the provider id as `name` and gain the catalog name as `label`.
-            # Alpha carries the denial decoration, whose subtitle outranks the id; beta shows the id.
+            # Alpha carries the denial decoration; neither id earns a subtitle, since
+            # "Alpha"/"Beta" spell their ids.
             data_by_name = {row["name"]: row for row in ui["data"]}
             assert data_by_name["alpha"]["label"] == "Alpha"
             assert data_by_name["alpha"]["icon"] == "shield-off"
             assert data_by_name["alpha"]["subtitle"] == "Not permitted by your license"
             assert data_by_name["beta"]["label"] == "Beta"
             assert "icon" not in data_by_name["beta"]
-            assert data_by_name["beta"]["subtitle"] == "beta"
+            assert "subtitle" not in data_by_name["beta"]
         finally:
             engine.event_manager.remove_authorization_hook(deny_alpha)
+
+    def test_id_is_shown_as_a_subtitle_only_when_the_label_drops_detail(self) -> None:
+        """A dated id earns a second line; an id its label already spells does not.
+
+        Two thirds of the real catalog names a model the way its id spells it
+        ("GPT-5.5" / ``gpt-5.5``), and ``o3``'s display name IS ``o3``, so an
+        unconditional subtitle would double every such row's height to repeat the
+        text above it.
+        """
+        node, _helper = _install_probe_node_with_helper(
+            model_choices=["beta", "vendor-dated-pro-260101"],
+            default_model="beta",
+        )
+
+        param = node.get_parameter_by_name("model")
+        assert param is not None
+        data_by_name = {row["name"]: row for row in param.ui_options["data"]}
+        # "Dated Pro" drops the prefix and the build date, so the id is worth showing.
+        assert data_by_name["vendor-dated-pro-260101"]["label"] == "Dated Pro"
+        assert data_by_name["vendor-dated-pro-260101"]["subtitle"] == "vendor-dated-pro-260101"
+        # "Beta" differs from `beta` only in case.
+        assert "subtitle" not in data_by_name["beta"]
 
     def test_choice_the_catalog_does_not_describe_carries_no_label(self) -> None:
         """An undeclared choice renders as its own id rather than an invented name.

--- a/tests/unit/exe_types/param_components/test_model_access_component.py
+++ b/tests/unit/exe_types/param_components/test_model_access_component.py
@@ -297,6 +297,38 @@ class TestInstall:
         # "Beta" differs from `beta` only in case.
         assert "subtitle" not in data_by_name["beta"]
 
+    def test_denial_subtitle_outranks_the_id_subtitle(self, engine) -> None:  # noqa: ANN001
+        """A gated row says why it is gated, even when its id would earn a subtitle.
+
+        The two subtitle writers meet only here: a dated id claims the subtitle,
+        and a denial then replaces it. Writing them in the other order would leave
+        a gated row showing its build id where the reason should be, and the artist
+        would see no explanation for a model they cannot use.
+        """
+        from griptape_nodes.retained_mode.managers.authorization_checkpoint import CheckpointDenial, CheckpointFailure
+
+        def deny_dated(checkpoint: object) -> CheckpointDenial | None:
+            if checkpoint.attributes.get("id") == "gtc_test_dated":  # type: ignore[attr-defined]
+                return CheckpointDenial(failures=(CheckpointFailure(detail="Dated Pro not enabled."),))
+            return None
+
+        engine.event_manager.add_authorization_hook(deny_dated)
+        try:
+            node, _helper = _install_probe_node_with_helper(
+                model_choices=["beta", "vendor-dated-pro-260101"],
+                default_model="beta",
+            )
+
+            param = node.get_parameter_by_name("model")
+            assert param is not None
+            data_by_name = {row["name"]: row for row in param.ui_options["data"]}
+            dated = data_by_name["vendor-dated-pro-260101"]
+            assert dated["label"] == "Dated Pro"
+            assert dated["icon"] == "shield-off"
+            assert dated["subtitle"] == "Not permitted by your license"
+        finally:
+            engine.event_manager.remove_authorization_hook(deny_dated)
+
     def test_choice_the_catalog_does_not_describe_carries_no_label(self) -> None:
         """An undeclared choice renders as its own id rather than an invented name.
 


### PR DESCRIPTION
<img width="1298" height="450" alt="image" src="https://github.com/user-attachments/assets/9f6ab36a-30e8-437f-91d5-706f3311cf14" />

Closes https://github.com/griptape-ai/griptape-nodes-library-standard/issues/610 and closes https://github.com/griptape-ai/griptape-nodes-library-standard/issues/611

## Problem

Model dropdowns render the raw `provider_model_id`, so a row reads `dola-seedream-5-0-pro-260628` rather than "Seedream 5.0 Pro". Reported in griptape-ai/griptape-nodes-library-standard#610 across 36 node files.

Three of the four pieces already existed: the GUI renders a per-row `label` (`db5022cd`, Aug 11), every catalog `Model` carries a required `display_name`, and `ModelAccessComponent` already queries the catalog for every row to decide denial decoration. Nothing carried the name between them.

## Change

`display_name` rides along on the policy query the component already issues:

- `ModelAccessVerdict` gains `display_name`, populated from `resolved.model.display_name` in `AccessManager._evaluate` (the same `resolved` already read for `provider_model_id`).
- `ModelPolicySnapshot` gains `display_name_by_provider_id` plus `display_name_for()`.
- `_build_ui_options` emits it as the row's `label`, and moves the raw id to `subtitle`.

## `name` does not change

This is the load-bearing property. A row's `name` stays the `provider_model_id`, so all of these are untouched by how a row reads:

- what the UI pairs against `Options.choices`
- what the parameter stores in a saved workflow
- what the proxy receives
- what the provenance metadata embedded in generated PNGs records (`collect_workflow_metadata` reads `get_parameter_value`)

The label is written to exactly one place and is never assigned to the parameter. A studio auditing a render still recovers the exact dated build id; only the dropdown reads differently. Display names are deliberately not treated as identities: two catalog entries may share a `provider_model_id`, and names get re-cased and reused between generations.

## Degradation

A choice the catalog does not describe carries no `label` and renders as its id, which is what every dropdown did before this change. The component does not synthesize a name. Denial decoration keeps its subtitle rather than the id: it is the actionable line, and it keeps a gated row identical to `HuggingFaceModelParameter`'s.

`display_name_by_provider_id` is a handle-to-single-value map, the shape `ModelPolicySnapshot`'s docstring argues against for catalog ids. It is safe only because a name decides nothing, so there is no any-wins rule to inherit. That reasoning is written into the docstring so it does not read as an oversight.

## Verification

- `make test/unit` — 5964 passed
- `make test/integration` — 9 passed, 6 xfailed
- `make check/lint check/types` — clean; `ruff format --check` clean

Updated `test_install_populates_ui_options_with_dropdown_data` to the new row shape and added coverage for the undeclared-choice path, which was previously untested.

`make check` also fails on four untracked `docs/design/*.md` files in my working tree that predate this branch and are not part of it.

## Downstream

griptape-ai/griptape-nodes-library-standard adds a test asserting every offered choice resolves to a label. That test needs this released; its runtime behavior degrades gracefully without it.
