### PR TITLE
Track a pending request on a future with no owning loop

### DIFF
--- a/src/griptape_nodes/api_client/request_client.py
+++ b/src/griptape_nodes/api_client/request_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import json
 import logging
 import threading
@@ -22,15 +23,12 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class _PendingRequest:
-    future: asyncio.Future
+    # concurrent.futures.Future, not asyncio.Future: the settling side (the transport loop) and
+    # the awaiting side (whichever loop issued the request) differ. An asyncio future belongs to
+    # one loop and set_result wakes its waiter through a non-threadsafe call_soon, so a foreign
+    # settle marks it done without waking the sleeping loop. This one has no loop to get wrong.
+    future: concurrent.futures.Future
     tag: str
-    # The loop the future belongs to, which is NOT always the loop that resolves it. Websocket
-    # messages are handled on the transport loop while a request may have been issued from the
-    # loop running a flow, and asyncio futures are single-loop objects: set_result schedules the
-    # waiting task through `future._loop.call_soon`, which does not wake a loop it is not called
-    # from. Without this the result sits in the target loop's ready queue until something
-    # unrelated wakes it.
-    loop: asyncio.AbstractEventLoop
     # When True, EventResultFailure responses resolve the future with
     # the full payload dict instead of rejecting it with
     # ``Exception(error_msg)``. The default (False) preserves the
@@ -163,9 +161,9 @@ class RequestClient:
             # Wait for response with optional timeout
             if timeout_ms:
                 timeout_sec = timeout_ms / 1000
-                result = await asyncio.wait_for(response_future, timeout=timeout_sec)
+                result = await asyncio.wait_for(asyncio.wrap_future(response_future), timeout=timeout_sec)
             else:
-                result = await response_future
+                result = await asyncio.wrap_future(response_future)
 
         except TimeoutError:
             logger.error("Request %s timed out", request_id)
@@ -226,9 +224,9 @@ class RequestClient:
 
             if timeout_ms:
                 timeout_sec = timeout_ms / 1000
-                result = await asyncio.wait_for(response_future, timeout=timeout_sec)
+                result = await asyncio.wait_for(asyncio.wrap_future(response_future), timeout=timeout_sec)
             else:
-                result = await response_future
+                result = await asyncio.wrap_future(response_future)
 
         except TimeoutError:
             logger.error("Forwarded request %s timed out", request_id)
@@ -291,7 +289,7 @@ class RequestClient:
         # Pre-register futures for every inner request so _try_match can resolve
         # them as responses arrive in arbitrary order.
         inner_events: list[dict[str, Any]] = []
-        futures: list[asyncio.Future] = []
+        futures: list[concurrent.futures.Future] = []
         request_ids: list[str] = []
         for request_type, raw_payload in requests:
             request_id = str(uuid.uuid4())
@@ -313,7 +311,9 @@ class RequestClient:
 
         try:
             await self.client.publish("EventRequestBatch", batch_payload, request_topic)
-            gather = asyncio.gather(*futures, return_exceptions=return_exceptions)
+            gather = asyncio.gather(
+                *(asyncio.wrap_future(future) for future in futures), return_exceptions=return_exceptions
+            )
             if timeout_ms:
                 results = await asyncio.wait_for(gather, timeout=timeout_ms / 1000)
             else:
@@ -333,7 +333,7 @@ class RequestClient:
         tag: str = "",
         *,
         resolve_failures_as_payload: bool = False,
-    ) -> asyncio.Future:
+    ) -> concurrent.futures.Future:
         """Register a future for an outgoing request and return it.
 
         Use this when the send path is handled externally (e.g. WorkerManager
@@ -351,7 +351,8 @@ class RequestClient:
                 ``ResultPayloadFailure`` (preserving exception fidelity).
 
         Returns:
-            Future that will be resolved when the matching response arrives
+            A loop-agnostic future, settled when the matching response arrives. Adapt it with
+            ``asyncio.wrap_future`` to await it; the awaiting loop need not be this one.
         """
         return await self._track_request(request_id, tag=tag, resolve_failures_as_payload=resolve_failures_as_payload)
 
@@ -365,7 +366,7 @@ class RequestClient:
             to_cancel = [rid for rid, entry in self._pending_requests.items() if entry.tag == tag]
             for rid in to_cancel:
                 entry = self._pending_requests.pop(rid)
