### PR TITLE
fix(models): report a written message when a model download fails

### DIFF
--- a/src/griptape_nodes/cli/commands/models.py
+++ b/src/griptape_nodes/cli/commands/models.py
@@ -30,6 +30,7 @@ from griptape_nodes.retained_mode.events.model_events import (
 )
 from griptape_nodes.retained_mode.managers.model_manager import _PROGRESS_PIPE_ENV_VAR
 from griptape_nodes.retained_mode.retained_mode import GriptapeNodes
+from griptape_nodes.utils.exception_utils import readable_exception_message
 from griptape_nodes.utils.model_download_errors import (
     DownloadFailure,
     classify,
@@ -148,7 +149,7 @@ async def _download_model(
             ignore_patterns=None,
         )
     except Exception as e:
-        failure = DownloadFailure(kind=classify(e), detail=str(e))
+        failure = DownloadFailure(kind=classify(e), detail=readable_exception_message(e))
         _emit_error_event(failure)
         console.print(f"[bold red]{describe(failure, model_id=model_id, revision=revision)}[/bold red]")
         sys.exit(1)

--- a/src/griptape_nodes/cli/commands/models.py
+++ b/src/griptape_nodes/cli/commands/models.py
@@ -1,13 +1,11 @@
 """Models command for managing AI models."""
 
 import asyncio
-import json
 import os
 import sys
 from typing import TYPE_CHECKING
 
 import typer
-from huggingface_hub.errors import GatedRepoError, RepositoryNotFoundError
 from rich.table import Table
 
 from griptape_nodes.cli.shared import console
@@ -32,6 +30,12 @@ from griptape_nodes.retained_mode.events.model_events import (
 )
 from griptape_nodes.retained_mode.managers.model_manager import _PROGRESS_PIPE_ENV_VAR
 from griptape_nodes.retained_mode.retained_mode import GriptapeNodes
+from griptape_nodes.utils.model_download_errors import (
+    DownloadFailure,
+    classify,
+    describe,
+    format_error_event,
+)
 
 if TYPE_CHECKING:
     from griptape_nodes.retained_mode.events.model_events import ModelDownloadStatus
@@ -103,15 +107,19 @@ def search_command(
     asyncio.run(_search_models(query, task, limit, sort, direction))
 
 
-def _emit_error_event(error_type: str, error_message: str) -> None:
+def _emit_error_event(failure: DownloadFailure) -> None:
     """Write a structured JSON error event to stderr when running in pipe mode.
 
     Only emits when GRIPTAPE_NODES_PROGRESS_PIPE is set, i.e. when spawned by
     the ModelManager subprocess. On direct CLI invocations this is a no-op.
     Uses stderr to avoid mixing with stdout JSON progress events.
+
+    Every failed download emits one of these. It is the only channel by which the
+    parent learns why a download failed, because the parent cannot tell the human
+    text below apart from the progress bars and library warnings sharing the pipe.
     """
     if os.environ.get(_PROGRESS_PIPE_ENV_VAR) == "1":
-        sys.stderr.write(json.dumps({"error_type": error_type, "error_message": error_message}) + "\n")
+        sys.stderr.write(format_error_event(failure))
         sys.stderr.flush()
 
 
@@ -139,25 +147,14 @@ async def _download_model(
             allow_patterns=None,
             ignore_patterns=None,
         )
-
-        # Success case
-        console.print("[bold green]Model downloaded successfully![/bold green]")
-        console.print(f"[green]Downloaded to: {local_path}[/green]")
-
-    except GatedRepoError as e:
-        _emit_error_event("gated_repo", str(e))
-        console.print(f"[bold red]Model download failed:[/bold red] {e}")
-        sys.exit(1)
-
-    except RepositoryNotFoundError as e:
-        _emit_error_event("repo_not_found", str(e))
-        console.print(f"[bold red]Model download failed:[/bold red] {e}")
-        sys.exit(1)
-
     except Exception as e:
-        console.print("[bold red]Model download failed:[/bold red]")
-        console.print(f"[red]{e}[/red]")
+        failure = DownloadFailure(kind=classify(e), detail=str(e))
+        _emit_error_event(failure)
+        console.print(f"[bold red]{describe(failure, model_id=model_id, revision=revision)}[/bold red]")
         sys.exit(1)
+
+    console.print("[bold green]Model downloaded successfully![/bold green]")
+    console.print(f"[green]Downloaded to: {local_path}[/green]")
 
 
 async def _list_models() -> None:

--- a/src/griptape_nodes/cli/commands/models.py
+++ b/src/griptape_nodes/cli/commands/models.py
@@ -6,6 +6,7 @@ import sys
 from typing import TYPE_CHECKING
 
 import typer
+from rich.markup import escape
 from rich.table import Table
 
 from griptape_nodes.cli.shared import console
@@ -147,7 +148,10 @@ async def _download_model(
     except Exception as e:
         failure = DownloadFailure(kind=classify(e), detail=readable_exception_message(e))
         _emit_error_event(failure)
-        console.print(f"[bold red]{describe(failure, model_id=model_id, revision=revision)}[/bold red]")
+        # Escaped because the message can carry an exception's own text, and a stray bracket in
+        # it is markup to rich: it either raises or eats the span, losing the sentence.
+        reason = escape(describe(failure, model_id=model_id, revision=revision))
+        console.print(f"[bold red]{reason}[/bold red]")
         sys.exit(1)
 
     console.print("[bold green]Model downloaded successfully![/bold green]")

--- a/src/griptape_nodes/cli/commands/models.py
+++ b/src/griptape_nodes/cli/commands/models.py
@@ -114,10 +114,6 @@ def _emit_error_event(failure: DownloadFailure) -> None:
     Only emits when GRIPTAPE_NODES_PROGRESS_PIPE is set, i.e. when spawned by
     the ModelManager subprocess. On direct CLI invocations this is a no-op.
     Uses stderr to avoid mixing with stdout JSON progress events.
-
-    Every failed download emits one of these. It is the only channel by which the
-    parent learns why a download failed, because the parent cannot tell the human
-    text below apart from the progress bars and library warnings sharing the pipe.
     """
     if os.environ.get(_PROGRESS_PIPE_ENV_VAR) == "1":
         sys.stderr.write(format_error_event(failure))

--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
-from huggingface_hub import get_token, list_models, scan_cache_dir, snapshot_download
+from huggingface_hub import list_models, scan_cache_dir, snapshot_download
 from huggingface_hub import model_info as hf_model_info
 from huggingface_hub.utils.tqdm import tqdm
 from xdg_base_dirs import xdg_data_home
@@ -823,13 +823,9 @@ class ModelManager(EngineScoped):
         Returns:
             ResultPayload: Success with exact size and metadata, or failure with error details
         """
-        if get_token() is None:
-            error_msg = (
-                "No Hugging Face token found. Fetching info for gated models requires authentication. "
-                "Set your HF_TOKEN environment variable or log in with `huggingface-cli login`."
-            )
-            return GetModelInfoResultFailure(result_details=error_msg)
-
+        # Deliberately no token check: a public model answers anonymously, and a gated one
+        # answers with a 401 the caller can report. Refusing up front meant a token-less user
+        # got no size for any model, gated or not.
         try:
             info = await asyncio.to_thread(hf_model_info, request.model_id)
         except Exception as e:

--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -377,6 +377,10 @@ class ModelManager(EngineScoped):
         super().__init__(engine)
         self._download_tasks = {}
         self._download_processes = {}
+        # Model ids whose subprocess this manager killed on purpose. A killed child exits
+        # non-zero with no verdict, which is indistinguishable from a crash unless the side
+        # that did the killing says so.
+        self._cancelled_downloads: set[str] = set()
 
         if event_manager is not None:
             event_manager.assign_manager_to_request_type(DownloadModelRequest, self.on_handle_download_model_request)
@@ -678,6 +682,12 @@ class ModelManager(EngineScoped):
                     "progress_percent": 100.0,
                 }
                 await asyncio.to_thread(self._write_download_status, status_file, final_data)
+            elif model_id in self._cancelled_downloads:
+                # Killing the child is how a cancel is carried out, so its non-zero exit is the
+                # expected end of one. The cancelling handler removes the status file itself;
+                # writing a terminal status here would either race that or leave a "Failed" row
+                # for a download the user stopped on purpose.
+                logger.info("Download of model '%s' was cancelled", model_id)
             else:
                 # The child's structured event is the only thing here that describes the
                 # failure. Its stderr also carries progress frames and library warnings, so
@@ -706,6 +716,9 @@ class ModelManager(EngineScoped):
         finally:
             if model_id in self._download_processes:
                 del self._download_processes[model_id]
+            # Discarded here rather than where it is read, so a claim left by a kill that lost
+            # the race to a finishing download cannot make the next failure read as a cancel.
+            self._cancelled_downloads.discard(model_id)
 
     async def on_handle_list_models_request(self, request: ListModelsRequest) -> ResultPayload:  # noqa: ARG002
         """Handle model listing requests asynchronously.
@@ -1386,6 +1399,9 @@ class ModelManager(EngineScoped):
             # Cancel active download process if it exists
             if model_id in self._download_processes:
                 process = self._download_processes[model_id]
+                # Claimed before the kill, because the task can reach its own exit handling as
+                # soon as the process dies and has to find the claim already there.
+                self._cancelled_downloads.add(model_id)
                 await cancel_subprocess(process, f"download process for model '{model_id}'")
                 del self._download_processes[model_id]
 

--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -155,8 +155,7 @@ def _create_progress_tracker(model_id: str) -> type[tqdm]:  # noqa: C901
             )
 
         def display(self, *args, **kwargs) -> bool | None:
-            """Render nothing while the parent is reading events off the pipe.
-            """
+            """Render nothing while the parent is reading events off the pipe."""
             if self._emit_progress:
                 return False
             return super().display(*args, **kwargs)

--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -61,6 +61,7 @@ from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
 from griptape_nodes.retained_mode.managers.settings import MODELS_TO_DOWNLOAD_KEY
 from griptape_nodes.utils.async_utils import cancel_subprocess
 from griptape_nodes.utils.model_download_errors import (
+    RETRYABLE_KINDS,
     DownloadErrorKind,
     DownloadFailure,
     describe,
@@ -709,6 +710,9 @@ class ModelManager(EngineScoped):
                     "updated_at": current_time,
                     "failed_at": current_time,
                     "error_message": error_msg,
+                    # Recorded so a resume can tell a failure that will clear on its own from one
+                    # that needs the user first. Not part of ModelDownloadStatus: nothing renders it.
+                    "error_kind": failure.kind.value,
                 }
                 await asyncio.to_thread(self._write_download_status, status_file, final_data)
                 raise ValueError(error_msg)
@@ -1161,10 +1165,16 @@ class ModelManager(EngineScoped):
         return statuses
 
     def _find_unfinished_downloads(self) -> list[str]:
-        """Find model IDs with unfinished downloads from status files.
+        """Find model IDs worth picking up again from status files.
+
+        A download interrupted mid-transfer always is. A failed one only is when its recorded
+        kind is something a later attempt gets past on its own: a gated model with no token, or
+        an id that does not exist, reaches the same verdict every time, and resuming it spends a
+        subprocess per engine start to log the same error until the user deletes the row. A
+        failure written before the kind was recorded is retried, which is what it did before.
 
         Returns:
-            list[str]: List of model IDs with status 'downloading' or 'failed'
+            list[str]: List of model IDs to download again
         """
         status_dir = self._get_status_directory()
 
@@ -1179,11 +1189,23 @@ class ModelManager(EngineScoped):
 
             status = data.get("status", "")
             model_id = data.get("model_id", "")
+            if not model_id:
+                continue
 
-            if model_id and status in ("downloading", "failed"):
+            interrupted = status == "downloading"
+            retryable_failure = status == "failed" and self._failure_is_worth_retrying(data)
+            if interrupted or retryable_failure:
                 unfinished_models.append(model_id)
 
         return unfinished_models
+
+    @staticmethod
+    def _failure_is_worth_retrying(data: dict) -> bool:
+        """Whether a failed download's recorded kind is one a later attempt can get past."""
+        recorded_kind = data.get("error_kind")
+        if recorded_kind is None:
+            return True
+        return recorded_kind in RETRYABLE_KINDS
 
     async def on_handle_list_model_downloads_request(self, request: ListModelDownloadsRequest) -> ResultPayload:
         """Handle model download status requests asynchronously.

--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -156,11 +156,6 @@ def _create_progress_tracker(model_id: str) -> type[tqdm]:  # noqa: C901
 
         def display(self, *args, **kwargs) -> bool | None:
             """Render nothing while the parent is reading events off the pipe.
-
-            tqdm draws to stderr, which is also where a failure is reported. Suppressing
-            the drawing rather than passing tqdm `disable=True` keeps the bar's own
-            bookkeeping intact -- a disabled tqdm never records `desc` or `unit`, which is
-            how this class tells a byte-level bar from the file enumeration bar.
             """
             if self._emit_progress:
                 return False

--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -60,6 +60,12 @@ from griptape_nodes.retained_mode.managers.authorization_checkpoint import (
 )
 from griptape_nodes.retained_mode.managers.settings import MODELS_TO_DOWNLOAD_KEY
 from griptape_nodes.utils.async_utils import cancel_subprocess
+from griptape_nodes.utils.model_download_errors import (
+    DownloadErrorKind,
+    DownloadFailure,
+    describe,
+    parse_error_event,
+)
 
 if TYPE_CHECKING:
     from griptape_nodes.node_library.library_declarations import ResolvedModel
@@ -70,9 +76,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("griptape_nodes")
 
-
-HTTP_UNAUTHORIZED = 401
-HTTP_FORBIDDEN = 403
 
 MIN_CACHE_DIR_PARTS = 3
 
@@ -119,12 +122,13 @@ def _create_progress_tracker(model_id: str) -> type[tqdm]:  # noqa: C901
         """Tqdm subclass that emits JSON progress events to stdout for the parent process to handle."""
 
         def __init__(self, *args, **kwargs) -> None:
+            # Only emit JSON progress events when spawned by the main process, not on direct CLI invocation.
+            # Assigned before tqdm's constructor because that constructor renders, and rendering reads it.
+            self._emit_progress = os.environ.get(_PROGRESS_PIPE_ENV_VAR) == "1"
             super().__init__(*args, **kwargs)
             self.model_id = model_id
             self._cumulative_bytes = 0
             self._last_emit_time = 0.0
-            # Only emit JSON progress events when spawned by the main process, not on direct CLI invocation
-            self._emit_progress = os.environ.get(_PROGRESS_PIPE_ENV_VAR) == "1"
 
             # Check if this is a byte-level progress bar or file enumeration bar
             unit = getattr(self, "unit", "")
@@ -149,6 +153,18 @@ def _create_progress_tracker(model_id: str) -> type[tqdm]:  # noqa: C901
                 unit,
                 desc,
             )
+
+        def display(self, *args, **kwargs) -> bool | None:
+            """Render nothing while the parent is reading events off the pipe.
+
+            tqdm draws to stderr, which is also where a failure is reported. Suppressing
+            the drawing rather than passing tqdm `disable=True` keeps the bar's own
+            bookkeeping intact -- a disabled tqdm never records `desc` or `unit`, which is
+            how this class tells a byte-level bar from the file enumeration bar.
+            """
+            if self._emit_progress:
+                return False
+            return super().display(*args, **kwargs)
 
         def update(self, n: int = 1) -> None:
             """Override update to emit rate-limited JSON progress to stdout."""
@@ -478,13 +494,10 @@ class ModelManager(EngineScoped):
         if parsed_model_id != request.model_id:
             logger.debug("Parsed model ID '%s' from URL '%s'", parsed_model_id, request.model_id)
 
-        if get_token() is None:
-            error_msg = (
-                "No Hugging Face token found. Set your HF_TOKEN environment variable "
-                "or log in with `huggingface-cli login` before downloading models."
-            )
-            return DownloadModelResultFailure(result_details=error_msg)
-
+        # Deliberately no token check: public models download without one, and Hugging Face
+        # answers a gated model with a 401 the download reports as a missing-token failure.
+        # Refusing up front blocked downloads that would have worked, and returned before a
+        # status file existed, so the editor had no row to show the reason on.
         try:
             download_params = DownloadParams(
                 model_id=parsed_model_id,
@@ -597,7 +610,7 @@ class ModelManager(EngineScoped):
             lines.append(line.decode())
         return lines
 
-    async def _download_model_task(self, download_params: DownloadParams) -> None:  # noqa: C901
+    async def _download_model_task(self, download_params: DownloadParams) -> None:
         """Background task for downloading a model using CLI command.
 
         Owns the full status file lifecycle: writes initial status before launching the
@@ -674,26 +687,20 @@ class ModelManager(EngineScoped):
                 }
                 await asyncio.to_thread(self._write_download_status, status_file, final_data)
             else:
-                # Scan stderr for a structured error event emitted by the subprocess CLI
-                error_type = None
-                error_msg = None
-                for line in stderr_lines:
-                    try:
-                        event = json.loads(line.strip())
-                        if isinstance(event, dict) and "error_type" in event:
-                            error_type = event.get("error_type")
-                            error_msg = event.get("error_message")
-                            break
-                    except json.JSONDecodeError:
-                        pass
-                model_url = f"https://huggingface.co/{model_id}"
-                if error_type == "gated_repo":
-                    error_msg = f"Model '{model_id}' is gated and requires access approval. Visit {model_url} to request access."
-                elif error_type == "repo_not_found":
-                    error_msg = f"Model '{model_id}' was not found. Check that the model ID is correct at {model_url}."
-                elif not error_msg:
-                    error_msg = "".join(stderr_lines).strip()
-                logger.error("Failed to download model '%s': %s", model_id, error_msg)
+                # The child's structured event is the only thing here that describes the
+                # failure. Its stderr also carries progress frames and library warnings, so
+                # text taken from the stream itself would put those in front of the user.
+                stderr_output = "".join(stderr_lines)
+                failure = parse_error_event(stderr_output) or DownloadFailure(
+                    kind=DownloadErrorKind.UNKNOWN, detail=None
+                )
+                error_msg = describe(failure, model_id=model_id, revision=download_params.revision)
+                logger.error(
+                    "Failed to download model '%s' (%s). Subprocess stderr:\n%s",
+                    model_id,
+                    failure.kind.value,
+                    stderr_output.strip(),
+                )
                 final_data = {
                     **last_known,
                     "status": "failed",

--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -490,8 +490,6 @@ class ModelManager(EngineScoped):
 
         # Deliberately no token check: public models download without one, and Hugging Face
         # answers a gated model with a 401 the download reports as a missing-token failure.
-        # Refusing up front blocked downloads that would have worked, and returned before a
-        # status file existed, so the editor had no row to show the reason on.
         try:
             download_params = DownloadParams(
                 model_id=parsed_model_id,

--- a/src/griptape_nodes/utils/model_download_errors.py
+++ b/src/griptape_nodes/utils/model_download_errors.py
@@ -3,9 +3,11 @@
 A download runs in a child process (`griptape_nodes.cli.commands.models download`),
 so the exception is raised in one process and the message is shown by another. The
 child classifies the exception it caught and reports the verdict; the parent turns
-that verdict into the sentence the user reads. Both halves live here so a download
-failure reads the same in the editor as it does in a terminal, and so the wire
-format has its writer and its reader side by side.
+that verdict into the sentence the user reads. Both halves live here so the editor
+and a direct CLI run cannot drift into wording a failure differently, and so the
+wire format has its writer and its reader side by side. The wording is aimed at the
+editor, which is where downloads are started from; a CLI run gets the same sentence,
+naming settings it has to reach through the editor.
 
 The parent must never build a message out of the child's output streams. Those
 streams also carry progress bars and library warnings, so text scavenged from them
@@ -25,6 +27,7 @@ from huggingface_hub.errors import (
     GatedRepoError,
     HfHubHTTPError,
     HFValidationError,
+    LocalEntryNotFoundError,
     RepositoryNotFoundError,
     RevisionNotFoundError,
 )
@@ -74,7 +77,7 @@ def classify(exc: Exception) -> DownloadErrorKind:  # noqa: PLR0911
     # Order is load-bearing: GatedRepoError is a RepositoryNotFoundError, and every
     # HfHubHTTPError is also an httpx.HTTPError and an OSError.
     if isinstance(exc, GatedRepoError):
-        if _status_code(exc) == HTTPStatus.FORBIDDEN:
+        if exc.response.status_code == HTTPStatus.FORBIDDEN:
             return DownloadErrorKind.GATED_NO_ACCESS
         # Hugging Face answers an anonymous or rejected request with 401 and a
         # gated-repo code, so anything that is not an explicit 403 is a credential
@@ -87,12 +90,15 @@ def classify(exc: Exception) -> DownloadErrorKind:  # noqa: PLR0911
     if isinstance(exc, HFValidationError):
         return DownloadErrorKind.INVALID_MODEL_ID
     if isinstance(exc, HfHubHTTPError):
-        if _status_code(exc) == HTTPStatus.TOO_MANY_REQUESTS:
+        if exc.response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
             return DownloadErrorKind.RATE_LIMITED
         return DownloadErrorKind.UNKNOWN
     if isinstance(exc, OSError) and exc.errno == errno.ENOSPC:
         return DownloadErrorKind.NO_DISK_SPACE
-    if isinstance(exc, httpx.TransportError):
+    # `snapshot_download` catches the transport error at the metadata step and, with nothing
+    # cached to fall back to, re-raises it as this, so it is the shape an offline download
+    # actually fails with. A live transport error only escapes when the network dies mid-transfer.
+    if isinstance(exc, LocalEntryNotFoundError | httpx.TransportError):
         return DownloadErrorKind.NETWORK_UNREACHABLE
     return DownloadErrorKind.UNKNOWN
 
@@ -127,7 +133,14 @@ def describe(failure: DownloadFailure, *, model_id: str, revision: str | None = 
             f"{model_url}, then start the download again."
         )
     if failure.kind is DownloadErrorKind.REPO_NOT_FOUND:
-        return f"{attempted} Hugging Face has no model with that id. Check the id at {model_url}."
+        # Hugging Face answers a missing repo and a private one the caller cannot see with the
+        # same 401, so this cannot promise the id is wrong. Naming both keeps the owner of a
+        # private model from hunting for a typo that is not there.
+        return (
+            f"{attempted} Hugging Face has no model with that id, or it is private and this machine "
+            f"has no token with access to it. Check the id at {model_url}, and if the model is "
+            f"private, add your Hugging Face token as HF_TOKEN under Settings -> API Keys & Secrets."
+        )
     if failure.kind is DownloadErrorKind.REVISION_NOT_FOUND:
         pinned = f"revision '{revision}'" if revision else "the requested revision"
         return (
@@ -205,17 +218,6 @@ def parse_error_event(stderr: str) -> DownloadFailure | None:
             kind=_to_kind(event[_EVENT_KIND_KEY]),
             detail=detail if isinstance(detail, str) else None,
         )
-    return None
-
-
-def _status_code(exc: HfHubHTTPError) -> int | None:
-    """Read the HTTP status off a hub error, which carries its response."""
-    response = getattr(exc, "response", None)
-    if response is None:
-        return None
-    status_code = getattr(response, "status_code", None)
-    if isinstance(status_code, int):
-        return status_code
     return None
 
 

--- a/src/griptape_nodes/utils/model_download_errors.py
+++ b/src/griptape_nodes/utils/model_download_errors.py
@@ -1,0 +1,229 @@
+"""Classification, wording, and subprocess wire format for model download failures.
+
+A download runs in a child process (`griptape_nodes.cli.commands.models download`),
+so the exception is raised in one process and the message is shown by another. The
+child classifies the exception it caught and reports the verdict; the parent turns
+that verdict into the sentence the user reads. Both halves live here so a download
+failure reads the same in the editor as it does in a terminal, and so the wire
+format has its writer and its reader side by side.
+
+The parent must never build a message out of the child's output streams. Those
+streams also carry progress bars and library warnings, so text scavenged from them
+surfaces animation frames where an explanation belongs.
+"""
+
+from __future__ import annotations
+
+import errno
+import json
+from enum import StrEnum
+from http import HTTPStatus
+from typing import NamedTuple
+
+import httpx
+from huggingface_hub.errors import (
+    GatedRepoError,
+    HfHubHTTPError,
+    HFValidationError,
+    RepositoryNotFoundError,
+    RevisionNotFoundError,
+)
+
+HF_TOKEN_PAGE = "https://huggingface.co/settings/tokens"  # noqa: S105  # a page about tokens, not a token
+
+_EVENT_KIND_KEY = "error_type"
+_EVENT_DETAIL_KEY = "error_message"
+
+
+class DownloadErrorKind(StrEnum):
+    """Why a download failed, at the granularity that changes what the user should do."""
+
+    GATED_UNAUTHENTICATED = "gated_unauthenticated"
+    GATED_NO_ACCESS = "gated_no_access"
+    REPO_NOT_FOUND = "repo_not_found"
+    REVISION_NOT_FOUND = "revision_not_found"
+    INVALID_MODEL_ID = "invalid_model_id"
+    RATE_LIMITED = "rate_limited"
+    NO_DISK_SPACE = "no_disk_space"
+    NETWORK_UNREACHABLE = "network_unreachable"
+    UNKNOWN = "unknown"
+
+
+class DownloadFailure(NamedTuple):
+    """A child's verdict on a failed download.
+
+    Attributes:
+        kind: The classification the child assigned.
+        detail: The underlying exception's own text, for the log and for the
+            unclassified case. Never the contents of an output stream.
+    """
+
+    kind: DownloadErrorKind
+    detail: str | None
+
+
+def classify(exc: Exception) -> DownloadErrorKind:  # noqa: PLR0911
+    """Assign a download exception the kind whose advice fits it.
+
+    Args:
+        exc: The exception that ended the download.
+
+    Returns:
+        DownloadErrorKind: The matching kind, or `UNKNOWN` when nothing fits.
+    """
+    # Order is load-bearing: GatedRepoError is a RepositoryNotFoundError, and every
+    # HfHubHTTPError is also an httpx.HTTPError and an OSError.
+    if isinstance(exc, GatedRepoError):
+        if _status_code(exc) == HTTPStatus.FORBIDDEN:
+            return DownloadErrorKind.GATED_NO_ACCESS
+        # Hugging Face answers an anonymous or rejected request with 401 and a
+        # gated-repo code, so anything that is not an explicit 403 is a credential
+        # problem rather than a pending access request.
+        return DownloadErrorKind.GATED_UNAUTHENTICATED
+    if isinstance(exc, RevisionNotFoundError):
+        return DownloadErrorKind.REVISION_NOT_FOUND
+    if isinstance(exc, RepositoryNotFoundError):
+        return DownloadErrorKind.REPO_NOT_FOUND
+    if isinstance(exc, HFValidationError):
+        return DownloadErrorKind.INVALID_MODEL_ID
+    if isinstance(exc, HfHubHTTPError):
+        if _status_code(exc) == HTTPStatus.TOO_MANY_REQUESTS:
+            return DownloadErrorKind.RATE_LIMITED
+        return DownloadErrorKind.UNKNOWN
+    if isinstance(exc, OSError) and exc.errno == errno.ENOSPC:
+        return DownloadErrorKind.NO_DISK_SPACE
+    if isinstance(exc, httpx.TransportError):
+        return DownloadErrorKind.NETWORK_UNREACHABLE
+    return DownloadErrorKind.UNKNOWN
+
+
+def describe(failure: DownloadFailure, *, model_id: str, revision: str | None = None) -> str:  # noqa: PLR0911
+    """Word a download failure for the person who started it.
+
+    Bare URLs are deliberate: the editor renders these messages as markdown, which
+    autolinks them, and a terminal shows them as-is. Markdown link syntax would only
+    read as punctuation in the terminal.
+
+    Args:
+        failure: The child's verdict.
+        model_id: The model the user asked for.
+        revision: The revision the user asked for, when one was pinned.
+
+    Returns:
+        str: A sentence naming the model, what went wrong, and the next step.
+    """
+    model_url = f"https://huggingface.co/{model_id}"
+    attempted = f"Attempted to download '{model_id}'."
+
+    if failure.kind is DownloadErrorKind.GATED_UNAUTHENTICATED:
+        return (
+            f"{attempted} Hugging Face restricts this model to accounts it can identify, and it did not "
+            f"accept this request. Add your Hugging Face token as HF_TOKEN under Settings -> API Keys & "
+            f"Secrets, then start the download again. Create a token with 'Read' access at {HF_TOKEN_PAGE}."
+        )
+    if failure.kind is DownloadErrorKind.GATED_NO_ACCESS:
+        return (
+            f"{attempted} Your Hugging Face account has not been granted access to it. Request access at "
+            f"{model_url}, then start the download again."
+        )
+    if failure.kind is DownloadErrorKind.REPO_NOT_FOUND:
+        return f"{attempted} Hugging Face has no model with that id. Check the id at {model_url}."
+    if failure.kind is DownloadErrorKind.REVISION_NOT_FOUND:
+        pinned = f"revision '{revision}'" if revision else "the requested revision"
+        return (
+            f"Attempted to download '{model_id}' at {pinned}. That revision does not exist. The model's "
+            f"available revisions are listed at {model_url}."
+        )
+    if failure.kind is DownloadErrorKind.INVALID_MODEL_ID:
+        return (
+            f"{attempted} That is not a valid Hugging Face model id. An id looks like "
+            f"'black-forest-labs/FLUX.1-dev': an owner, a slash, then the model name."
+        )
+    if failure.kind is DownloadErrorKind.RATE_LIMITED:
+        return (
+            f"{attempted} Hugging Face is limiting how many requests this machine may make. Wait a few "
+            f"minutes and start the download again. Adding your Hugging Face token as HF_TOKEN under "
+            f"Settings -> API Keys & Secrets raises the limit; create one at {HF_TOKEN_PAGE}."
+        )
+    if failure.kind is DownloadErrorKind.NO_DISK_SPACE:
+        return (
+            f"{attempted} The drive holding the model cache is out of space. Free up space, or delete "
+            f"models you no longer need in Model Management, then start the download again."
+        )
+    if failure.kind is DownloadErrorKind.NETWORK_UNREACHABLE:
+        return (
+            f"{attempted} Could not reach huggingface.co. Check this machine's internet connection, then "
+            f"start the download again."
+        )
+    if failure.detail:
+        return f"{attempted} Failed due to: {failure.detail}"
+    return f"{attempted} Failed for an unexpected reason. The engine log has the details."
+
+
+def format_error_event(failure: DownloadFailure) -> str:
+    """Serialize a verdict for the child to write to stderr.
+
+    Leads with a newline because tqdm ends a progress frame with a bare carriage
+    return: an event written straight after one shares a line with it, and a reader
+    splitting on newlines alone would never see the event.
+
+    Args:
+        failure: The verdict to report.
+
+    Returns:
+        str: The bytes to write, newline-delimited on both sides.
+    """
+    event = {_EVENT_KIND_KEY: failure.kind.value, _EVENT_DETAIL_KEY: failure.detail}
+    return "\n" + json.dumps(event) + "\n"
+
+
+def parse_error_event(stderr: str) -> DownloadFailure | None:
+    """Recover the child's verdict from what it wrote to stderr.
+
+    Splits on carriage returns as well as newlines, so a frame the child's own
+    leading newline did not separate cannot hide the event behind it.
+
+    Args:
+        stderr: Everything the child wrote to stderr.
+
+    Returns:
+        DownloadFailure | None: The reported verdict, or None when the child died
+            without reporting one.
+    """
+    for fragment in stderr.replace("\r", "\n").splitlines():
+        candidate = fragment.strip()
+        if not candidate.startswith("{"):
+            continue
+        try:
+            event = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict) or _EVENT_KIND_KEY not in event:
+            continue
+        detail = event.get(_EVENT_DETAIL_KEY)
+        return DownloadFailure(
+            kind=_to_kind(event[_EVENT_KIND_KEY]),
+            detail=detail if isinstance(detail, str) else None,
+        )
+    return None
+
+
+def _status_code(exc: HfHubHTTPError) -> int | None:
+    """Read the HTTP status off a hub error, which carries its response."""
+    response = getattr(exc, "response", None)
+    if response is None:
+        return None
+    status_code = getattr(response, "status_code", None)
+    if isinstance(status_code, int):
+        return status_code
+    return None
+
+
+def _to_kind(value: object) -> DownloadErrorKind:
+    """Map a kind off the wire, tolerating one this build does not know."""
+    if isinstance(value, str):
+        try:
+            return DownloadErrorKind(value)
+        except ValueError:
+            return DownloadErrorKind.UNKNOWN
+    return DownloadErrorKind.UNKNOWN

--- a/src/griptape_nodes/utils/model_download_errors.py
+++ b/src/griptape_nodes/utils/model_download_errors.py
@@ -65,7 +65,7 @@ class DownloadFailure(NamedTuple):
     detail: str | None
 
 
-def classify(exc: Exception) -> DownloadErrorKind:  # noqa: PLR0911
+def classify(exc: Exception) -> DownloadErrorKind:  # noqa: C901, PLR0911
     """Assign a download exception the kind whose advice fits it.
 
     Args:
@@ -95,10 +95,9 @@ def classify(exc: Exception) -> DownloadErrorKind:  # noqa: PLR0911
         return DownloadErrorKind.UNKNOWN
     if isinstance(exc, OSError) and exc.errno == errno.ENOSPC:
         return DownloadErrorKind.NO_DISK_SPACE
-    # `snapshot_download` catches the transport error at the metadata step and, with nothing
-    # cached to fall back to, re-raises it as this, so it is the shape an offline download
-    # actually fails with. A live transport error only escapes when the network dies mid-transfer.
-    if isinstance(exc, LocalEntryNotFoundError | httpx.TransportError):
+    if isinstance(exc, LocalEntryNotFoundError):
+        return _classify_hub_fallback(exc)
+    if isinstance(exc, httpx.TransportError):
         return DownloadErrorKind.NETWORK_UNREACHABLE
     return DownloadErrorKind.UNKNOWN
 
@@ -219,6 +218,20 @@ def parse_error_event(stderr: str) -> DownloadFailure | None:
             detail=detail if isinstance(detail, str) else None,
         )
     return None
+
+
+def _classify_hub_fallback(exc: LocalEntryNotFoundError) -> DownloadErrorKind:
+    """Read the verdict off whatever the hub's cache-fallback error is standing in for.
+
+    Everything that stopped `snapshot_download` reaching the Hub with nothing cached to fall back
+    to arrives as this one error, an unreachable host and a 429 and a 500 alike, so the wrapper
+    cannot speak for any of them. It chains what it caught, and only a genuinely offline attempt
+    reaches here with nothing usable chained.
+    """
+    cause = exc.__cause__
+    if isinstance(cause, Exception) and not isinstance(cause, LocalEntryNotFoundError):
+        return classify(cause)
+    return DownloadErrorKind.NETWORK_UNREACHABLE
 
 
 def _to_kind(value: object) -> DownloadErrorKind:

--- a/src/griptape_nodes/utils/model_download_errors.py
+++ b/src/griptape_nodes/utils/model_download_errors.py
@@ -52,6 +52,22 @@ class DownloadErrorKind(StrEnum):
     UNKNOWN = "unknown"
 
 
+RETRYABLE_KINDS = frozenset(
+    {
+        DownloadErrorKind.NETWORK_UNREACHABLE,
+        DownloadErrorKind.RATE_LIMITED,
+        DownloadErrorKind.UNKNOWN,
+    }
+)
+"""Kinds a later attempt can get past on its own.
+
+Everything else needs the user to do something first -- add a token, be granted access, fix
+an id, free a disk -- and they start the download again when they have. Retrying those on a
+timer only spends a subprocess to reach the same verdict. `UNKNOWN` is in because it covers
+Hub downtime, which does clear on its own.
+"""
+
+
 class DownloadFailure(NamedTuple):
     """A child's verdict on a failed download.
 

--- a/tests/unit/retained_mode/managers/test_model_manager.py
+++ b/tests/unit/retained_mode/managers/test_model_manager.py
@@ -684,6 +684,37 @@ class TestFailedDownloadMessages:
         assert "Fetching" not in message
 
     @pytest.mark.asyncio
+    async def test_a_cancelled_download_is_not_reported_as_a_failure(self, model_manager: ModelManager) -> None:
+        """A cancel is carried out by killing the child, so its non-zero exit is expected.
+
+        Reported as a failure, it told the user their deliberate cancel "failed for an
+        unexpected reason" and left a Failed row behind the handler that removes it.
+        """
+        model_manager._download_tasks = {}
+        model_manager._download_processes = {}
+        model_manager._cancelled_downloads = {"black-forest-labs/FLUX.1-dev"}
+
+        process = SimpleNamespace(
+            stdout=None,
+            stderr=_FakeStderr([]),
+            returncode=-15,
+            wait=AsyncMock(return_value=-15),
+        )
+        written: list[dict] = []
+
+        async def fake_create_subprocess_exec(*_cmd: str, **_kwargs: object) -> SimpleNamespace:
+            return process
+
+        with (
+            patch("asyncio.create_subprocess_exec", side_effect=fake_create_subprocess_exec),
+            patch.object(model_manager, "_write_download_status", side_effect=lambda _f, data: written.append(data)),
+        ):
+            await model_manager._download_model_task(DownloadParams(model_id="black-forest-labs/FLUX.1-dev"))
+
+        assert [record["status"] for record in written] == ["downloading"]
+        assert model_manager._cancelled_downloads == set()
+
+    @pytest.mark.asyncio
     async def test_the_pinned_revision_reaches_the_message(self, model_manager: ModelManager) -> None:
         event = b'\n{"error_type": "revision_not_found", "error_message": "404 Client Error."}\n'
 

--- a/tests/unit/retained_mode/managers/test_model_manager.py
+++ b/tests/unit/retained_mode/managers/test_model_manager.py
@@ -43,10 +43,12 @@ from griptape_nodes.retained_mode.events.model_events import (
 )
 from griptape_nodes.retained_mode.managers.event_manager import EventManager
 from griptape_nodes.retained_mode.managers.model_manager import (
+    _PROGRESS_PIPE_ENV_VAR,
     _STATUS_READ_LOCK_ATTEMPTS,
     _STATUS_READ_TORN_ATTEMPTS,
     DownloadParams,
     ModelManager,
+    _create_progress_tracker,
     _load_status_file,
 )
 
@@ -554,6 +556,51 @@ class TestDownloadModelTaskSubprocess:
 
         assert captured_cmd[3] == "download"
         assert "org/model" in captured_cmd
+
+
+# ---------------------------------------------------------------------------
+# _create_progress_tracker — bars stay off the channel a failure is reported on
+# ---------------------------------------------------------------------------
+
+
+class TestProgressTrackerInPipeMode:
+    @pytest.fixture
+    def pipe_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(_PROGRESS_PIPE_ENV_VAR, "1")
+
+    def test_a_tracked_bar_draws_nothing_but_still_counts(self, pipe_mode: None) -> None:  # noqa: ARG002
+        """Bars must stay off stderr.
+
+        Progress reaches the parent as JSON on stdout, so a drawn bar is only noise the parent
+        has to tell apart from a failure report on the same stream.
+        """
+        downloaded_bytes = 40
+        stream = io.StringIO()
+        tracker = _create_progress_tracker("org/model")
+
+        # Typed loosely because the factory hands back `type[tqdm]`: the counters this asserts on
+        # belong to the subclass it builds, which the annotation cannot name.
+        bar: Any = tracker(total=100, unit="B", desc="Downloading bytes", file=stream)
+        bar.update(downloaded_bytes)
+        bar.close()
+
+        assert stream.getvalue().strip() == ""
+        assert bar._cumulative_bytes == downloaded_bytes
+
+    def test_the_file_enumeration_bar_is_still_excluded(self, pipe_mode: None) -> None:  # noqa: ARG002
+        """Fences off tqdm's own `disable=True` as a way to stop the drawing.
+
+        A disabled tqdm returns from `tqdm.__init__` before recording `desc` or `unit`, which is
+        what this bar is recognized by, so switching to it would flip `_should_track` on and report
+        a file count as a byte total. Passes on either implementation today; it exists to fail on
+        that refactor.
+        """
+        tracker = _create_progress_tracker("org/model")
+
+        bar: Any = tracker(total=29, unit="it", desc="Fetching 29 files", file=io.StringIO())
+        bar.close()
+
+        assert bar._should_track is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/retained_mode/managers/test_model_manager.py
+++ b/tests/unit/retained_mode/managers/test_model_manager.py
@@ -66,17 +66,26 @@ def model_manager() -> ModelManager:
 
 class TestOnHandleGetModelInfoRequest:
     @pytest.mark.asyncio
-    async def test_returns_failure_when_no_hf_token(self, model_manager: ModelManager) -> None:
+    async def test_a_public_model_answers_without_a_token(self, model_manager: ModelManager) -> None:
+        """Hugging Face serves a public model's metadata anonymously.
+
+        Refusing the lookup without a token left every model in the picker with no size, not
+        just the gated ones it was meant to speak for.
+        """
+        expected_size = 11_125_567_216
+        fake_info = SimpleNamespace(used_storage=expected_size, safetensors=None)
+
         with patch(
-            "griptape_nodes.retained_mode.managers.model_manager.get_token",
-            return_value=None,
-        ):
+            "griptape_nodes.retained_mode.managers.model_manager.hf_model_info",
+            return_value=fake_info,
+        ) as hf_info:
             result = await model_manager.on_handle_get_model_info_request(
-                GetModelInfoRequest(model_id="microsoft/phi-2")
+                GetModelInfoRequest(model_id="google/t5-v1_1-xxl")
             )
 
-        assert isinstance(result, GetModelInfoResultFailure)
-        assert "No Hugging Face token found" in str(result.result_details)
+        assert isinstance(result, GetModelInfoResultSuccess)
+        assert result.size_bytes == expected_size
+        assert hf_info.called
 
     @pytest.mark.asyncio
     async def test_returns_success_with_size_and_metadata(self, model_manager: ModelManager) -> None:
@@ -94,15 +103,9 @@ class TestOnHandleGetModelInfoRequest:
             likes=expected_likes,
         )
 
