### PR TITLE
fix(models): fetch model info without requiring a token

### DIFF
--- a/src/griptape_nodes/retained_mode/managers/model_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/model_manager.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
-from huggingface_hub import get_token, list_models, scan_cache_dir, snapshot_download
+from huggingface_hub import list_models, scan_cache_dir, snapshot_download
 from huggingface_hub import model_info as hf_model_info
 from huggingface_hub.utils.tqdm import tqdm
 from xdg_base_dirs import xdg_data_home
@@ -823,13 +823,9 @@ class ModelManager(EngineScoped):
         Returns:
             ResultPayload: Success with exact size and metadata, or failure with error details
         """
-        if get_token() is None:
-            error_msg = (
-                "No Hugging Face token found. Fetching info for gated models requires authentication. "
-                "Set your HF_TOKEN environment variable or log in with `huggingface-cli login`."
-            )
-            return GetModelInfoResultFailure(result_details=error_msg)
-
+        # Deliberately no token check: a public model answers anonymously, and a gated one
+        # answers with a 401 the caller can report. Refusing up front meant a token-less user
+        # got no size for any model, gated or not.
         try:
             info = await asyncio.to_thread(hf_model_info, request.model_id)
         except Exception as e:

--- a/tests/unit/retained_mode/managers/test_model_manager.py
+++ b/tests/unit/retained_mode/managers/test_model_manager.py
@@ -66,17 +66,26 @@ def model_manager() -> ModelManager:
 
 class TestOnHandleGetModelInfoRequest:
     @pytest.mark.asyncio
-    async def test_returns_failure_when_no_hf_token(self, model_manager: ModelManager) -> None:
+    async def test_a_public_model_answers_without_a_token(self, model_manager: ModelManager) -> None:
+        """Hugging Face serves a public model's metadata anonymously.
+
+        Refusing the lookup without a token left every model in the picker with no size, not
+        just the gated ones it was meant to speak for.
+        """
+        expected_size = 11_125_567_216
+        fake_info = SimpleNamespace(used_storage=expected_size, safetensors=None)
+
         with patch(
-            "griptape_nodes.retained_mode.managers.model_manager.get_token",
-            return_value=None,
-        ):
+            "griptape_nodes.retained_mode.managers.model_manager.hf_model_info",
+            return_value=fake_info,
+        ) as hf_info:
             result = await model_manager.on_handle_get_model_info_request(
-                GetModelInfoRequest(model_id="microsoft/phi-2")
+                GetModelInfoRequest(model_id="google/t5-v1_1-xxl")
             )
 
-        assert isinstance(result, GetModelInfoResultFailure)
-        assert "No Hugging Face token found" in str(result.result_details)
+        assert isinstance(result, GetModelInfoResultSuccess)
+        assert result.size_bytes == expected_size
+        assert hf_info.called
 
     @pytest.mark.asyncio
     async def test_returns_success_with_size_and_metadata(self, model_manager: ModelManager) -> None:
@@ -94,15 +103,9 @@ class TestOnHandleGetModelInfoRequest:
             likes=expected_likes,
         )
 
-        with (
-            patch(
-                "griptape_nodes.retained_mode.managers.model_manager.get_token",
-                return_value="hf_token",
-            ),
-            patch(
-                "griptape_nodes.retained_mode.managers.model_manager.hf_model_info",
-                return_value=fake_info,
-            ),
+        with patch(
+            "griptape_nodes.retained_mode.managers.model_manager.hf_model_info",
+            return_value=fake_info,
         ):
             result = await model_manager.on_handle_get_model_info_request(
                 GetModelInfoRequest(model_id="microsoft/phi-2")
@@ -120,15 +123,9 @@ class TestOnHandleGetModelInfoRequest:
 
     @pytest.mark.asyncio
     async def test_returns_failure_when_hf_api_raises(self, model_manager: ModelManager) -> None:
-        with (
-            patch(
-                "griptape_nodes.retained_mode.managers.model_manager.get_token",
-                return_value="hf_token",
-            ),
-            patch(
-                "griptape_nodes.retained_mode.managers.model_manager.hf_model_info",
-                side_effect=ValueError("model not found"),
-            ),
+        with patch(
+            "griptape_nodes.retained_mode.managers.model_manager.hf_model_info",
+            side_effect=ValueError("model not found"),
         ):
             result = await model_manager.on_handle_get_model_info_request(GetModelInfoRequest(model_id="bad/model"))
 
@@ -148,15 +145,9 @@ class TestOnHandleGetModelInfoRequest:
             likes=None,
         )
 
-        with (
-            patch(
-                "griptape_nodes.retained_mode.managers.model_manager.get_token",
-                return_value="hf_token",
-            ),
-            patch(
-                "griptape_nodes.retained_mode.managers.model_manager.hf_model_info",
-                return_value=fake_info,
-            ),
+        with patch(
+            "griptape_nodes.retained_mode.managers.model_manager.hf_model_info",
+            return_value=fake_info,
         ):
             result = await model_manager.on_handle_get_model_info_request(GetModelInfoRequest(model_id="some/model"))
 
@@ -708,12 +699,17 @@ class TestFailedDownloadMessages:
 
 class TestDownloadWithoutAToken:
     @pytest.mark.asyncio
-    async def test_a_missing_token_does_not_block_the_attempt(self, model_manager: ModelManager) -> None:
+    async def test_a_missing_token_does_not_block_the_attempt(
+        self, model_manager: ModelManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Public models download anonymously, and a gated one needs the 401 to reach the user.
 
         Refusing here also returned before any status file existed, leaving the editor's
         download list with no row to show a reason on.
         """
+        # No token discoverable from either place `huggingface_hub` looks for one.
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        monkeypatch.setenv("HF_TOKEN_PATH", "/nonexistent/hf/token")
         model_manager._download_tasks = {}
         model_manager._download_processes = {}
 
@@ -725,7 +721,6 @@ class TestDownloadWithoutAToken:
             return process
 
         with (
-            patch("griptape_nodes.retained_mode.managers.model_manager.get_token", return_value=None),
             patch("asyncio.create_subprocess_exec", side_effect=fake_create_subprocess_exec),
             patch.object(model_manager, "_write_download_status"),
         ):


### PR DESCRIPTION
Follow-up to #5528, which took the same blanket token check off downloads. Stacked on `fix/3126-model-download-errors`; review that one first.

`on_handle_get_model_info_request` refused to look anything up without a Hugging Face token, on the grounds that gated models need one. Public models do not: `HfApi(token=False).model_info("google-bert/bert-base-uncased")` returns `used_storage` fine. So a token-less user got no size for *any* model in Model Management, and the failure surfaced as an error toast about a request they never made, since the picker fires this lookup on selection.

It also gave the last piece of advice in this area that pointed away from the editor, telling users to set an environment variable and run `huggingface-cli login` for something Settings → API Keys & Secrets configures.

A gated model now answers with a 401 the caller reports, the same way a download does. The lookup's failure is dropped by its only caller and shows no size (`ModelDownloadForm.tsx`), and griptape-vsl-gui#2954 marks the request so it stops toasting.

`make check` clean, full unit suite passes. The test that pinned the old refusal is replaced by one asserting a public model answers with no token available.