-                RequestClient._settle(entry, entry.future.cancel)
+                RequestClient._settle(entry.future.cancel)
                 logger.debug("Cancelled request %s (tag=%s)", rid, tag)
 
     async def _track_request(
@@ -374,7 +375,7 @@ class RequestClient:
         tag: str = "",
         *,
         resolve_failures_as_payload: bool = False,
-    ) -> asyncio.Future:
+    ) -> concurrent.futures.Future:
         """Start tracking a request and return a future that will be resolved on response.
 
         Args:
@@ -393,38 +394,26 @@ class RequestClient:
                 msg = f"Request ID already exists: {request_id}"
                 raise ValueError(msg)
 
-            loop = asyncio.get_running_loop()
-            future: asyncio.Future = loop.create_future()
+            future: concurrent.futures.Future = concurrent.futures.Future()
             self._pending_requests[request_id] = _PendingRequest(
-                future, tag, loop, resolve_failures_as_payload=resolve_failures_as_payload
+                future, tag, resolve_failures_as_payload=resolve_failures_as_payload
             )
             logger.debug("Tracking request: %s (tag=%s)", request_id, tag)
             return future
 
     @staticmethod
-    def _settle(entry: _PendingRequest, settle: Callable[[], object]) -> None:
-        """Apply a terminal state to a pending request's future, on the loop that owns it.
+    def _settle(settle: Callable[[], object]) -> None:
+        """Apply a terminal state to a pending request's future.
 
-        A future is bound to one loop. Calling set_result/set_exception/cancel from a different
-        loop marks it done but schedules the waiting task's wakeup with a non-threadsafe
-        `call_soon`, so a sleeping owner loop never learns about it. call_soon_threadsafe is the
-        same operation plus the wakeup, and is safe to use even from the owning loop, so there is
-        one path rather than a same-loop special case to keep in sync.
-
-        The done-check is re-run inside the callback because it runs later, on the other loop,
-        where a cancellation may have landed first.
+        Valid from any thread and needs no loop bookkeeping: the future locks its own state, and
+        each awaiter is woken by the threadsafe callback `asyncio.wrap_future` installs.
         """
-
-        def apply() -> None:
-            if not entry.future.done():
-                settle()
-
         try:
-            entry.loop.call_soon_threadsafe(apply)
-        except RuntimeError:
-            # The owning loop is closed, so nothing is waiting on this future any more. Shutdown
-            # races here rather than an error worth surfacing.
-            logger.debug("Dropping a settled request: its loop is closed")
+            settle()
+        except concurrent.futures.InvalidStateError:
+            # A waiter that times out cancels the future through wrap_future without holding
+            # self._lock, so a response arriving at that moment finds it already cancelled.
+            logger.debug("Dropping a settle for an already-finished request")
 
     def _resolve_request_unlocked(self, request_id: str, result: Any) -> None:
         """Resolve a request's future. Caller must hold self._lock.
@@ -439,7 +428,7 @@ class RequestClient:
             logger.warning("Received response for unknown request: %s", request_id)
             return
 
-        RequestClient._settle(entry, lambda: entry.future.set_result(result))
+        RequestClient._settle(lambda: entry.future.set_result(result))
         logger.debug("Resolved request: %s", request_id)
 
     def _reject_request_unlocked(self, request_id: str, error: Exception) -> None:
@@ -455,7 +444,7 @@ class RequestClient:
             logger.warning("Received error for unknown request: %s", request_id)
             return
 
-        RequestClient._settle(entry, lambda: entry.future.set_exception(error))
+        RequestClient._settle(lambda: entry.future.set_exception(error))
         logger.debug("Rejected request: %s with error: %s", request_id, error)
 
     async def _resolve_request(self, request_id: str, result: Any) -> None:
@@ -491,7 +480,7 @@ class RequestClient:
                 logger.debug("Request already completed or unknown: %s", request_id)
                 return
 
-            RequestClient._settle(entry, entry.future.cancel)
+            RequestClient._settle(entry.future.cancel)
             logger.debug("Cancelled request: %s", request_id)
 
     @property

--- a/src/griptape_nodes/retained_mode/managers/event_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/event_manager.py
@@ -860,12 +860,11 @@ class EventManager(EngineScoped):
         Called once at worker startup after the RequestClient is constructed and topics
         are subscribed. Inert on the orchestrator (never called there).
 
-        websocket_event_loop is the loop that owns the Client/RequestClient (the daemon
-        thread's loop). All RequestClient primitives -- its asyncio.Lock, the pending-
-        request Future, and the _try_match filter that claims responses -- are bound to
-        that loop. Forwarding calls must be dispatched there via run_coroutine_threadsafe;
-        awaiting RequestClient methods directly from the main loop or a ThreadRunner loop
-        causes cross-loop contention that stalls for seconds per request.
+        websocket_event_loop is the loop that owns the Client (the daemon thread's loop).
+        Forwarding is dispatched there via run_coroutine_threadsafe so the sync
+        handle_request path can block its own thread on the result, which is only safe when
+        the coroutine runs on another thread's loop. RequestClient's own state is
+        loop-agnostic, so the hop is about the blocking caller rather than about reaching it.
         """
         self._worker_request_client = request_client
         self._orchestrator_request_topic = orchestrator_request_topic