-        with (
-            patch(
-                "griptape_nodes.retained_mode.managers.model_manager.get_token",
-                return_value="hf_token",
-            ),
-            patch(
-                "griptape_nodes.retained_mode.managers.model_manager.hf_model_info",
-                return_value=fake_info,
-            ),
+        with patch(
+            "griptape_nodes.retained_mode.managers.model_manager.hf_model_info",
+            return_value=fake_info,
         ):
             result = await model_manager.on_handle_get_model_info_request(
                 GetModelInfoRequest(model_id="microsoft/phi-2")
@@ -120,15 +123,9 @@ class TestOnHandleGetModelInfoRequest:
 
     @pytest.mark.asyncio
     async def test_returns_failure_when_hf_api_raises(self, model_manager: ModelManager) -> None:
-        with (
-            patch(
-                "griptape_nodes.retained_mode.managers.model_manager.get_token",
-                return_value="hf_token",
-            ),
-            patch(
-                "griptape_nodes.retained_mode.managers.model_manager.hf_model_info",
-                side_effect=ValueError("model not found"),
-            ),
+        with patch(
+            "griptape_nodes.retained_mode.managers.model_manager.hf_model_info",
+            side_effect=ValueError("model not found"),
         ):
             result = await model_manager.on_handle_get_model_info_request(GetModelInfoRequest(model_id="bad/model"))
 
@@ -148,15 +145,9 @@ class TestOnHandleGetModelInfoRequest:
             likes=None,
         )
 
-        with (
-            patch(
-                "griptape_nodes.retained_mode.managers.model_manager.get_token",
-                return_value="hf_token",
-            ),
-            patch(
-                "griptape_nodes.retained_mode.managers.model_manager.hf_model_info",
-                return_value=fake_info,
-            ),
+        with patch(
+            "griptape_nodes.retained_mode.managers.model_manager.hf_model_info",
+            return_value=fake_info,
         ):
             result = await model_manager.on_handle_get_model_info_request(GetModelInfoRequest(model_id="some/model"))
 
@@ -708,12 +699,17 @@ class TestFailedDownloadMessages:
 
 class TestDownloadWithoutAToken:
     @pytest.mark.asyncio
-    async def test_a_missing_token_does_not_block_the_attempt(self, model_manager: ModelManager) -> None:
+    async def test_a_missing_token_does_not_block_the_attempt(
+        self, model_manager: ModelManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Public models download anonymously, and a gated one needs the 401 to reach the user.
 
         Refusing here also returned before any status file existed, leaving the editor's
         download list with no row to show a reason on.
         """
+        # No token discoverable from either place `huggingface_hub` looks for one.
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        monkeypatch.setenv("HF_TOKEN_PATH", "/nonexistent/hf/token")
         model_manager._download_tasks = {}
         model_manager._download_processes = {}
 
@@ -725,7 +721,6 @@ class TestDownloadWithoutAToken:
             return process
 
         with (
-            patch("griptape_nodes.retained_mode.managers.model_manager.get_token", return_value=None),
             patch("asyncio.create_subprocess_exec", side_effect=fake_create_subprocess_exec),
             patch.object(model_manager, "_write_download_status"),
         ):

--- a/tests/unit/retained_mode/managers/test_model_manager.py
+++ b/tests/unit/retained_mode/managers/test_model_manager.py
@@ -14,6 +14,7 @@ import importlib.util
 import io
 import json
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -932,3 +933,51 @@ class TestAppInitializationCompleteWorkerGuard:
 
         find_unfinished.assert_called_once()
         assert handle_download.await_args_list[0].args[0].model_id == "org/model"
+
+
+# ---------------------------------------------------------------------------
+# _find_unfinished_downloads — which failures are worth another attempt
+# ---------------------------------------------------------------------------
+
+
+class TestFindUnfinishedDownloads:
+    """A failure the user has to act on first must not be retried once per engine start."""
+
+    @pytest.fixture
+    def status_dir(self, model_manager: ModelManager, tmp_path: Path) -> Iterator[Path]:
+        with patch.object(model_manager, "_get_status_directory", return_value=tmp_path):
+            yield tmp_path
+
+    def _write(self, status_dir: Path, model_id: str, **fields: Any) -> None:
+        record = {"model_id": model_id, "started_at": "s", "updated_at": "u", **fields}
+        (status_dir / f"{model_id.replace('/', '--')}.json").write_text(json.dumps(record), encoding="utf-8")
+
+    def test_an_interrupted_download_is_resumed(self, model_manager: ModelManager, status_dir: Path) -> None:
+        self._write(status_dir, "org/interrupted", status="downloading")
+
+        assert model_manager._find_unfinished_downloads() == ["org/interrupted"]
+
+    def test_a_failure_that_clears_on_its_own_is_retried(self, model_manager: ModelManager, status_dir: Path) -> None:
+        self._write(status_dir, "org/offline", status="failed", error_kind="network_unreachable")
+
+        assert model_manager._find_unfinished_downloads() == ["org/offline"]
+
+    def test_a_failure_needing_the_user_first_is_not_retried(
+        self, model_manager: ModelManager, status_dir: Path
+    ) -> None:
+        """Without a token, this one reached the same 401 on every engine start, forever."""
+        self._write(status_dir, "org/gated", status="failed", error_kind="gated_unauthenticated")
+
+        assert model_manager._find_unfinished_downloads() == []
+
+    def test_a_failure_recorded_before_kinds_existed_is_still_retried(
+        self, model_manager: ModelManager, status_dir: Path
+    ) -> None:
+        self._write(status_dir, "org/legacy", status="failed")
+
+        assert model_manager._find_unfinished_downloads() == ["org/legacy"]
+
+    def test_a_completed_download_is_left_alone(self, model_manager: ModelManager, status_dir: Path) -> None:
+        self._write(status_dir, "org/done", status="completed")
+
+        assert model_manager._find_unfinished_downloads() == []

--- a/tests/unit/retained_mode/managers/test_model_manager.py
+++ b/tests/unit/retained_mode/managers/test_model_manager.py
@@ -4,7 +4,9 @@ Covers:
 - `on_handle_get_model_info_request` — token guard and HF API delegation
 - `on_handle_search_models_request` — search result handling
 - `on_handle_declare_model_invocation_request` — clears a declared invocation past the pre-dispatch chain
-- `_download_model_task` — the spawned subprocess targets a runnable module
+- `_download_model_task` — the spawned subprocess targets a runnable module, and a failed
+  download reports a written message rather than whatever landed in the subprocess pipe
+- `on_handle_download_model_request` — a missing Hugging Face token does not block the attempt
 - `_load_status_file` — status file reads survive a concurrent status file write
 """
 
@@ -28,6 +30,8 @@ from griptape_nodes.retained_mode.events.model_events import (
     DeclareModelInvocationRequest,
     DeclareModelInvocationResultFailure,
     DeclareModelInvocationResultSuccess,
+    DownloadModelRequest,
+    DownloadModelResultSuccess,
     GetModelInfoRequest,
     GetModelInfoResultFailure,
     GetModelInfoResultSuccess,
@@ -550,6 +554,146 @@ class TestDownloadModelTaskSubprocess:
 
         assert captured_cmd[3] == "download"
         assert "org/model" in captured_cmd
+
+
+# ---------------------------------------------------------------------------
+# _download_model_task — what a failed download tells the user
+# ---------------------------------------------------------------------------
+
+
+class _FakeStderr:
+    """Subprocess stderr that hands back preloaded chunks, then EOF."""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = list(chunks)
+
+    async def readline(self) -> bytes:
+        if not self._chunks:
+            return b""
+        return self._chunks.pop(0)
+
+
+_TQDM_FRAMES = (
+    b"\rFetching 29 files:   0%|          | 0/29 [00:00<?, ?it/s]"
+    b"\rFetching 29 files:   7%| | 2/29 [00:00<00:02, 12.14it/s]\n"
+)
+
+
+class TestFailedDownloadMessages:
+    """A download failure must report a sentence someone wrote.
+
+    The subprocess pipe also carries tqdm frames and library warnings, so text taken
+    from the stream surfaces a progress animation where an explanation belongs (#3126).
+    """
+
+    async def _run_failed_download(
+        self,
+        model_manager: ModelManager,
+        stderr_chunks: list[bytes],
+        revision: str | None = None,
+    ) -> str:
+        """Run a download whose subprocess exits non-zero; return the reported message."""
+        model_manager._download_tasks = {}
+        model_manager._download_processes = {}
+
+        process = SimpleNamespace(
+            stdout=None,
+            stderr=_FakeStderr(stderr_chunks),
+            returncode=1,
+            wait=AsyncMock(return_value=1),
+        )
+        written: list[dict] = []
+
+        async def fake_create_subprocess_exec(*_cmd: str, **_kwargs: object) -> SimpleNamespace:
+            return process
+
+        with (
+            patch("asyncio.create_subprocess_exec", side_effect=fake_create_subprocess_exec),
+            patch.object(model_manager, "_write_download_status", side_effect=lambda _f, data: written.append(data)),
+            pytest.raises(ValueError, match="Attempted to download"),
+        ):
+            await model_manager._download_model_task(
+                DownloadParams(model_id="black-forest-labs/FLUX.1-dev", revision=revision)
+            )
+
+        assert written[-1]["status"] == "failed"
+        return written[-1]["error_message"]
+
+    @pytest.mark.asyncio
+    async def test_progress_frames_never_become_the_error_message(self, model_manager: ModelManager) -> None:
+        event = b'\n{"error_type": "gated_unauthenticated", "error_message": "401 Client Error."}\n'
+
+        message = await self._run_failed_download(model_manager, [_TQDM_FRAMES, event])
+
+        assert "Fetching" not in message
+        assert "HF_TOKEN" in message
+
+    @pytest.mark.asyncio
+    async def test_a_child_that_reported_nothing_still_yields_a_message(self, model_manager: ModelManager) -> None:
+        """A killed or crashed child leaves no verdict; the row must still read as English."""
+        message = await self._run_failed_download(model_manager, [])
+
+        assert "black-forest-labs/FLUX.1-dev" in message
+        assert "engine log" in message
+
+    @pytest.mark.asyncio
+    async def test_unreported_failures_do_not_leak_the_stream(self, model_manager: ModelManager) -> None:
+        noise = b"Ignored error while writing tree cache file: [Errno 1] Operation not permitted\n"
+
+        message = await self._run_failed_download(model_manager, [noise, _TQDM_FRAMES])
+
+        assert "Errno 1" not in message
+        assert "Fetching" not in message
+
+    @pytest.mark.asyncio
+    async def test_the_pinned_revision_reaches_the_message(self, model_manager: ModelManager) -> None:
+        event = b'\n{"error_type": "revision_not_found", "error_message": "404 Client Error."}\n'
+
+        message = await self._run_failed_download(model_manager, [event], revision="refs/pr/1")
+
+        assert "refs/pr/1" in message
+
+
+# ---------------------------------------------------------------------------
+# on_handle_download_model_request — the token is not a precondition
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadWithoutAToken:
+    @pytest.mark.asyncio
+    async def test_a_missing_token_does_not_block_the_attempt(self, model_manager: ModelManager) -> None:
+        """Public models download anonymously, and a gated one needs the 401 to reach the user.
+
+        Refusing here also returned before any status file existed, leaving the editor's
+        download list with no row to show a reason on.
+        """
+        model_manager._download_tasks = {}
+        model_manager._download_processes = {}
+
+        process = SimpleNamespace(stdout=None, stderr=None, returncode=0, wait=AsyncMock(return_value=0))
+        spawned: list[str] = []
+
+        async def fake_create_subprocess_exec(*cmd: str, **_kwargs: object) -> SimpleNamespace:
+            spawned.extend(cmd)
+            return process
+
+        with (
+            patch("griptape_nodes.retained_mode.managers.model_manager.get_token", return_value=None),
+            patch("asyncio.create_subprocess_exec", side_effect=fake_create_subprocess_exec),
+            patch.object(model_manager, "_write_download_status"),
+        ):
+            result = await model_manager.on_handle_download_model_request(
+                DownloadModelRequest(
+                    model_id="google/t5-v1_1-xxl",
+                    local_dir=None,
+                    revision="main",
+                    allow_patterns=None,
+                    ignore_patterns=None,
+                )
+            )
+
+        assert isinstance(result, DownloadModelResultSuccess)
+        assert "google/t5-v1_1-xxl" in spawned
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/utils/test_model_download_errors.py
+++ b/tests/unit/utils/test_model_download_errors.py
@@ -1,0 +1,180 @@
+"""Unit tests for model_download_errors module."""
+
+from __future__ import annotations
+
+import errno
+
+import httpx
+import pytest
+from huggingface_hub.errors import (
+    GatedRepoError,
+    HfHubHTTPError,
+    HFValidationError,
+    RepositoryNotFoundError,
+    RevisionNotFoundError,
+)
+
+from griptape_nodes.utils.model_download_errors import (
+    DownloadErrorKind,
+    DownloadFailure,
+    classify,
+    describe,
+    format_error_event,
+    parse_error_event,
+)
+
+MODEL_ID = "black-forest-labs/FLUX.1-dev"
+
+
+def _hub_error(error_class: type[HfHubHTTPError], status_code: int) -> HfHubHTTPError:
+    """Build a hub error the way `hf_raise_for_status` does, response and all."""
+    request = httpx.Request("GET", f"https://huggingface.co/api/models/{MODEL_ID}")
+    return error_class(f"{status_code} Client Error.", response=httpx.Response(status_code, request=request))
+
+
+class TestClassify:
+    def test_anonymous_gated_access_reads_as_a_credential_problem(self) -> None:
+        """Hugging Face answers an unauthenticated request for a gated repo with 401."""
+        assert classify(_hub_error(GatedRepoError, 401)) is DownloadErrorKind.GATED_UNAUTHENTICATED
+
+    def test_authenticated_gated_access_reads_as_a_pending_access_request(self) -> None:
+        assert classify(_hub_error(GatedRepoError, 403)) is DownloadErrorKind.GATED_NO_ACCESS
+
+    def test_a_gated_error_without_a_usable_response_is_not_a_crash(self) -> None:
+        error = _hub_error(GatedRepoError, 401)
+        error.response = None  # type: ignore[assignment]
+
+        assert classify(error) is DownloadErrorKind.GATED_UNAUTHENTICATED
+
+    def test_missing_repo(self) -> None:
+        assert classify(_hub_error(RepositoryNotFoundError, 401)) is DownloadErrorKind.REPO_NOT_FOUND
+
+    def test_missing_revision(self) -> None:
+        assert classify(_hub_error(RevisionNotFoundError, 404)) is DownloadErrorKind.REVISION_NOT_FOUND
+
+    def test_malformed_model_id(self) -> None:
+        assert classify(HFValidationError("Repo id must be in the form 'repo_name'")) is (
+            DownloadErrorKind.INVALID_MODEL_ID
+        )
+
+    def test_rate_limit(self) -> None:
+        assert classify(_hub_error(HfHubHTTPError, 429)) is DownloadErrorKind.RATE_LIMITED
+
+    def test_other_http_failures_stay_unclassified(self) -> None:
+        assert classify(_hub_error(HfHubHTTPError, 500)) is DownloadErrorKind.UNKNOWN
+
+    def test_full_disk(self) -> None:
+        assert classify(OSError(errno.ENOSPC, "No space left on device")) is DownloadErrorKind.NO_DISK_SPACE
+
+    def test_unreachable_host(self) -> None:
+        assert classify(httpx.ConnectError("nodename nor servname provided")) is (DownloadErrorKind.NETWORK_UNREACHABLE)
+
+    def test_an_http_error_is_not_mistaken_for_a_transport_or_disk_error(self) -> None:
+        """Every HfHubHTTPError is also an httpx.HTTPError and an OSError."""
+        assert classify(_hub_error(HfHubHTTPError, 500)) is DownloadErrorKind.UNKNOWN
+
+    def test_anything_else(self) -> None:
+        assert classify(RuntimeError("boom")) is DownloadErrorKind.UNKNOWN
+
+
+class TestDescribe:
+    @pytest.mark.parametrize("kind", list(DownloadErrorKind))
+    def test_every_kind_names_the_model(self, kind: DownloadErrorKind) -> None:
+        message = describe(DownloadFailure(kind=kind, detail="raw"), model_id=MODEL_ID)
+
+        assert MODEL_ID in message
+
+    def test_unauthenticated_gate_asks_for_a_token_not_for_access_approval(self) -> None:
+        message = describe(
+            DownloadFailure(kind=DownloadErrorKind.GATED_UNAUTHENTICATED, detail="401 Client Error."),
+            model_id=MODEL_ID,
+        )
+
+        assert "HF_TOKEN" in message
+        assert "Settings -> API Keys & Secrets" in message
+        assert "Request access" not in message
+
+    def test_granted_access_gate_asks_for_access_approval_not_for_a_token(self) -> None:
+        message = describe(
+            DownloadFailure(kind=DownloadErrorKind.GATED_NO_ACCESS, detail="403 Client Error."),
+            model_id=MODEL_ID,
+        )
+
+        assert f"https://huggingface.co/{MODEL_ID}" in message
+        assert "HF_TOKEN" not in message
+
+    def test_a_pinned_revision_is_named(self) -> None:
+        message = describe(
+            DownloadFailure(kind=DownloadErrorKind.REVISION_NOT_FOUND, detail=None),
+            model_id=MODEL_ID,
+            revision="refs/pr/1",
+        )
+
+        assert "refs/pr/1" in message
+
+    def test_an_unpinned_revision_reads_as_a_sentence(self) -> None:
+        message = describe(
+            DownloadFailure(kind=DownloadErrorKind.REVISION_NOT_FOUND, detail=None),
+            model_id=MODEL_ID,
+            revision=None,
+        )
+
+        assert "the requested revision" in message
+        assert "None" not in message
+
+    def test_an_unclassified_failure_carries_the_exception_text(self) -> None:
+        message = describe(
+            DownloadFailure(kind=DownloadErrorKind.UNKNOWN, detail="[Errno 1] Operation not permitted"),
+            model_id=MODEL_ID,
+        )
+
+        assert "[Errno 1] Operation not permitted" in message
+
+    def test_an_unclassified_failure_with_nothing_to_say_points_at_the_log(self) -> None:
+        message = describe(DownloadFailure(kind=DownloadErrorKind.UNKNOWN, detail=None), model_id=MODEL_ID)
+
+        assert "engine log" in message
+        assert "None" not in message
+
+
+class TestErrorEventRoundTrip:
+    def test_a_written_event_reads_back(self) -> None:
+        failure = DownloadFailure(kind=DownloadErrorKind.GATED_NO_ACCESS, detail="403 Client Error.")
+
+        assert parse_error_event(format_error_event(failure)) == failure
+
+    def test_an_event_behind_progress_frames_is_still_found(self) -> None:
+        """Tqdm separates frames with a bare carriage return, not a newline."""
+        stderr = "\rFetching 29 files:   0%|          | 0/29 [00:00<?, ?it/s]" + format_error_event(
+            DownloadFailure(kind=DownloadErrorKind.GATED_UNAUTHENTICATED, detail="401")
+        )
+
+        failure = parse_error_event(stderr)
+
+        assert failure is not None
+        assert failure.kind is DownloadErrorKind.GATED_UNAUTHENTICATED
+
+    def test_an_event_sharing_a_line_with_a_frame_is_still_found(self) -> None:
+        """Guards the reader against a writer that does not lead with a newline."""
+        stderr = '\rFetching 29 files:   0%|  | 0/29\r{"error_type": "repo_not_found", "error_message": "404"}\n'
+
+        failure = parse_error_event(stderr)
+
+        assert failure is not None
+        assert failure.kind is DownloadErrorKind.REPO_NOT_FOUND
+
+    def test_a_kind_this_build_does_not_know_reads_as_unclassified(self) -> None:
+        failure = parse_error_event('{"error_type": "invented_later", "error_message": "details"}\n')
+
+        assert failure is not None
+        assert failure.kind is DownloadErrorKind.UNKNOWN
+        assert failure.detail == "details"
+
+    def test_progress_frames_alone_are_not_a_verdict(self) -> None:
+        assert parse_error_event("\rFetching 29 files:   7%|  | 2/29 [00:00<00:02, 12.14it/s]\n") is None
+
+    def test_silence_is_not_a_verdict(self) -> None:
+        assert parse_error_event("") is None
+
+    def test_unrelated_json_is_not_a_verdict(self) -> None:
+        assert parse_error_event('{"downloaded_bytes": 0, "total_bytes": 0}\n') is None

--- a/tests/unit/utils/test_model_download_errors.py
+++ b/tests/unit/utils/test_model_download_errors.py
@@ -33,6 +33,15 @@ def _hub_error(error_class: type[HfHubHTTPError], status_code: int) -> HfHubHTTP
     return error_class(f"{status_code} Client Error.", response=httpx.Response(status_code, request=request))
 
 
+def _wrapped_by_the_hub(cause: Exception) -> LocalEntryNotFoundError:
+    """Wrap `cause` the way `snapshot_download` does when it cannot reach the Hub."""
+    error = LocalEntryNotFoundError(
+        f"Got: {type(cause).__name__}: {cause}\nAn error happened while trying to locate the files on the Hub."
+    )
+    error.__cause__ = cause
+    return error
+
+
 class TestClassify:
     def test_anonymous_gated_access_reads_as_a_credential_problem(self) -> None:
         """Hugging Face answers an unauthenticated request for a gated repo with 401."""
@@ -56,6 +65,7 @@ class TestClassify:
         assert classify(_hub_error(HfHubHTTPError, 429)) is DownloadErrorKind.RATE_LIMITED
 
     def test_other_http_failures_stay_unclassified(self) -> None:
+        """Also guards the branch order: every HfHubHTTPError is an httpx.HTTPError and an OSError."""
         assert classify(_hub_error(HfHubHTTPError, 500)) is DownloadErrorKind.UNKNOWN
 
     def test_full_disk(self) -> None:
@@ -71,16 +81,25 @@ class TestClassify:
         `LocalEntryNotFoundError`, which is a FileNotFoundError rather than an httpx error, so the
         transport branch alone left the common offline case unclassified.
         """
-        offline = LocalEntryNotFoundError(
-            "Got: ConnectError: [Errno 8] nodename nor servname provided, or not known\n"
-            "An error happened while trying to locate the files on the Hub."
-        )
+        offline = _wrapped_by_the_hub(httpx.ConnectError("[Errno 8] nodename nor servname provided"))
 
         assert classify(offline) is DownloadErrorKind.NETWORK_UNREACHABLE
 
-    def test_an_http_error_is_not_mistaken_for_a_transport_or_disk_error(self) -> None:
-        """Every HfHubHTTPError is also an httpx.HTTPError and an OSError."""
-        assert classify(_hub_error(HfHubHTTPError, 500)) is DownloadErrorKind.UNKNOWN
+    def test_an_http_failure_the_hub_wrapped_keeps_its_own_verdict(self) -> None:
+        """The wrapper is not evidence of a network problem.
+
+        `snapshot_download` re-raises every failure it could not reach the Hub through as
+        `LocalEntryNotFoundError`, a 429 and a 500 included, so reading the wrapper alone told a
+        rate-limited user to check their internet connection and left `RATE_LIMITED` unreachable.
+        """
+        rate_limited = _wrapped_by_the_hub(_hub_error(HfHubHTTPError, 429))
+
+        assert classify(rate_limited) is DownloadErrorKind.RATE_LIMITED
+
+    def test_a_wrapper_chained_to_itself_still_terminates(self) -> None:
+        assert classify(_wrapped_by_the_hub(LocalEntryNotFoundError("nested"))) is (
+            DownloadErrorKind.NETWORK_UNREACHABLE
+        )
 
     def test_anything_else(self) -> None:
         assert classify(RuntimeError("boom")) is DownloadErrorKind.UNKNOWN

--- a/tests/unit/utils/test_model_download_errors.py
+++ b/tests/unit/utils/test_model_download_errors.py
@@ -10,6 +10,7 @@ from huggingface_hub.errors import (
     GatedRepoError,
     HfHubHTTPError,
     HFValidationError,
+    LocalEntryNotFoundError,
     RepositoryNotFoundError,
     RevisionNotFoundError,
 )
@@ -40,12 +41,6 @@ class TestClassify:
     def test_authenticated_gated_access_reads_as_a_pending_access_request(self) -> None:
         assert classify(_hub_error(GatedRepoError, 403)) is DownloadErrorKind.GATED_NO_ACCESS
 
-    def test_a_gated_error_without_a_usable_response_is_not_a_crash(self) -> None:
-        error = _hub_error(GatedRepoError, 401)
-        error.response = None  # type: ignore[assignment]
-
-        assert classify(error) is DownloadErrorKind.GATED_UNAUTHENTICATED
-
     def test_missing_repo(self) -> None:
         assert classify(_hub_error(RepositoryNotFoundError, 401)) is DownloadErrorKind.REPO_NOT_FOUND
 
@@ -66,8 +61,22 @@ class TestClassify:
     def test_full_disk(self) -> None:
         assert classify(OSError(errno.ENOSPC, "No space left on device")) is DownloadErrorKind.NO_DISK_SPACE
 
-    def test_unreachable_host(self) -> None:
+    def test_unreachable_host_mid_transfer(self) -> None:
         assert classify(httpx.ConnectError("nodename nor servname provided")) is (DownloadErrorKind.NETWORK_UNREACHABLE)
+
+    def test_unreachable_host_before_any_transfer(self) -> None:
+        """The shape an offline download actually fails with.
+
+        `snapshot_download` catches the transport error while reading metadata and re-raises it as
+        `LocalEntryNotFoundError`, which is a FileNotFoundError rather than an httpx error, so the
+        transport branch alone left the common offline case unclassified.
+        """
+        offline = LocalEntryNotFoundError(
+            "Got: ConnectError: [Errno 8] nodename nor servname provided, or not known\n"
+            "An error happened while trying to locate the files on the Hub."
+        )
+
+        assert classify(offline) is DownloadErrorKind.NETWORK_UNREACHABLE
 
     def test_an_http_error_is_not_mistaken_for_a_transport_or_disk_error(self) -> None:
         """Every HfHubHTTPError is also an httpx.HTTPError and an OSError."""
@@ -78,11 +87,21 @@ class TestClassify:
 
 
 class TestDescribe:
-    @pytest.mark.parametrize("kind", list(DownloadErrorKind))
-    def test_every_kind_names_the_model(self, kind: DownloadErrorKind) -> None:
-        message = describe(DownloadFailure(kind=kind, detail="raw"), model_id=MODEL_ID)
+    @pytest.mark.parametrize("kind", [kind for kind in DownloadErrorKind if kind is not DownloadErrorKind.UNKNOWN])
+    def test_every_classified_kind_is_worded(self, kind: DownloadErrorKind) -> None:
+        """A kind added to the enum and to `classify` but not to `describe` falls through to UNKNOWN.
+
+        Comparing against the UNKNOWN wording is what makes that visible: asserting only that the
+        message names the model passes on the fallback, which names it too.
+        """
+        detail = "401 Client Error. Cannot access gated repo"
+        unworded = describe(DownloadFailure(kind=DownloadErrorKind.UNKNOWN, detail=detail), model_id=MODEL_ID)
+
+        message = describe(DownloadFailure(kind=kind, detail=detail), model_id=MODEL_ID)
 
         assert MODEL_ID in message
+        assert message != unworded
+        assert detail not in message
 
     def test_unauthenticated_gate_asks_for_a_token_not_for_access_approval(self) -> None:
         message = describe(


### PR DESCRIPTION
Closes #3126.

## The defect

A download runs in a child process (`griptape_nodes.cli.commands.models download`, a subprocess so a cancel can kill it). The parent built the user-facing error out of the child's **stderr**, which also carries tqdm frames and library warnings, while the message someone actually wrote went to **stdout** via `rich` and was discarded there. The screenshot on the issue is that: `⠏ Loading Griptape Nodes...` frames rendered as an explanation.

Only two error types had a hand-authored message; everything else got scavenged text. Reproduced on `main` before this change:

| Failure | What the editor showed |
|---|---|
| Unwritable destination | an HF log line + `\rFetching 10 files: 0%\|…` frames |
| Bad revision | *nothing* — stderr was empty, so `error_message` was `""`, which the error box treats as falsy |
| Gated repo, no token | never reached the subprocess; a blanket token check refused it first |

## The change

The child classifies every failure and emits one structured event; the parent words the message from that verdict alone and never reads a stream for error text. `utils/model_download_errors.py` owns the classification, the wording, and the wire format, so the writer and the reader sit together and the editor and a CLI run cannot drift.

Classification, all verified against live Hugging Face responses rather than assumed:

- **401 vs 403 on a gated repo.** An anonymous request for FLUX.1-dev returns 401, so the old "request access" advice was wrong for the case in the issue: that user needs a token, not a license click. 403 keeps the request-access wording.
- **A missing repo and a private one are the same 401** and `huggingface_hub` says so in its own source, so that message names both instead of promising the id is wrong.
- **The hub's cache-fallback error is not evidence of a network problem.** `snapshot_download` re-raises everything it could not reach the Hub through as `LocalEntryNotFoundError`, a 429 and a 500 included, so reading the wrapper alone told a rate-limited user to check a connection that was fine and left the rate-limit wording unreachable. The wrapper chains its cause, and that is where the verdict is.
- Plus missing revisions, malformed ids, a full disk, and an unreachable host. Anything unclassified carries the exception's own text, so nothing is ever blank.

Also here:

- **The blanket `get_token()` checks are gone**, from downloads and from the model-info lookup. Public models download and report their size anonymously (verified: `snapshot_download(..., token=False)` succeeds with only a rate-limit warning), and the download check returned before a status file existed, so the editor had no row to show a reason on. A gated model now fails on the first file and classifies as needing a token, which is a better message than the check produced.
- **Progress bars no longer render into the error channel** while the parent reads events off the pipe. Suppressing `display()` rather than passing tqdm `disable=True` is deliberate: a disabled tqdm never records `desc` or `unit`, which is how the tracker tells a byte-level bar from the `Fetching N files` bar, so disabling it would report a file count as a byte total. A test fences that off.
- **The CLI escapes the message before rich sees it.** It can carry an exception's own text, and a stray bracket there is markup: `[/]` raised `MarkupError` and `([blob])` rendered as `()`, so a terminal run got a traceback or a sentence with holes.
- **Startup resume no longer retries failures the user has to act on first.** It treats `failed` as unfinished, so a gated model with no token spawned a subprocess, hit the same 401, and logged another ERROR on every engine start, forever. That was invisible while such a download was refused before anything was written. The record now carries its kind, and resume takes only the kinds a later attempt gets past on its own.
- Two unused HTTP status constants, left from an earlier attempt at the 401/403 split, are removed.

## Verification

`make check` clean; 6010 unit tests pass. Every case below was run live in pipe mode, exactly as `ModelManager` spawns the child:

- **FLUX.1-dev with no token** → `gated_unauthenticated`; stderr carries the event and no frames.
- **Unwritable destination** → `Attempted to download 'X'. Failed due to: [Errno 1] Operation not permitted: '/System/nope_not_writable'`
- **Bad revision** → names the revision and links the model's revision list, where it previously showed nothing.
- **429 / 500 / 503 / 403 through `snapshot_download`** → the 429 classifies as rate limited; an offline attempt still as unreachable.
- **A real successful download** → progress events still flow and the final event reports `completed: true`, so the render suppression left byte tracking intact.

The editor renders `error_message` as markdown with GFM autolinks, so these messages are plain sentences with bare URLs: clickable in the editor, readable in a terminal.

## Not addressed

- A 500 or 503 classifies as `unknown`, so the user sees HF's own message rather than a wrong network claim. Telling Hub downtime apart properly would need a new kind.
- **The cancel path.** An earlier commit here guarded against a cancelled download being reported as a failure; @feltech showed the branch is effectively unreachable, since the cancelling handler wins the race to cancel the download task, so it was reverted rather than defended. On a cancel the task still dies on `CancelledError`, writes no terminal status, and the handler removes the row. What remains untouched is that the request then resolves as `DownloadModelResultSuccess` with `result_details="Successfully downloaded model 'X'"`, which is wrong for a cancel but predates this change.
- `_collect_download_stderr` uses `readline()`, which raises once 64 KiB arrives with no newline. Suppressing the bars removes today's trigger, but the parent's robustness still depends on what the child renders. Pre-existing, untouched here.
- The editor half is griptape-ai/griptape-vsl-gui#2953.