@@ -959,11 +958,11 @@ class EventManager(EngineScoped):
         payload, and reconstructs it as an EventResultSuccess/EventResultFailure whose
         shape matches the locally-dispatched path.
 
-        The RequestClient send/track/await happens on the websocket event loop
-        (configured via configure_worker_forwarding) so that its asyncio.Lock and
-        the pending-request Future live on the same loop as the _try_match filter
-        that resolves them. Awaiting those primitives from any other loop causes
-        cross-loop contention that stalls for seconds.
+        The send/track/await is dispatched onto the websocket event loop (configured via
+        configure_worker_forwarding), the loop that owns the transport. Reaching
+        RequestClient state does not require that -- the state is loop-agnostic -- but the
+        sync handle_request path does, since it blocks its own thread on the result and can
+        only do so when the coroutine runs on another thread's loop.
         """
         if (
             self._worker_request_client is None

--- a/src/griptape_nodes/retained_mode/managers/worker_manager.py
+++ b/src/griptape_nodes/retained_mode/managers/worker_manager.py
@@ -451,7 +451,9 @@ class WorkerManager(EngineScoped):
         # RequestClient.cancel_requests_by_tag, so a dead worker still surfaces
         # to the caller without a per-request ceiling.
         try:
-            return await future
+            # The future is settled by whichever loop the transport runs on, which is not this one.
+            # wrap_future adapts it for this loop and installs the threadsafe wakeup.
+            return await asyncio.wrap_future(future)
         except asyncio.CancelledError:
             # Eviction cancels this future from underneath the awaiting task. A bare
             # CancelledError is indistinguishable from the artist pressing stop, and the

--- a/tests/unit/api_client/test_request_client_cross_loop.py
+++ b/tests/unit/api_client/test_request_client_cross_loop.py
@@ -14,6 +14,7 @@ future's done flag: the flag was always set promptly, which is exactly why the b
 from __future__ import annotations
 
 import asyncio
+import logging
 import threading
 import time
 from typing import Any
@@ -59,7 +60,7 @@ def _await_tracked(client: RequestClient, request_id: str) -> Any:
     async def run() -> tuple[Any, float]:
         future = await client.track_request(request_id)
         started = time.monotonic()
-        result = await asyncio.wait_for(future, timeout=WAITER_TIMEOUT_S)
+        result = await asyncio.wait_for(asyncio.wrap_future(future), timeout=WAITER_TIMEOUT_S)
         return result, time.monotonic() - started
 
     return run()
@@ -102,7 +103,7 @@ class TestCrossLoopSettlement:
                 future = await client.track_request("req-3", tag="worker-a")
                 started = time.monotonic()
                 try:
-                    await asyncio.wait_for(future, timeout=WAITER_TIMEOUT_S)
+                    await asyncio.wait_for(asyncio.wrap_future(future), timeout=WAITER_TIMEOUT_S)
                 except asyncio.CancelledError:
                     return time.monotonic() - started
                 msg = "expected cancellation"
@@ -113,7 +114,7 @@ class TestCrossLoopSettlement:
 
             # cancel_requests_by_tag is async only for its lock; drive its body from here.
             entry = client._pending_requests.pop("req-3")
-            RequestClient._settle(entry, entry.future.cancel)
+            RequestClient._settle(entry.future.cancel)
             elapsed = pending.result(timeout=WAITER_TIMEOUT_S + 5)
 
         assert elapsed < PROMPT_S, f"waiter learned of the cancel after {elapsed:.1f}s"
@@ -144,3 +145,84 @@ class TestLockCrossesLoops:
 
             assert "req-a" not in client._pending_requests
             assert "req-b" in client._pending_requests
+
+
+class TestTheFutureHasNoOwningLoop:
+    """A tracked future outlives, and is independent of, the loop that created it."""
+
+    def test_a_future_is_awaited_from_a_loop_that_did_not_create_it(self) -> None:
+        client = _client()
+        # asyncio.run closes its loop on the way out, so by the time anything waits on this
+        # future the loop that created it no longer exists.
+        future = asyncio.run(client.track_request("portable-1"))
+
+        async def wait_for_it() -> Any:
+            return await asyncio.wait_for(asyncio.wrap_future(future), timeout=WAITER_TIMEOUT_S)
+
+        with _LoopInThread() as third_loop:
+            pending = asyncio.run_coroutine_threadsafe(wait_for_it(), third_loop)
+            time.sleep(0.2)
+            client._resolve_request_unlocked("portable-1", {"ok": True})
+
+            assert pending.result(timeout=PROMPT_S) == {"ok": True}
+
+    def test_a_result_survives_its_creating_loop_being_closed(self) -> None:
+        """The loop-bound design had to drop this settle; there is no longer anything to drop.
+
+        Its owning loop was gone, so `call_soon_threadsafe` raised and the result was discarded
+        with a debug line. Nothing was waiting by then, but the settle had to be defended against.
+        """
+        client = _client()
+        future = asyncio.run(client.track_request("orphan-1"))
+
+        client._resolve_request_unlocked("orphan-1", {"ok": True})
+
+        assert future.result(timeout=0) == {"ok": True}
+
+
+class TestSettlingAnAlreadyFinishedRequest:
+    """A waiter that gives up settles the future itself, without holding the client's lock.
+
+    `wrap_future` propagates the waiter's cancellation into the tracked future, so a response
+    landing at that moment meets a future that is already done. The loop-bound design could not
+    reach this state: every settle was funnelled through one loop's callback queue, which
+    serialized them for free.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_response_arriving_after_the_waiter_timed_out_is_dropped(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        client = _client()
+        future = await client.track_request("late-1")
+
+        with pytest.raises(TimeoutError):
+            await asyncio.wait_for(asyncio.wrap_future(future), timeout=0.01)
+        assert future.cancelled(), "the waiter's timeout should have cancelled the tracked future"
+
+        # The transport has no idea the waiter left. Delivering to it must not raise.
+        with caplog.at_level(logging.DEBUG, logger="griptape_nodes.api_client.request_client"):
+            await client._resolve_request("late-1", {"ok": True})
+
+        # Asserted so the guard cannot quietly become unreachable: without it this settle raises.
+        assert "already-finished" in caplog.text
+        assert client.pending_count == 0
+
+    @pytest.mark.asyncio
+    async def test_a_rejection_arriving_after_a_cancel_by_tag_is_dropped(self) -> None:
+        client = _client()
+        await client.track_request("late-2", tag="worker-a")
+
+        await client.cancel_requests_by_tag("worker-a")
+        # cancel_requests_by_tag already popped the entry, so this is the unknown-request path.
+        await client._reject_request("late-2", RuntimeError("worker died"))
+
+        assert client.pending_count == 0
+
+    @pytest.mark.asyncio
+    async def test_a_duplicate_request_id_still_raises(self) -> None:
+        client = _client()
+        await client.track_request("dup-1")
+
+        with pytest.raises(ValueError, match="Request ID already exists"):
+            await client.track_request("dup-1")

--- a/tests/unit/app/test_app_worker.py
+++ b/tests/unit/app/test_app_worker.py
@@ -8,6 +8,7 @@ the route_to_worker / pending-future mechanism.
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import json
 import sys
 import threading
@@ -44,11 +45,10 @@ class _FakeRequestClient:
 
     async def track_request(
         self, request_id: str, tag: str = "", *, resolve_failures_as_payload: bool = False
-    ) -> asyncio.Future:
-        loop = asyncio.get_running_loop()
-        future: asyncio.Future = loop.create_future()
+    ) -> concurrent.futures.Future:
+        future: concurrent.futures.Future = concurrent.futures.Future()
         self._pending_requests[request_id] = _PendingRequest(
-            future, tag, loop, resolve_failures_as_payload=resolve_failures_as_payload
+            future, tag, resolve_failures_as_payload=resolve_failures_as_payload
         )
         return future
 


### PR DESCRIPTION
Stacked on #5467, targeting its branch. Answers @collindutter's question on `request_client.py` there: *"Is this patching over some incorrect behavior for request client? Put another way, would we need all this if we were doing this from scratch?"*

## What that question turned up

The two-loop reach into `RequestClient` is real and pre-dates the stack. The app runs loop A (main thread: engine event queue, library load) and loop B (`websocket-tasks` daemon thread), split so library load cannot stall heartbeats. On the orchestrator, four paths reach the client and they are split across both:

| Entry point | Loop |
|---|---|
| `_try_match` → resolve/reject | B (websocket message handler) |
| `route_to_worker` → `track_request` + await | A (node execution) |
| `evict_worker` → `cancel_requests_by_tag` | B (heartbeat monitor) |
| `reset_workers` → `cancel_requests_by_tag` | A (LibraryManager pre-reload callback; also session-end) |

So #5467 is not patching over a request-client bug — the object genuinely has to be safe from more than one loop, and its `asyncio.Lock` was not providing exclusion at all (`Lock.acquire` only consults its bound loop on the contended path, so two loops both sail through the uncontended fast path). That half stands and is unchanged here.

What #5467 got wrong is the **primitive**. It keeps `asyncio.Future` — a single-loop object — and compensates by recording each request's loop and re-dispatching every settle through `call_soon_threadsafe`. That is bookkeeping the stdlib already does.

## What this changes

`concurrent.futures.Future` locks its own state and has no loop affinity; `asyncio.wrap_future` is the stdlib adapter for awaiting one from a loop. Callers wrap, and the client stops tracking who is waiting or where.

Deleted:
- the per-request `loop` field
- the deferred `call_soon_threadsafe` re-dispatch
- the closed-loop `RuntimeError` branch, which dropped a result when the creating loop had gone

Added: `asyncio.wrap_future(...)` at four await sites, and an `InvalidStateError` guard. That guard replaces the old deferred done-check and is genuinely reachable now: `wrap_future` propagates a waiter's timeout into the tracked future *without* holding `self._lock`, so a response can land on an already-cancelled future. The loop-bound design could not reach that state, because funnelling every settle through one loop's callback queue serialized them for free.

`threading.Lock` stays. `_pending_requests` is mutated from both loops regardless of what the futures are.

## Feature parity

The existing tests are the parity evidence — they assert on behavior, not mechanism, and pass unchanged apart from callers now wrapping:

- `test_request_client_cross_loop.py` — result / rejection / cancel-by-tag settled from another thread must wake the waiter, asserted on **elapsed time**
- `test_request_client_batch.py` — ordering, failure-cancels-siblings, `return_exceptions`, timeout-cancels-pending
- `test_app_worker.py` — `test_evicted_worker_raises_rather_than_cancelling`, `test_flow_cancellation_still_cancels`, `test_reset_settles_in_flight_requests_too`

`route_to_worker`'s cancel discrimination survives: an externally cancelled future still leaves `task.cancelling() == 0`, so eviction raises the worker-died `RuntimeError` and a real flow cancel still propagates.

Five tests added for what this change alters:
- a future is awaited from a loop that did not create it
- a result survives its creating loop being closed (the old code had to drop this)
- a response arriving after the waiter timed out is dropped — asserts the guard **logged**, so it cannot quietly become unreachable
- a rejection arriving after `cancel_requests_by_tag` is dropped
- a duplicate `request_id` still raises `ValueError`

**Verified:** `make check` clean (ruff, mdformat, pyright 0 errors, typos); unit **6048 passed** (6043 baseline + 5); e2e **118 passed**; integration **9 passed, 6 xfailed**.

## Size

Against #5467's base, `request_client.py` goes from **+57 −21** to **+55 −30** — about 11 net lines smaller. Correcting an earlier estimate of mine: this is a more modest line reduction than I first projected. The point is not the line count but that the "which loop owns this future" concept is gone rather than tracked.

## Also included

Two docstrings in `event_manager.py` justified the worker-forwarding hop by the loop affinity of RequestClient's lock and futures. #5467 already falsified that and this makes it plainer, so leaving them would have the tree asserting single-loop ownership in one file and loop-agnostic safety in another. The hop itself stays — `_invoke_handler_from_sync` blocks its own thread on the result, which is only safe when the coroutine runs on another thread's loop.

## Not included

Deliberately out of scope; each would exist without this change:
- letting the sync path block on `cf.result(timeout=...)` and dropping `run_coroutine_threadsafe` entirely
- collapsing to a single loop (needs a fully async request path)
- a written process-wide loop-ownership rule
